### PR TITLE
feat: schedule MCP ツールにギルドコンテキストを導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ OpenCode が使用する MCP サーバーを提供する。
    - `send_message` / `reply` はオプションで画像ファイルパス（`file_path`）を受け取り、添付ファイルとして送信可能
 2. **code-exec**: コード実行
    - `execute_code` (JavaScript, TypeScript, Python, Shell)
-3. **schedule**: Heartbeat スケジュール管理
-   - `get_heartbeat_config`, `list_reminders`, `add_reminder`, `update_reminder`, `remove_reminder`, `set_base_interval`
+3. **schedule**: Heartbeat スケジュール管理（ギルドスコープ対応）
+   - `get_heartbeat_config`, `list_reminders(guild_id)`, `add_reminder(guild_id, ..., global?)`, `update_reminder(guild_id, ...)`, `remove_reminder(guild_id, ...)`, `set_base_interval`
+   - `list_reminders`, `add_reminder`, `update_reminder`, `remove_reminder` は `guild_id` 必須。現在のギルド＋グローバルリマインダーのみ操作可能。`add_reminder` の `global` オプションでギルド横断リマインダーを作成可能。
 4. **memory**: メモリ・人格の自己更新
    - `read_memory`, `update_memory`: MEMORY.md の読み書き
    - `read_soul`: SOUL.md の読み取り

--- a/context/TOOLS.md
+++ b/context/TOOLS.md
@@ -20,10 +20,10 @@
 ### schedule サーバー
 
 - `get_heartbeat_config` - 現在の heartbeat 設定を表示
-- `list_reminders` - リマインダー一覧
-- `add_reminder(id, description, schedule_type, interval_minutes?, daily_hour?, daily_minute?)` - リマインダー追加
-- `update_reminder(id, description?, enabled?, schedule_type?, interval_minutes?, daily_hour?, daily_minute?)` - リマインダー更新
-- `remove_reminder(id)` - リマインダー削除
+- `list_reminders(guild_id)` - リマインダー一覧（現在のギルド＋グローバルのみ表示）
+- `add_reminder(guild_id, id, description, schedule_type, interval_minutes?, daily_hour?, daily_minute?, global?)` - リマインダー追加（デフォルトで現在のギルドに紐づく。`global: true` でギルド横断リマインダー）
+- `update_reminder(guild_id, id, description?, enabled?, schedule_type?, interval_minutes?, daily_hour?, daily_minute?)` - リマインダー更新（自ギルドまたはグローバルのみ）
+- `remove_reminder(guild_id, id)` - リマインダー削除（自ギルドまたはグローバルのみ）
 - `set_base_interval(minutes)` - ベースチェック間隔を変更
 
 ### memory サーバー

--- a/packages/agent/src/discord/context-builder.ts
+++ b/packages/agent/src/discord/context-builder.ts
@@ -120,7 +120,7 @@ export class ContextBuilder implements ContextBuilderPort {
 	private appendGuildContext(guildId: string | undefined, sections: string[]): void {
 		if (guildId) {
 			sections.push(
-				`<guild-context>\ncurrent_guild_id: ${guildId}\nメモリツール使用時は guild_id: "${guildId}" を必ず指定してください。\n</guild-context>`,
+				`<guild-context>\ncurrent_guild_id: ${guildId}\nメモリツール・スケジュールツール使用時は guild_id: "${guildId}" を必ず指定してください。\n</guild-context>`,
 			);
 		}
 	}

--- a/packages/mcp/src/tools/schedule.ts
+++ b/packages/mcp/src/tools/schedule.ts
@@ -7,6 +7,20 @@ import { createDefaultHeartbeatConfig } from "@vicissitude/shared/functions";
 import type { HeartbeatConfig, HeartbeatReminder } from "@vicissitude/shared/types";
 import { z } from "zod";
 
+const GUILD_ID_REGEX = /^\d+$/;
+const guildIdSchema = z.string().regex(GUILD_ID_REGEX).describe("Discord guild ID");
+
+export function filterRemindersByGuild(
+	reminders: HeartbeatReminder[],
+	guildId: string,
+): HeartbeatReminder[] {
+	return reminders.filter((r) => checkGuildScope(r, guildId));
+}
+
+export function checkGuildScope(reminder: HeartbeatReminder, guildId: string): boolean {
+	return reminder.guildId === guildId || reminder.guildId === undefined;
+}
+
 const DATA_DIR = process.env.DATA_DIR;
 const CONFIG_PATH = DATA_DIR
 	? resolve(DATA_DIR, "heartbeat-config.json")
@@ -33,32 +47,55 @@ export function registerScheduleTools(server: McpServer): void {
 		return { content: [{ type: "text", text: JSON.stringify(config, null, 2) }] };
 	});
 
-	server.tool("list_reminders", "リマインダー一覧を表示する", {}, () => {
-		const config = loadConfig();
-		const lines = config.reminders.map((r) => {
-			const schedule =
-				r.schedule.type === "interval"
-					? `${String(r.schedule.minutes)}分ごと`
-					: `毎日 ${String(r.schedule.hour)}:${String(r.schedule.minute).padStart(2, "0")}`;
-			const status = r.enabled ? "有効" : "無効";
-			const last = r.lastExecutedAt ?? "未実行";
-			return `- [${r.id}] ${r.description} (${schedule}, ${status}, 最後: ${last})`;
-		});
-		return { content: [{ type: "text", text: lines.join("\n") || "リマインダーなし" }] };
-	});
+	server.tool(
+		"list_reminders",
+		"リマインダー一覧を表示する（現在のギルド＋グローバルのみ）",
+		{ guild_id: guildIdSchema },
+		({ guild_id }) => {
+			const config = loadConfig();
+			const visible = filterRemindersByGuild(config.reminders, guild_id);
+			const lines = visible.map((r) => {
+				const schedule =
+					r.schedule.type === "interval"
+						? `${String(r.schedule.minutes)}分ごと`
+						: `毎日 ${String(r.schedule.hour)}:${String(r.schedule.minute).padStart(2, "0")}`;
+				const status = r.enabled ? "有効" : "無効";
+				const last = r.lastExecutedAt ?? "未実行";
+				const scope = r.guildId ? `guild:${r.guildId}` : "global";
+				return `- [${r.id}] ${r.description} (${schedule}, ${status}, ${scope}, 最後: ${last})`;
+			});
+			return { content: [{ type: "text", text: lines.join("\n") || "リマインダーなし" }] };
+		},
+	);
 
 	server.tool(
 		"add_reminder",
-		"新しいリマインダーを追加する",
+		"新しいリマインダーを追加する（デフォルトで現在のギルドに紐づく）",
 		{
+			guild_id: guildIdSchema,
 			id: z.string().describe("一意の識別子"),
 			description: z.string().describe("リマインダーの説明"),
 			schedule_type: z.enum(["interval", "daily"]).describe("スケジュールタイプ"),
 			interval_minutes: z.number().min(1).optional().describe("interval の場合の分数（1以上）"),
 			daily_hour: z.number().min(0).max(23).optional().describe("daily の場合の時"),
 			daily_minute: z.number().min(0).max(59).optional().describe("daily の場合の分"),
+			global: z
+				.boolean()
+				.optional()
+				.describe(
+					"true にするとギルドに紐づかないグローバルリマインダーになる（デフォルト: false）",
+				),
 		},
-		async ({ id, description, schedule_type, interval_minutes, daily_hour, daily_minute }) => {
+		async ({
+			guild_id,
+			id,
+			description,
+			schedule_type,
+			interval_minutes,
+			daily_hour,
+			daily_minute,
+			global: isGlobal,
+		}) => {
 			const config = loadConfig();
 
 			if (config.reminders.some((r) => r.id === id)) {
@@ -66,6 +103,8 @@ export function registerScheduleTools(server: McpServer): void {
 					content: [{ type: "text", text: `エラー: ID "${id}" は既に存在します` }],
 				};
 			}
+
+			const guildId = isGlobal ? undefined : guild_id;
 
 			let reminder: HeartbeatReminder;
 			if (schedule_type === "interval") {
@@ -80,6 +119,7 @@ export function registerScheduleTools(server: McpServer): void {
 					schedule: { type: "interval", minutes: interval_minutes },
 					lastExecutedAt: null,
 					enabled: true,
+					guildId,
 				};
 			} else {
 				reminder = {
@@ -92,6 +132,7 @@ export function registerScheduleTools(server: McpServer): void {
 					},
 					lastExecutedAt: null,
 					enabled: true,
+					guildId,
 				};
 			}
 
@@ -105,8 +146,9 @@ export function registerScheduleTools(server: McpServer): void {
 
 	server.tool(
 		"update_reminder",
-		"リマインダーを更新する",
+		"リマインダーを更新する（自ギルドまたはグローバルのみ）",
 		{
+			guild_id: guildIdSchema,
 			id: z.string().describe("更新するリマインダーの ID"),
 			description: z.string().optional().describe("新しい説明"),
 			enabled: z.boolean().optional().describe("有効/無効"),
@@ -116,6 +158,7 @@ export function registerScheduleTools(server: McpServer): void {
 			daily_minute: z.number().min(0).max(59).optional().describe("daily の場合の分"),
 		},
 		async ({
+			guild_id,
 			id,
 			description,
 			enabled,
@@ -130,6 +173,17 @@ export function registerScheduleTools(server: McpServer): void {
 			if (!reminder) {
 				return {
 					content: [{ type: "text", text: `エラー: ID "${id}" が見つかりません` }],
+				};
+			}
+
+			if (!checkGuildScope(reminder, guild_id)) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `エラー: リマインダー "${id}" は他のギルドに属しているため更新できません`,
+						},
+					],
 				};
 			}
 
@@ -155,19 +209,33 @@ export function registerScheduleTools(server: McpServer): void {
 
 	server.tool(
 		"remove_reminder",
-		"リマインダーを削除する",
-		{ id: z.string().describe("削除するリマインダーの ID") },
-		async ({ id }) => {
+		"リマインダーを削除する（自ギルドまたはグローバルのみ）",
+		{
+			guild_id: guildIdSchema,
+			id: z.string().describe("削除するリマインダーの ID"),
+		},
+		async ({ guild_id, id }) => {
 			const config = loadConfig();
-			const index = config.reminders.findIndex((r) => r.id === id);
+			const reminder = config.reminders.find((r) => r.id === id);
 
-			if (index === -1) {
+			if (!reminder) {
 				return {
 					content: [{ type: "text", text: `エラー: ID "${id}" が見つかりません` }],
 				};
 			}
 
-			config.reminders.splice(index, 1);
+			if (!checkGuildScope(reminder, guild_id)) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `エラー: リマインダー "${id}" は他のギルドに属しているため削除できません`,
+						},
+					],
+				};
+			}
+
+			config.reminders.splice(config.reminders.indexOf(reminder), 1);
 			await saveConfig(config);
 			return {
 				content: [{ type: "text", text: `リマインダー "${id}" を削除しました` }],

--- a/spec/mcp/tools/schedule-guild-scope.spec.ts
+++ b/spec/mcp/tools/schedule-guild-scope.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+
+import { checkGuildScope, filterRemindersByGuild } from "@vicissitude/mcp/tools/schedule";
+import type { HeartbeatReminder } from "@vicissitude/shared/types";
+
+// ─── テストデータ ──────────────────────────────────────────────
+
+function makeReminder(id: string, guildId?: string): HeartbeatReminder {
+	return {
+		id,
+		description: `reminder-${id}`,
+		schedule: { type: "interval", minutes: 60 },
+		lastExecutedAt: null,
+		enabled: true,
+		guildId,
+	};
+}
+
+const GUILD_A = "111111111111111111";
+const GUILD_B = "222222222222222222";
+
+// ─── filterRemindersByGuild ─────────────────────────────────────
+
+describe("filterRemindersByGuild", () => {
+	it("指定ギルドのリマインダーを返す", () => {
+		const reminders = [makeReminder("a1", GUILD_A), makeReminder("b1", GUILD_B)];
+
+		const result = filterRemindersByGuild(reminders, GUILD_A);
+
+		expect(result.map((r) => r.id)).toEqual(["a1"]);
+	});
+
+	it("グローバルリマインダー（guildId なし）も含めて返す", () => {
+		const reminders = [
+			makeReminder("a1", GUILD_A),
+			makeReminder("global1"),
+			makeReminder("b1", GUILD_B),
+		];
+
+		const result = filterRemindersByGuild(reminders, GUILD_A);
+
+		expect(result.map((r) => r.id)).toEqual(["a1", "global1"]);
+	});
+
+	it("他ギルドのリマインダーは返さない", () => {
+		const reminders = [makeReminder("b1", GUILD_B), makeReminder("b2", GUILD_B)];
+
+		const result = filterRemindersByGuild(reminders, GUILD_A);
+
+		expect(result).toEqual([]);
+	});
+
+	it("リマインダーが空なら空配列を返す", () => {
+		const result = filterRemindersByGuild([], GUILD_A);
+
+		expect(result).toEqual([]);
+	});
+
+	it("グローバルリマインダーのみの場合も正しく返す", () => {
+		const reminders = [makeReminder("g1"), makeReminder("g2")];
+
+		const result = filterRemindersByGuild(reminders, GUILD_A);
+
+		expect(result.map((r) => r.id)).toEqual(["g1", "g2"]);
+	});
+});
+
+// ─── checkGuildScope ────────────────────────────────────────────
+
+describe("checkGuildScope", () => {
+	it("自ギルドのリマインダーなら true を返す", () => {
+		const reminder = makeReminder("a1", GUILD_A);
+
+		expect(checkGuildScope(reminder, GUILD_A)).toBe(true);
+	});
+
+	it("グローバルリマインダーなら true を返す", () => {
+		const reminder = makeReminder("g1");
+
+		expect(checkGuildScope(reminder, GUILD_A)).toBe(true);
+	});
+
+	it("他ギルドのリマインダーなら false を返す", () => {
+		const reminder = makeReminder("b1", GUILD_B);
+
+		expect(checkGuildScope(reminder, GUILD_A)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- `list_reminders`, `add_reminder`, `update_reminder`, `remove_reminder` に `guild_id` 必須パラメータを追加し、ギルド単位のリマインダー管理を実現
- `add_reminder` に `global` オプションを追加（`true` でギルド横断リマインダー）
- 他ギルドのリマインダーへの更新・削除をスコープチェックでブロック
- `filterRemindersByGuild`, `checkGuildScope` を純粋関数として抽出し、仕様テストでカバー

## Changes

| ファイル | 変更内容 |
|---|---|
| `packages/mcp/src/tools/schedule.ts` | guild_id パラメータ追加、スコープ制限、ヘルパー関数エクスポート |
| `packages/agent/src/discord/context-builder.ts` | guild-context 指示にスケジュールツールを追加 |
| `context/TOOLS.md` | schedule ツールのドキュメント更新 |
| `README.md` | 仕様にギルドスコープ対応を反映 |
| `spec/mcp/tools/schedule-guild-scope.spec.ts` | 仕様テスト新規作成（8テスト） |

## Test plan

- [x] `bun test spec/mcp/tools/schedule-guild-scope.spec.ts` — 8 tests pass
- [x] `nr check` — 型チェック pass
- [x] `nr lint` — lint pass (既存 warning のみ)
- [x] 既存テスト全 893 件 pass（影響なし）

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)