### PR TITLE
chore: relax repo-local codex sandbox settings

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,4 +3,3 @@ sandbox_mode = "workspace-write"
 
 [sandbox_workspace_write]
 network_access = true
-writable_roots = [ "/dev/ptmx", "/dev/pts" ]


### PR DESCRIPTION
## Summary
- set repo-local Codex approval policy to never
- keep workspace-write sandbox with network access enabled
- add tty device paths to writable roots so git hooks can run under Codex sandbox

## Testing
- git commit
