### PR TITLE
fix: Minecraft 接続を Microsoft 認証に変更

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ LTM_EMBEDDING_MODEL=embeddinggemma
 # Minecraft (optional)
 # MC_HOST=host.containers.internal
 # MC_PORT=25565
-# MC_USERNAME=fua
+# MC_USERNAME=hua_icissitude
 # MC_AUTH_MODE=microsoft
 # MC_PROFILES_FOLDER=/app/data/mc-profiles
 # MC_MCP_PORT=3001


### PR DESCRIPTION
Closes #219 の残タスク（接続設定の確認）

## Summary
- `MC_AUTH_MODE=microsoft` に変更し、online-mode の Minecraft サーバーに対応
- `MC_PROFILES_FOLDER` を追加して認証トークンを永続化
- `.env.example` を更新

## Test plan
- [x] `host.containers.internal` 経由で NixOS 側の Minecraft サーバーに接続成功
- [x] bot が `hua_vicissitude` としてスポーン確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)