### PR TITLE
feat: TTS パッケージ実装 (EmotionToTtsStyleMapper + Style-Bert-VITS2 アダプター)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -139,6 +139,12 @@
         "drizzle-orm": "^0.45.1",
       },
     },
+    "packages/tts": {
+      "name": "@vicissitude/tts",
+      "dependencies": {
+        "@vicissitude/shared": "workspace:*",
+      },
+    },
   },
   "packages": {
     "@azure/msal-common": ["@azure/msal-common@14.16.1", "", {}, "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w=="],
@@ -590,6 +596,8 @@
     "@vicissitude/shared": ["@vicissitude/shared@workspace:packages/shared"],
 
     "@vicissitude/store": ["@vicissitude/store@workspace:packages/store"],
+
+    "@vicissitude/tts": ["@vicissitude/tts@workspace:packages/tts"],
 
     "@vicissitude/web": ["@vicissitude/web@workspace:apps/web"],
 

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -45,6 +45,7 @@ graph LR
   scheduling --> shared
   shared
   store --> shared
+  tts --> shared
 ```
 
 ## モジュール別依存一覧
@@ -137,10 +138,16 @@ graph LR
 
 - 内部依存: なし
 - 外部依存: .bun, path
-- ファイル数: 15
+- ファイル数: 16
 
 ### store
 
 - 内部依存: shared
 - 外部依存: .bun, bun:sqlite, fs, path
 - ファイル数: 13
+
+### tts
+
+- 内部依存: shared
+- 外部依存: なし
+- ファイル数: 3

--- a/packages/tts/DEPS.md
+++ b/packages/tts/DEPS.md
@@ -1,0 +1,27 @@
+# tts/ 依存関係（自動生成）
+
+> commit 時に自動再生成。手動編集禁止。
+
+## ファイル依存関係図
+
+```mermaid
+graph LR
+  emotion_to_tts_style_mapper["emotion-to-tts-style-mapper"]
+  index --> emotion_to_tts_style_mapper["emotion-to-tts-style-mapper"]
+  index --> style_bert_vits2_synthesizer["style-bert-vits2-synthesizer"]
+  style_bert_vits2_synthesizer["style-bert-vits2-synthesizer"]
+```
+
+## ファイル別依存一覧
+
+### emotion-to-tts-style-mapper.ts
+
+- 他モジュール依存: shared
+
+### index.ts
+
+- モジュール内依存: emotion-to-tts-style-mapper, style-bert-vits2-synthesizer
+
+### style-bert-vits2-synthesizer.ts
+
+- 他モジュール依存: shared

--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "@vicissitude/tts",
+	"private": true,
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"dependencies": {
+		"@vicissitude/shared": "workspace:*"
+	}
+}

--- a/packages/tts/src/emotion-to-tts-style-mapper.test.ts
+++ b/packages/tts/src/emotion-to-tts-style-mapper.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "bun:test";
+
+import { createEmotion } from "@vicissitude/shared/emotion";
+
+import { createEmotionToTtsStyleMapper } from "./emotion-to-tts-style-mapper";
+
+const mapper = createEmotionToTtsStyleMapper();
+
+// ─── determineStyle: fallback 分岐 ──────────────────────────────
+//
+// spec テストでは基本マッピング (V, A の符号で決まるケース) を検証済み。
+// ここでは V=0 や D=0 など境界上の fallback パスを網羅する。
+
+describe("determineStyle — fallback branches", () => {
+	it("V=0, A>0, D>0 → angry (fallback: a>0 && d>0)", () => {
+		const result = mapper.mapToStyle(createEmotion(0, 0.5, 0.4));
+		expect(result.style).toBe("angry");
+	});
+
+	it("V=0, A>0, D<0 → fear (fallback: a>0 && d<0)", () => {
+		const result = mapper.mapToStyle(createEmotion(0, 0.5, -0.4));
+		expect(result.style).toBe("fear");
+	});
+
+	it("V=0, A>0, D=0 → happy (fallback: a>0)", () => {
+		const result = mapper.mapToStyle(createEmotion(0, 0.5, 0));
+		expect(result.style).toBe("happy");
+	});
+
+	it("V=0, A<0, D=0 → sad (fallback: a<0)", () => {
+		const result = mapper.mapToStyle(createEmotion(0, -0.5, 0));
+		expect(result.style).toBe("sad");
+	});
+
+	it("V=0, A=0, D=0.5 → neutral (final fallback)", () => {
+		// V=0, A=0 だが |D|>=0.2 なので neutral 条件 (|V|<0.2 && |A|<0.2 && |D|<0.2) を満たさない
+		// しかし他のどのルールにも当てはまらないので最終 fallback の neutral
+		const result = mapper.mapToStyle(createEmotion(0, 0, 0.5));
+		expect(result.style).toBe("neutral");
+	});
+
+	it("V=0, A=0, D=-0.5 → neutral (final fallback)", () => {
+		const result = mapper.mapToStyle(createEmotion(0, 0, -0.5));
+		expect(result.style).toBe("neutral");
+	});
+
+	it("surprised 境界: A=0.7, D=-0.01 → surprised", () => {
+		const result = mapper.mapToStyle(createEmotion(0, 0.7, -0.01));
+		expect(result.style).toBe("surprised");
+	});
+
+	it("surprised 境界外: A=0.69, D<0 → surprised にならない", () => {
+		const result = mapper.mapToStyle(createEmotion(0, 0.69, -0.5));
+		expect(result.style).not.toBe("surprised");
+	});
+
+	it("surprised 境界外: A=0.7, D=0 → surprised にならない", () => {
+		const result = mapper.mapToStyle(createEmotion(0, 0.7, 0));
+		expect(result.style).not.toBe("surprised");
+	});
+});
+
+// ─── computeStyleWeight: neutral パス ────────────────────────────
+
+describe("computeStyleWeight — neutral path", () => {
+	it("原点 (0,0,0) で weight = 1 (distance=0 → 1 - 0/max = 1)", () => {
+		const result = mapper.mapToStyle(createEmotion(0, 0, 0));
+		expect(result.styleWeight).toBeCloseTo(1.0, 5);
+	});
+
+	it("neutral 境界ギリギリ (0.19, 0.19, 0.19) で weight > 0", () => {
+		const result = mapper.mapToStyle(createEmotion(0.19, 0.19, 0.19));
+		expect(result.style).toBe("neutral");
+		// distance = sqrt(0.19^2 * 3) ≈ 0.329
+		// maxDistance = sqrt(0.2^2 * 3) ≈ 0.346
+		// weight = 1 - 0.329/0.346 ≈ 0.05
+		expect(result.styleWeight).toBeGreaterThan(0);
+		expect(result.styleWeight).toBeLessThan(0.1);
+	});
+
+	it("neutral 領域中間 (0.1, 0.1, 0.1) で weight は原点より低い", () => {
+		const atOrigin = mapper.mapToStyle(createEmotion(0, 0, 0));
+		const atMiddle = mapper.mapToStyle(createEmotion(0.1, 0.1, 0.1));
+		expect(atMiddle.style).toBe("neutral");
+		expect(atMiddle.styleWeight).toBeLessThan(atOrigin.styleWeight);
+	});
+});
+
+// ─── computeStyleWeight: non-neutral パス ────────────────────────
+
+describe("computeStyleWeight — non-neutral path", () => {
+	it("computeWeight は |V|, |A|, |D| の平均値", () => {
+		// happy: V=0.6, A=0.4, D=0.2
+		// weight = (0.6 + 0.4 + 0.2) / 3 = 0.4
+		const result = mapper.mapToStyle(createEmotion(0.6, 0.4, 0.2));
+		expect(result.style).toBe("happy");
+		expect(result.styleWeight).toBeCloseTo(0.4, 5);
+	});
+
+	it("sad: V=-0.9, A=-0.6, D=-0.3 → weight = (0.9+0.6+0.3)/3 = 0.6", () => {
+		const result = mapper.mapToStyle(createEmotion(-0.9, -0.6, -0.3));
+		expect(result.style).toBe("sad");
+		expect(result.styleWeight).toBeCloseTo(0.6, 5);
+	});
+
+	it("全軸最大 (1,1,1) → weight = 1.0", () => {
+		const result = mapper.mapToStyle(createEmotion(1, 1, 1));
+		expect(result.styleWeight).toBeCloseTo(1.0, 5);
+	});
+
+	it("低い値 (0.21, 0.21, 0.0) → weight = (0.21+0.21+0)/3 = 0.14", () => {
+		const result = mapper.mapToStyle(createEmotion(0.21, 0.21, 0.0));
+		expect(result.style).toBe("happy");
+		expect(result.styleWeight).toBeCloseTo(0.14, 2);
+	});
+});
+
+// ─── computeSpeed ────────────────────────────────────────────────
+
+describe("computeSpeed — exact values", () => {
+	it("arousal=0 → speed = 1.0 + 0*0.3 = 1.0", () => {
+		const result = mapper.mapToStyle(createEmotion(0, 0, 0));
+		expect(result.speed).toBeCloseTo(1.0, 5);
+	});
+
+	it("arousal=1 → speed = 1.0 + 1*0.3 = 1.3", () => {
+		const result = mapper.mapToStyle(createEmotion(0.5, 1.0, 0.3));
+		expect(result.speed).toBeCloseTo(1.3, 5);
+	});
+
+	it("arousal=-1 → speed = 1.0 + (-1)*0.3 = 0.7", () => {
+		const result = mapper.mapToStyle(createEmotion(-0.5, -1.0, -0.3));
+		expect(result.speed).toBeCloseTo(0.7, 5);
+	});
+
+	it("arousal=0.5 → speed = 1.0 + 0.5*0.3 = 1.15", () => {
+		const result = mapper.mapToStyle(createEmotion(0.5, 0.5, 0.3));
+		expect(result.speed).toBeCloseTo(1.15, 5);
+	});
+});
+
+describe("computeSpeed — clamp behavior", () => {
+	it("speed は下限 0.5 以上（arousal が極端に低くても clamp される）", () => {
+		// arousal=-1 → raw = 0.7 > 0.5 なので通常は clamp されない
+		// しかし createEmotion は [-1,1] に clamp するので arousal は最低 -1
+		// raw = 1.0 + (-1)*0.3 = 0.7 → 0.5 以上
+		const result = mapper.mapToStyle(createEmotion(0.5, -1, 0.3));
+		expect(result.speed).toBeGreaterThanOrEqual(0.5);
+	});
+
+	it("speed は上限 2.0 以下（arousal が極端に高くても clamp される）", () => {
+		// arousal=1 → raw = 1.3 < 2.0 なので通常は clamp されない
+		const result = mapper.mapToStyle(createEmotion(0.5, 1, 0.3));
+		expect(result.speed).toBeLessThanOrEqual(2.0);
+	});
+});
+
+// ─── createTtsStyleParams zod validation ─────────────────────────
+
+describe("createTtsStyleParams — zod validation errors", () => {
+	it("styleWeight > 1 のとき ZodError がスローされる", () => {
+		// createTtsStyleParams は内部で TtsStyleParamsSchema.parse() を呼ぶ
+		const { createTtsStyleParams } = require("@vicissitude/shared/tts");
+		expect(() => createTtsStyleParams("happy", 1.5, 1.0)).toThrow();
+	});
+
+	it("styleWeight < 0 のとき ZodError がスローされる", () => {
+		const { createTtsStyleParams } = require("@vicissitude/shared/tts");
+		expect(() => createTtsStyleParams("happy", -0.1, 1.0)).toThrow();
+	});
+
+	it("speed > 2.0 のとき ZodError がスローされる", () => {
+		const { createTtsStyleParams } = require("@vicissitude/shared/tts");
+		expect(() => createTtsStyleParams("happy", 0.5, 2.5)).toThrow();
+	});
+
+	it("speed < 0.5 のとき ZodError がスローされる", () => {
+		const { createTtsStyleParams } = require("@vicissitude/shared/tts");
+		expect(() => createTtsStyleParams("happy", 0.5, 0.3)).toThrow();
+	});
+});

--- a/packages/tts/src/emotion-to-tts-style-mapper.ts
+++ b/packages/tts/src/emotion-to-tts-style-mapper.ts
@@ -1,0 +1,75 @@
+import type { Emotion } from "@vicissitude/shared/emotion";
+import type { EmotionToTtsStyleMapper } from "@vicissitude/shared/ports";
+import { type TtsStyle, type TtsStyleParams, createTtsStyleParams } from "@vicissitude/shared/tts";
+
+/**
+ * VAD 感情値から TTS スタイルパラメータへのマッピングを行う実装を生成する。
+ *
+ * マッピングルール（優先順位順）:
+ * 1. surprised: A >= 0.7 && D < 0
+ * 2. neutral:   |V| < 0.2 && |A| < 0.2 && |D| < 0.2
+ * 3. happy:     V > 0, A > 0
+ * 4. relaxed:   V > 0, A < 0
+ * 5. angry:     V < 0, A > 0, D > 0
+ * 6. fear:      V < 0, A > 0, D < 0
+ * 7. sad:       V < 0, A < 0
+ * fallback:     neutral
+ */
+export function createEmotionToTtsStyleMapper(): EmotionToTtsStyleMapper {
+	return { mapToStyle };
+}
+
+function mapToStyle(emotion: Emotion): TtsStyleParams {
+	const { valence: v, arousal: a, dominance: d } = emotion;
+
+	const style = determineStyle(v, a, d);
+	const styleWeight = computeStyleWeight(style, v, a, d);
+	const speed = computeSpeed(a);
+
+	return createTtsStyleParams(style, styleWeight, speed);
+}
+
+function determineStyle(v: number, a: number, d: number): TtsStyle {
+	// 1. surprised (highest priority)
+	if (a >= 0.7 && d < 0) return "surprised";
+
+	// 2. neutral
+	if (Math.abs(v) < 0.2 && Math.abs(a) < 0.2 && Math.abs(d) < 0.2) return "neutral";
+
+	// 3-7: primary rules
+	if (v > 0 && a > 0) return "happy";
+	if (v > 0 && a < 0) return "relaxed";
+	if (v < 0 && a > 0 && d > 0) return "angry";
+	if (v < 0 && a > 0 && d < 0) return "fear";
+	if (v < 0 && a < 0) return "sad";
+
+	// fallback for boundary cases (v=0 etc.)
+	if (a > 0 && d > 0) return "angry";
+	if (a > 0 && d < 0) return "fear";
+	if (a > 0) return "happy";
+	if (a < 0) return "sad";
+	return "neutral";
+}
+
+function computeStyleWeight(style: TtsStyle, v: number, a: number, d: number): number {
+	if (style === "neutral") {
+		const distance = Math.sqrt(v * v + a * a + d * d);
+		const maxDistance = Math.sqrt(0.2 * 0.2 * 3);
+		return clamp(1 - distance / maxDistance, 0, 1);
+	}
+	return computeWeight(Math.abs(v), Math.abs(a), Math.abs(d));
+}
+
+function computeSpeed(arousal: number): number {
+	const raw = 1.0 + arousal * 0.3;
+	return clamp(raw, 0.5, 2.0);
+}
+
+function computeWeight(...values: number[]): number {
+	const sum = values.reduce((acc, val) => acc + val, 0);
+	return clamp(sum / values.length, 0, 1);
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}

--- a/packages/tts/src/index.ts
+++ b/packages/tts/src/index.ts
@@ -1,0 +1,2 @@
+export { createEmotionToTtsStyleMapper } from "./emotion-to-tts-style-mapper";
+export { createStyleBertVits2Synthesizer } from "./style-bert-vits2-synthesizer";

--- a/packages/tts/src/style-bert-vits2-synthesizer.test.ts
+++ b/packages/tts/src/style-bert-vits2-synthesizer.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+import { createTtsStyleParams } from "@vicissitude/shared/tts";
+
+import { createStyleBertVits2Synthesizer } from "./style-bert-vits2-synthesizer";
+
+const BASE_URL = "http://localhost:5000";
+const DEFAULT_STYLE = createTtsStyleParams("happy", 0.7, 1.2);
+
+const originalFetch = globalThis.fetch;
+let mockFetch: ReturnType<typeof mock>;
+
+beforeEach(() => {
+	mockFetch = mock();
+	globalThis.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+// ─── synthesize: URL query params ────────────────────────────────
+
+describe("synthesize — query params", () => {
+	it("正しい query params で /voice に POST する", async () => {
+		mockFetch.mockResolvedValueOnce(new Response(buildWav(48000, 96000), { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		await synth.synthesize("こんにちは", DEFAULT_STYLE);
+
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		const [url, init] = mockFetch.mock.calls[0] as [URL, RequestInit];
+
+		expect(url.pathname).toBe("/voice");
+		expect(url.searchParams.get("text")).toBe("こんにちは");
+		expect(url.searchParams.get("model_id")).toBe("0");
+		expect(url.searchParams.get("style")).toBe("Happy");
+		expect(url.searchParams.get("style_weight")).toBe("0.7");
+		expect(url.searchParams.get("length")).toBe("1.2");
+		expect(url.searchParams.get("language")).toBe("JP");
+		expect(init.method).toBe("POST");
+	});
+
+	it("style が capitalize される (fear → Fear)", async () => {
+		mockFetch.mockResolvedValueOnce(new Response(buildWav(48000, 96000), { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		const fearStyle = createTtsStyleParams("fear", 0.5, 1.0);
+		await synth.synthesize("test", fearStyle);
+
+		const [url] = mockFetch.mock.calls[0] as [URL, RequestInit];
+		expect(url.searchParams.get("style")).toBe("Fear");
+	});
+
+	it("style が capitalize される (surprised → Surprised)", async () => {
+		mockFetch.mockResolvedValueOnce(new Response(buildWav(48000, 96000), { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		const surprisedStyle = createTtsStyleParams("surprised", 0.8, 1.0);
+		await synth.synthesize("test", surprisedStyle);
+
+		const [url] = mockFetch.mock.calls[0] as [URL, RequestInit];
+		expect(url.searchParams.get("style")).toBe("Surprised");
+	});
+});
+
+// ─── synthesize: timeout ─────────────────────────────────────────
+
+describe("synthesize — timeout", () => {
+	it("デフォルトタイムアウト (30000ms) が使用される", async () => {
+		mockFetch.mockResolvedValueOnce(new Response(buildWav(48000, 48000), { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		await synth.synthesize("test", DEFAULT_STYLE);
+
+		const [, init] = mockFetch.mock.calls[0] as [URL, RequestInit];
+		expect(init.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("カスタムタイムアウトを設定できる", async () => {
+		mockFetch.mockResolvedValueOnce(new Response(buildWav(48000, 48000), { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({
+			baseUrl: BASE_URL,
+			timeout: 10_000,
+		});
+		await synth.synthesize("test", DEFAULT_STYLE);
+
+		const [, init] = mockFetch.mock.calls[0] as [URL, RequestInit];
+		expect(init.signal).toBeInstanceOf(AbortSignal);
+	});
+});
+
+// ─── computeWavDuration ──────────────────────────────────────────
+
+describe("computeWavDuration — calculation precision", () => {
+	it("known WAV: byteRate=48000, dataSize=96000 → duration=2.0s", async () => {
+		mockFetch.mockResolvedValueOnce(new Response(buildWav(48000, 96000), { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		const result = await synth.synthesize("test", DEFAULT_STYLE);
+
+		expect(result).not.toBeNull();
+		expect(result?.durationSec).toBeCloseTo(2.0, 5);
+	});
+
+	it("known WAV: byteRate=48000, dataSize=24000 → duration=0.5s", async () => {
+		mockFetch.mockResolvedValueOnce(new Response(buildWav(48000, 24000), { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		const result = await synth.synthesize("test", DEFAULT_STYLE);
+
+		expect(result).not.toBeNull();
+		expect(result?.durationSec).toBeCloseTo(0.5, 5);
+	});
+});
+
+describe("computeWavDuration — edge cases", () => {
+	it("44 bytes 未満のバッファ → durationSec=0", async () => {
+		const shortBuffer = new ArrayBuffer(20);
+		mockFetch.mockResolvedValueOnce(new Response(shortBuffer, { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		const result = await synth.synthesize("test", DEFAULT_STYLE);
+
+		expect(result).not.toBeNull();
+		expect(result?.durationSec).toBe(0);
+	});
+
+	it("byteRate=0 → durationSec=0", async () => {
+		mockFetch.mockResolvedValueOnce(new Response(buildWav(0, 96000), { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		const result = await synth.synthesize("test", DEFAULT_STYLE);
+
+		expect(result).not.toBeNull();
+		expect(result?.durationSec).toBe(0);
+	});
+
+	it("data chunk が存在しない → durationSec=0", async () => {
+		// 有効な WAV ヘッダーだが "data" マーカーを持たないバッファ
+		const noDataChunk = new Uint8Array(64);
+		// RIFF header
+		noDataChunk.set([0x52, 0x49, 0x46, 0x46], 0);
+		// WAVE
+		noDataChunk.set([0x57, 0x41, 0x56, 0x45], 8);
+		// fmt sub-chunk
+		noDataChunk.set([0x66, 0x6d, 0x74, 0x20], 12);
+		// byteRate at offset 28 = 48000
+		writeUint32LE(noDataChunk, 28, 48000);
+		// "data" marker は書かない
+
+		mockFetch.mockResolvedValueOnce(
+			new Response(noDataChunk.buffer as ArrayBuffer, { status: 200 }),
+		);
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		const result = await synth.synthesize("test", DEFAULT_STYLE);
+
+		expect(result).not.toBeNull();
+		expect(result?.durationSec).toBe(0);
+	});
+});
+
+// ─── readUint32LE — byte order ───────────────────────────────────
+
+describe("readUint32LE — byte order verification via WAV parsing", () => {
+	it("byteRate=0x00_01_00_00 (65536) が正しく読まれる", async () => {
+		// byteRate = 65536, dataSize = 65536 → duration = 1.0s
+		mockFetch.mockResolvedValueOnce(new Response(buildWav(65536, 65536), { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		const result = await synth.synthesize("test", DEFAULT_STYLE);
+
+		expect(result).not.toBeNull();
+		expect(result?.durationSec).toBeCloseTo(1.0, 5);
+	});
+
+	it("byteRate=0x01_02_03_04 が正しくリトルエンディアンで読まれる", async () => {
+		// byteRate bytes: [0x04, 0x03, 0x02, 0x01] → 0x01020304 = 16909060
+		// dataSize = 16909060 → duration = 1.0s
+		mockFetch.mockResolvedValueOnce(new Response(buildWav(16909060, 16909060), { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		const result = await synth.synthesize("test", DEFAULT_STYLE);
+
+		expect(result).not.toBeNull();
+		expect(result?.durationSec).toBeCloseTo(1.0, 5);
+	});
+});
+
+// ─── isAvailable ─────────────────────────────────────────────────
+
+describe("isAvailable — fetch call", () => {
+	it("baseUrl に GET でフェッチする", async () => {
+		mockFetch.mockResolvedValueOnce(new Response("OK", { status: 200 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		await synth.isAvailable();
+
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe(BASE_URL);
+		expect(init.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("HTTP 4xx でも false を返す", async () => {
+		mockFetch.mockResolvedValueOnce(new Response("Not Found", { status: 404 }));
+
+		const synth = createStyleBertVits2Synthesizer({ baseUrl: BASE_URL });
+		const result = await synth.isAvailable();
+
+		expect(result).toBe(false);
+	});
+});
+
+// ─── Helper: WAV バッファ構築 ────────────────────────────────────
+
+function buildWav(byteRate: number, dataSize: number): ArrayBuffer {
+	const headerSize = 44;
+	const totalSize = headerSize + dataSize;
+	const wav = new Uint8Array(totalSize);
+
+	// "RIFF"
+	wav.set([0x52, 0x49, 0x46, 0x46], 0);
+	// chunk size
+	writeUint32LE(wav, 4, totalSize - 8);
+	// "WAVE"
+	wav.set([0x57, 0x41, 0x56, 0x45], 8);
+	// "fmt "
+	wav.set([0x66, 0x6d, 0x74, 0x20], 12);
+	// sub-chunk size (16)
+	writeUint32LE(wav, 16, 16);
+	// audio format (PCM = 1)
+	wav[20] = 0x01;
+	wav[21] = 0x00;
+	// channels (1)
+	wav[22] = 0x01;
+	wav[23] = 0x00;
+	// sample rate (24000)
+	writeUint32LE(wav, 24, 24000);
+	// byte rate
+	writeUint32LE(wav, 28, byteRate);
+	// block align (2)
+	wav[32] = 0x02;
+	wav[33] = 0x00;
+	// bits per sample (16)
+	wav[34] = 0x10;
+	wav[35] = 0x00;
+	// "data"
+	wav.set([0x64, 0x61, 0x74, 0x61], 36);
+	// data size
+	writeUint32LE(wav, 40, dataSize);
+
+	return wav.buffer as ArrayBuffer;
+}
+
+function writeUint32LE(buf: Uint8Array, offset: number, value: number): void {
+	buf[offset] = value & 0xff;
+	buf[offset + 1] = (value >> 8) & 0xff;
+	buf[offset + 2] = (value >> 16) & 0xff;
+	buf[offset + 3] = (value >> 24) & 0xff;
+}

--- a/packages/tts/src/style-bert-vits2-synthesizer.ts
+++ b/packages/tts/src/style-bert-vits2-synthesizer.ts
@@ -1,0 +1,94 @@
+import type { TtsSynthesizer } from "@vicissitude/shared/ports";
+import type { TtsResult, TtsStyleParams } from "@vicissitude/shared/tts";
+
+const DEFAULT_TIMEOUT = 30_000;
+const HEALTH_CHECK_TIMEOUT = 5_000;
+
+export function createStyleBertVits2Synthesizer(config: {
+	baseUrl: string;
+	timeout?: number;
+}): TtsSynthesizer {
+	const { baseUrl, timeout = DEFAULT_TIMEOUT } = config;
+
+	return {
+		synthesize: (text, style) => synthesize(baseUrl, timeout, text, style),
+		isAvailable: () => isAvailable(baseUrl),
+	};
+}
+
+async function synthesize(
+	baseUrl: string,
+	timeout: number,
+	text: string,
+	style: TtsStyleParams,
+): Promise<TtsResult | null> {
+	try {
+		const url = new URL("/voice", baseUrl);
+		url.searchParams.set("text", text);
+		url.searchParams.set("model_id", "0");
+		url.searchParams.set("style", capitalize(style.style));
+		url.searchParams.set("style_weight", String(style.styleWeight));
+		url.searchParams.set("length", String(style.speed));
+		url.searchParams.set("language", "JP");
+
+		const response = await fetch(url, {
+			method: "POST",
+			signal: AbortSignal.timeout(timeout),
+		});
+
+		if (!response.ok) return null;
+
+		const buffer = await response.arrayBuffer();
+		const audio = new Uint8Array(buffer);
+		const durationSec = computeWavDuration(audio);
+
+		return { audio, format: "wav", durationSec };
+	} catch {
+		return null;
+	}
+}
+
+async function isAvailable(baseUrl: string): Promise<boolean> {
+	try {
+		const response = await fetch(baseUrl, {
+			signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT),
+		});
+		return response.ok;
+	} catch {
+		return false;
+	}
+}
+
+function capitalize(s: string): string {
+	return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function computeWavDuration(wav: Uint8Array): number {
+	// WAV header: find "data" chunk and read size, then divide by byte rate
+	// Byte rate is at offset 28 (4 bytes, little-endian)
+	// Data chunk: search for "data" marker, data size follows (4 bytes, little-endian)
+	if (wav.length < 44) return 0;
+
+	const byteRate = readUint32LE(wav, 28);
+	if (byteRate === 0) return 0;
+
+	const dataSize = findDataChunkSize(wav);
+	if (dataSize === 0) return 0;
+
+	return dataSize / byteRate;
+}
+
+function findDataChunkSize(wav: Uint8Array): number {
+	// Search for "data" sub-chunk ID starting after the RIFF header (offset 12)
+	for (let i = 12; i < wav.length - 8; i++) {
+		if (wav[i] === 0x64 && wav[i + 1] === 0x61 && wav[i + 2] === 0x74 && wav[i + 3] === 0x61) {
+			return readUint32LE(wav, i + 4);
+		}
+	}
+	return 0;
+}
+
+function readUint32LE(data: Uint8Array, offset: number): number {
+	const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+	return view.getUint32(offset, true);
+}

--- a/packages/tts/tsconfig.json
+++ b/packages/tts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["src"]
+}

--- a/spec/tts/emotion-to-tts-style-mapper.spec.ts
+++ b/spec/tts/emotion-to-tts-style-mapper.spec.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "bun:test";
+
+import { type Emotion, NEUTRAL_EMOTION, createEmotion } from "@vicissitude/shared/emotion";
+import type { EmotionToTtsStyleMapper } from "@vicissitude/shared/ports";
+import { TtsStyleParamsSchema } from "@vicissitude/shared/tts";
+import { createEmotionToTtsStyleMapper } from "@vicissitude/tts";
+
+// ─── テスト対象のファクトリ ─────────────────────────────────────
+//
+// packages/tts が公開する具象実装を生成する関数。
+// ブラックボックステスト: EmotionToTtsStyleMapper ポートの契約のみ検証する。
+
+function mapper(): EmotionToTtsStyleMapper {
+	return createEmotionToTtsStyleMapper();
+}
+
+// ─── TtsStyle 選択: 基本マッピング ──────────────────────────────
+
+describe("EmotionToTtsStyleMapper — style selection", () => {
+	it("happy: V > 0, A > 0 のとき happy を返す", () => {
+		const result = mapper().mapToStyle(createEmotion(0.6, 0.5, 0.3));
+		expect(result.style).toBe("happy");
+	});
+
+	it("relaxed: V > 0, A < 0 のとき relaxed を返す", () => {
+		const result = mapper().mapToStyle(createEmotion(0.5, -0.4, 0.2));
+		expect(result.style).toBe("relaxed");
+	});
+
+	it("angry: V < 0, A > 0, D > 0 のとき angry を返す", () => {
+		const result = mapper().mapToStyle(createEmotion(-0.6, 0.5, 0.4));
+		expect(result.style).toBe("angry");
+	});
+
+	it("fear: V < 0, A > 0, D < 0 のとき fear を返す", () => {
+		const result = mapper().mapToStyle(createEmotion(-0.5, 0.4, -0.3));
+		expect(result.style).toBe("fear");
+	});
+
+	it("sad: V < 0, A < 0 のとき sad を返す", () => {
+		const result = mapper().mapToStyle(createEmotion(-0.6, -0.5, 0.1));
+		expect(result.style).toBe("sad");
+	});
+
+	it("neutral: 全軸が原点付近 (|V|, |A|, |D| < 0.2) のとき neutral を返す", () => {
+		const result = mapper().mapToStyle(createEmotion(0.1, -0.1, 0.05));
+		expect(result.style).toBe("neutral");
+	});
+
+	it("neutral: 完全な原点 (0, 0, 0) で neutral を返す", () => {
+		const result = mapper().mapToStyle(NEUTRAL_EMOTION);
+		expect(result.style).toBe("neutral");
+	});
+});
+
+// ─── TtsStyle 選択: surprised（最優先ルール）────────────────────
+
+describe("EmotionToTtsStyleMapper — surprised priority", () => {
+	it("surprised: A >= 0.7, D < 0 のとき surprised を返す", () => {
+		const result = mapper().mapToStyle(createEmotion(0.0, 0.8, -0.5));
+		expect(result.style).toBe("surprised");
+	});
+
+	it("surprised は happy より優先: V > 0, A >= 0.7, D < 0", () => {
+		const result = mapper().mapToStyle(createEmotion(0.5, 0.8, -0.3));
+		expect(result.style).toBe("surprised");
+	});
+
+	it("surprised は fear より優先: V < 0, A >= 0.7, D < 0", () => {
+		const result = mapper().mapToStyle(createEmotion(-0.4, 0.9, -0.5));
+		expect(result.style).toBe("surprised");
+	});
+
+	it("A が高くても D >= 0 なら surprised にならない", () => {
+		const result = mapper().mapToStyle(createEmotion(0.5, 0.8, 0.3));
+		expect(result.style).not.toBe("surprised");
+	});
+
+	it("D < 0 でも A < 0.7 なら surprised にならない", () => {
+		const result = mapper().mapToStyle(createEmotion(0.3, 0.6, -0.4));
+		expect(result.style).not.toBe("surprised");
+	});
+});
+
+// ─── TtsStyle 選択: neutral 境界 ────────────────────────────────
+
+describe("EmotionToTtsStyleMapper — neutral boundary", () => {
+	it("neutral 境界: |V| = 0.19 は neutral", () => {
+		const result = mapper().mapToStyle(createEmotion(0.19, 0.1, -0.1));
+		expect(result.style).toBe("neutral");
+	});
+
+	it("neutral 境界外: |V| = 0.2 は neutral ではない", () => {
+		const result = mapper().mapToStyle(createEmotion(0.2, 0.1, 0.0));
+		expect(result.style).not.toBe("neutral");
+	});
+
+	it("neutral 境界外: |A| = 0.2 は neutral ではない", () => {
+		const result = mapper().mapToStyle(createEmotion(0.1, 0.2, 0.0));
+		expect(result.style).not.toBe("neutral");
+	});
+
+	it("neutral 境界外: |D| = 0.2 は neutral ではない", () => {
+		const result = mapper().mapToStyle(createEmotion(0.0, 0.1, 0.2));
+		expect(result.style).not.toBe("neutral");
+	});
+});
+
+// ─── styleWeight 計算 ───────────────────────────────────────────
+
+describe("EmotionToTtsStyleMapper — styleWeight", () => {
+	it("styleWeight は [0, 1] の範囲内", () => {
+		const testCases: Emotion[] = [
+			createEmotion(1, 1, 1),
+			createEmotion(-1, -1, -1),
+			createEmotion(0, 0, 0),
+			createEmotion(0.5, 0.3, -0.2),
+			createEmotion(-0.8, 0.9, -0.7),
+		];
+
+		for (const emotion of testCases) {
+			const result = mapper().mapToStyle(emotion);
+			expect(result.styleWeight).toBeGreaterThanOrEqual(0);
+			expect(result.styleWeight).toBeLessThanOrEqual(1);
+		}
+	});
+
+	it("VAD 値が強いほど styleWeight が高い", () => {
+		const weak = mapper().mapToStyle(createEmotion(0.3, 0.25, 0.1));
+		const strong = mapper().mapToStyle(createEmotion(0.9, 0.8, 0.5));
+
+		expect(weak.style).toBe("happy");
+		expect(strong.style).toBe("happy");
+		expect(strong.styleWeight).toBeGreaterThan(weak.styleWeight);
+	});
+
+	it("neutral の styleWeight は原点に近いほど高い", () => {
+		const veryNeutral = mapper().mapToStyle(createEmotion(0.01, 0.01, 0.01));
+		const barelyNeutral = mapper().mapToStyle(createEmotion(0.15, 0.15, 0.15));
+
+		expect(veryNeutral.style).toBe("neutral");
+		expect(barelyNeutral.style).toBe("neutral");
+		expect(veryNeutral.styleWeight).toBeGreaterThan(barelyNeutral.styleWeight);
+	});
+
+	it("極端な感情値 (1, 1, 1) で styleWeight が 1 に近い", () => {
+		const result = mapper().mapToStyle(createEmotion(1, 1, 1));
+		expect(result.styleWeight).toBeGreaterThanOrEqual(0.8);
+	});
+});
+
+// ─── speed 計算 ─────────────────────────────────────────────────
+
+describe("EmotionToTtsStyleMapper — speed", () => {
+	it("speed は [0.5, 2.0] の範囲内", () => {
+		const testCases: Emotion[] = [
+			createEmotion(1, 1, 1),
+			createEmotion(-1, -1, -1),
+			createEmotion(0, 0, 0),
+			createEmotion(0.5, 0.3, -0.2),
+			createEmotion(-0.8, 0.9, -0.7),
+		];
+
+		for (const emotion of testCases) {
+			const result = mapper().mapToStyle(emotion);
+			expect(result.speed).toBeGreaterThanOrEqual(0.5);
+			expect(result.speed).toBeLessThanOrEqual(2.0);
+		}
+	});
+
+	it("高 arousal で speed がデフォルト (1.0) より速い", () => {
+		const result = mapper().mapToStyle(createEmotion(0.6, 0.8, 0.3));
+		expect(result.speed).toBeGreaterThan(1.0);
+	});
+
+	it("低 arousal で speed がデフォルト (1.0) より遅い", () => {
+		const result = mapper().mapToStyle(createEmotion(0.5, -0.7, 0.2));
+		expect(result.speed).toBeLessThan(1.0);
+	});
+
+	it("neutral (arousal ~ 0) で speed が 1.0 付近", () => {
+		const result = mapper().mapToStyle(NEUTRAL_EMOTION);
+		expect(result.speed).toBeCloseTo(1.0, 1);
+	});
+});
+
+// ─── TtsStyleParamsSchema バリデーション ────────────────────────
+
+describe("EmotionToTtsStyleMapper — schema validity", () => {
+	it("返り値が TtsStyleParamsSchema で valid", () => {
+		const testCases: Emotion[] = [
+			createEmotion(0.6, 0.5, 0.3),
+			createEmotion(-0.5, 0.4, -0.3),
+			createEmotion(0.0, 0.8, -0.5),
+			createEmotion(0, 0, 0),
+			createEmotion(-1, -1, -1),
+			createEmotion(1, 1, 1),
+		];
+
+		for (const emotion of testCases) {
+			const result = mapper().mapToStyle(emotion);
+			expect(() => TtsStyleParamsSchema.parse(result)).not.toThrow();
+		}
+	});
+});
+
+// ─── 軸上の境界ケース ──────────────────────────────────────────
+
+describe("EmotionToTtsStyleMapper — axis boundaries", () => {
+	it("全軸が最大値 (1, 1, 1) でも有効な結果を返す", () => {
+		const result = mapper().mapToStyle(createEmotion(1, 1, 1));
+		expect(result.style).toBe("happy");
+		expect(result.styleWeight).toBeGreaterThan(0);
+	});
+
+	it("全軸が最小値 (-1, -1, -1) でも有効な結果を返す", () => {
+		const result = mapper().mapToStyle(createEmotion(-1, -1, -1));
+		expect(result.style).toBe("sad");
+		expect(result.styleWeight).toBeGreaterThan(0);
+	});
+});

--- a/spec/tts/style-bert-vits2-synthesizer.spec.ts
+++ b/spec/tts/style-bert-vits2-synthesizer.spec.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { TtsSynthesizer } from "@vicissitude/shared/ports";
+import { type TtsStyleParams, createTtsStyleParams } from "@vicissitude/shared/tts";
+import { createStyleBertVits2Synthesizer } from "@vicissitude/tts";
+
+// ─── テスト対象のファクトリ ─────────────────────────────────────
+//
+// packages/tts が公開する Style-Bert-VITS2 アダプターを生成する関数。
+// ブラックボックステスト: TtsSynthesizer ポートの契約のみ検証する。
+// 外部 HTTP 依存は global.fetch をモックして差し替える。
+
+const BASE_URL = "http://localhost:5000";
+
+function synthesizer(config?: { baseUrl?: string; timeout?: number }): TtsSynthesizer {
+	return createStyleBertVits2Synthesizer({
+		baseUrl: config?.baseUrl ?? BASE_URL,
+		timeout: config?.timeout,
+	});
+}
+
+// ─── fetch モック ───────────────────────────────────────────────
+
+// 最小限の WAV ヘッダー (44 bytes)
+const DUMMY_WAV_HEADER = new Uint8Array([
+	// "RIFF"
+	0x52, 0x49, 0x46, 0x46,
+	// chunk size (36 bytes of header + 0 data)
+	0x24, 0x00, 0x00, 0x00,
+	// "WAVE"
+	0x57, 0x41, 0x56, 0x45,
+	// "fmt " sub-chunk
+	0x66, 0x6d, 0x74, 0x20,
+	// sub-chunk size (16)
+	0x10, 0x00, 0x00, 0x00,
+	// audio format (1 = PCM)
+	0x01, 0x00,
+	// channels (1)
+	0x01, 0x00,
+	// sample rate (24000)
+	0xc0, 0x5d, 0x00, 0x00,
+	// byte rate (48000)
+	0x80, 0xbb, 0x00, 0x00,
+	// block align (2)
+	0x02, 0x00,
+	// bits per sample (16)
+	0x10, 0x00,
+	// "data" sub-chunk
+	0x64, 0x61, 0x74, 0x61,
+	// data size (0)
+	0x00, 0x00, 0x00, 0x00,
+]);
+
+const originalFetch = globalThis.fetch;
+let mockFetch: ReturnType<typeof mock>;
+
+beforeEach(() => {
+	mockFetch = mock();
+	globalThis.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+const DEFAULT_STYLE: TtsStyleParams = createTtsStyleParams("happy", 0.7, 1.0);
+
+// ─── synthesize: 正常系 ─────────────────────────────────────────
+
+describe("StyleBertVits2Synthesizer — synthesize", () => {
+	it("テキストとスタイルを渡して TtsResult を返す", async () => {
+		mockFetch.mockResolvedValueOnce(
+			new Response(DUMMY_WAV_HEADER.buffer as ArrayBuffer, {
+				status: 200,
+				headers: { "Content-Type": "audio/wav" },
+			}),
+		);
+
+		const result = await synthesizer().synthesize("こんにちは", DEFAULT_STYLE);
+
+		expect(result).not.toBeNull();
+		expect(result?.audio).toBeInstanceOf(Uint8Array);
+		expect(result?.audio.length).toBeGreaterThan(0);
+		expect(result?.format).toBe("wav");
+		expect(result?.durationSec).toBeGreaterThanOrEqual(0);
+	});
+
+	it("返り値の format が 'wav'", async () => {
+		mockFetch.mockResolvedValueOnce(
+			new Response(DUMMY_WAV_HEADER.buffer as ArrayBuffer, {
+				status: 200,
+				headers: { "Content-Type": "audio/wav" },
+			}),
+		);
+
+		const result = await synthesizer().synthesize("テスト", DEFAULT_STYLE);
+
+		expect(result).not.toBeNull();
+		expect(result?.format).toBe("wav");
+	});
+
+	it("durationSec が正の数または 0", async () => {
+		mockFetch.mockResolvedValueOnce(
+			new Response(DUMMY_WAV_HEADER.buffer as ArrayBuffer, {
+				status: 200,
+				headers: { "Content-Type": "audio/wav" },
+			}),
+		);
+
+		const result = await synthesizer().synthesize("テスト", DEFAULT_STYLE);
+
+		expect(result).not.toBeNull();
+		expect(result?.durationSec).toBeGreaterThanOrEqual(0);
+	});
+});
+
+// ─── synthesize: エラー系 ───────────────────────────────────────
+
+describe("StyleBertVits2Synthesizer — synthesize errors", () => {
+	it("HTTP 5xx エラー時に null を返す", async () => {
+		mockFetch.mockResolvedValueOnce(new Response("Internal Server Error", { status: 500 }));
+
+		const result = await synthesizer().synthesize("こんにちは", DEFAULT_STYLE);
+
+		expect(result).toBeNull();
+	});
+
+	it("ネットワーク不達時に null を返す", async () => {
+		mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+
+		const result = await synthesizer().synthesize("こんにちは", DEFAULT_STYLE);
+
+		expect(result).toBeNull();
+	});
+});
+
+// ─── isAvailable ────────────────────────────────────────────────
+
+describe("StyleBertVits2Synthesizer — isAvailable", () => {
+	it("ヘルスチェック成功時に true を返す", async () => {
+		mockFetch.mockResolvedValueOnce(new Response("OK", { status: 200 }));
+
+		const available = await synthesizer().isAvailable();
+
+		expect(available).toBe(true);
+	});
+
+	it("ヘルスチェック失敗時 (5xx) に false を返す", async () => {
+		mockFetch.mockResolvedValueOnce(new Response("Service Unavailable", { status: 503 }));
+
+		const available = await synthesizer().isAvailable();
+
+		expect(available).toBe(false);
+	});
+
+	it("ネットワーク不達時に false を返す", async () => {
+		mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+
+		const available = await synthesizer().isAvailable();
+
+		expect(available).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- `packages/tts` パッケージを新規作成 (`@vicissitude/tts`)
- `EmotionToTtsStyleMapper`: VAD 感情値 → TtsStyleParams のルールベースマッピング（EmotionToExpressionMapper と並列構造）
- `StyleBertVits2Synthesizer`: Style-Bert-VITS2 HTTP API アダプター（`POST /voice` → WAV、graceful degradation）

## Test plan

- [x] 仕様テスト 35 件パス (`spec/tts/`)
- [x] ユニットテスト 40 件パス (`packages/tts/src/*.test.ts`)
- [x] 既存テスト回帰なし (全 1012 テストパス)
- [x] `nr validate` パス (fmt, lint, 型チェック)

🤖 Generated with [Claude Code](https://claude.com/claude-code)