### PR TITLE
fix: resolve CI test failure from mock.module pollution

### DIFF
--- a/src/fenghuang/fenghuang-conversation-recorder.test.ts
+++ b/src/fenghuang/fenghuang-conversation-recorder.test.ts
@@ -1,10 +1,19 @@
-/* oxlint-disable max-classes-per-file -- mock module requires multiple inline classes */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, rmSync } from "fs";
 
 import type { LLMPort } from "fenghuang";
 
-// fenghuang モジュールをモック（fs はモックしない: 他テストへの汚染を防ぐ）
+import type { GuildInstance, GuildInstanceFactory } from "./fenghuang-conversation-recorder.ts";
+import { FenghuangConversationRecorder } from "./fenghuang-conversation-recorder.ts";
+
+const TEMP_DIR = `/tmp/vicissitude-fenghuang-test-${process.pid}`;
+
+afterEach(() => {
+	if (existsSync(TEMP_DIR)) {
+		rmSync(TEMP_DIR, { recursive: true, force: true });
+	}
+});
+
 const mockAddMessage = mock(() => Promise.resolve());
 const mockConsolidate = mock(() =>
 	Promise.resolve({
@@ -17,31 +26,15 @@ const mockConsolidate = mock(() =>
 );
 const mockStorageClose = mock(() => {});
 
-mock.module("fenghuang", () => ({
-	Segmenter: class MockSegmenter {
-		addMessage = mockAddMessage;
-	},
-	SQLiteStorageAdapter: class MockSQLiteStorageAdapter {
-		close = mockStorageClose;
-	},
-	ConsolidationPipeline: class MockConsolidationPipeline {
-		consolidate = mockConsolidate;
-	},
-}));
-
-const { FenghuangConversationRecorder } = await import("./fenghuang-conversation-recorder.ts");
-
-const TEMP_DIR = `/tmp/vicissitude-fenghuang-test-${process.pid}`;
-
-afterEach(() => {
-	if (existsSync(TEMP_DIR)) {
-		rmSync(TEMP_DIR, { recursive: true, force: true });
-	}
+const mockFactory: GuildInstanceFactory = (): GuildInstance => ({
+	segmenter: { addMessage: mockAddMessage },
+	storage: { close: mockStorageClose },
+	consolidation: { consolidate: mockConsolidate },
 });
 
 function createRecorder() {
 	const llm = {} as LLMPort;
-	return new FenghuangConversationRecorder(llm, TEMP_DIR);
+	return new FenghuangConversationRecorder(llm, TEMP_DIR, mockFactory);
 }
 
 const sampleMessage = {

--- a/src/fenghuang/fenghuang-conversation-recorder.ts
+++ b/src/fenghuang/fenghuang-conversation-recorder.ts
@@ -12,21 +12,34 @@ import type {
 
 const GUILD_ID_RE = /^\d+$/;
 
-interface GuildInstance {
-	segmenter: Segmenter;
-	storage: SQLiteStorageAdapter;
-	consolidation: ConsolidationPipeline;
+export interface GuildInstance {
+	segmenter: { addMessage(userId: string, msg: unknown): Promise<void> };
+	storage: { close(): void };
+	consolidation: { consolidate(userId: string): Promise<ConsolidationResult> };
 }
+
+export type GuildInstanceFactory = (dbPath: string, llm: LLMPort) => GuildInstance;
+
+const defaultFactory: GuildInstanceFactory = (dbPath, llm) => {
+	const storage = new SQLiteStorageAdapter(dbPath);
+	const segmenter = new Segmenter(llm, storage);
+	const consolidation = new ConsolidationPipeline(llm, storage);
+	return { segmenter, storage, consolidation };
+};
 
 export class FenghuangConversationRecorder implements ConversationRecorder, MemoryConsolidator {
 	private readonly instances = new Map<string, GuildInstance>();
 	/** record() 用ロック: segmenter のキュー競合を防ぐ */
 	private readonly locks = new Map<string, Promise<void>>();
+	private readonly factory: GuildInstanceFactory;
 
 	constructor(
 		private readonly llm: LLMPort,
 		private readonly dataDir: string,
-	) {}
+		factory?: GuildInstanceFactory,
+	) {
+		this.factory = factory ?? defaultFactory;
+	}
 
 	async record(guildId: string, message: ConversationMessage): Promise<void> {
 		if (!GUILD_ID_RE.test(guildId)) {
@@ -93,10 +106,7 @@ export class FenghuangConversationRecorder implements ConversationRecorder, Memo
 
 		const dbDir = resolve(this.dataDir, "guilds", guildId);
 		mkdirSync(dbDir, { recursive: true });
-		const storage = new SQLiteStorageAdapter(resolve(dbDir, "memory.db"));
-		const segmenter = new Segmenter(this.llm, storage);
-		const consolidation = new ConsolidationPipeline(this.llm, storage);
-		const instance = { segmenter, storage, consolidation };
+		const instance = this.factory(resolve(dbDir, "memory.db"), this.llm);
 		this.instances.set(guildId, instance);
 		return instance;
 	}

--- a/src/fenghuang/fenghuang-fact-reader.test.ts
+++ b/src/fenghuang/fenghuang-fact-reader.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Database } from "bun:sqlite";
 import { mkdirSync, rmSync } from "fs";
 import { resolve } from "path";
 
-import { SQLiteStorageAdapter, createFact } from "fenghuang";
 import type { FactCategory } from "fenghuang";
 
 import { FenghuangFactReader } from "./fenghuang-fact-reader.ts";
@@ -10,21 +10,36 @@ import { FenghuangFactReader } from "./fenghuang-fact-reader.ts";
 const TEST_DATA_DIR = resolve(import.meta.dirname, "../../.test-fact-reader");
 const GUILD_ID = "123456789";
 
-async function insertFact(
-	storage: SQLiteStorageAdapter,
+/**
+ * Insert a fact row directly via bun:sqlite to avoid depending on
+ * fenghuang's SQLiteStorageAdapter for test-data setup (CI compat).
+ */
+function insertFact(
+	db: Database,
 	userId: string,
 	category: FactCategory,
 	fact: string,
-): Promise<void> {
-	const f = createFact({
+): void {
+	db.exec(`CREATE TABLE IF NOT EXISTS semantic_facts (
+		id TEXT PRIMARY KEY, user_id TEXT NOT NULL, category TEXT NOT NULL, fact TEXT NOT NULL,
+		keywords TEXT NOT NULL, source_episodic_ids TEXT NOT NULL, embedding TEXT NOT NULL,
+		valid_at INTEGER NOT NULL, invalid_at INTEGER, created_at INTEGER NOT NULL)`);
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO semantic_facts (id, user_id, category, fact, keywords, source_episodic_ids, embedding, valid_at, invalid_at, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		crypto.randomUUID(),
 		userId,
 		category,
 		fact,
-		keywords: ["test"],
-		sourceEpisodicIds: ["ep1"],
-		embedding: [0.1],
-	});
-	await storage.saveFact(userId, f);
+		JSON.stringify(["test"]),
+		JSON.stringify(["ep1"]),
+		JSON.stringify([0.1]),
+		now,
+		null,
+		now,
+	);
 }
 
 beforeEach(() => {
@@ -38,10 +53,10 @@ afterEach(() => {
 describe("FenghuangFactReader", () => {
 	it("指定 guildId のファクトを返す", async () => {
 		const dbPath = resolve(TEST_DATA_DIR, "guilds", GUILD_ID, "memory.db");
-		const storage = new SQLiteStorageAdapter(dbPath);
-		await insertFact(storage, GUILD_ID, "preference", "コーヒーが好き");
-		await insertFact(storage, GUILD_ID, "interest", "TypeScript が得意");
-		storage.close();
+		const db = new Database(dbPath);
+		insertFact(db, GUILD_ID, "preference", "コーヒーが好き");
+		insertFact(db, GUILD_ID, "interest", "TypeScript が得意");
+		db.close();
 
 		const reader = new FenghuangFactReader(TEST_DATA_DIR);
 		const facts = await reader.getFacts(GUILD_ID);
@@ -74,9 +89,9 @@ describe("FenghuangFactReader", () => {
 
 	it("close() で接続が解放される", async () => {
 		const dbPath = resolve(TEST_DATA_DIR, "guilds", GUILD_ID, "memory.db");
-		const storage = new SQLiteStorageAdapter(dbPath);
-		await insertFact(storage, GUILD_ID, "identity", "テスト");
-		storage.close();
+		const db = new Database(dbPath);
+		insertFact(db, GUILD_ID, "identity", "テスト");
+		db.close();
 
 		const reader = new FenghuangFactReader(TEST_DATA_DIR);
 		await reader.getFacts(GUILD_ID);


### PR DESCRIPTION
## Summary

- `fenghuang-conversation-recorder.test.ts` の `mock.module("fenghuang", ...)` がプロセス全体のモジュールキャッシュを汚染し、同じプロセスで実行される `fenghuang-fact-reader.test.ts` がモックされた（メソッド不足の）`SQLiteStorageAdapter` を受け取っていた
- `FenghuangConversationRecorder` にコンストラクタインジェクション（`GuildInstanceFactory`）を導入し、`mock.module` を完全に除去
- `fenghuang-fact-reader.test.ts` のテストデータセットアップを `bun:sqlite` 生SQLに変更（fenghuang の `SQLiteStorageAdapter` に依存しない）

## Test plan

- [x] `bun test src/fenghuang/` — 28 tests pass (0 fail)
- [x] `bun test` — 419 tests pass (0 fail)
- [ ] CI (GitHub Actions) で Test Quality workflow が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)