### PR TITLE
fix: lint エラーを修正し spec ファイルの除外設定を追加

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -54,14 +54,15 @@
 			}
 		},
 		{
-			"files": ["**/*.test.ts", "**/test-helpers.ts"],
+			"files": ["**/*.test.ts", "**/*.spec.ts", "**/test-helpers.ts"],
 			"rules": {
 				"eslint/max-lines-per-function": "off",
+				"eslint/max-lines": "off",
 				"import/max-dependencies": "off"
 			}
 		},
 		{
-			"files": ["**/mcp/tools/*.ts", "**/mcp/core-server.ts"],
+			"files": ["**/mcp/tools/*.ts", "**/mcp/core-server.ts", "**/mcp/minecraft/mcp-tools.ts"],
 			"rules": {
 				"eslint/max-lines-per-function": "off",
 				"import/max-dependencies": "off"

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -92,7 +92,7 @@ graph LR
 
 - 内部依存: core/
 - 外部依存: @opencode-ai/sdk/v2
-- ファイル数: 2
+- ファイル数: 3
 
 ### scheduling/
 

--- a/spec/mcp/tools/mc-memory.spec.ts
+++ b/spec/mcp/tools/mc-memory.spec.ts
@@ -196,9 +196,11 @@ describe("mc_record_skill の追記ロジック", () => {
 		const preconditions = sanitizeSingleLine("石のピッケル以上が必要");
 		const failurePatterns = sanitizeSingleLine("夜間は敵mobで中断されやすい");
 
-		const lines = [`\n## ${safeName}\n\n${safeDescription}`];
-		lines.push(`\n**前提条件**: ${preconditions}`);
-		lines.push(`\n**失敗パターン**: ${failurePatterns}`);
+		const lines = [
+			`\n## ${safeName}\n\n${safeDescription}`,
+			`\n**前提条件**: ${preconditions}`,
+			`\n**失敗パターン**: ${failurePatterns}`,
+		];
 		const entry = `${lines.join("")}\n`;
 		const updated = existing + entry;
 		writeOverlay(dataDir, "MINECRAFT-SKILLS.md", updated);
@@ -218,8 +220,10 @@ describe("mc_record_skill の追記ロジック", () => {
 		const safeDescription = sanitizeSkillDescription("説明文");
 		const preconditions = sanitizeSingleLine("条件1\n条件2\r\n条件3");
 
-		const lines = [`\n## ${safeName}\n\n${safeDescription}`];
-		lines.push(`\n**前提条件**: ${preconditions}`);
+		const lines = [
+			`\n## ${safeName}\n\n${safeDescription}`,
+			`\n**前提条件**: ${preconditions}`,
+		];
 		const entry = `${lines.join("")}\n`;
 		const updated = existing + entry;
 		writeOverlay(dataDir, "MINECRAFT-SKILLS.md", updated);

--- a/src/ltm/ltm-storage.ts
+++ b/src/ltm/ltm-storage.ts
@@ -48,7 +48,8 @@ function sortBySimilarity<T extends { embedding: number[] }>(
 /** SQLite-based LTM storage */
 export class LtmStorage {
 	private db: Database;
-	private cachedDimension: number | null | undefined = undefined; // undefined = not loaded yet
+	/** undefined = not loaded yet */
+	private cachedDimension: number | null | undefined = undefined;
 
 	constructor(path = ":memory:") {
 		this.db = new Database(path);
@@ -74,7 +75,7 @@ export class LtmStorage {
 		const dim = this.inferDimensionFromExistingData();
 		if (dim !== null) {
 			this.upsertDimension(dim);
-			return this.cachedDimension!;
+			return dim;
 		}
 		this.cachedDimension = null;
 		return null;

--- a/src/mcp/core-server.ts
+++ b/src/mcp/core-server.ts
@@ -59,12 +59,16 @@ const ollama = new OllamaEmbeddingAdapter(OLLAMA_BASE_URL, LTM_EMBEDDING_MODEL);
 
 /** LtmLlmPort that only supports embed — chat/chatStructured throw since they are unused here */
 const embedOnlyLlm: LtmLlmPort = {
-	async chat(): Promise<never> {
-		throw new Error("chat is not available in core-server (consolidation runs in main process)");
+	chat(): Promise<never> {
+		return Promise.reject(
+			new Error("chat is not available in core-server (consolidation runs in main process)"),
+		);
 	},
-	async chatStructured(): Promise<never> {
-		throw new Error(
-			"chatStructured is not available in core-server (consolidation runs in main process)",
+	chatStructured(): Promise<never> {
+		return Promise.reject(
+			new Error(
+				"chatStructured is not available in core-server (consolidation runs in main process)",
+			),
 		);
 	},
 	embed: (text: string) => ollama.embed(text),
@@ -137,7 +141,7 @@ const { cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
 
 // --- Graceful Shutdown ---
 
-async function shutdown() {
+function shutdown() {
 	clearInterval(cleanupTimer);
 	closeAllSessions();
 	stopServer();

--- a/src/opencode/DEPS.md
+++ b/src/opencode/DEPS.md
@@ -6,17 +6,24 @@
 
 ```mermaid
 graph LR
-  session_adapter["session-adapter"]
+  session_adapter["session-adapter"] --> stream_helpers["stream-helpers"]
   session_port["session-port"]
+  stream_helpers["stream-helpers"]
 ```
 
 ## ファイル別依存一覧
 
 ### session-adapter.ts
 
+- モジュール内依存: stream-helpers
 - 他モジュール依存: core/
 - 外部依存: @opencode-ai/sdk/v2
 
 ### session-port.ts
 
 - 他モジュール依存: core/
+
+### stream-helpers.ts
+
+- 他モジュール依存: core/
+- 外部依存: @opencode-ai/sdk/v2

--- a/src/opencode/session-adapter.ts
+++ b/src/opencode/session-adapter.ts
@@ -1,17 +1,11 @@
 import {
 	createOpencode,
 	type Event,
-	type EventMessageUpdated,
-	type EventSessionCompacted,
-	type EventSessionError,
-	type EventSessionIdle,
 	type McpLocalConfig,
 	type McpRemoteConfig,
 	type OpencodeClient,
-	type Part,
 } from "@opencode-ai/sdk/v2";
 
-import { withTimeout } from "../core/functions.ts";
 import type {
 	OpencodePromptParams,
 	OpencodeSessionEvent,
@@ -19,6 +13,15 @@ import type {
 	PromptResult,
 	TokenUsage,
 } from "../core/types.ts";
+import {
+	abortSession,
+	classifyEvent,
+	extractText,
+	extractTokens,
+	nextStreamEvent,
+	returnStreamOnce,
+	sumTokens,
+} from "./stream-helpers.ts";
 
 export interface OpencodeSessionAdapterConfig {
 	port: number;
@@ -154,155 +157,4 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		this.closeServer = result.server.close;
 		return this.client;
 	}
-}
-type AbortableAsyncStream<T> = AsyncIterator<T> & {
-	return?: (value?: unknown) => Promise<IteratorResult<T>>;
-};
-const STREAM_RETURNED = Symbol("streamReturned"),
-	STREAM_RETURN_PROMISE = Symbol("streamReturnPromise");
-type StreamReadResult = { type: "event"; value: unknown } | { type: "done" } | { type: "aborted" };
-
-/** signal なしの stream.next() に適用するタイムアウト（5分） */
-const STREAM_NEXT_TIMEOUT_MS = 5 * 60 * 1000;
-
-async function nextStreamEvent(
-	stream: AbortableAsyncStream<unknown>,
-	signal: AbortSignal | undefined,
-	onAbort: () => Promise<void>,
-): Promise<StreamReadResult> {
-	if (!signal) {
-		const result = await withTimeout(
-			stream.next(),
-			STREAM_NEXT_TIMEOUT_MS,
-			"stream.next() timed out after 5 minutes",
-		);
-		return result.done ? { type: "done" } : { type: "event", value: result.value };
-	}
-	return waitForNextStreamEvent(stream, signal, onAbort);
-}
-function waitForNextStreamEvent(
-	stream: AbortableAsyncStream<unknown>,
-	signal: AbortSignal,
-	onAbort: () => Promise<void>,
-): Promise<StreamReadResult> {
-	return new Promise<StreamReadResult>((resolve, reject) => {
-		let settled = false;
-		const finish = (complete: () => void) => {
-			if (settled) return;
-			settled = true;
-			signal.removeEventListener("abort", handleAbort);
-			complete();
-		};
-		const handleAbort = () => {
-			finish(() => {
-				void onAbort();
-				void returnStreamOnce(stream).catch(() => {});
-				resolve({ type: "aborted" });
-			});
-		};
-		signal.addEventListener("abort", handleAbort, { once: true });
-		if (signal.aborted) {
-			handleAbort();
-			return;
-		}
-		void (async () => {
-			try {
-				const result = await stream.next();
-				finish(() =>
-					resolve(result.done ? { type: "done" } : { type: "event", value: result.value }),
-				);
-			} catch (error) {
-				finish(() => reject(error));
-			}
-		})();
-	});
-}
-function returnStreamOnce(stream: AbortableAsyncStream<unknown>): Promise<void> {
-	const managed = stream as AbortableAsyncStream<unknown> & {
-		[STREAM_RETURNED]?: boolean;
-		[STREAM_RETURN_PROMISE]?: Promise<unknown>;
-	};
-	if (managed[STREAM_RETURN_PROMISE]) return managed[STREAM_RETURN_PROMISE] as Promise<void>;
-	if (managed[STREAM_RETURNED]) return Promise.resolve();
-	managed[STREAM_RETURNED] = true;
-	managed[STREAM_RETURN_PROMISE] = managed.return ? managed.return() : Promise.resolve();
-	return managed[STREAM_RETURN_PROMISE] as Promise<void>;
-}
-async function abortSession(oc: OpencodeClient, sessionId: string): Promise<void> {
-	try {
-		const result = await oc.session.abort({ sessionID: sessionId });
-		if (result.error) {
-		}
-	} catch {
-		// 停止経路ではベストエフォート。unhandled rejection にはしない。
-	}
-}
-function classifyEvent(
-	typed: Event,
-	sessionId: string,
-	tokensByMessage: Map<string, TokenUsage>,
-): OpencodeSessionEvent | null {
-	if (typed.type === "message.updated") {
-		accumulateTokens(typed as EventMessageUpdated, sessionId, tokensByMessage);
-		return null;
-	}
-	if (typed.type === "session.idle") {
-		const idle = typed as EventSessionIdle;
-		if (idle.properties.sessionID === sessionId) {
-			return { type: "idle", tokens: sumTokens(tokensByMessage) };
-		}
-	}
-	if (typed.type === "session.compacted") {
-		const compacted = typed as EventSessionCompacted;
-		if (compacted.properties.sessionID === sessionId) return { type: "compacted" };
-	}
-	if (typed.type === "session.error") {
-		const err = typed as EventSessionError;
-		if (err.properties.sessionID === sessionId) {
-			return { type: "error", message: JSON.stringify(err.properties) };
-		}
-	}
-	return null;
-}
-function accumulateTokens(
-	typed: EventMessageUpdated,
-	sessionId: string,
-	tokensByMessage: Map<string, TokenUsage>,
-): void {
-	const info = typed.properties.info;
-	if (info.role === "assistant" && info.sessionID === sessionId) {
-		tokensByMessage.set(info.id, {
-			input: info.tokens.input,
-			output: info.tokens.output,
-			cacheRead: info.tokens.cache?.read ?? 0,
-		});
-	}
-}
-function extractText(parts: Part[]): string {
-	return parts
-		.filter((p): p is Part & { type: "text" } => p.type === "text")
-		.map((p) => p.text)
-		.join("");
-}
-function extractTokens(info: {
-	tokens?: { input: number; output: number; cache?: { read: number } };
-}): TokenUsage | undefined {
-	if (!info.tokens) return undefined;
-	return {
-		input: info.tokens.input,
-		output: info.tokens.output,
-		cacheRead: info.tokens.cache?.read ?? 0,
-	};
-}
-function sumTokens(tokensByMessage: Map<string, TokenUsage>): TokenUsage | undefined {
-	if (tokensByMessage.size === 0) return undefined;
-	let cacheRead = 0;
-	let input = 0;
-	let output = 0;
-	for (const t of tokensByMessage.values()) {
-		input += t.input;
-		output += t.output;
-		cacheRead += t.cacheRead;
-	}
-	return { input, output, cacheRead };
 }

--- a/src/opencode/stream-helpers.ts
+++ b/src/opencode/stream-helpers.ts
@@ -1,0 +1,164 @@
+import type {
+	Event,
+	EventMessageUpdated,
+	EventSessionCompacted,
+	EventSessionError,
+	EventSessionIdle,
+	OpencodeClient,
+	Part,
+} from "@opencode-ai/sdk/v2";
+
+import { withTimeout } from "../core/functions.ts";
+import type { OpencodeSessionEvent, TokenUsage } from "../core/types.ts";
+
+export type AbortableAsyncStream<T> = AsyncIterator<T> & {
+	return?: (value?: unknown) => Promise<IteratorResult<T>>;
+};
+const STREAM_RETURNED = Symbol("streamReturned"),
+	STREAM_RETURN_PROMISE = Symbol("streamReturnPromise");
+type StreamReadResult = { type: "event"; value: unknown } | { type: "done" } | { type: "aborted" };
+
+/** signal なしの stream.next() に適用するタイムアウト（5分） */
+const STREAM_NEXT_TIMEOUT_MS = 5 * 60 * 1000;
+
+export async function nextStreamEvent(
+	stream: AbortableAsyncStream<unknown>,
+	signal: AbortSignal | undefined,
+	onAbort: () => Promise<void>,
+): Promise<StreamReadResult> {
+	if (!signal) {
+		const result = await withTimeout(
+			stream.next(),
+			STREAM_NEXT_TIMEOUT_MS,
+			"stream.next() timed out after 5 minutes",
+		);
+		return result.done ? { type: "done" } : { type: "event", value: result.value };
+	}
+	return waitForNextStreamEvent(stream, signal, onAbort);
+}
+function waitForNextStreamEvent(
+	stream: AbortableAsyncStream<unknown>,
+	signal: AbortSignal,
+	onAbort: () => Promise<void>,
+): Promise<StreamReadResult> {
+	return new Promise<StreamReadResult>((resolve, reject) => {
+		let settled = false;
+		const finish = (complete: () => void) => {
+			if (settled) return;
+			settled = true;
+			signal.removeEventListener("abort", handleAbort);
+			complete();
+		};
+		const handleAbort = () => {
+			finish(() => {
+				void onAbort();
+				void returnStreamOnce(stream).catch(() => {});
+				resolve({ type: "aborted" });
+			});
+		};
+		signal.addEventListener("abort", handleAbort, { once: true });
+		if (signal.aborted) {
+			handleAbort();
+			return;
+		}
+		void (async () => {
+			try {
+				const result = await stream.next();
+				finish(() =>
+					resolve(result.done ? { type: "done" } : { type: "event", value: result.value }),
+				);
+			} catch (error) {
+				finish(() => reject(error));
+			}
+		})();
+	});
+}
+export function returnStreamOnce(stream: AbortableAsyncStream<unknown>): Promise<void> {
+	const managed = stream as AbortableAsyncStream<unknown> & {
+		[STREAM_RETURNED]?: boolean;
+		[STREAM_RETURN_PROMISE]?: Promise<unknown>;
+	};
+	if (managed[STREAM_RETURN_PROMISE]) return managed[STREAM_RETURN_PROMISE] as Promise<void>;
+	if (managed[STREAM_RETURNED]) return Promise.resolve();
+	managed[STREAM_RETURNED] = true;
+	managed[STREAM_RETURN_PROMISE] = managed.return ? managed.return() : Promise.resolve();
+	return managed[STREAM_RETURN_PROMISE] as Promise<void>;
+}
+export async function abortSession(oc: OpencodeClient, sessionId: string): Promise<void> {
+	try {
+		const result = await oc.session.abort({ sessionID: sessionId });
+		if (result.error) {
+		}
+	} catch {
+		// 停止経路ではベストエフォート。unhandled rejection にはしない。
+	}
+}
+export function classifyEvent(
+	typed: Event,
+	sessionId: string,
+	tokensByMessage: Map<string, TokenUsage>,
+): OpencodeSessionEvent | null {
+	if (typed.type === "message.updated") {
+		accumulateTokens(typed as EventMessageUpdated, sessionId, tokensByMessage);
+		return null;
+	}
+	if (typed.type === "session.idle") {
+		const idle = typed as EventSessionIdle;
+		if (idle.properties.sessionID === sessionId) {
+			return { type: "idle", tokens: sumTokens(tokensByMessage) };
+		}
+	}
+	if (typed.type === "session.compacted") {
+		const compacted = typed as EventSessionCompacted;
+		if (compacted.properties.sessionID === sessionId) return { type: "compacted" };
+	}
+	if (typed.type === "session.error") {
+		const err = typed as EventSessionError;
+		if (err.properties.sessionID === sessionId) {
+			return { type: "error", message: JSON.stringify(err.properties) };
+		}
+	}
+	return null;
+}
+function accumulateTokens(
+	typed: EventMessageUpdated,
+	sessionId: string,
+	tokensByMessage: Map<string, TokenUsage>,
+): void {
+	const info = typed.properties.info;
+	if (info.role === "assistant" && info.sessionID === sessionId) {
+		tokensByMessage.set(info.id, {
+			input: info.tokens.input,
+			output: info.tokens.output,
+			cacheRead: info.tokens.cache?.read ?? 0,
+		});
+	}
+}
+export function extractText(parts: Part[]): string {
+	return parts
+		.filter((p): p is Part & { type: "text" } => p.type === "text")
+		.map((p) => p.text)
+		.join("");
+}
+export function extractTokens(info: {
+	tokens?: { input: number; output: number; cache?: { read: number } };
+}): TokenUsage | undefined {
+	if (!info.tokens) return undefined;
+	return {
+		input: info.tokens.input,
+		output: info.tokens.output,
+		cacheRead: info.tokens.cache?.read ?? 0,
+	};
+}
+export function sumTokens(tokensByMessage: Map<string, TokenUsage>): TokenUsage | undefined {
+	if (tokensByMessage.size === 0) return undefined;
+	let cacheRead = 0;
+	let input = 0;
+	let output = 0;
+	for (const t of tokensByMessage.values()) {
+		input += t.input;
+		output += t.output;
+		cacheRead += t.cacheRead;
+	}
+	return { input, output, cacheRead };
+}


### PR DESCRIPTION
## Summary
- `.oxlintrc.json` に `*.spec.ts` の `max-lines-per-function` / `max-lines` 除外を追加
- `mcp/minecraft/mcp-tools.ts` を MCP override に追加
- `src/ltm/ltm-storage.ts`: インラインコメント→JSDoc、非null アサーション `!` を除去
- `src/mcp/core-server.ts`: `async` + `throw` → `Promise.reject()`、不要な `async` 除去
- `src/opencode/session-adapter.ts`: ストリーム/イベントヘルパーを `stream-helpers.ts` に分離して `max-lines` 制限内に収める
- `spec/mcp/tools/mc-memory.spec.ts`: 配列初期化直後の `push()` をリテラル内に移動

## Test plan
- [x] `nr lint` — エラー 0 件
- [x] `nr test` — 全 766 テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)