### PR TITLE
docs: CLAUDE.md のディレクトリツリーを実際の構成に合わせて更新

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,11 +46,15 @@ src/
 ├── application/      # アプリケーション層 — ユースケース
 │   └── use-cases/
 ├── infrastructure/   # インフラ層 — ポートの具象実装
+│   ├── context/
 │   ├── discord/
+│   ├── fenghuang/
+│   ├── logging/
+│   ├── metrics/
+│   ├── ollama/
 │   ├── opencode/
 │   ├── persistence/
-│   ├── context/
-│   └── logging/
+│   └── scheduler/
 ├── mcp/              # MCP サーバー（独立プロセス、レイヤー外）
 ├── bootstrap-context.ts    # ブートストラップ共有型
 ├── bootstrap-helpers.ts    # ブートストラップ共有ヘルパー


### PR DESCRIPTION
## Summary
- `.claude/CLAUDE.md` のディレクトリツリーを実際の `src/infrastructure/` 構成に合わせて更新
- 欠落していた `fenghuang/`, `metrics/`, `ollama/`, `scheduler/` を追加し、アルファベット順に整理

## Test plan
- [x] ドキュメントのみの変更のため、動作への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
