### PR TITLE
fix: correct provider and model IDs for GitHub Copilot

### DIFF
--- a/src/agents/opencode.ts
+++ b/src/agents/opencode.ts
@@ -53,7 +53,7 @@ export const opencodeAgent = {
       path: { id: realId },
       body: {
         parts: [{ type: "text", text: prompt }],
-        model: { providerID: "copilot", modelID: "claude-sonnet-4-6" },
+        model: { providerID: "github-copilot", modelID: "claude-sonnet-4.6" },
       },
     });
 


### PR DESCRIPTION
## Summary
- `providerID` を `"copilot"` から `"github-copilot"` に修正
- `modelID` を `"claude-sonnet-4-6"` から `"claude-sonnet-4.6"` に修正
- これにより LLM が応答を生成せず `(no response)` が返される問題を解決

## Test plan
- [x] ボットを起動し、Discord でメンションして応答が返ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)