### PR TITLE
chore: compose.yaml から Minecraft サービスを分離

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ OLLAMA_BASE_URL=http://ollama:11434
 LTM_EMBEDDING_MODEL=embeddinggemma
 
 # Minecraft (optional)
-# MC_HOST=minecraft
+# MC_HOST=host.containers.internal
 # MC_PORT=25565
 # MC_USERNAME=fua
 # MC_MCP_PORT=3001

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,6 @@ networks:
 
 volumes:
   ollama-data:
-  minecraft-data:
   bot-node-modules:
   bot-dist:
 
@@ -95,38 +94,6 @@ services:
       ollama:
         condition: service_healthy
     command: ["xvfb-run", "-a", "bun", "run", "dist/index.js"]
-
-  minecraft:
-    container_name: vicissitude-minecraft
-    image: docker.io/itzg/minecraft-server:java21
-    environment:
-      EULA: "TRUE"
-      ONLINE_MODE: "FALSE"
-      TYPE: "VANILLA"
-      VERSION: "1.21.4"
-      MEMORY: "1G"
-      MAX_MEMORY: "1G"
-      DIFFICULTY: "normal"
-      SPAWN_PROTECTION: "0"
-      VIEW_DISTANCE: "8"
-      SIMULATION_DISTANCE: "6"
-    mem_limit: 2g
-    cpus: 2
-    volumes:
-      - minecraft-data:/data
-    networks:
-      - vicissitude-net
-    healthcheck:
-      test: ["CMD", "mc-health"]
-      interval: 10s
-      timeout: 5s
-      retries: 12
-      start_period: 120s
-    logging:
-      driver: journald
-      options:
-        tag: vicissitude-minecraft
-    restart: unless-stopped
 
   ollama:
     container_name: vicissitude-ollama


### PR DESCRIPTION
Closes #219

## Summary
- `compose.yaml` から `minecraft` サービスと `minecraft-data` ボリュームを削除
- `MC_HOST` を `minecraft`（コンテナ名）から `host.containers.internal`（ホスト到達）に変更
- Minecraft サーバーの管理は NixOS (dotfiles) 側に移行済み

## Test plan
- [ ] `nr deploy` でコンテナが正常に起動することを確認
- [ ] bot から Minecraft サーバーへの接続が `host.containers.internal` 経由で成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)