### PR TITLE
fix: fenghuang の依存を file: から github: に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@modelcontextprotocol/sdk": "^1.27.1",
 		"@opencode-ai/sdk": "^1.2.15",
 		"discord.js": "^14.25.1",
-		"fenghuang": "file:../fenghuang"
+		"fenghuang": "github:OJII3/fenghuang"
 	},
 	"devDependencies": {
 		"@types/bun": "latest",


### PR DESCRIPTION
## Summary

- `fenghuang` パッケージの依存を `file:../fenghuang`（ローカルパス）から `github:OJII3/fenghuang` に変更
- コンテナビルド時にローカルパスが解決できず失敗していた問題を修正

## Test plan

- [x] `bun install` 成功
- [x] `nr validate` パス
- [x] `nr deploy:rebuild` でコンテナビルド・デプロイ成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)