### PR TITLE
refactor: createMockMetrics の重複を spec/test-helpers.ts に集約

### DIFF
--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -1,23 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 
-import type {
-	ConsolidationResult,
-	MemoryConsolidator,
-	MetricsCollector,
-} from "../../src/core/types.ts";
+import type { ConsolidationResult, MemoryConsolidator } from "../../src/core/types.ts";
 import { ConsolidationScheduler } from "../../src/scheduling/consolidation-scheduler.ts";
-import { createMockLogger } from "../test-helpers.ts";
-
-function createMockMetrics(): MetricsCollector {
-	return {
-		incrementCounter: mock(() => {}),
-		addCounter: mock(() => {}),
-		setGauge: mock(() => {}),
-		incrementGauge: mock(() => {}),
-		decrementGauge: mock(() => {}),
-		observeHistogram: mock(() => {}),
-	};
-}
+import { createMockLogger, createMockMetrics } from "../test-helpers.ts";
 
 function createMockConsolidator(overrides: Partial<MemoryConsolidator> = {}): MemoryConsolidator {
 	return {

--- a/spec/test-helpers.ts
+++ b/spec/test-helpers.ts
@@ -1,11 +1,22 @@
 import { mock } from "bun:test";
 
-import type { Logger } from "../src/core/types.ts";
+import type { Logger, MetricsCollector } from "../src/core/types.ts";
 
 export function createMockLogger(): Logger {
 	return {
 		info: mock(() => {}),
 		error: mock(() => {}),
 		warn: mock(() => {}),
+	};
+}
+
+export function createMockMetrics(): MetricsCollector {
+	return {
+		incrementCounter: mock(() => {}),
+		addCounter: mock(() => {}),
+		setGauge: mock(() => {}),
+		incrementGauge: mock(() => {}),
+		decrementGauge: mock(() => {}),
+		observeHistogram: mock(() => {}),
 	};
 }

--- a/src/scheduling/heartbeat-scheduler.test.ts
+++ b/src/scheduling/heartbeat-scheduler.test.ts
@@ -2,22 +2,11 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 
-import { createMockLogger } from "../../spec/test-helpers.ts";
-import type { AiAgent, HeartbeatConfig, MetricsCollector } from "../core/types.ts";
+import { createMockLogger, createMockMetrics } from "../../spec/test-helpers.ts";
+import type { AiAgent, HeartbeatConfig } from "../core/types.ts";
 import { HeartbeatScheduler } from "./heartbeat-scheduler.ts";
 
 const TEMP_ROOT = `/tmp/vicissitude-heartbeat-scheduler-${process.pid}`;
-
-function createMockMetrics(): MetricsCollector {
-	return {
-		incrementCounter: mock(() => {}),
-		addCounter: mock(() => {}),
-		setGauge: mock(() => {}),
-		incrementGauge: mock(() => {}),
-		decrementGauge: mock(() => {}),
-		observeHistogram: mock(() => {}),
-	};
-}
 
 function createMockAgent(): AiAgent {
 	return {


### PR DESCRIPTION
## Summary

- `createMockMetrics()` が `spec/scheduling/consolidation-scheduler.spec.ts` と `src/scheduling/heartbeat-scheduler.test.ts` で重複していたのを `spec/test-helpers.ts` に集約
- 両ファイルから共有ヘルパーをインポートするように変更

Closes #187

## Test plan

- [x] `nr test` — 全766テスト通過
- [x] `nr validate` — 今回の変更に起因するエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)