### PR TITLE
fix: stream.next() タイムアウト未適用によるエージェントハング修正

### DIFF
--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -62,7 +62,11 @@ function waitForNextStreamEvent(
 		}
 		void (async () => {
 			try {
-				const result = await stream.next();
+				const result = await withTimeout(
+					stream.next(),
+					STREAM_NEXT_TIMEOUT_MS,
+					"stream.next() timed out after 5 minutes",
+				);
 				finish(() =>
 					resolve(result.done ? { type: "done" } : { type: "event", value: result.value }),
 				);


### PR DESCRIPTION
## Summary
- `waitForNextStreamEvent` で `signal` が渡された場合、`stream.next()` にタイムアウトが適用されていなかった
- OpenCode イベントストリームが切断されると、Discord エージェントが永久にハングし、以降のメッセージに一切応答しなくなる
- `withTimeout(stream.next(), 5分)` を適用して、ストリーム切断時にエラーとしてリカバリーさせる

## Test plan
- [x] `nr validate` 通過
- [x] `nr test:unit -- --filter opencode` 通過
- [ ] デプロイ後、Discord でメッセージ送信して応答を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)