### PR TITLE
fix: MC_USERNAME の typo 修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ LTM_EMBEDDING_MODEL=embeddinggemma
 # Minecraft (optional)
 # MC_HOST=host.containers.internal
 # MC_PORT=25565
-# MC_USERNAME=hua_icissitude
+# MC_USERNAME=hua_vicissitude
 # MC_AUTH_MODE=microsoft
 # MC_PROFILES_FOLDER=/app/data/mc-profiles
 # MC_MCP_PORT=3001


### PR DESCRIPTION
## Summary
- `.env.example` の `MC_USERNAME` を `hua_icissitude` → `hua_vicissitude` に修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)