### PR TITLE
fix: メッセージ受信時に即座にポーリングループを起動する

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -213,6 +213,7 @@ function setupEventHandlers(
 	gateway: DiscordGateway,
 	ingestionService: MessageIngestionService,
 	metricsCollector: PrometheusCollector,
+	agents: Map<string, DiscordAgent>,
 ): void {
 	gateway.onHomeChannelMessage((msg) => {
 		const selfUserId = gateway.getClient()?.user?.id;
@@ -221,6 +222,9 @@ function setupEventHandlers(
 			recordConversation: true,
 			bufferEvent: msg.authorId !== selfUserId,
 		});
+		if (msg.guildId && msg.authorId !== selfUserId) {
+			agents.get(msg.guildId)?.ensurePolling();
+		}
 		return Promise.resolve();
 	});
 
@@ -229,6 +233,9 @@ function setupEventHandlers(
 			channel_type: "mention",
 		});
 		ingestionService.handleIncomingMessage(msg);
+		if (msg.guildId) {
+			agents.get(msg.guildId)?.ensurePolling();
+		}
 		return Promise.resolve();
 	});
 }
@@ -409,7 +416,7 @@ export async function bootstrap(): Promise<void> {
 	});
 
 	// Event handlers
-	setupEventHandlers(gateway, ingestionService, metrics.collector);
+	setupEventHandlers(gateway, ingestionService, metrics.collector, agents);
 
 	// Emoji tracking
 	gateway.onEmojiUsed((guildId, emojiName) => incrementEmoji(db, guildId, emojiName));


### PR DESCRIPTION
## Summary
- Discord メッセージ受信時に `DiscordAgent.ensurePolling()` を呼び出し、ポーリングループを即座に起動するようにした
- これまでは Heartbeat (60秒間隔) の `send()` が初回トリガーだったため、起動直後のメッセージに応答しない問題があった
- ホームチャンネル（自分以外のメッセージ）とメンションの両方で対応

## Test plan
- [ ] Bot起動直後にDiscordでメッセージを送り、Heartbeat待ちなしで応答されることを確認
- [ ] ホームチャンネルとメンションの両方で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)