### PR TITLE
fix: opencode SDK のエラーハンドリングを修正

### DIFF
--- a/src/infrastructure/opencode/opencode-agent.ts
+++ b/src/infrastructure/opencode/opencode-agent.ts
@@ -81,7 +81,7 @@ export class OpencodeAgent implements AiAgent {
 			});
 			if (created.error || !created.data) {
 				throw new Error(
-					`Failed to create session: ${JSON.stringify(created.error) ?? "no data returned"}`,
+					`Failed to create session: ${created.error ? JSON.stringify(created.error) : "no data returned"}`,
 				);
 			}
 			realId = created.data.id;


### PR DESCRIPTION
## Summary

- opencode SDK は `throwOnError: false` がデフォルトのため、HTTP エラー時に例外をスローせず `{ error }` を返す
- `session.get()` の `try/catch` が機能せず、存在しないセッション ID でそのまま prompt を送信していた
- `result.error` チェック方式に変更し、セッション不在時に正しく新規作成されるようにした
- `session.prompt()` / `session.create()` にも同様のエラーチェックを追加

## Test plan

- [ ] Discord でメッセージを送信し、`(no response)` ではなく正常な応答が返ることを確認
- [ ] コンテナ再起動後（セッション ID がリセットされた状態）でも正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)