### PR TITLE
chore: deploy スクリプトを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"fmt:check": "oxfmt --check .",
 		"test": "bun test",
 		"validate": "bun run fmt:check && bun run lint && bun run check",
-		"container:build": "podman build -t vicissitude-code-exec containers/code-exec"
+		"container:build": "podman build -t vicissitude-code-exec containers/code-exec",
+		"deploy": "tmux kill-session -t vicissitude 2>/dev/null; tmux new-session -d -s vicissitude 'bun run src/index.ts' && echo 'Deployed to tmux session: vicissitude'"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.1",


### PR DESCRIPTION
## Summary
- `nr deploy` で tmux セッションを再作成して bot を起動するスクリプトを追加
- 既存セッションがあれば kill してから再作成する

## Test plan
- [ ] `nr deploy` で bot が tmux セッション `vicissitude` で起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)