### PR TITLE
fix: crypto.randomUUID() を HTTP 環境でも動作する方式に置換

### DIFF
--- a/apps/web/src/components/chat/ChatPanel.tsx
+++ b/apps/web/src/components/chat/ChatPanel.tsx
@@ -162,7 +162,10 @@ export function ChatPanel({ onExpressionChange }: ChatPanelProps) {
 	const handleSend = useCallback(
 		(text: string) => {
 			if (!clientRef.current) return;
-			setMessages((prev) => [...prev, { id: crypto.randomUUID(), role: "user", text }]);
+			setMessages((prev) => [
+				...prev,
+				{ id: Math.random().toString(36).slice(2), role: "user", text },
+			]);
 			clientRef.current.send({
 				type: "chat_input",
 				text,


### PR DESCRIPTION
## Summary
- `crypto.randomUUID()` はセキュアコンテキスト（HTTPS）でのみ利用可能なため、HTTP 環境（Tailscale 越し等）でエラーになっていた
- React key 用の ID 生成を `Math.random().toString(36).slice(2)` に変更

## Test plan
- [ ] HTTP 環境でチャット画面を開き、メッセージ送信時にエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)