### PR TITLE
fix: CopilotPollingAgent のポート競合を解消

### DIFF
--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -109,6 +109,8 @@ export async function bootstrap(): Promise<void> {
 	}
 }
 
+// bootstrapDefault パスの OpencodeAgent(4096) / OpencodeJudgeAgent(4097) と
+// 範囲が重複するが、bootstrapCopilot と bootstrapDefault は排他的に実行される
 const COPILOT_BASE_PORT = 4096;
 
 function createGuildAgents(ctx: BootstrapContext, guildIds: string[]) {

--- a/src/infrastructure/opencode/copilot-polling-agent.ts
+++ b/src/infrastructure/opencode/copilot-polling-agent.ts
@@ -45,7 +45,7 @@ export class CopilotPollingAgent implements AiAgent {
 		private readonly contextLoaderFactory: ContextLoaderFactory,
 		private readonly eventBuffer: EventBuffer,
 		private readonly logger: Logger,
-		private readonly port?: number,
+		private readonly port: number,
 	) {}
 
 	async send(options: SendOptions): Promise<AgentResponse> {


### PR DESCRIPTION
## Summary
- 複数ギルドの `CopilotPollingAgent` が全てデフォルトポート 4096 で OpenCode サーバーを起動しようとし、`EADDRINUSE` で失敗 → 30秒バックオフで無限リトライしていた
- 各ギルドにベースポート 4096 からインデックス分ずらしたポートを割り当てるよう修正（ギルド0→4096, ギルド1→4097, ギルド2→4098）

## Test plan
- [ ] `nr validate` 通過済み
- [ ] デプロイ後に `nr deploy:logs` でポート競合エラーが出ないことを確認
- [ ] 各ギルドの copilot-polling セッションが正常に起動・動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)