### PR TITLE
fix: Node.js 24 LTS + GCC 14 対応のコンテナビルド修正

### DIFF
--- a/containers/bot/Containerfile
+++ b/containers/bot/Containerfile
@@ -18,7 +18,8 @@ WORKDIR /app
 
 COPY package.json bun.lock ./
 # gl@6 の ANGLE ソースが GCC 14 の <cstdint> 必須化に未対応のため強制インクルード
-ENV CXXFLAGS="-include cstdint"
+# TODO: gl パッケージが GCC 14+ 対応したらこのワークアラウンドを削除する
+ARG CXXFLAGS="-include cstdint"
 RUN bun install --frozen-lockfile --production
 RUN bun install -g opencode-ai@1.2.15 && \
     rm /usr/local/bin/opencode && \


### PR DESCRIPTION
## Summary

- Debian リポジトリの Node.js 20 を NodeSource の Node.js 24 LTS に変更
- Python 3.13 で削除された `distutils` に対応 (`python3-setuptools` 追加)
- `gl@6` パッケージの ANGLE ビルドに必要な依存追加 (`libxi-dev`, `python` symlink, `CXXFLAGS`)

## Test plan

- [x] `podman build` 成功
- [x] `podman-compose up -d` でコンテナ正常起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)