### PR TITLE
fix: 死亡画面スタック時のリスポーン

### DIFF
--- a/src/mcp/minecraft/mcp-tools.ts
+++ b/src/mcp/minecraft/mcp-tools.ts
@@ -31,6 +31,19 @@ function registerObserveStateTool(
 				return { content: [{ type: "text", text: "ボット未接続" }] };
 			}
 
+			// 死亡画面でスタックしている場合、リスポーンを試みる
+			if (bot.health <= 0) {
+				bot.respawn();
+				return {
+					content: [
+						{
+							type: "text",
+							text: "ボットは死亡状態です。リスポーンを試みました。少し待ってから再度確認してください。",
+						},
+					],
+				};
+			}
+
 			const pos = bot.entity.position;
 			const timeOfDay = bot.time?.timeOfDay;
 			const roundedPos = { x: Math.round(pos.x), y: Math.round(pos.y), z: Math.round(pos.z) };


### PR DESCRIPTION
## Summary

- Bot が health 0（死亡画面）でスタックした場合、`observe_state` ツールが `bot.respawn()` を呼んでリスポーンを試みる
- mineflayer の auto-respawn（`options.respawn = true`）が失敗した場合のフォールバック

## 原因

mineflayer の respawn フロー:
1. `update_health`（health ≤ 0）→ `death` イベント → `bot.respawn()` 送信
2. サーバーが `respawn` パケット返却 → `isAlive = false`
3. `update_health`（health > 0）→ `isAlive = true` → `spawn` イベント

ステップ 2-3 間でパケットが失われるか遅延すると、Bot が死亡画面でスタックする。

## Test plan

- [x] `bun test` 782 pass（0 fail）
- [x] `bun run check` 通過
- [ ] Minecraft で Bot を殺してリスポーンを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)