### PR TITLE
fix: Grafana Loki クエリのラベルセレクターを修正

### DIFF
--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -551,7 +551,7 @@
 			},
 			"targets": [
 				{
-					"expr": "sum by (level) (count_over_time({container_tag=\"vicissitude\"} | json [1m]))",
+					"expr": "sum by (level) (count_over_time({job=\"vicissitude\"} | json [1m]))",
 					"legendFormat": "{{level}}"
 				}
 			],
@@ -585,7 +585,7 @@
 			},
 			"targets": [
 				{
-					"expr": "sum by (component) (count_over_time({container_tag=\"vicissitude\"} | json [1m]))",
+					"expr": "sum by (component) (count_over_time({job=\"vicissitude\"} | json [1m]))",
 					"legendFormat": "{{component}}"
 				}
 			],
@@ -609,7 +609,7 @@
 			},
 			"targets": [
 				{
-					"expr": "{container_tag=\"vicissitude\"} | json | level =~ `error|warn`",
+					"expr": "{job=\"vicissitude\"} | json | level =~ `error|warn`",
 					"legendFormat": ""
 				}
 			],
@@ -633,7 +633,7 @@
 			},
 			"targets": [
 				{
-					"expr": "{container_tag=\"vicissitude\"} | json",
+					"expr": "{job=\"vicissitude\"} | json",
 					"legendFormat": ""
 				}
 			],


### PR DESCRIPTION
## Summary
- Grafana ダッシュボードの Loki パネル（4つ）が `{container_tag="vicissitude"}` でクエリしていたが、Loki に `container_tag` ラベルが存在しないためデータが返らなかった
- Promtail は `__journal_container_tag` をフィルタリング（`action: keep`）にのみ使用しており、Loki に転送されるラベルは `job="vicissitude"`
- 全 Loki クエリのセレクターを `{job="vicissitude"}` に修正

## Test plan
- [x] `curl` で `{job="vicissitude"}` クエリが Loki からデータを返すことを確認済み
- [ ] Grafana ダッシュボードを再インポートし、Logs セクションの4パネルにデータが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)