### PR TITLE
fix: mise ベースイメージに移行し xauth 欠落を修正

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
       - ./data:/app/data:rw
       - ./context:/app/context:ro
       - ${XDG_RUNTIME_DIR:-/run/user/1000}/podman/podman.sock:/run/podman/podman.sock:ro
-      - ${HOME}/.local/share/opencode/auth.json:/home/bun/.local/share/opencode/auth.json:ro
+      - ${HOME}/.local/share/opencode/auth.json:/app/.local/share/opencode/auth.json:ro
     networks:
       - vicissitude-net
     logging:

--- a/containers/bot/Containerfile
+++ b/containers/bot/Containerfile
@@ -30,8 +30,11 @@ RUN mise x -- bun install -g opencode-ai@1.2.15 && \
 COPY src/ ./src/
 COPY tsconfig.json ./
 
-RUN mkdir -p data/context && \
-    mkdir -p /root/.local/share/opencode /root/.local/state
+# userns keep-id で uid 1000 として実行されるため書き込み可能にする
+RUN mkdir -p data/context \
+    .local/share/opencode/bin .local/state/mise .config && \
+    chown -R 1000:1000 /app/data/context /app/.local /app/.config && \
+    chown 1000:1000 /app
 
 ENV CONTAINER_HOST=unix:///run/podman/podman.sock
 


### PR DESCRIPTION
## Summary

- `oven/bun:1-slim` + NodeSource から `ghcr.io/jdx/mise` ベースイメージに移行
- mise で `bun@1`, `node@24`, `python@3.11` をランタイム管理（NodeSource 依存を排除）
- `xauth` パッケージ欠落による `xvfb-run` クラッシュを解決
- Python 3.11 を使用することで `distutils` 互換性を確保（node-gyp ビルド用）

## Test plan

- [x] `nr container:build:bot` でビルド成功を確認
- [x] `podman-compose up -d` でデプロイ成功を確認
- [x] ボットが `ふあ#0409` として正常にログインすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)