### PR TITLE
refactor: テストヘルパーの重複を共有モジュールに集約

### DIFF
--- a/spec/application/heartbeat-service.spec.ts
+++ b/spec/application/heartbeat-service.spec.ts
@@ -5,15 +5,8 @@ import {
 	buildHeartbeatPrompt,
 	groupByGuild,
 } from "../../src/application/heartbeat-service.ts";
-import type { AiAgent, DueReminder, Logger } from "../../src/core/types.ts";
-
-function createMockLogger(): Logger {
-	return {
-		info: mock(() => {}),
-		error: mock(() => {}),
-		warn: mock(() => {}),
-	};
-}
+import type { AiAgent, DueReminder } from "../../src/core/types.ts";
+import { createMockLogger } from "../test-helpers.ts";
 
 describe("buildHeartbeatPrompt", () => {
 	test("due reminder を人間可読な prompt に変換する", () => {

--- a/spec/application/message-ingestion-service.spec.ts
+++ b/spec/application/message-ingestion-service.spec.ts
@@ -2,20 +2,8 @@ import { describe, expect, mock, test } from "bun:test";
 
 import type { BufferedEventStore } from "../../src/application/message-ingestion-service.ts";
 import { MessageIngestionService } from "../../src/application/message-ingestion-service.ts";
-import type {
-	BufferedEvent,
-	ConversationRecorder,
-	IncomingMessage,
-	Logger,
-} from "../../src/core/types.ts";
-
-function createMockLogger(): Logger {
-	return {
-		info: mock(() => {}),
-		error: mock(() => {}),
-		warn: mock(() => {}),
-	};
-}
+import type { BufferedEvent, ConversationRecorder, IncomingMessage } from "../../src/core/types.ts";
+import { createMockLogger } from "../test-helpers.ts";
 
 function createMockMessage(overrides: Partial<IncomingMessage> = {}): IncomingMessage {
 	return {

--- a/spec/ltm/consolidation.spec.ts
+++ b/spec/ltm/consolidation.spec.ts
@@ -3,30 +3,17 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { ConsolidationOutput } from "../../src/ltm/consolidation.ts";
 import { ConsolidationPipeline } from "../../src/ltm/consolidation.ts";
-import { createEpisode } from "../../src/ltm/episode.ts";
 import { EpisodicMemory } from "../../src/ltm/episodic.ts";
 import type { LtmLlmPort, Schema } from "../../src/ltm/llm-port.ts";
 import { LtmStorage } from "../../src/ltm/ltm-storage.ts";
 import { createFact } from "../../src/ltm/semantic-fact.ts";
 import type { ChatMessage } from "../../src/ltm/types.ts";
+import { createInvalidLLM, createMockLLM, makeEpisode } from "./test-helpers.ts";
 
 const userId = "user-1";
 
-// --- Mock LLM ---
-
-function createMockLLM(consolidationResponse?: ConsolidationOutput): LtmLlmPort {
-	return {
-		async chat(_messages: ChatMessage[]): Promise<string> {
-			return "mock response";
-		},
-		async chatStructured<T>(_messages: ChatMessage[], schema: Schema<T>): Promise<T> {
-			const response = consolidationResponse ?? { facts: [] };
-			return schema.parse(response);
-		},
-		async embed(_text: string): Promise<number[]> {
-			return [0.1, 0.2, 0.3];
-		},
-	};
+function createConsolidationLLM(consolidationResponse?: ConsolidationOutput): LtmLlmPort {
+	return createMockLLM({ structuredResponse: consolidationResponse ?? { facts: [] } });
 }
 
 function createDynamicMockLLM(
@@ -46,32 +33,6 @@ function createDynamicMockLLM(
 	};
 }
 
-function createInvalidLLM(invalidResponse: unknown): LtmLlmPort {
-	return {
-		chat: async () => "",
-		chatStructured: async <T>(_msgs: ChatMessage[], schema: Schema<T>) =>
-			schema.parse(invalidResponse),
-		embed: async () => [0.1, 0.2],
-	};
-}
-
-function makeEpisode(overrides: Partial<Parameters<typeof createEpisode>[0]> = {}) {
-	return createEpisode({
-		userId,
-		title: "Test Episode",
-		summary: "A conversation about TypeScript",
-		messages: [
-			{ role: "user", content: "I love TypeScript" },
-			{ role: "assistant", content: "That's great!" },
-		],
-		embedding: [0.1, 0.2, 0.3],
-		surprise: 0.2,
-		startAt: new Date(),
-		endAt: new Date(),
-		...overrides,
-	});
-}
-
 describe("ConsolidationPipeline — no episodes", () => {
 	let storage: LtmStorage;
 
@@ -84,7 +45,7 @@ describe("ConsolidationPipeline — no episodes", () => {
 	});
 
 	test("returns zero counts when no unconsolidated episodes", async () => {
-		const pipeline = new ConsolidationPipeline(createMockLLM(), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(), storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.processedEpisodes).toBe(0);
@@ -99,7 +60,7 @@ describe("ConsolidationPipeline — no episodes", () => {
 		await storage.saveEpisode(userId, episode);
 		await storage.markEpisodeConsolidated(userId, episode.id);
 
-		const pipeline = new ConsolidationPipeline(createMockLLM(), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(), storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.processedEpisodes).toBe(0);
@@ -132,7 +93,7 @@ describe("ConsolidationPipeline — new facts", () => {
 			],
 		};
 
-		const pipeline = new ConsolidationPipeline(createMockLLM(llmResponse), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.processedEpisodes).toBe(1);
@@ -168,7 +129,7 @@ describe("ConsolidationPipeline — new facts", () => {
 			],
 		};
 
-		const pipeline = new ConsolidationPipeline(createMockLLM(llmResponse), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.newFacts).toBe(2);
@@ -214,7 +175,7 @@ describe("ConsolidationPipeline — reinforce", () => {
 			],
 		};
 
-		const pipeline = new ConsolidationPipeline(createMockLLM(llmResponse), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.reinforced).toBe(1);
@@ -242,7 +203,7 @@ describe("ConsolidationPipeline — reinforce", () => {
 			],
 		};
 
-		const pipeline = new ConsolidationPipeline(createMockLLM(llmResponse), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.reinforced).toBe(0);
@@ -288,7 +249,7 @@ describe("ConsolidationPipeline — update", () => {
 			],
 		};
 
-		const pipeline = new ConsolidationPipeline(createMockLLM(llmResponse), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.updated).toBe(1);
@@ -337,7 +298,7 @@ describe("ConsolidationPipeline — invalidate", () => {
 			],
 		};
 
-		const pipeline = new ConsolidationPipeline(createMockLLM(llmResponse), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.invalidated).toBe(1);
@@ -389,7 +350,7 @@ describe("ConsolidationPipeline — multiple episodes", () => {
 			],
 		};
 
-		const pipeline = new ConsolidationPipeline(createMockLLM(llmResponse), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.processedEpisodes).toBe(2);
@@ -556,7 +517,7 @@ describe("ConsolidationPipeline — episode marking", () => {
 		const episode = makeEpisode();
 		await storage.saveEpisode(userId, episode);
 
-		const pipeline = new ConsolidationPipeline(createMockLLM({ facts: [] }), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM({ facts: [] }), storage);
 		await pipeline.consolidate(userId);
 
 		const unconsolidated = await storage.getUnconsolidatedEpisodes(userId);
@@ -570,7 +531,7 @@ describe("ConsolidationPipeline — episode marking", () => {
 		const episode = makeEpisode();
 		await storage.saveEpisode(userId, episode);
 
-		const pipeline = new ConsolidationPipeline(createMockLLM({ facts: [] }), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM({ facts: [] }), storage);
 		await pipeline.consolidate(userId);
 
 		const ep = await storage.getEpisodeById(userId, episode.id);
@@ -799,7 +760,11 @@ describe("ConsolidationPipeline — FSRS learning loop", () => {
 		expect(before!.lastReviewedAt).toBeNull();
 
 		const episodic = new EpisodicMemory(storage);
-		const pipeline = new ConsolidationPipeline(createMockLLM({ facts: [] }), storage, episodic);
+		const pipeline = new ConsolidationPipeline(
+			createConsolidationLLM({ facts: [] }),
+			storage,
+			episodic,
+		);
 		await pipeline.consolidate(userId);
 
 		// After: lastReviewedAt should be updated
@@ -811,7 +776,7 @@ describe("ConsolidationPipeline — FSRS learning loop", () => {
 		const episode = makeEpisode();
 		await storage.saveEpisode(userId, episode);
 
-		const pipeline = new ConsolidationPipeline(createMockLLM({ facts: [] }), storage);
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM({ facts: [] }), storage);
 		await pipeline.consolidate(userId);
 
 		const after = await storage.getEpisodeById(userId, episode.id);

--- a/spec/ltm/episodic.spec.ts
+++ b/spec/ltm/episodic.spec.ts
@@ -2,26 +2,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { Episode } from "../../src/ltm/episode.ts";
-import { createEpisode } from "../../src/ltm/episode.ts";
 import { EpisodicMemory } from "../../src/ltm/episodic.ts";
 import { LtmStorage } from "../../src/ltm/ltm-storage.ts";
-import type { ChatMessage } from "../../src/ltm/types.ts";
+import { makeEpisode } from "./test-helpers.ts";
 
 const userId = "user-1";
-
-function makeEpisode(overrides: Record<string, unknown> = {}): Episode {
-	return createEpisode({
-		userId,
-		title: "Test Episode",
-		summary: "A test summary",
-		messages: [{ role: "user", content: "hello" }] as ChatMessage[],
-		embedding: [0.1, 0.2],
-		surprise: 0.5,
-		startAt: new Date("2026-01-01T00:00:00Z"),
-		endAt: new Date("2026-01-01T01:00:00Z"),
-		...overrides,
-	});
-}
 
 describe("EpisodicMemory — retrieval", () => {
 	let storage: LtmStorage;

--- a/spec/ltm/fsrs-learning-loop.spec.ts
+++ b/spec/ltm/fsrs-learning-loop.spec.ts
@@ -1,37 +1,16 @@
 /* oxlint-disable no-non-null-assertion, require-await -- FSRS learning loop integration tests */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { createEpisode } from "../../src/ltm/episode.ts";
 import { EpisodicMemory } from "../../src/ltm/episodic.ts";
 import { retrievability } from "../../src/ltm/fsrs.ts";
-import type { LtmLlmPort } from "../../src/ltm/llm-port.ts";
 import { LtmStorage } from "../../src/ltm/ltm-storage.ts";
 import { Retrieval } from "../../src/ltm/retrieval.ts";
-import type { ChatMessage } from "../../src/ltm/types.ts";
+import { createMockLLM, makeEpisode } from "./test-helpers.ts";
 
 const userId = "user-1";
 
-function mockLlm(embedding: number[]): LtmLlmPort {
-	return {
-		chat: async () => "",
-		chatStructured: async <T>(_: ChatMessage[], schema: { parse: (d: unknown) => T }) =>
-			schema.parse({}),
-		embed: async () => embedding,
-	};
-}
-
-function makeEpisode(overrides: Record<string, unknown> = {}) {
-	return createEpisode({
-		userId,
-		title: "Test Episode",
-		summary: "A summary",
-		messages: [{ role: "user", content: "hello" }] as ChatMessage[],
-		embedding: [1, 0, 0],
-		surprise: 0.5,
-		startAt: new Date("2026-01-01T00:00:00Z"),
-		endAt: new Date("2026-01-01T01:00:00Z"),
-		...overrides,
-	});
+function mockLlm(embedding: number[]) {
+	return createMockLLM({ embedding });
 }
 
 describe("FSRS learning loop — retrieve auto-review", () => {
@@ -50,7 +29,7 @@ describe("FSRS learning loop — retrieve auto-review", () => {
 	});
 
 	test("retrieve fires review and updates lastReviewedAt asynchronously", async () => {
-		const ep = makeEpisode({ title: "TypeScript Guide" });
+		const ep = makeEpisode({ title: "TypeScript Guide", embedding: [1, 0, 0] });
 		await storage.saveEpisode(userId, ep);
 
 		const before = await storage.getEpisodeById(userId, ep.id);
@@ -65,7 +44,7 @@ describe("FSRS learning loop — retrieve auto-review", () => {
 	});
 
 	test("returned scores reflect pre-review state", async () => {
-		const ep = makeEpisode({ title: "TypeScript Guide" });
+		const ep = makeEpisode({ title: "TypeScript Guide", embedding: [1, 0, 0] });
 		await storage.saveEpisode(userId, ep);
 
 		// Episode has null lastReviewedAt → retrievability = 1.0
@@ -83,7 +62,7 @@ describe("FSRS learning loop — retrieve auto-review", () => {
 	});
 
 	test("episode retrieved twice has more recent lastReviewedAt", async () => {
-		const ep = makeEpisode({ title: "TypeScript Guide" });
+		const ep = makeEpisode({ title: "TypeScript Guide", embedding: [1, 0, 0] });
 		await storage.saveEpisode(userId, ep);
 
 		const t1 = new Date("2026-03-01T00:00:00Z");
@@ -120,7 +99,7 @@ describe("FSRS learning loop — retrieve auto-review", () => {
 	test("without episodic, retrieve does not update FSRS", async () => {
 		const bareRetrieval = new Retrieval(mockLlm([1, 0, 0]), storage);
 
-		const ep = makeEpisode({ title: "TypeScript Bare" });
+		const ep = makeEpisode({ title: "TypeScript Bare", embedding: [1, 0, 0] });
 		await storage.saveEpisode(userId, ep);
 
 		const now = new Date("2026-06-01T00:00:00Z");
@@ -134,8 +113,8 @@ describe("FSRS learning loop — retrieve auto-review", () => {
 	test("recently reviewed episode scores higher in search results", async () => {
 		const now = new Date("2026-06-01T00:00:00Z");
 
-		const epRecent = makeEpisode({ title: "TypeScript Recent" });
-		const epStale = makeEpisode({ title: "TypeScript Stale" });
+		const epRecent = makeEpisode({ title: "TypeScript Recent", embedding: [1, 0, 0] });
+		const epStale = makeEpisode({ title: "TypeScript Stale", embedding: [1, 0, 0] });
 		await storage.saveEpisode(userId, epRecent);
 		await storage.saveEpisode(userId, epStale);
 

--- a/spec/ltm/ltm-storage.spec.ts
+++ b/spec/ltm/ltm-storage.spec.ts
@@ -1,38 +1,11 @@
 /* oxlint-disable max-lines, no-non-null-assertion, require-await, no-await-in-loop -- comprehensive storage adapter tests */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { createEpisode } from "../../src/ltm/episode.ts";
 import { LtmStorage } from "../../src/ltm/ltm-storage.ts";
-import { createFact } from "../../src/ltm/semantic-fact.ts";
 import type { ChatMessage } from "../../src/ltm/types.ts";
+import { makeEpisode, makeFact } from "./test-helpers.ts";
 
 const userId = "user-1";
-
-function makeEpisode(overrides: Record<string, unknown> = {}) {
-	return createEpisode({
-		userId,
-		title: "Test Episode",
-		summary: "A summary",
-		messages: [{ role: "user", content: "hello" }] as ChatMessage[],
-		embedding: [0.1, 0.2],
-		surprise: 0.5,
-		startAt: new Date("2026-01-01T00:00:00Z"),
-		endAt: new Date("2026-01-01T01:00:00Z"),
-		...overrides,
-	});
-}
-
-function makeFact(overrides: Record<string, unknown> = {}) {
-	return createFact({
-		userId,
-		category: "preference",
-		fact: "Likes TypeScript",
-		keywords: ["typescript"],
-		sourceEpisodicIds: ["ep-1"],
-		embedding: [0.1, 0.2],
-		...overrides,
-	});
-}
 
 describe("LtmStorage — episodic memory", () => {
 	let storage: LtmStorage;

--- a/spec/ltm/retrieval.spec.ts
+++ b/spec/ltm/retrieval.spec.ts
@@ -1,48 +1,14 @@
 /* oxlint-disable max-lines, no-non-null-assertion, require-await, no-await-in-loop -- comprehensive retrieval tests */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { createEpisode } from "../../src/ltm/episode.ts";
-import type { LtmLlmPort } from "../../src/ltm/llm-port.ts";
 import { LtmStorage } from "../../src/ltm/ltm-storage.ts";
 import { Retrieval, reciprocalRankFusion } from "../../src/ltm/retrieval.ts";
-import { createFact } from "../../src/ltm/semantic-fact.ts";
-import type { ChatMessage } from "../../src/ltm/types.ts";
+import { createMockLLM, makeEpisode, makeFact } from "./test-helpers.ts";
 
 const userId = "user-1";
 
-function mockLlm(embedding: number[]): LtmLlmPort {
-	return {
-		chat: async () => "",
-		chatStructured: async <T>(_: ChatMessage[], schema: { parse: (d: unknown) => T }) =>
-			schema.parse({}),
-		embed: async () => embedding,
-	};
-}
-
-function makeEpisode(overrides: Record<string, unknown> = {}) {
-	return createEpisode({
-		userId,
-		title: "Test Episode",
-		summary: "A summary",
-		messages: [{ role: "user", content: "hello" }] as ChatMessage[],
-		embedding: [0.1, 0.2, 0.3],
-		surprise: 0.5,
-		startAt: new Date("2026-01-01T00:00:00Z"),
-		endAt: new Date("2026-01-01T01:00:00Z"),
-		...overrides,
-	});
-}
-
-function makeFact(overrides: Record<string, unknown> = {}) {
-	return createFact({
-		userId,
-		category: "preference",
-		fact: "Likes TypeScript",
-		keywords: ["typescript"],
-		sourceEpisodicIds: ["ep-1"],
-		embedding: [0.1, 0.2, 0.3],
-		...overrides,
-	});
+function mockLlm(embedding: number[]) {
+	return createMockLLM({ embedding });
 }
 
 describe("reciprocalRankFusion", () => {

--- a/spec/ltm/segmenter-integration.spec.ts
+++ b/spec/ltm/segmenter-integration.spec.ts
@@ -2,32 +2,17 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { EpisodicMemory } from "../../src/ltm/episodic.ts";
-import type { LtmLlmPort, Schema } from "../../src/ltm/llm-port.ts";
 import { LtmStorage } from "../../src/ltm/ltm-storage.ts";
 import type { SegmentationOutput } from "../../src/ltm/segmenter.ts";
 import { Segmenter } from "../../src/ltm/segmenter.ts";
 import type { ChatMessage } from "../../src/ltm/types.ts";
 import { SURPRISE_VALUES } from "../../src/ltm/types.ts";
+import { createMockLLM, makeMessage } from "./test-helpers.ts";
 
 const userId = "user-1";
 
-function createMockLLM(segmentationResponse?: SegmentationOutput): LtmLlmPort {
-	return {
-		async chat(_messages: ChatMessage[]): Promise<string> {
-			return "mock response";
-		},
-		async chatStructured<T>(_messages: ChatMessage[], schema: Schema<T>): Promise<T> {
-			const response = segmentationResponse ?? { segments: [] };
-			return schema.parse(response);
-		},
-		async embed(_text: string): Promise<number[]> {
-			return [0.1, 0.2, 0.3];
-		},
-	};
-}
-
-function makeMessage(content: string, role: ChatMessage["role"] = "user"): ChatMessage {
-	return { role, content, timestamp: new Date() };
+function createSegmentationLLM(segmentationResponse?: SegmentationOutput) {
+	return createMockLLM({ structuredResponse: segmentationResponse ?? { segments: [] } });
 }
 
 async function addMessagesSequentially(
@@ -64,7 +49,7 @@ describe("Integration: Segmenter + LtmStorage + EpisodicMemory", () => {
 			],
 		};
 
-		const llm = createMockLLM(segResponse);
+		const llm = createSegmentationLLM(segResponse);
 		const segmenter = new Segmenter(llm, storage, {
 			minMessages: 3,
 			softTrigger: 5,
@@ -98,7 +83,7 @@ describe("Integration: Segmenter + LtmStorage + EpisodicMemory", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 5,
 			hardTrigger: 20,
@@ -125,7 +110,7 @@ describe("Integration: Segmenter + LtmStorage + EpisodicMemory", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 5,
 			hardTrigger: 20,
@@ -166,7 +151,7 @@ describe("Integration: Segmenter + LtmStorage + EpisodicMemory", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 10,
 			hardTrigger: 20,
@@ -196,7 +181,7 @@ describe("Integration: Segmenter + LtmStorage + EpisodicMemory", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 10,
 			hardTrigger: 20,
@@ -222,7 +207,7 @@ describe("Integration: Segmenter + LtmStorage + EpisodicMemory", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 5,
 			hardTrigger: 20,

--- a/spec/ltm/segmenter.spec.ts
+++ b/spec/ltm/segmenter.spec.ts
@@ -2,38 +2,15 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { Episode } from "../../src/ltm/episode.ts";
-import type { LtmLlmPort, Schema } from "../../src/ltm/llm-port.ts";
 import { LtmStorage } from "../../src/ltm/ltm-storage.ts";
 import type { SegmentationOutput } from "../../src/ltm/segmenter.ts";
 import { Segmenter } from "../../src/ltm/segmenter.ts";
 import type { ChatMessage, SurpriseLevel } from "../../src/ltm/types.ts";
 import { SURPRISE_VALUES } from "../../src/ltm/types.ts";
+import { createInvalidLLM, createMockLLM, makeMessage, makeMessages } from "./test-helpers.ts";
 
-// --- Mock LtmLlmPort ---
-
-function createMockLLM(segmentationResponse?: SegmentationOutput): LtmLlmPort {
-	return {
-		async chat(_messages: ChatMessage[]): Promise<string> {
-			return "mock response";
-		},
-		async chatStructured<T>(_messages: ChatMessage[], schema: Schema<T>): Promise<T> {
-			const response = segmentationResponse ?? { segments: [] };
-			return schema.parse(response);
-		},
-		async embed(_text: string): Promise<number[]> {
-			return [0.1, 0.2, 0.3];
-		},
-	};
-}
-
-function makeMessage(content: string, role: ChatMessage["role"] = "user"): ChatMessage {
-	return { role, content, timestamp: new Date() };
-}
-
-function makeMessages(count: number): ChatMessage[] {
-	return Array.from({ length: count }, (_, i) =>
-		makeMessage(`message ${i}`, i % 2 === 0 ? "user" : "assistant"),
-	);
+function createSegmentationLLM(segmentationResponse?: SegmentationOutput) {
+	return createMockLLM({ structuredResponse: segmentationResponse ?? { segments: [] } });
 }
 
 async function addMessagesSequentially(
@@ -60,7 +37,7 @@ describe("Segmenter — threshold checks", () => {
 	});
 
 	test("below softTrigger returns no episodes", async () => {
-		const segmenter = new Segmenter(createMockLLM(), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(), storage, {
 			minMessages: 5,
 			softTrigger: 20,
 			hardTrigger: 40,
@@ -88,7 +65,7 @@ describe("Segmenter — threshold checks", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 10,
 			hardTrigger: 20,
@@ -114,7 +91,7 @@ describe("Segmenter — threshold checks", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 10,
 			hardTrigger: 5,
@@ -128,7 +105,7 @@ describe("Segmenter — threshold checks", () => {
 	});
 
 	test("LLM returns no segments at softTrigger returns no episodes", async () => {
-		const segmenter = new Segmenter(createMockLLM({ segments: [] }), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM({ segments: [] }), storage, {
 			minMessages: 3,
 			softTrigger: 5,
 			hardTrigger: 20,
@@ -165,7 +142,7 @@ describe("Segmenter — episode creation", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 5,
 			hardTrigger: 20,
@@ -198,7 +175,7 @@ describe("Segmenter — episode creation", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 5,
 			hardTrigger: 20,
@@ -231,7 +208,7 @@ describe("Segmenter — episode creation", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 10,
 			hardTrigger: 20,
@@ -262,7 +239,7 @@ describe("Segmenter — episode creation", () => {
 				],
 			};
 
-			const segmenter = new Segmenter(createMockLLM(segResponse), localStorage, {
+			const segmenter = new Segmenter(createSegmentationLLM(segResponse), localStorage, {
 				minMessages: 3,
 				softTrigger: 5,
 				hardTrigger: 20,
@@ -301,7 +278,7 @@ describe("Segmenter — queue management", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 5,
 			hardTrigger: 20,
@@ -326,7 +303,7 @@ describe("Segmenter — queue management", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 10,
 			hardTrigger: 20,
@@ -352,7 +329,7 @@ describe("Segmenter — queue management", () => {
 			],
 		};
 
-		const segmenter = new Segmenter(createMockLLM(segResponse), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(segResponse), storage, {
 			minMessages: 3,
 			softTrigger: 5,
 			hardTrigger: 20,
@@ -371,17 +348,6 @@ describe("Segmenter — queue management", () => {
 		expect(user1Episodes).toHaveLength(1);
 	});
 });
-
-// --- Invalid LLM mock for schema validation tests ---
-
-function createInvalidLLM(invalidResponse: unknown): LtmLlmPort {
-	return {
-		chat: async () => "",
-		chatStructured: async <T>(_msgs: ChatMessage[], schema: Schema<T>) =>
-			schema.parse(invalidResponse),
-		embed: async () => [0.1, 0.2],
-	};
-}
 
 describe("Segmenter — schema validation", () => {
 	let storage: LtmStorage;
@@ -500,7 +466,7 @@ describe("Segmenter — maxQueueSize", () => {
 	});
 
 	test("throws when queue exceeds maxQueueSize", async () => {
-		const segmenter = new Segmenter(createMockLLM(), storage, {
+		const segmenter = new Segmenter(createSegmentationLLM(), storage, {
 			minMessages: 5,
 			softTrigger: 100,
 			hardTrigger: 200,

--- a/spec/ltm/semantic-memory.spec.ts
+++ b/spec/ltm/semantic-memory.spec.ts
@@ -2,22 +2,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { LtmStorage } from "../../src/ltm/ltm-storage.ts";
-import { createFact } from "../../src/ltm/semantic-fact.ts";
 import { SemanticMemory } from "../../src/ltm/semantic-memory.ts";
+import { makeFact } from "./test-helpers.ts";
 
 const userId = "user-1";
-
-function makeFact(overrides: Partial<Parameters<typeof createFact>[0]> = {}) {
-	return createFact({
-		userId,
-		category: "preference",
-		fact: "User likes TypeScript",
-		keywords: ["typescript", "programming"],
-		sourceEpisodicIds: ["ep-1"],
-		embedding: [0.1, 0.2, 0.3],
-		...overrides,
-	});
-}
 
 describe("SemanticMemory — getFacts", () => {
 	let storage: LtmStorage;

--- a/spec/ltm/test-helpers.ts
+++ b/spec/ltm/test-helpers.ts
@@ -1,0 +1,67 @@
+/* oxlint-disable require-await -- mock implementations */
+import type { Episode } from "../../src/ltm/episode.ts";
+import { createEpisode } from "../../src/ltm/episode.ts";
+import type { LtmLlmPort, Schema } from "../../src/ltm/llm-port.ts";
+import { createFact } from "../../src/ltm/semantic-fact.ts";
+import type { ChatMessage } from "../../src/ltm/types.ts";
+
+const defaultUserId = "user-1";
+
+export function makeEpisode(overrides: Partial<Parameters<typeof createEpisode>[0]> = {}): Episode {
+	return createEpisode({
+		userId: defaultUserId,
+		title: "Test Episode",
+		summary: "A summary",
+		messages: [{ role: "user", content: "hello" }] as ChatMessage[],
+		embedding: [0.1, 0.2, 0.3],
+		surprise: 0.5,
+		startAt: new Date("2026-01-01T00:00:00Z"),
+		endAt: new Date("2026-01-01T01:00:00Z"),
+		...overrides,
+	});
+}
+
+export function makeFact(overrides: Partial<Parameters<typeof createFact>[0]> = {}) {
+	return createFact({
+		userId: defaultUserId,
+		category: "preference",
+		fact: "Likes TypeScript",
+		keywords: ["typescript"],
+		sourceEpisodicIds: ["ep-1"],
+		embedding: [0.1, 0.2, 0.3],
+		...overrides,
+	});
+}
+
+export interface MockLLMOptions {
+	structuredResponse?: unknown;
+	embedding?: number[];
+}
+
+export function createMockLLM(opts: MockLLMOptions = {}): LtmLlmPort {
+	const { structuredResponse, embedding = [0.1, 0.2, 0.3] } = opts;
+	return {
+		chat: async () => "mock response",
+		chatStructured: async <T>(_: ChatMessage[], schema: Schema<T>) =>
+			schema.parse(structuredResponse ?? {}),
+		embed: async () => embedding,
+	};
+}
+
+export function createInvalidLLM(invalidResponse: unknown): LtmLlmPort {
+	return {
+		chat: async () => "",
+		chatStructured: async <T>(_: ChatMessage[], schema: Schema<T>) => schema.parse(invalidResponse),
+		embed: async () => [0.1, 0.2],
+	};
+}
+
+export function makeMessage(content: string, role: ChatMessage["role"] = "user"): ChatMessage {
+	return { role, content, timestamp: new Date() };
+}
+
+export function makeMessages(count: number): ChatMessage[] {
+	return Array.from({ length: count }, (_, i) =>
+		makeMessage(`message ${i}`, i % 2 === 0 ? "user" : "assistant"),
+	);
+}

--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -2,19 +2,11 @@ import { describe, expect, mock, test } from "bun:test";
 
 import type {
 	ConsolidationResult,
-	Logger,
 	MemoryConsolidator,
 	MetricsCollector,
 } from "../../src/core/types.ts";
 import { ConsolidationScheduler } from "../../src/scheduling/consolidation-scheduler.ts";
-
-function createMockLogger(): Logger {
-	return {
-		info: mock(() => {}),
-		error: mock(() => {}),
-		warn: mock(() => {}),
-	};
-}
+import { createMockLogger } from "../test-helpers.ts";
 
 function createMockMetrics(): MetricsCollector {
 	return {

--- a/spec/test-helpers.ts
+++ b/spec/test-helpers.ts
@@ -1,0 +1,11 @@
+import { mock } from "bun:test";
+
+import type { Logger } from "../src/core/types.ts";
+
+export function createMockLogger(): Logger {
+	return {
+		info: mock(() => {}),
+		error: mock(() => {}),
+		warn: mock(() => {}),
+	};
+}

--- a/src/scheduling/heartbeat-scheduler.test.ts
+++ b/src/scheduling/heartbeat-scheduler.test.ts
@@ -2,18 +2,11 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 
-import type { AiAgent, HeartbeatConfig, Logger, MetricsCollector } from "../core/types.ts";
+import { createMockLogger } from "../../spec/test-helpers.ts";
+import type { AiAgent, HeartbeatConfig, MetricsCollector } from "../core/types.ts";
 import { HeartbeatScheduler } from "./heartbeat-scheduler.ts";
 
 const TEMP_ROOT = `/tmp/vicissitude-heartbeat-scheduler-${process.pid}`;
-
-function createMockLogger(): Logger {
-	return {
-		info: mock(() => {}),
-		error: mock(() => {}),
-		warn: mock(() => {}),
-	};
-}
 
 function createMockMetrics(): MetricsCollector {
 	return {


### PR DESCRIPTION
## Summary

- `spec/test-helpers.ts` に汎用ヘルパー (`createMockLogger`) を集約
- `spec/ltm/test-helpers.ts` に LTM 関連ヘルパー (`makeEpisode`, `makeFact`, `createMockLLM`, `createInvalidLLM`, `makeMessage`, `makeMessages`) を集約
- overrides 型を `Partial<Parameters<...>>` に統一して型安全性を向上
- `createMockLLM` を `{ structuredResponse, embedding }` オプションで汎用化
- 12 ファイルのローカル定義を削除しインポートに置換（-293行 / +144行）

Closes #176

## Test plan

- [x] `nr test` — 全 766 テスト通過
- [x] `nr validate` — フォーマット・lint（新規ファイルにエラーなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)