### PR TITLE
fix: Vite allowedHosts を有効化し Tailscale 越しのアクセスを許可

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
 	server: {
 		port: Number(process.env.WEB_PORT ?? 4000),
 		host: true,
+		allowedHosts: true,
 	},
 });


### PR DESCRIPTION
## Summary
- Vite dev server の `allowedHosts: true` を追加し、Tailscale ホスト名経由でのアクセス時にブロックされる問題を修正

## Test plan
- [x] Tailscale 越しに Web UI にアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)