### PR TITLE
ci: pin actions to commit hashes

### DIFF
--- a/.github/workflows/test-quality.yml
+++ b/.github/workflows/test-quality.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: test-quality
           path: artifacts/test-quality/
@@ -47,9 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload flake artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: test-quality-flake
           path: artifacts/test-quality/


### PR DESCRIPTION
## Summary

- GitHub Actions をバージョンタグからコミットハッシュ固定に変更（サプライチェーン攻撃対策）
- 全アクションを最新バージョンに更新
- バージョンコメントを併記して可読性を確保

## Changes

### `.github/workflows/test-quality.yml`
| Action | Before | After |
|--------|--------|-------|
| actions/checkout | `@v4` | `@de0fac2e...` (v6.0.2) |
| oven-sh/setup-bun | `@v2` | `@ecf28ddc...` (v2.1.3) |
| actions/upload-artifact | `@v4` | `@bbbca2dd...` (v7.0.0) |

## Test plan

- [ ] CI が hash 指定のアクションで正常に動作することを確認
