### PR TITLE
fix: bot_name "fua" → "hua" に修正

### DIFF
--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -34,7 +34,7 @@ function createMetrics(logger: Logger) {
 	collector.registerHistogram(METRIC.HEARTBEAT_TICK_DURATION, "Heartbeat tick duration in seconds");
 	collector.registerGauge(METRIC.LLM_ACTIVE_SESSIONS, "Registered LLM sessions");
 	collector.registerGauge(METRIC.LLM_BUSY_SESSIONS, "LLM sessions currently processing");
-	collector.setGauge(METRIC.BOT_INFO, 1, { bot_name: "fua" });
+	collector.setGauge(METRIC.BOT_INFO, 1, { bot_name: "hua" });
 	return { collector, server: new PrometheusServer(collector, logger) };
 }
 

--- a/src/infrastructure/metrics/prometheus-collector.test.ts
+++ b/src/infrastructure/metrics/prometheus-collector.test.ts
@@ -69,10 +69,10 @@ describe("PrometheusCollector", () => {
 		it("should support gauge with labels", () => {
 			const c = new PrometheusCollector();
 			c.registerGauge("bot_info", "Bot information");
-			c.setGauge("bot_info", 1, { bot_name: "fua" });
+			c.setGauge("bot_info", 1, { bot_name: "hua" });
 
 			const output = c.serialize();
-			expect(output).toContain('bot_info{bot_name="fua"} 1');
+			expect(output).toContain('bot_info{bot_name="hua"} 1');
 		});
 
 		it("should increment gauge value", () => {


### PR DESCRIPTION
## Summary
- 「ふあ」の正しいローマ字表記は "hua"（"fua" ではない）
- `composition-root.ts` のメトリクスラベルとテストの3箇所を修正

## Test plan
- [x] `bun test` — メトリクステスト全通過
- [x] `nr validate` — フォーマット・lint・型チェック全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)