### PR TITLE
feat: Grafana ダッシュボードに Loki ログパネルを追加

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -71,6 +71,12 @@ nr deploy:rebuild
   journalctl CONTAINER_TAG=vicissitude -f          # リアルタイム表示
   journalctl CONTAINER_TAG=vicissitude --no-pager -n 100  # 直近 100 行
   ```
+- **Grafana ダッシュボード** (`monitoring/grafana-dashboard.json`) の Logs セクションでも確認可能:
+  - Log Volume by Level: レベル別ログボリュームの推移
+  - Log Volume by Component: コンポーネント別ログボリュームの推移
+  - Errors & Warnings: error/warn レベルのログのみ表示
+  - All Logs: 全ログの検索・閲覧
+  - Loki データソースの設定が必要（インポート時にプロンプトが表示される）
 
 **注意:**
 

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -596,6 +596,7 @@
 			"datasource": { "type": "loki", "uid": "${DS_LOKI}" },
 			"gridPos": { "h": 10, "w": 24, "x": 0, "y": 52 },
 			"id": 16,
+			"maxDataPoints": 200,
 			"options": {
 				"dedupStrategy": "none",
 				"enableLogDetails": true,
@@ -619,6 +620,7 @@
 			"datasource": { "type": "loki", "uid": "${DS_LOKI}" },
 			"gridPos": { "h": 12, "w": 24, "x": 0, "y": 62 },
 			"id": 17,
+			"maxDataPoints": 500,
 			"options": {
 				"dedupStrategy": "none",
 				"enableLogDetails": true,


### PR DESCRIPTION
## Summary
- 既存の Grafana ダッシュボード JSON に Loki データソースとログパネルセクションを追加
- `container_tag="vicissitude"` で journald 経由のログを取得し、JSON パーサーで構造化フィールドを展開
- 4パネル: レベル別ログボリューム、コンポーネント別ログボリューム、エラー&警告ログ、全ログ

## Test plan
- [ ] Grafana にダッシュボード JSON をインポートし、Loki データソースを選択
- [ ] ログパネルにコンテナログが表示されることを確認
- [ ] レベル別・コンポーネント別のボリュームグラフが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)