### PR TITLE
chore: devShell に podman-compose を追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
               opencode
               podman
               python311
+              podman-compose
             ];
             shellHook = config.pre-commit.installationScript;
           };


### PR DESCRIPTION
## Summary

- devShell に `podman-compose` パッケージを追加
- デプロイスクリプト (`nr deploy` 等) が `podman-compose` を使用するため必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)