### PR TITLE
refactor: abortSession の空 if ブロックを削除

### DIFF
--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -85,9 +85,7 @@ export function returnStreamOnce(stream: AbortableAsyncStream<unknown>): Promise
 }
 export async function abortSession(oc: OpencodeClient, sessionId: string): Promise<void> {
 	try {
-		const result = await oc.session.abort({ sessionID: sessionId });
-		if (result.error) {
-		}
+		await oc.session.abort({ sessionID: sessionId });
 	} catch {
 		// 停止経路ではベストエフォート。unhandled rejection にはしない。
 	}


### PR DESCRIPTION
## Summary
- `abortSession` 関数の空 `if (result.error) {}` ブロックと不要な `result` 変数への代入を削除

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)