### PR TITLE
feat: ChannelConfig に guildId を追加 & ホームチャンネル追加

### DIFF
--- a/src/domain/entities/channel-config.ts
+++ b/src/domain/entities/channel-config.ts
@@ -2,6 +2,7 @@ export type ChannelRole = "home" | "default";
 
 export interface ChannelConfig {
 	channelId: string;
+	guildId: string;
 	role: ChannelRole;
 	cooldownSeconds: number;
 }

--- a/src/infrastructure/context/json-channel-config-loader.ts
+++ b/src/infrastructure/context/json-channel-config-loader.ts
@@ -5,6 +5,7 @@ interface ChannelsJson {
 	defaultCooldownSeconds: number;
 	channels: Array<{
 		channelId: string;
+		guildId: string;
 		role: ChannelRole;
 		cooldownSeconds?: number;
 	}>;
@@ -20,6 +21,7 @@ export class JsonChannelConfigLoader implements ChannelConfigLoader {
 		for (const ch of json.channels) {
 			this.configs.set(ch.channelId, {
 				channelId: ch.channelId,
+				guildId: ch.guildId,
 				role: ch.role,
 				cooldownSeconds: ch.cooldownSeconds ?? json.defaultCooldownSeconds,
 			});


### PR DESCRIPTION
## Summary
- `ChannelConfig` エンティティと `JsonChannelConfigLoader` の JSON スキーマに `guildId` フィールドを追加
- `data/context/channels.json` にチャンネル `967510602056618106` をホームチャンネルとして追加（gitignore 対象のためコミット外）

## 変更内容
- `src/domain/entities/channel-config.ts`: `guildId: string` フィールド追加
- `src/infrastructure/context/json-channel-config-loader.ts`: JSON スキーマに `guildId` 追加、Map 構築時に反映

## Note
- `data/context/channels.json` は `.gitignore` 対象のため、デプロイ先で直接更新が必要です
- 既存チャンネル `1394217700498079815` にも `guildId: "683939861539192860"` を追加してください
- 新規ホームチャンネル `967510602056618106`（guildId: `967510601578446941`）を追加してください

## Test plan
- [x] `nr validate` 通過（fmt:check + lint + 型チェック）
- [ ] デプロイ先で `data/context/channels.json` を更新後、bot が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)