### PR TITLE
fix: テストHTTPサーバーのポート競合を解消

### DIFF
--- a/spec/mcp/minecraft/http-server.spec.ts
+++ b/spec/mcp/minecraft/http-server.spec.ts
@@ -4,10 +4,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { startHttpServer } from "../../../src/mcp/minecraft/http-server.ts";
 
-// テスト用ポート（他と競合しない高ポート）
-const TEST_PORT = 49_731;
-const TEST_PORT_ERROR = 49_732;
-
 const MCP_INIT_BODY = JSON.stringify({
 	jsonrpc: "2.0",
 	id: 1,
@@ -29,11 +25,8 @@ function createTestServer(): McpServer {
 }
 
 describe("MCP HTTP Server ライフサイクル", () => {
-	const { cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
-		createTestServer,
-		TEST_PORT,
-	);
-	const baseUrl = `http://localhost:${TEST_PORT}`;
+	const { port, cleanupTimer, closeAllSessions, stopServer } = startHttpServer(createTestServer, 0);
+	const baseUrl = `http://localhost:${port}`;
 
 	afterAll(() => {
 		clearInterval(cleanupTimer);
@@ -120,11 +113,11 @@ function createFailingServer(): McpServer {
 }
 
 describe("createServer 例外ハンドリング", () => {
-	const { cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
+	const { port, cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
 		createFailingServer,
-		TEST_PORT_ERROR,
+		0,
 	);
-	const baseUrl = `http://localhost:${TEST_PORT_ERROR}`;
+	const baseUrl = `http://localhost:${port}`;
 
 	afterAll(() => {
 		clearInterval(cleanupTimer);

--- a/spec/mcp/minecraft/lazy-connection.spec.ts
+++ b/spec/mcp/minecraft/lazy-connection.spec.ts
@@ -33,8 +33,7 @@ describe("BotContext — bot null 時の安全性", () => {
 });
 
 describe("HTTP 経由で bot 未接続ツールが graceful に応答", () => {
-	const TEST_PORT = 49_741;
-	const baseUrl = `http://localhost:${TEST_PORT}`;
+	let baseUrl: string;
 
 	const ctx = createBotContext();
 	const jobManager = new JobManager(
@@ -48,11 +47,12 @@ describe("HTTP 経由で bot 未接続ツールが graceful に応答", () => {
 		return server;
 	}
 
-	const { cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
+	const { port, cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
 		createTestServer,
-		TEST_PORT,
+		0,
 		"test-minecraft",
 	);
+	baseUrl = `http://localhost:${port}`;
 
 	afterAll(() => {
 		clearInterval(cleanupTimer);

--- a/spec/mcp/tools/mc-bridge-http.spec.ts
+++ b/spec/mcp/tools/mc-bridge-http.spec.ts
@@ -8,8 +8,7 @@ import { registerDiscordBridgeTools } from "../../../src/mcp/tools/mc-bridge-dis
 import { tryAcquireSessionLock, setMcConnectionStatus } from "../../../src/store/mc-bridge.ts";
 import { createTestDb } from "../../../src/store/test-helpers.ts";
 
-const TEST_PORT = 49_740;
-const baseUrl = `http://localhost:${TEST_PORT}`;
+let baseUrl: string;
 
 const MCP_HEADERS = {
 	"Content-Type": "application/json",
@@ -74,11 +73,12 @@ describe("MCP HTTP + mc-bridge ツール結合テスト", () => {
 		return server;
 	}
 
-	const { cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
+	const { port, cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
 		createTestMcpServer,
-		TEST_PORT,
+		0,
 		"test-mc-bridge",
 	);
+	baseUrl = `http://localhost:${port}`;
 
 	afterAll(() => {
 		clearInterval(cleanupTimer);

--- a/src/mcp/http-server.ts
+++ b/src/mcp/http-server.ts
@@ -62,6 +62,7 @@ function createFetchHandler(
 }
 
 export interface HttpServerHandle {
+	port: number;
 	cleanupTimer: ReturnType<typeof setInterval>;
 	closeAllSessions: () => void;
 	stopServer: () => void;
@@ -102,7 +103,7 @@ export function startHttpServer(
 		}
 	}, SESSION_CLEANUP_INTERVAL_MS);
 
-	console.error(`[${label}] MCP server listening on port ${port}`);
+	console.error(`[${label}] MCP server listening on port ${httpServer.port}`);
 
-	return { cleanupTimer, closeAllSessions, stopServer };
+	return { port: httpServer.port, cleanupTimer, closeAllSessions, stopServer };
 }


### PR DESCRIPTION
## Summary
- テストで使っていた固定ポート(49731, 49732, 49740, 49741)をポート0(OS自動割り当て)に変更
- `HttpServerHandle` に `port` プロパティを追加し、実際に割り当てられたポートを取得可能に
- CI並行テスト実行時の "Unhandled error between tests: Failed to start server. Is port 49740 in use?" を解消

## Test plan
- [x] 修正対象の3テストファイルが通ること確認済み
- [x] 全760テスト通過確認済み
- [ ] CI で 0 error になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)