### PR TITLE
fix: deploy 時に bot コンテナも再作成してコード変更を反映する

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"container:build": "podman build -t vicissitude-code-exec containers/code-exec",
 		"container:build:base": "podman build -t vicissitude-base -f containers/bot/Containerfile containers/bot",
 		"container:build:all": "bun run container:build && bun run container:build:base",
-		"deploy": "podman image exists vicissitude-base || bun run container:build:base; podman-compose rm -f installer builder 2>/dev/null; podman-compose up -d && echo 'Deployed: nr deploy:logs to follow logs'",
+		"deploy": "podman image exists vicissitude-base || bun run container:build:base; podman-compose rm -f -s installer builder bot 2>/dev/null; podman-compose up -d && echo 'Deployed: nr deploy:logs to follow logs'",
 		"deploy:rebuild": "bun run deploy",
 		"deploy:rebuild-base": "bun run container:build:base && podman-compose down && podman volume ls --format '{{.Name}}' | grep -E 'bot-(node-modules|dist)$' | xargs -r podman volume rm -f; podman-compose up -d && echo 'Base rebuilt and deployed: nr deploy:logs to follow logs'",
 		"deploy:logs": "podman-compose logs -f",


### PR DESCRIPTION
## Summary
- `nr deploy` で `installer`/`builder` は再作成されるが `bot` コンテナが running のまま残り、古いコードで動き続ける問題を修正
- `bot` も `rm -f -s` の対象に含めることで、毎回新しいビルド成果物で起動するように変更
- `ollama`/`minecraft` は影響なし（running のまま）

## Test plan
- [ ] `nr deploy` でコード変更が反映されることを確認
- [ ] `nr deploy:logs` で bot が正常起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)