### PR TITLE
refactor: OpencodeChatAdapter → FenghuangChatAdapter にリネーム＆移動

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,9 +130,9 @@
   - 1分間隔の `setInterval` ループ
   - `running` フラグで重複実行を防止
 - `logging/console-logger.ts`: `ConsoleLogger implements Logger` — JSON 構造化ログ（NDJSON）を `process.stdout/stderr` に出力。`[component]` プレフィックスを `component` フィールドに抽出。journald + Grafana Loki 連携を想定。
-- `opencode/opencode-chat-adapter.ts`: `OpencodeChatAdapter` — OpenCode SDK を使って chat / chatStructured を提供するアダプタ。fenghuang の LLMPort 用。独自の OpenCode インスタンスをポート `LTM_OPENCODE_PORT` で起動し、全組み込みツール・MCP を無効化。
+- `fenghuang/fenghuang-chat-adapter.ts`: `FenghuangChatAdapter` — OpenCode SDK を使って chat / chatStructured を提供するアダプタ。fenghuang の LLMPort 用。独自の OpenCode インスタンスをポート `LTM_OPENCODE_PORT` で起動し、全組み込みツール・MCP を無効化。
 - `ollama/ollama-embedding-adapter.ts`: `OllamaEmbeddingAdapter` — Ollama HTTP API でテキスト埋め込みベクトルを取得するアダプタ。30 秒タイムアウト。
-- `fenghuang/composite-llm-adapter.ts`: `CompositeLLMAdapter implements LLMPort` — chat/chatStructured を `OpencodeChatAdapter`、embed を `OllamaEmbeddingAdapter` に委譲するコンポジットアダプタ。ltm-server で使用。
+- `fenghuang/composite-llm-adapter.ts`: `CompositeLLMAdapter implements LLMPort` — chat/chatStructured を `FenghuangChatAdapter`、embed を `OllamaEmbeddingAdapter` に委譲するコンポジットアダプタ。ltm-server で使用。
 
 ### 4.4 MCP サーバー（独立プロセス、レイヤー外）
 

--- a/src/infrastructure/fenghuang/composite-llm-adapter.ts
+++ b/src/infrastructure/fenghuang/composite-llm-adapter.ts
@@ -1,12 +1,12 @@
 import type { ChatMessage, LLMPort, Schema } from "fenghuang";
 
 import type { OllamaEmbeddingAdapter } from "../ollama/ollama-embedding-adapter.ts";
-import type { OpencodeChatAdapter } from "../opencode/opencode-chat-adapter.ts";
+import type { FenghuangChatAdapter } from "./fenghuang-chat-adapter.ts";
 
 /** Composite LLMPort: chat/chatStructured via OpenCode, embed via Ollama */
 export class CompositeLLMAdapter implements LLMPort {
 	constructor(
-		private readonly chatAdapter: OpencodeChatAdapter,
+		private readonly chatAdapter: FenghuangChatAdapter,
 		private readonly embeddingAdapter: OllamaEmbeddingAdapter,
 	) {}
 

--- a/src/infrastructure/fenghuang/fenghuang-chat-adapter.test.ts
+++ b/src/infrastructure/fenghuang/fenghuang-chat-adapter.test.ts
@@ -8,7 +8,7 @@ import {
 	cleanJsonResponse,
 	extractText,
 	separateMessages,
-} from "./opencode-chat-adapter.ts";
+} from "./fenghuang-chat-adapter.ts";
 
 describe("separateMessages", () => {
 	it("should separate system messages from non-system messages", () => {

--- a/src/infrastructure/fenghuang/fenghuang-chat-adapter.ts
+++ b/src/infrastructure/fenghuang/fenghuang-chat-adapter.ts
@@ -8,8 +8,8 @@ interface Schema<T> {
 	parse(data: unknown): T;
 }
 
-/** Adapter that uses OpenCode SDK for chat / chatStructured */
-export class OpencodeChatAdapter {
+/** Adapter that uses OpenCode SDK for fenghuang chat / chatStructured */
+export class FenghuangChatAdapter {
 	private client: OpencodeClient | null = null;
 	private closeServer: (() => void) | null = null;
 
@@ -98,7 +98,7 @@ export class OpencodeChatAdapter {
 
 	private getClient(): OpencodeClient {
 		if (!this.client) {
-			throw new Error("OpencodeChatAdapter not initialized — call initialize() first");
+			throw new Error("FenghuangChatAdapter not initialized — call initialize() first");
 		}
 		return this.client;
 	}

--- a/src/mcp/ltm-server.ts
+++ b/src/mcp/ltm-server.ts
@@ -12,8 +12,8 @@ import {
 import { z } from "zod";
 
 import { CompositeLLMAdapter } from "../infrastructure/fenghuang/composite-llm-adapter.ts";
+import { FenghuangChatAdapter } from "../infrastructure/fenghuang/fenghuang-chat-adapter.ts";
 import { OllamaEmbeddingAdapter } from "../infrastructure/ollama/ollama-embedding-adapter.ts";
-import { OpencodeChatAdapter } from "../infrastructure/opencode/opencode-chat-adapter.ts";
 
 // --- Configuration from environment ---
 
@@ -28,7 +28,7 @@ const guildIdSchema = z.string().regex(GUILD_ID_REGEX).describe("Discord guild I
 
 // --- Initialize adapters ---
 
-const chatAdapter = new OpencodeChatAdapter(LTM_OPENCODE_PORT, LTM_MODEL_ID);
+const chatAdapter = new FenghuangChatAdapter(LTM_OPENCODE_PORT, LTM_MODEL_ID);
 await chatAdapter.initialize();
 
 const ollama = new OllamaEmbeddingAdapter(OLLAMA_BASE_URL, LTM_EMBEDDING_MODEL);


### PR DESCRIPTION
## Summary
- `OpencodeChatAdapter` を `FenghuangChatAdapter` にリネームし、`infrastructure/opencode/` → `infrastructure/fenghuang/` に移動
- bot 本筋の opencode エージェント群（polling-agent, guild-routing-agent 等）と fenghuang LTM 用チャットアダプタの命名の紛らわしさを解消

## Changes
| ファイル | 変更内容 |
|---|---|
| `infrastructure/fenghuang/fenghuang-chat-adapter.ts` | `opencode/opencode-chat-adapter.ts` から移動。クラス名 `OpencodeChatAdapter` → `FenghuangChatAdapter` |
| `infrastructure/fenghuang/fenghuang-chat-adapter.test.ts` | テストファイルも同様に移動。インポートパス更新 |
| `infrastructure/fenghuang/composite-llm-adapter.ts` | インポートパス・型参照を `FenghuangChatAdapter` に更新 |
| `mcp/ltm-server.ts` | インポートパス・インスタンス生成を `FenghuangChatAdapter` に更新 |
| `docs/ARCHITECTURE.md` | ドキュメントの記載を更新 |

## Test plan
- [x] `nr validate` (fmt:check + lint + check) 通過
- [x] `bun test fenghuang-chat-adapter.test.ts` 全18テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
