### PR TITLE
docs: update STATUS.md to reflect current state

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,19 +4,22 @@
 
 - 2026-03-01
 - 更新者: AI
+- PR: #6 (fix/known-bugs) マージ済み
 
 ## 2. 現在の真実（Project Truth）
 
-- Clean Architecture への移行が完了している（`feat/clean-architecture` ブランチ、未マージ）。
+- Clean Architecture への移行が完了し、main にマージ済み。
 - domain / application / infrastructure の 3 層構成で、依存方向ルールは正しく守られている。
 - DI は手動コンストラクタ注入（Pure DI）で `composition-root.ts` に集約している。
-- テストは一切存在しない。
+- テストは `bun test` で実行可能（11件: splitMessage 6件 + HandleIncomingMessageUseCase 5件）。
 - Bot メンションまたはスレッド内メッセージに AI が応答する。
 - AI 推論は OpenCode SDK 経由で `github-copilot:claude-sonnet-4.6` を使用する。
-- セッションは `data/sessions.json` に JSON で永続化している。
+- セッションは `data/sessions.json` に JSON で永続化している（coalesce パターンで書き込み直列化済み）。
 - ブートストラップコンテキストは `context/` 配下の Markdown から読込む。
 - MCP サーバーは `discord-server.ts`（Discord 操作）と `code-exec-server.ts`（コード実行）の 2 つ。
-- `nr validate` (fmt:check + lint + check) は通る。
+- `nr validate` (fmt:check + lint + check) および `bun test` が通る。
+- Graceful shutdown（SIGINT/SIGTERM）実装済み。
+- エラー時はユーザーに汎用メッセージを返し、詳細はログのみに記録する。
 
 ## 3. 確定済み方針
 
@@ -49,7 +52,7 @@
 
 - [x] **セッションファイルの同時書き込み競合** — `json-session-repository.ts:57-60`
   - 複数の Discord メッセージ同時処理で `Bun.write()` が同一ファイルに並行書き込みし、ファイル破損の可能性。
-  - 修正済み: async IIFE による書き込み直列化を実装した。
+  - 修正済み: coalesce パターン（writing フラグ + 再帰的 flush）で書き込み直列化を実装した。
 
 - [x] **ユースケースが `"discord"` をハードコード** — `handle-incoming-message.use-case.ts:18`
   - application 層がプラットフォーム固有の文字列を知っている（Clean Architecture 違反）。
@@ -71,7 +74,7 @@
 
 - [x] **Graceful shutdown 未実装** — `composition-root.ts`
   - `SIGINT`/`SIGTERM` ハンドラがなく、`gateway.stop()` / `agent.stop()` が呼ばれない。
-  - 修正済み: `bootstrap()` 内で SIGINT/SIGTERM シグナルハンドラを追加した。
+  - 修正済み: `bootstrap()` 内で SIGINT/SIGTERM シグナルハンドラを追加した（二重呼び出し防止ガード + 1s 待機）。
 
 - [x] **`package.json` の `lint:fix` が CLAUDE.md に未記載**
   - 確認済み: CLAUDE.md にはすでに `nr lint:fix` が記載されていた。
@@ -84,14 +87,13 @@
 
 - [x] **子プロセスへの環境変数継承** — `mcp/code-exec-server.ts`
   - `Bun.spawn` がデフォルトで親プロセスの環境変数を継承するため、`DISCORD_TOKEN` 等が code-exec 内のコードから参照可能。
-  - 修正済み: `Bun.spawn` の `env` に `SAFE_ENV`（PATH, HOME, LANG のみ）を明示的に指定した。
+  - 修正済み: 全ての `Bun.spawn` の `env` に `SAFE_ENV`（PATH, HOME, LANG のみ）を明示的に指定した（tmux kill-session 含む）。
 
 ## 5. 直近タスク
 
-1. ~~Critical バグの修正（`isNew` 判定、エラーメッセージ漏洩）~~ — 完了
-2. ~~テスト追加（`splitMessage`, `HandleIncomingMessageUseCase`）~~ — 完了
-3. ~~セッション書き込み競合対策~~ — 完了
-4. テストカバレッジの拡充（infrastructure 層のテスト等）
+1. テストカバレッジの拡充（infrastructure 層のテスト等）
+2. code-exec のコンテナ化によるサンドボックス実装
+3. 機能拡張（SPEC.md の未実装機能）
 
 ## 6. ブロッカー
 
@@ -99,9 +101,8 @@
 
 ## 7. リスクメモ
 
-1. ~~テストゼロ状態でのリグレッションリスク。~~ — テスト追加済み（10件）
-2. code-exec のサンドボックス欠如による RCE リスク（説明文は修正済み、コンテナ化は未対応）。
-3. ~~セッションファイル競合によるデータ破損リスク。~~ — 書き込み直列化で対応済み
+1. code-exec のサンドボックス欠如による RCE リスク（説明文は修正済み、環境変数は制限済み、コンテナ化は未対応）。
+2. テストは 11 件あるが infrastructure 層はカバーされていない。
 
 ## 8. 再開時コンテキスト
 


### PR DESCRIPTION
## Summary

- PR #6 マージ後の STATUS.md を最新の状態に更新
- Project Truth セクション: CA マージ済み、テスト 11 件、graceful shutdown 等を反映
- バグ修正の記述をレビュー対応後の実装に合わせて修正（coalesce パターン、SAFE_ENV 全適用等）
- 直近タスク・リスクメモから完了済み項目を整理

## Test plan

- [x] ドキュメントのみの変更のため、コード変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)