### PR TITLE
refactor: server.tool() を registerTool() に移行

### DIFF
--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -109,7 +109,7 @@ graph LR
 
 - 内部依存: mcp, observability, shared, store
 - 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, path
-- ファイル数: 22
+- ファイル数: 23
 
 ### observability
 

--- a/packages/mcp/src/code-exec-server.ts
+++ b/packages/mcp/src/code-exec-server.ts
@@ -117,12 +117,14 @@ async function checkPodmanSetup(): Promise<void> {
 	}
 }
 
-server.tool(
+server.registerTool(
 	"execute_code",
-	"Execute code in a sandboxed container and return the output",
 	{
-		language: z.enum(SUPPORTED_LANGUAGES),
-		code: z.string().max(MAX_CODE_LENGTH),
+		description: "Execute code in a sandboxed container and return the output",
+		inputSchema: {
+			language: z.enum(SUPPORTED_LANGUAGES),
+			code: z.string().max(MAX_CODE_LENGTH),
+		},
 	},
 	async ({ language, code }) => {
 		const cmd = buildPodmanCmd(language, code);

--- a/packages/mcp/src/tools/discord.ts
+++ b/packages/mcp/src/tools/discord.ts
@@ -60,10 +60,13 @@ export function registerDiscordTools(server: McpServer, deps: DiscordDeps): () =
 		return channel;
 	}
 
-	server.tool(
+	server.registerTool(
 		"send_typing",
-		"Send a typing indicator to a Discord channel. Automatically repeats every 8s until send_message/reply is called, or 60s timeout.",
-		{ channel_id: z.string() },
+		{
+			description:
+				"Send a typing indicator to a Discord channel. Automatically repeats every 8s until send_message/reply is called, or 60s timeout.",
+			inputSchema: { channel_id: z.string() },
+		},
 		async ({ channel_id }) => {
 			const channel = await getTextChannel(channel_id);
 			if (!("sendTyping" in channel)) {
@@ -82,13 +85,15 @@ export function registerDiscordTools(server: McpServer, deps: DiscordDeps): () =
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"send_message",
-		"Send a message to a Discord channel (optionally with a file attachment)",
 		{
-			channel_id: z.string(),
-			content: z.string(),
-			file_path: z.string().optional().describe("添付するファイルのパス"),
+			description: "Send a message to a Discord channel (optionally with a file attachment)",
+			inputSchema: {
+				channel_id: z.string(),
+				content: z.string(),
+				file_path: z.string().optional().describe("添付するファイルのパス"),
+			},
 		},
 		async ({ channel_id, content, file_path }) => {
 			clearTyping(channel_id);
@@ -103,14 +108,17 @@ export function registerDiscordTools(server: McpServer, deps: DiscordDeps): () =
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"reply",
-		"Reply to a specific message in a Discord channel (optionally with a file attachment)",
 		{
-			channel_id: z.string(),
-			message_id: z.string(),
-			content: z.string(),
-			file_path: z.string().optional().describe("添付するファイルのパス"),
+			description:
+				"Reply to a specific message in a Discord channel (optionally with a file attachment)",
+			inputSchema: {
+				channel_id: z.string(),
+				message_id: z.string(),
+				content: z.string(),
+				file_path: z.string().optional().describe("添付するファイルのパス"),
+			},
 		},
 		async ({ channel_id, message_id, content, file_path }) => {
 			clearTyping(channel_id);
@@ -126,10 +134,12 @@ export function registerDiscordTools(server: McpServer, deps: DiscordDeps): () =
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"add_reaction",
-		"Add a reaction emoji to a message",
-		{ channel_id: z.string(), message_id: z.string(), emoji: z.string() },
+		{
+			description: "Add a reaction emoji to a message",
+			inputSchema: { channel_id: z.string(), message_id: z.string(), emoji: z.string() },
+		},
 		async ({ channel_id, message_id, emoji }) => {
 			const channel = await getTextChannel(channel_id);
 			const target = await channel.messages.fetch(message_id);
@@ -138,10 +148,12 @@ export function registerDiscordTools(server: McpServer, deps: DiscordDeps): () =
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"read_messages",
-		"Read recent messages from a Discord channel",
-		{ channel_id: z.string(), limit: z.number().min(1).max(50).default(10) },
+		{
+			description: "Read recent messages from a Discord channel",
+			inputSchema: { channel_id: z.string(), limit: z.number().min(1).max(50).default(10) },
+		},
 		async ({ channel_id, limit }) => {
 			const channel = await getTextChannel(channel_id);
 			const messages = await channel.messages.fetch({ limit });
@@ -154,10 +166,12 @@ export function registerDiscordTools(server: McpServer, deps: DiscordDeps): () =
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"list_channels",
-		"List text channels in a Discord guild",
-		{ guild_id: z.string() },
+		{
+			description: "List text channels in a Discord guild",
+			inputSchema: { guild_id: z.string() },
+		},
 		async ({ guild_id }) => {
 			const guild = await discordClient.guilds.fetch(guild_id);
 			const channels = await guild.channels.fetch();

--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -47,15 +47,18 @@ export async function pollEvents(
 export function registerEventBufferTools(server: McpServer, deps: EventBufferDeps): void {
 	const { db } = deps;
 
-	server.tool(
+	server.registerTool(
 		"wait_for_events",
-		"イベントが届くまで待機し、届いたら最大10件まとめて消費して返す。タイムアウト時は空配列を返す。",
 		{
-			agent_id: z
-				.string()
-				.min(1)
-				.describe("対象のエージェント ID (例: discord:123456, minecraft:brain)"),
-			timeout_seconds: z.number().min(1).max(172800).default(60),
+			description:
+				"イベントが届くまで待機し、届いたら最大10件まとめて消費して返す。タイムアウト時は空配列を返す。",
+			inputSchema: {
+				agent_id: z
+					.string()
+					.min(1)
+					.describe("対象のエージェント ID (例: discord:123456, minecraft:brain)"),
+				timeout_seconds: z.number().min(1).max(172800).default(60),
+			},
 		},
 		async ({ agent_id, timeout_seconds }) => {
 			const immediate = consumeEvents(db, agent_id, MAX_BATCH_SIZE);

--- a/packages/mcp/src/tools/ltm.ts
+++ b/packages/mcp/src/tools/ltm.ts
@@ -19,13 +19,16 @@ export interface LtmDeps {
 export function registerLtmTools(server: McpServer, deps: LtmDeps): void {
 	const { getOrCreateLtm } = deps;
 
-	server.tool(
+	server.registerTool(
 		"ltm_retrieve",
-		"クエリに関連する長期記憶をハイブリッド検索（テキスト＋ベクトル＋FSRS リランキング）で取得する",
 		{
-			guild_id: guildIdSchema,
-			query: z.string().min(1).describe("検索クエリ"),
-			limit: z.number().min(1).max(50).optional().describe("最大取得件数（デフォルト: 10）"),
+			description:
+				"クエリに関連する長期記憶をハイブリッド検索（テキスト＋ベクトル＋FSRS リランキング）で取得する",
+			inputSchema: {
+				guild_id: guildIdSchema,
+				query: z.string().min(1).describe("検索クエリ"),
+				limit: z.number().min(1).max(50).optional().describe("最大取得件数（デフォルト: 10）"),
+			},
 		},
 		async ({ guild_id, query, limit }) => {
 			try {
@@ -71,24 +74,26 @@ export function registerLtmTools(server: McpServer, deps: LtmDeps): void {
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"ltm_get_facts",
-		"蓄積されたファクト（意味記憶）一覧を取得する",
 		{
-			guild_id: guildIdSchema,
-			category: z
-				.enum([
-					"identity",
-					"preference",
-					"interest",
-					"personality",
-					"relationship",
-					"experience",
-					"goal",
-					"guideline",
-				])
-				.optional()
-				.describe("カテゴリでフィルタ（省略で全件）"),
+			description: "蓄積されたファクト（意味記憶）一覧を取得する",
+			inputSchema: {
+				guild_id: guildIdSchema,
+				category: z
+					.enum([
+						"identity",
+						"preference",
+						"interest",
+						"personality",
+						"relationship",
+						"experience",
+						"goal",
+						"guideline",
+					])
+					.optional()
+					.describe("カテゴリでフィルタ（省略で全件）"),
+			},
 		},
 		async ({ guild_id, category }) => {
 			try {

--- a/packages/mcp/src/tools/mc-bridge-discord.ts
+++ b/packages/mcp/src/tools/mc-bridge-discord.ts
@@ -19,11 +19,13 @@ const MAX_COMMAND_CHARS = 10_000;
 export function registerDiscordBridgeTools(server: McpServer, deps: McBridgeDeps): void {
 	const { db } = deps;
 
-	server.tool(
+	server.registerTool(
 		"minecraft_delegate",
-		"マイクラの自分に指示を出す。次のポーリングで反映される。",
 		{
-			command: z.string().min(1).max(MAX_COMMAND_CHARS).describe("マイクラでやること"),
+			description: "マイクラの自分に指示を出す。次のポーリングで反映される。",
+			inputSchema: {
+				command: z.string().min(1).max(MAX_COMMAND_CHARS).describe("マイクラでやること"),
+			},
 		},
 		({ command }) => {
 			const event = {
@@ -41,7 +43,7 @@ export function registerDiscordBridgeTools(server: McpServer, deps: McBridgeDeps
 		},
 	);
 
-	server.tool("minecraft_status", "マイクラの最新状況を確認する。", {}, () => {
+	server.registerTool("minecraft_status", { description: "マイクラの最新状況を確認する。" }, () => {
 		const status = getMcConnectionStatus(db);
 		const label = status.connected ? "接続中" : "未接続";
 		const text = `接続状態: ${label}${status.since ? ` (${status.since})` : ""}`;
@@ -51,11 +53,13 @@ export function registerDiscordBridgeTools(server: McpServer, deps: McBridgeDeps
 		};
 	});
 
-	server.tool(
+	server.registerTool(
 		"minecraft_start_session",
-		"マイクラのセッションを開始する。マイクラが停止中のときに使う。",
 		{
-			guild_id: z.string().min(1).describe("呼び出し元の guild ID"),
+			description: "マイクラのセッションを開始する。マイクラが停止中のときに使う。",
+			inputSchema: {
+				guild_id: z.string().min(1).describe("呼び出し元の guild ID"),
+			},
 		},
 		({ guild_id }) => {
 			const lock = tryAcquireSessionLock(db, guild_id);
@@ -80,11 +84,13 @@ export function registerDiscordBridgeTools(server: McpServer, deps: McBridgeDeps
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"minecraft_stop_session",
-		"マイクラのセッションを停止する。",
 		{
-			guild_id: z.string().min(1).describe("呼び出し元の guild ID"),
+			description: "マイクラのセッションを停止する。",
+			inputSchema: {
+				guild_id: z.string().min(1).describe("呼び出し元の guild ID"),
+			},
 		},
 		({ guild_id }) => {
 			const released = releaseSessionLock(db, guild_id);

--- a/packages/mcp/src/tools/mc-bridge-minecraft.ts
+++ b/packages/mcp/src/tools/mc-bridge-minecraft.ts
@@ -10,21 +10,23 @@ const MAX_REPORT_CHARS = 10_000;
 export function registerMinecraftBridgeTools(server: McpServer, deps: { db: StoreDb }): void {
 	const { db } = deps;
 
-	server.tool(
+	server.registerTool(
 		"mc_report",
-		"Discord 側にレポートを送信する。",
 		{
-			message: z.string().min(1).max(MAX_REPORT_CHARS).describe("レポート内容"),
-			importance: z
-				.enum(["low", "medium", "high", "critical"])
-				.default("medium")
-				.describe("重要度"),
-			category: z
-				.enum(["progress", "completion", "stuck", "danger", "discovery", "status"])
-				.default("status")
-				.describe(
-					"レポート種別: progress=作業中間報告, completion=目標達成, stuck=行き詰まり, danger=危険回避, discovery=新発見, status=一般状態",
-				),
+			description: "Discord 側にレポートを送信する。",
+			inputSchema: {
+				message: z.string().min(1).max(MAX_REPORT_CHARS).describe("レポート内容"),
+				importance: z
+					.enum(["low", "medium", "high", "critical"])
+					.default("medium")
+					.describe("重要度"),
+				category: z
+					.enum(["progress", "completion", "stuck", "danger", "discovery", "status"])
+					.default("status")
+					.describe(
+						"レポート種別: progress=作業中間報告, completion=目標達成, stuck=行き詰まり, danger=危険回避, discovery=新発見, status=一般状態",
+					),
+			},
 		},
 		({ message, importance, category }) => {
 			const guildId = getSessionLockGuildId(db);

--- a/packages/mcp/src/tools/mc-memory.ts
+++ b/packages/mcp/src/tools/mc-memory.ts
@@ -68,22 +68,29 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 
 	// --- Goals ---
 
-	server.tool("mc_read_goals", "Minecraft 目標ファイルを読む（現在の目標のみ）", {}, () => {
-		const content = readOverlay(dataDir, GOALS_FILENAME);
-		return {
-			content: [{ type: "text" as const, text: content || "(目標ファイルは空です)" }],
-		};
-	});
+	server.registerTool(
+		"mc_read_goals",
+		{ description: "Minecraft 目標ファイルを読む（現在の目標のみ）" },
+		() => {
+			const content = readOverlay(dataDir, GOALS_FILENAME);
+			return {
+				content: [{ type: "text" as const, text: content || "(目標ファイルは空です)" }],
+			};
+		},
+	);
 
-	server.tool(
+	server.registerTool(
 		"mc_update_goals",
-		"Minecraft 目標ファイルを上書き更新する（バックアップ自動作成）。現在の目標のみ記載すること。達成済み目標や探索メモは mc_update_progress に記録する。",
 		{
-			content: z
-				.string()
-				.min(1)
-				.max(MAX_GOALS_CHARS)
-				.describe("新しい MINECRAFT-GOALS.md の内容（最大 20,000 文字）"),
+			description:
+				"Minecraft 目標ファイルを上書き更新する（バックアップ自動作成）。現在の目標のみ記載すること。達成済み目標や探索メモは mc_update_progress に記録する。",
+			inputSchema: {
+				content: z
+					.string()
+					.min(1)
+					.max(MAX_GOALS_CHARS)
+					.describe("新しい MINECRAFT-GOALS.md の内容（最大 20,000 文字）"),
+			},
 		},
 		({ content }) => {
 			writeOverlay(dataDir, GOALS_FILENAME, content);
@@ -100,10 +107,12 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 
 	// --- Progress ---
 
-	server.tool(
+	server.registerTool(
 		"mc_read_progress",
-		"Minecraft ワールド進捗を読む（装備段階、拠点、探索範囲、主要資源、達成済み目標、プレイヤーメモ）",
-		{},
+		{
+			description:
+				"Minecraft ワールド進捗を読む（装備段階、拠点、探索範囲、主要資源、達成済み目標、プレイヤーメモ）",
+		},
 		() => {
 			const content = readOverlay(dataDir, PROGRESS_FILENAME);
 			return {
@@ -112,15 +121,18 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"mc_update_progress",
-		"Minecraft ワールド進捗を更新する（バックアップ自動作成）。装備段階、拠点、探索範囲、主要資源、達成済み目標、プレイヤーメモを記録する。",
 		{
-			content: z
-				.string()
-				.min(1)
-				.max(MAX_PROGRESS_CHARS)
-				.describe("新しい MINECRAFT-PROGRESS.md の内容（最大 20,000 文字）"),
+			description:
+				"Minecraft ワールド進捗を更新する（バックアップ自動作成）。装備段階、拠点、探索範囲、主要資源、達成済み目標、プレイヤーメモを記録する。",
+			inputSchema: {
+				content: z
+					.string()
+					.min(1)
+					.max(MAX_PROGRESS_CHARS)
+					.describe("新しい MINECRAFT-PROGRESS.md の内容（最大 20,000 文字）"),
+			},
 		},
 		({ content }) => {
 			writeOverlay(dataDir, PROGRESS_FILENAME, content);
@@ -137,29 +149,32 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 
 	// --- Skills ---
 
-	server.tool("mc_read_skills", "Minecraft スキルライブラリを読む", {}, () => {
+	server.registerTool("mc_read_skills", { description: "Minecraft スキルライブラリを読む" }, () => {
 		const content = readOverlay(dataDir, SKILLS_FILENAME);
 		return {
 			content: [{ type: "text" as const, text: content || "(スキルライブラリは空です)" }],
 		};
 	});
 
-	server.tool(
+	server.registerTool(
 		"mc_record_skill",
-		"Minecraft スキルライブラリにスキルを追記する（有効条件・前提装備・失敗パターン付き）",
 		{
-			name: z.string().min(1).max(200).describe("スキル名"),
-			description: z.string().min(1).max(2_000).describe("スキルの説明・手順"),
-			preconditions: z
-				.string()
-				.max(500)
-				.optional()
-				.describe("有効条件・前提装備（例: 石のピッケル以上が必要）"),
-			failure_patterns: z
-				.string()
-				.max(500)
-				.optional()
-				.describe("既知の失敗パターン（例: 夜間は敵mobで中断されやすい）"),
+			description:
+				"Minecraft スキルライブラリにスキルを追記する（有効条件・前提装備・失敗パターン付き）",
+			inputSchema: {
+				name: z.string().min(1).max(200).describe("スキル名"),
+				description: z.string().min(1).max(2_000).describe("スキルの説明・手順"),
+				preconditions: z
+					.string()
+					.max(500)
+					.optional()
+					.describe("有効条件・前提装備（例: 石のピッケル以上が必要）"),
+				failure_patterns: z
+					.string()
+					.max(500)
+					.optional()
+					.describe("既知の失敗パターン（例: 夜間は敵mobで中断されやすい）"),
+			},
 		},
 		({ name, description, preconditions, failure_patterns }) => {
 			const existing = readOverlay(dataDir, SKILLS_FILENAME);

--- a/packages/mcp/src/tools/memory.ts
+++ b/packages/mcp/src/tools/memory.ts
@@ -17,10 +17,12 @@ import {
 } from "../memory-helpers.ts";
 
 export function registerMemoryTools(server: McpServer): void {
-	server.tool(
+	server.registerTool(
 		"read_memory",
-		"MEMORY.md を読み取る（guild_id 指定時は Guild 固有のメモリ）",
-		{ guild_id: guildIdSchema },
+		{
+			description: "MEMORY.md を読み取る（guild_id 指定時は Guild 固有のメモリ）",
+			inputSchema: { guild_id: guildIdSchema },
+		},
 		({ guild_id }) => {
 			const { memoryPath } = resolveContextPaths(guild_id);
 			const content = readWithFallback(memoryPath);
@@ -30,16 +32,19 @@ export function registerMemoryTools(server: McpServer): void {
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"update_memory",
-		"MEMORY.md を上書き更新する（.bak バックアップ自動作成、guild_id 指定時は Guild 固有。運用設定・行動ルール・週次目標が対象、ユーザー背景情報は LTM に委譲）",
 		{
-			content: z
-				.string()
-				.min(1)
-				.max(MAX_MEMORY_CHARS)
-				.describe("新しい MEMORY.md の内容（最大 50,000 文字）"),
-			guild_id: guildIdSchema,
+			description:
+				"MEMORY.md を上書き更新する（.bak バックアップ自動作成、guild_id 指定時は Guild 固有。運用設定・行動ルール・週次目標が対象、ユーザー背景情報は LTM に委譲）",
+			inputSchema: {
+				content: z
+					.string()
+					.min(1)
+					.max(MAX_MEMORY_CHARS)
+					.describe("新しい MEMORY.md の内容（最大 50,000 文字）"),
+				guild_id: guildIdSchema,
+			},
 		},
 		({ content, guild_id }) => {
 			const { memoryPath } = resolveContextPaths(guild_id);
@@ -57,17 +62,19 @@ export function registerMemoryTools(server: McpServer): void {
 		},
 	);
 
-	server.tool("read_soul", "SOUL.md を読み取る", {}, () => {
+	server.registerTool("read_soul", { description: "SOUL.md を読み取る" }, () => {
 		const content = readWithFallback(SOUL_PATH);
 		return {
 			content: [{ type: "text", text: content || "(SOUL.md は空です)" }],
 		};
 	});
 
-	server.tool(
+	server.registerTool(
 		"read_lessons",
-		"LESSONS.md を読み取る（guild_id 指定時は Guild 固有）",
-		{ guild_id: guildIdSchema },
+		{
+			description: "LESSONS.md を読み取る（guild_id 指定時は Guild 固有）",
+			inputSchema: { guild_id: guildIdSchema },
+		},
 		({ guild_id }) => {
 			const { lessonsPath } = resolveContextPaths(guild_id);
 			const content = readWithFallback(lessonsPath);
@@ -82,16 +89,19 @@ export function registerMemoryTools(server: McpServer): void {
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"update_lessons",
-		"LESSONS.md を上書き更新する（更新前に ltm_get_facts で guideline カテゴリを確認し重複を避ける。バックアップ自動作成、guild_id 指定時は Guild 固有）",
 		{
-			content: z
-				.string()
-				.min(1)
-				.max(MAX_LESSONS_CHARS)
-				.describe("新しい LESSONS.md の内容（最大 30,000 文字）"),
-			guild_id: guildIdSchema,
+			description:
+				"LESSONS.md を上書き更新する（更新前に ltm_get_facts で guideline カテゴリを確認し重複を避ける。バックアップ自動作成、guild_id 指定時は Guild 固有）",
+			inputSchema: {
+				content: z
+					.string()
+					.min(1)
+					.max(MAX_LESSONS_CHARS)
+					.describe("新しい LESSONS.md の内容（最大 30,000 文字）"),
+				guild_id: guildIdSchema,
+			},
 		},
 		({ content, guild_id }) => {
 			const { lessonsPath } = resolveContextPaths(guild_id);

--- a/packages/mcp/src/tools/schedule.ts
+++ b/packages/mcp/src/tools/schedule.ts
@@ -42,15 +42,21 @@ async function saveConfig(config: HeartbeatConfig): Promise<void> {
 }
 
 export function registerScheduleTools(server: McpServer): void {
-	server.tool("get_heartbeat_config", "現在の heartbeat 設定を表示する", {}, () => {
-		const config = loadConfig();
-		return { content: [{ type: "text", text: JSON.stringify(config, null, 2) }] };
-	});
+	server.registerTool(
+		"get_heartbeat_config",
+		{ description: "現在の heartbeat 設定を表示する" },
+		() => {
+			const config = loadConfig();
+			return { content: [{ type: "text", text: JSON.stringify(config, null, 2) }] };
+		},
+	);
 
-	server.tool(
+	server.registerTool(
 		"list_reminders",
-		"リマインダー一覧を表示する（現在のギルド＋グローバルのみ）",
-		{ guild_id: guildIdSchema },
+		{
+			description: "リマインダー一覧を表示する（現在のギルド＋グローバルのみ）",
+			inputSchema: { guild_id: guildIdSchema },
+		},
 		({ guild_id }) => {
 			const config = loadConfig();
 			const visible = filterRemindersByGuild(config.reminders, guild_id);
@@ -68,23 +74,25 @@ export function registerScheduleTools(server: McpServer): void {
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"add_reminder",
-		"新しいリマインダーを追加する（デフォルトで現在のギルドに紐づく）",
 		{
-			guild_id: guildIdSchema,
-			id: z.string().describe("一意の識別子"),
-			description: z.string().describe("リマインダーの説明"),
-			schedule_type: z.enum(["interval", "daily"]).describe("スケジュールタイプ"),
-			interval_minutes: z.number().min(1).optional().describe("interval の場合の分数（1以上）"),
-			daily_hour: z.number().min(0).max(23).optional().describe("daily の場合の時"),
-			daily_minute: z.number().min(0).max(59).optional().describe("daily の場合の分"),
-			global: z
-				.boolean()
-				.optional()
-				.describe(
-					"true にするとギルドに紐づかないグローバルリマインダーになる（デフォルト: false）",
-				),
+			description: "新しいリマインダーを追加する（デフォルトで現在のギルドに紐づく）",
+			inputSchema: {
+				guild_id: guildIdSchema,
+				id: z.string().describe("一意の識別子"),
+				description: z.string().describe("リマインダーの説明"),
+				schedule_type: z.enum(["interval", "daily"]).describe("スケジュールタイプ"),
+				interval_minutes: z.number().min(1).optional().describe("interval の場合の分数（1以上）"),
+				daily_hour: z.number().min(0).max(23).optional().describe("daily の場合の時"),
+				daily_minute: z.number().min(0).max(59).optional().describe("daily の場合の分"),
+				global: z
+					.boolean()
+					.optional()
+					.describe(
+						"true にするとギルドに紐づかないグローバルリマインダーになる（デフォルト: false）",
+					),
+			},
 		},
 		async ({
 			guild_id,
@@ -144,18 +152,23 @@ export function registerScheduleTools(server: McpServer): void {
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"update_reminder",
-		"リマインダーを更新する（自ギルドまたはグローバルのみ）",
 		{
-			guild_id: guildIdSchema,
-			id: z.string().describe("更新するリマインダーの ID"),
-			description: z.string().optional().describe("新しい説明"),
-			enabled: z.boolean().optional().describe("有効/無効"),
-			schedule_type: z.enum(["interval", "daily"]).optional().describe("新しいスケジュールタイプ"),
-			interval_minutes: z.number().min(1).optional().describe("interval の場合の分数（1以上）"),
-			daily_hour: z.number().min(0).max(23).optional().describe("daily の場合の時"),
-			daily_minute: z.number().min(0).max(59).optional().describe("daily の場合の分"),
+			description: "リマインダーを更新する（自ギルドまたはグローバルのみ）",
+			inputSchema: {
+				guild_id: guildIdSchema,
+				id: z.string().describe("更新するリマインダーの ID"),
+				description: z.string().optional().describe("新しい説明"),
+				enabled: z.boolean().optional().describe("有効/無効"),
+				schedule_type: z
+					.enum(["interval", "daily"])
+					.optional()
+					.describe("新しいスケジュールタイプ"),
+				interval_minutes: z.number().min(1).optional().describe("interval の場合の分数（1以上）"),
+				daily_hour: z.number().min(0).max(23).optional().describe("daily の場合の時"),
+				daily_minute: z.number().min(0).max(59).optional().describe("daily の場合の分"),
+			},
 		},
 		async ({
 			guild_id,
@@ -207,12 +220,14 @@ export function registerScheduleTools(server: McpServer): void {
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"remove_reminder",
-		"リマインダーを削除する（自ギルドまたはグローバルのみ）",
 		{
-			guild_id: guildIdSchema,
-			id: z.string().describe("削除するリマインダーの ID"),
+			description: "リマインダーを削除する（自ギルドまたはグローバルのみ）",
+			inputSchema: {
+				guild_id: guildIdSchema,
+				id: z.string().describe("削除するリマインダーの ID"),
+			},
 		},
 		async ({ guild_id, id }) => {
 			const config = loadConfig();
@@ -243,10 +258,12 @@ export function registerScheduleTools(server: McpServer): void {
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"set_base_interval",
-		"ベースチェック間隔を変更する（分）",
-		{ minutes: z.number().min(1).describe("チェック間隔（分）") },
+		{
+			description: "ベースチェック間隔を変更する（分）",
+			inputSchema: { minutes: z.number().min(1).describe("チェック間隔（分）") },
+		},
 		async ({ minutes }) => {
 			const config = loadConfig();
 			config.baseIntervalMinutes = minutes;

--- a/packages/minecraft/DEPS.md
+++ b/packages/minecraft/DEPS.md
@@ -14,6 +14,7 @@ graph LR
   actions_index["actions/index"] --> actions_jobs["actions/jobs"]
   actions_index["actions/index"] --> actions_movement["actions/movement"]
   actions_index["actions/index"] --> actions_shared["actions/shared"]
+  actions_index["actions/index"] --> actions_smelting["actions/smelting"]
   actions_index["actions/index"] --> actions_survival_index["actions/survival/index"]
   actions_index["actions/index"] --> job_manager["job-manager"]
   actions_interaction["actions/interaction"] --> actions_shared["actions/shared"]
@@ -23,6 +24,8 @@ graph LR
   actions_movement["actions/movement"] --> bot_queries["bot-queries"]
   actions_movement["actions/movement"] --> job_manager["job-manager"]
   actions_shared["actions/shared"] --> job_manager["job-manager"]
+  actions_smelting["actions/smelting"] --> actions_shared["actions/shared"]
+  actions_smelting["actions/smelting"] --> job_manager["job-manager"]
   actions_survival_escape["actions/survival/escape"] --> actions_shared["actions/shared"]
   actions_survival_escape["actions/survival/escape"] --> bot_queries["bot-queries"]
   actions_survival_escape["actions/survival/escape"] --> job_manager["job-manager"]
@@ -69,7 +72,7 @@ graph LR
 
 ### actions/index.ts
 
-- モジュール内依存: actions/combat, actions/interaction, actions/jobs, actions/movement, actions/shared, actions/survival/index, job-manager
+- モジュール内依存: actions/combat, actions/interaction, actions/jobs, actions/movement, actions/shared, actions/smelting, actions/survival/index, job-manager
 - 他モジュール依存: shared
 - 外部依存: @modelcontextprotocol/sdk/server/mcp.js
 
@@ -93,6 +96,11 @@ graph LR
 
 - モジュール内依存: job-manager
 - 外部依存: .bun
+
+### actions/smelting.ts
+
+- モジュール内依存: actions/shared, job-manager
+- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/survival/escape.ts
 

--- a/packages/minecraft/package.json
+++ b/packages/minecraft/package.json
@@ -15,6 +15,7 @@
 		"./mc-metrics": "./src/mc-metrics.ts",
 		"./helpers": "./src/helpers.ts",
 		"./actions/jobs": "./src/actions/jobs.ts",
+		"./actions/smelting": "./src/actions/smelting.ts",
 		"./actions/survival": "./src/actions/survival/index.ts"
 	},
 	"dependencies": {

--- a/packages/minecraft/src/actions/combat.ts
+++ b/packages/minecraft/src/actions/combat.ts
@@ -156,22 +156,25 @@ export function registerAttackEntity(
 	getBot: GetBot,
 	jobManager: JobManager,
 ): void {
-	server.tool(
+	server.registerTool(
 		"attack_entity",
-		"指定エンティティを攻撃する（非同期ジョブ: 即座に jobId を返す、最適武器自動装備）",
 		{
-			entityName: z
-				.string()
-				.min(1)
-				.max(64)
-				.describe('攻撃対象のエンティティ名（例: "zombie", "cow"）'),
-			maxHits: z
-				.number()
-				.int()
-				.min(1)
-				.max(100)
-				.default(20)
-				.describe("最大攻撃回数（デフォルト: 20、安全弁）"),
+			description:
+				"指定エンティティを攻撃する（非同期ジョブ: 即座に jobId を返す、最適武器自動装備）",
+			inputSchema: {
+				entityName: z
+					.string()
+					.min(1)
+					.max(64)
+					.describe('攻撃対象のエンティティ名（例: "zombie", "cow"）'),
+				maxHits: z
+					.number()
+					.int()
+					.min(1)
+					.max(100)
+					.default(20)
+					.describe("最大攻撃回数（デフォルト: 20、安全弁）"),
+			},
 		},
 		async ({ entityName, maxHits }) => {
 			const bot = getBot();

--- a/packages/minecraft/src/actions/index.ts
+++ b/packages/minecraft/src/actions/index.ts
@@ -4,7 +4,7 @@ import type { Logger } from "@vicissitude/shared/types";
 import type { JobManager } from "../job-manager.ts";
 import { registerAttackEntity } from "./combat.ts";
 import { registerSendChat, registerEquipItem, registerPlaceBlock } from "./interaction.ts";
-import { registerCraftItem, registerSleepInBed, registerSmeltItem } from "./jobs.ts";
+import { registerCraftItem, registerSleepInBed } from "./jobs.ts";
 import {
 	registerFollowPlayer,
 	registerGoTo,
@@ -12,6 +12,7 @@ import {
 	registerStop,
 } from "./movement.ts";
 import type { GetBot } from "./shared.ts";
+import { registerSmeltItem } from "./smelting.ts";
 import { registerSurvivalTools } from "./survival/index.ts";
 
 export function registerActionTools(

--- a/packages/minecraft/src/actions/interaction.ts
+++ b/packages/minecraft/src/actions/interaction.ts
@@ -38,15 +38,17 @@ async function placeOnAdjacentBlock(
 }
 
 export function registerSendChat(server: McpServer, getBot: GetBot): void {
-	server.tool(
+	server.registerTool(
 		"send_chat",
-		"Minecraft ゲーム内チャットにメッセージを送信する（コマンド送信不可）",
 		{
-			message: z
-				.string()
-				.min(1)
-				.max(MAX_CHAT_LENGTH)
-				.describe(`送信するメッセージ（最大 ${String(MAX_CHAT_LENGTH)} 文字、"/" 始まり禁止）`),
+			description: "Minecraft ゲーム内チャットにメッセージを送信する（コマンド送信不可）",
+			inputSchema: {
+				message: z
+					.string()
+					.min(1)
+					.max(MAX_CHAT_LENGTH)
+					.describe(`送信するメッセージ（最大 ${String(MAX_CHAT_LENGTH)} 文字、"/" 始まり禁止）`),
+			},
 		},
 		({ message }) => {
 			const bot = getBot();
@@ -59,15 +61,17 @@ export function registerSendChat(server: McpServer, getBot: GetBot): void {
 }
 
 export function registerEquipItem(server: McpServer, getBot: GetBot): void {
-	server.tool(
+	server.registerTool(
 		"equip_item",
-		"インベントリのアイテムを装備する",
 		{
-			itemName: z.string().describe('アイテム名（例: "diamond_sword", "iron_helmet"）'),
-			destination: z
-				.enum(["hand", "head", "torso", "legs", "feet", "off-hand"])
-				.default("hand")
-				.describe("装備先（デフォルト: hand）"),
+			description: "インベントリのアイテムを装備する",
+			inputSchema: {
+				itemName: z.string().describe('アイテム名（例: "diamond_sword", "iron_helmet"）'),
+				destination: z
+					.enum(["hand", "head", "torso", "legs", "feet", "off-hand"])
+					.default("hand")
+					.describe("装備先（デフォルト: hand）"),
+			},
 		},
 		async ({ itemName, destination }) => {
 			const bot = getBot();
@@ -83,16 +87,18 @@ export function registerEquipItem(server: McpServer, getBot: GetBot): void {
 }
 
 export function registerPlaceBlock(server: McpServer, getBot: GetBot): void {
-	server.tool(
+	server.registerTool(
 		"place_block",
-		"指定座標にブロックを設置する（インベントリからアイテムを自動装備）",
 		{
-			blockName: z
-				.string()
-				.describe('設置するブロックのアイテム名（例: "cobblestone", "oak_planks"）'),
-			x: z.number().int().describe("設置先の X 座標"),
-			y: z.number().int().describe("設置先の Y 座標"),
-			z: z.number().int().describe("設置先の Z 座標"),
+			description: "指定座標にブロックを設置する（インベントリからアイテムを自動装備）",
+			inputSchema: {
+				blockName: z
+					.string()
+					.describe('設置するブロックのアイテム名（例: "cobblestone", "oak_planks"）'),
+				x: z.number().int().describe("設置先の X 座標"),
+				y: z.number().int().describe("設置先の Y 座標"),
+				z: z.number().int().describe("設置先の Z 座標"),
+			},
 		},
 		async ({ blockName, x, y, z: zCoord }) => {
 			const bot = getBot();

--- a/packages/minecraft/src/actions/jobs.ts
+++ b/packages/minecraft/src/actions/jobs.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Logger } from "@vicissitude/shared/types";
 import type mineflayer from "mineflayer";
-import type { Furnace } from "mineflayer";
 import { goals } from "mineflayer-pathfinder";
 import type { Recipe } from "prismarine-recipe";
 import { z } from "zod";
@@ -114,18 +113,21 @@ async function executeSleep(
 }
 
 export function registerCraftItem(server: McpServer, getBot: GetBot, jobManager: JobManager): void {
-	server.tool(
+	server.registerTool(
 		"craft_item",
-		"指定アイテムをクラフトする（非同期ジョブ: 即座に jobId を返す、作業台が必要な場合は自動で移動）",
 		{
-			itemName: z.string().describe('クラフトするアイテム名（例: "stick", "crafting_table"）'),
-			count: z
-				.number()
-				.int()
-				.min(1)
-				.max(MAX_CRAFT_COUNT)
-				.default(1)
-				.describe(`クラフト個数（デフォルト: 1、最大: ${String(MAX_CRAFT_COUNT)}）`),
+			description:
+				"指定アイテムをクラフトする（非同期ジョブ: 即座に jobId を返す、作業台が必要な場合は自動で移動）",
+			inputSchema: {
+				itemName: z.string().describe('クラフトするアイテム名（例: "stick", "crafting_table"）'),
+				count: z
+					.number()
+					.int()
+					.min(1)
+					.max(MAX_CRAFT_COUNT)
+					.default(1)
+					.describe(`クラフト個数（デフォルト: 1、最大: ${String(MAX_CRAFT_COUNT)}）`),
+			},
 		},
 		({ itemName, count }) => {
 			const bot = getBot();
@@ -154,16 +156,18 @@ export function registerSleepInBed(
 	jobManager: JobManager,
 	logger: Logger,
 ): void {
-	server.tool(
+	server.registerTool(
 		"sleep_in_bed",
-		"近くのベッドで就寝を試みる（非同期ジョブ: 即座に jobId を返す）",
 		{
-			maxDistance: z
-				.number()
-				.min(1)
-				.max(64)
-				.default(32)
-				.describe("ベッド検索範囲（デフォルト: 32、最大: 64）"),
+			description: "近くのベッドで就寝を試みる（非同期ジョブ: 即座に jobId を返す）",
+			inputSchema: {
+				maxDistance: z
+					.number()
+					.min(1)
+					.max(64)
+					.default(32)
+					.describe("ベッド検索範囲（デフォルト: 32、最大: 64）"),
+			},
 		},
 		({ maxDistance }) => {
 			const bot = getBot();
@@ -180,177 +184,6 @@ export function registerSleepInBed(
 			if (!started.ok) return started.result;
 
 			return textResult(`就寝を開始しました（jobId: ${started.jobId}）`);
-		},
-	);
-}
-
-const SMELT_TIMEOUT_PER_ITEM_MS = 12_000;
-const SMELT_TIMEOUT_BUFFER_MS = 5_000;
-const MAX_SMELT_COUNT = 64;
-const FURNACE_SEARCH_DISTANCE = 32;
-
-/** かまどブロック ID（furnace / lit_furnace）を収集する */
-function collectFurnaceIds(bot: mineflayer.Bot): number[] {
-	const ids: number[] = [];
-	for (const name of ["furnace", "lit_furnace"]) {
-		const block = bot.registry.blocksByName[name];
-		if (block) ids.push(block.id);
-	}
-	return ids;
-}
-
-/** 精錬完了（outputItem の count が目標に達する）を待機する */
-function waitForSmeltComplete(
-	furnace: Furnace,
-	targetCount: number,
-	signal: AbortSignal,
-): Promise<void> {
-	return new Promise<void>((resolve, reject) => {
-		const timeoutMs = targetCount * SMELT_TIMEOUT_PER_ITEM_MS + SMELT_TIMEOUT_BUFFER_MS;
-		const timeout = setTimeout(() => {
-			cleanup();
-			const output = furnace.outputItem();
-			const got = output ? output.count : 0;
-			reject(
-				new Error(
-					`精錬がタイムアウトしました（${String(got)}/${String(targetCount)} 個完了）。燃料不足の可能性があります`,
-				),
-			);
-		}, timeoutMs);
-
-		const onUpdate = () => {
-			const output = furnace.outputItem();
-			if (output && output.count >= targetCount) {
-				cleanup();
-				resolve();
-			}
-		};
-
-		const onAbort = () => {
-			cleanup();
-			resolve();
-		};
-
-		const cleanup = () => {
-			clearTimeout(timeout);
-			furnace.removeListener("update", onUpdate);
-			signal.removeEventListener("abort", onAbort);
-		};
-
-		furnace.on("update", onUpdate);
-		signal.addEventListener("abort", onAbort, { once: true });
-
-		onUpdate();
-	});
-}
-
-interface SmeltParams {
-	bot: mineflayer.Bot;
-	itemId: number;
-	fuelId: number;
-	fuelName: string;
-	count: number;
-	signal: AbortSignal;
-}
-
-async function executeSmelt(params: SmeltParams): Promise<void> {
-	const { bot, itemId, fuelId, fuelName, count, signal } = params;
-	const furnaceIds = collectFurnaceIds(bot);
-	if (furnaceIds.length === 0) throw new Error("かまどブロックの定義が見つかりません");
-
-	const furnaceBlock = bot.findBlock({
-		matching: furnaceIds,
-		maxDistance: FURNACE_SEARCH_DISTANCE,
-	});
-	if (!furnaceBlock)
-		throw new Error(
-			`近くにかまどが見つかりません（${String(FURNACE_SEARCH_DISTANCE)} ブロック以内）`,
-		);
-
-	const { x, y, z: fz } = furnaceBlock.position;
-	await bot.pathfinder.goto(new goals.GoalGetToBlock(x, y, fz));
-
-	if (signal.aborted) return;
-
-	const furnace = await bot.openFurnace(furnaceBlock);
-	try {
-		// 既存の output を先に回収し、完了判定の誤検知を防ぐ
-		if (furnace.outputItem()) {
-			await furnace.takeOutput();
-		}
-
-		if (!furnace.fuelItem()) {
-			const fuelInInventory = bot.inventory.items().find((i) => i.name === fuelName);
-			if (!fuelInInventory) throw new Error(`インベントリに燃料 "${fuelName}" がありません`);
-			await furnace.putFuel(fuelId, null, Math.min(fuelInInventory.count, count));
-		}
-
-		if (signal.aborted) return;
-
-		await furnace.putInput(itemId, null, count);
-
-		if (signal.aborted) return;
-
-		await waitForSmeltComplete(furnace, count, signal);
-
-		if (signal.aborted) return;
-
-		await furnace.takeOutput();
-	} finally {
-		furnace.close();
-	}
-}
-
-export function registerSmeltItem(server: McpServer, getBot: GetBot, jobManager: JobManager): void {
-	server.tool(
-		"smelt_item",
-		"かまどでアイテムを精錬する（非同期ジョブ: 即座に jobId を返す、近くのかまどまで自動で移動）",
-		{
-			itemName: z
-				.string()
-				.describe('精錬するアイテム名（例: "raw_iron", "raw_gold", "cobblestone"）'),
-			count: z
-				.number()
-				.int()
-				.min(1)
-				.max(MAX_SMELT_COUNT)
-				.default(1)
-				.describe(`精錬個数（デフォルト: 1、最大: ${String(MAX_SMELT_COUNT)}）`),
-			fuelName: z
-				.string()
-				.default("coal")
-				.describe('燃料アイテム名（デフォルト: "coal"、例: "charcoal", "oak_planks"）'),
-		},
-		({ itemName, count, fuelName }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
-
-			const itemType = bot.registry.itemsByName[itemName];
-			if (!itemType) return textResult(`不明なアイテム名: "${itemName}"`);
-
-			const fuelType = bot.registry.itemsByName[fuelName];
-			if (!fuelType) return textResult(`不明な燃料名: "${fuelName}"`);
-
-			const itemInInventory = bot.inventory.items().find((i) => i.name === itemName);
-			if (!itemInInventory) return textResult(`インベントリに "${itemName}" がありません`);
-
-			const started = tryStartJob(jobManager, "smelting", itemName, async (signal) => {
-				ensureMovements(bot);
-				registerAbortHandler(bot, signal);
-				await executeSmelt({
-					bot,
-					itemId: itemType.id,
-					fuelId: fuelType.id,
-					fuelName,
-					count,
-					signal,
-				});
-			});
-			if (!started.ok) return started.result;
-
-			return textResult(
-				`${itemName} の精錬を開始しました（jobId: ${started.jobId}, 目標: ${String(count)} 個, 燃料: ${fuelName}）`,
-			);
 		},
 	);
 }

--- a/packages/minecraft/src/actions/movement.ts
+++ b/packages/minecraft/src/actions/movement.ts
@@ -101,12 +101,14 @@ export function registerFollowPlayer(
 	getBot: GetBot,
 	jobManager: JobManager,
 ): void {
-	server.tool(
+	server.registerTool(
 		"follow_player",
-		"指定プレイヤーへの追従を開始する（非同期ジョブ: 即座に jobId を返す）",
 		{
-			username: z.string().describe("追従対象のプレイヤー名"),
-			range: z.number().min(1).default(3).describe("何ブロック以内に接近するか（デフォルト: 3）"),
+			description: "指定プレイヤーへの追従を開始する（非同期ジョブ: 即座に jobId を返す）",
+			inputSchema: {
+				username: z.string().describe("追従対象のプレイヤー名"),
+				range: z.number().min(1).default(3).describe("何ブロック以内に接近するか（デフォルト: 3）"),
+			},
 		},
 		async ({ username, range }) => {
 			const bot = getBot();
@@ -130,14 +132,16 @@ export function registerFollowPlayer(
 }
 
 export function registerGoTo(server: McpServer, getBot: GetBot, jobManager: JobManager): void {
-	server.tool(
+	server.registerTool(
 		"go_to",
-		"指定座標への移動を開始する（非同期ジョブ: 即座に jobId を返す）",
 		{
-			x: z.number().describe("X 座標"),
-			y: z.number().describe("Y 座標"),
-			z: z.number().describe("Z 座標"),
-			range: z.number().min(0).default(2).describe("目標地点からの許容距離（デフォルト: 2）"),
+			description: "指定座標への移動を開始する（非同期ジョブ: 即座に jobId を返す）",
+			inputSchema: {
+				x: z.number().describe("X 座標"),
+				y: z.number().describe("Y 座標"),
+				z: z.number().describe("Z 座標"),
+				range: z.number().min(0).default(2).describe("目標地点からの許容距離（デフォルト: 2）"),
+			},
 		},
 		({ x, y, z: zCoord, range }) => {
 			const bot = getBot();
@@ -162,19 +166,22 @@ export function registerCollectBlock(
 	getBot: GetBot,
 	jobManager: JobManager,
 ): void {
-	server.tool(
+	server.registerTool(
 		"collect_block",
-		"指定ブロックの採集を開始する（非同期ジョブ: 即座に jobId を返す、最適ツール自動装備）",
 		{
-			blockName: z.string().describe('ブロック名（例: "oak_log", "diamond_ore"）'),
-			count: z
-				.number()
-				.int()
-				.min(1)
-				.max(MAX_COLLECT_COUNT)
-				.default(1)
-				.describe(`採集する個数（デフォルト: 1、最大: ${String(MAX_COLLECT_COUNT)}）`),
-			maxDistance: z.number().min(1).default(32).describe("検索範囲（デフォルト: 32）"),
+			description:
+				"指定ブロックの採集を開始する（非同期ジョブ: 即座に jobId を返す、最適ツール自動装備）",
+			inputSchema: {
+				blockName: z.string().describe('ブロック名（例: "oak_log", "diamond_ore"）'),
+				count: z
+					.number()
+					.int()
+					.min(1)
+					.max(MAX_COLLECT_COUNT)
+					.default(1)
+					.describe(`採集する個数（デフォルト: 1、最大: ${String(MAX_COLLECT_COUNT)}）`),
+				maxDistance: z.number().min(1).default(32).describe("検索範囲（デフォルト: 32）"),
+			},
 		},
 		({ blockName, count, maxDistance }) => {
 			const bot = getBot();
@@ -196,11 +203,15 @@ export function registerCollectBlock(
 }
 
 export function registerStop(server: McpServer, jobManager: JobManager): void {
-	server.tool("stop", "現在のジョブ（移動・追従・採集・クラフト・就寝）を停止する", {}, () => {
-		const cancelled = jobManager.cancelCurrentJob();
-		if (cancelled) {
-			return textResult("ジョブを停止しました");
-		}
-		return textResult("実行中のジョブはありません");
-	});
+	server.registerTool(
+		"stop",
+		{ description: "現在のジョブ（移動・追従・採集・クラフト・就寝）を停止する" },
+		() => {
+			const cancelled = jobManager.cancelCurrentJob();
+			if (cancelled) {
+				return textResult("ジョブを停止しました");
+			}
+			return textResult("実行中のジョブはありません");
+		},
+	);
 }

--- a/packages/minecraft/src/actions/smelting.ts
+++ b/packages/minecraft/src/actions/smelting.ts
@@ -1,0 +1,188 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type mineflayer from "mineflayer";
+import type { Furnace } from "mineflayer";
+import { goals } from "mineflayer-pathfinder";
+import { z } from "zod";
+
+import type { JobManager } from "../job-manager.ts";
+import {
+	type GetBot,
+	ensureMovements,
+	registerAbortHandler,
+	textResult,
+	tryStartJob,
+} from "./shared.ts";
+
+const SMELT_TIMEOUT_PER_ITEM_MS = 12_000;
+const SMELT_TIMEOUT_BUFFER_MS = 5_000;
+const MAX_SMELT_COUNT = 64;
+const FURNACE_SEARCH_DISTANCE = 32;
+
+/** かまどブロック ID（furnace / lit_furnace）を収集する */
+function collectFurnaceIds(bot: mineflayer.Bot): number[] {
+	const ids: number[] = [];
+	for (const name of ["furnace", "lit_furnace"]) {
+		const block = bot.registry.blocksByName[name];
+		if (block) ids.push(block.id);
+	}
+	return ids;
+}
+
+/** 精錬完了（outputItem の count が目標に達する）を待機する */
+function waitForSmeltComplete(
+	furnace: Furnace,
+	targetCount: number,
+	signal: AbortSignal,
+): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		const timeoutMs = targetCount * SMELT_TIMEOUT_PER_ITEM_MS + SMELT_TIMEOUT_BUFFER_MS;
+		const timeout = setTimeout(() => {
+			cleanup();
+			const output = furnace.outputItem();
+			const got = output ? output.count : 0;
+			reject(
+				new Error(
+					`精錬がタイムアウトしました（${String(got)}/${String(targetCount)} 個完了）。燃料不足の可能性があります`,
+				),
+			);
+		}, timeoutMs);
+
+		const onUpdate = () => {
+			const output = furnace.outputItem();
+			if (output && output.count >= targetCount) {
+				cleanup();
+				resolve();
+			}
+		};
+
+		const onAbort = () => {
+			cleanup();
+			resolve();
+		};
+
+		const cleanup = () => {
+			clearTimeout(timeout);
+			furnace.removeListener("update", onUpdate);
+			signal.removeEventListener("abort", onAbort);
+		};
+
+		furnace.on("update", onUpdate);
+		signal.addEventListener("abort", onAbort, { once: true });
+
+		onUpdate();
+	});
+}
+
+interface SmeltParams {
+	bot: mineflayer.Bot;
+	itemId: number;
+	fuelId: number;
+	fuelName: string;
+	count: number;
+	signal: AbortSignal;
+}
+
+async function executeSmelt(params: SmeltParams): Promise<void> {
+	const { bot, itemId, fuelId, fuelName, count, signal } = params;
+	const furnaceIds = collectFurnaceIds(bot);
+	if (furnaceIds.length === 0) throw new Error("かまどブロックの定義が見つかりません");
+
+	const furnaceBlock = bot.findBlock({
+		matching: furnaceIds,
+		maxDistance: FURNACE_SEARCH_DISTANCE,
+	});
+	if (!furnaceBlock)
+		throw new Error(
+			`近くにかまどが見つかりません（${String(FURNACE_SEARCH_DISTANCE)} ブロック以内）`,
+		);
+
+	const { x, y, z: fz } = furnaceBlock.position;
+	await bot.pathfinder.goto(new goals.GoalGetToBlock(x, y, fz));
+
+	if (signal.aborted) return;
+
+	const furnace = await bot.openFurnace(furnaceBlock);
+	try {
+		// 既存の output を先に回収し、完了判定の誤検知を防ぐ
+		if (furnace.outputItem()) {
+			await furnace.takeOutput();
+		}
+
+		if (!furnace.fuelItem()) {
+			const fuelInInventory = bot.inventory.items().find((i) => i.name === fuelName);
+			if (!fuelInInventory) throw new Error(`インベントリに燃料 "${fuelName}" がありません`);
+			await furnace.putFuel(fuelId, null, Math.min(fuelInInventory.count, count));
+		}
+
+		if (signal.aborted) return;
+
+		await furnace.putInput(itemId, null, count);
+
+		if (signal.aborted) return;
+
+		await waitForSmeltComplete(furnace, count, signal);
+
+		if (signal.aborted) return;
+
+		await furnace.takeOutput();
+	} finally {
+		furnace.close();
+	}
+}
+
+export function registerSmeltItem(server: McpServer, getBot: GetBot, jobManager: JobManager): void {
+	server.registerTool(
+		"smelt_item",
+		{
+			description:
+				"かまどでアイテムを精錬する（非同期ジョブ: 即座に jobId を返す、近くのかまどまで自動で移動）",
+			inputSchema: {
+				itemName: z
+					.string()
+					.describe('精錬するアイテム名（例: "raw_iron", "raw_gold", "cobblestone"）'),
+				count: z
+					.number()
+					.int()
+					.min(1)
+					.max(MAX_SMELT_COUNT)
+					.default(1)
+					.describe(`精錬個数（デフォルト: 1、最大: ${String(MAX_SMELT_COUNT)}）`),
+				fuelName: z
+					.string()
+					.default("coal")
+					.describe('燃料アイテム名（デフォルト: "coal"、例: "charcoal", "oak_planks"）'),
+			},
+		},
+		({ itemName, count, fuelName }) => {
+			const bot = getBot();
+			if (!bot?.entity) return textResult("ボット未接続");
+
+			const itemType = bot.registry.itemsByName[itemName];
+			if (!itemType) return textResult(`不明なアイテム名: "${itemName}"`);
+
+			const fuelType = bot.registry.itemsByName[fuelName];
+			if (!fuelType) return textResult(`不明な燃料名: "${fuelName}"`);
+
+			const itemInInventory = bot.inventory.items().find((i) => i.name === itemName);
+			if (!itemInInventory) return textResult(`インベントリに "${itemName}" がありません`);
+
+			const started = tryStartJob(jobManager, "smelting", itemName, async (signal) => {
+				ensureMovements(bot);
+				registerAbortHandler(bot, signal);
+				await executeSmelt({
+					bot,
+					itemId: itemType.id,
+					fuelId: fuelType.id,
+					fuelName,
+					count,
+					signal,
+				});
+			});
+			if (!started.ok) return started.result;
+
+			return textResult(
+				`${itemName} の精錬を開始しました（jobId: ${started.jobId}, 目標: ${String(count)} 個, 燃料: ${fuelName}）`,
+			);
+		},
+	);
+}

--- a/packages/minecraft/src/actions/survival/escape.ts
+++ b/packages/minecraft/src/actions/survival/escape.ts
@@ -17,21 +17,23 @@ export function registerFleeFromEntity(
 	getBot: GetBot,
 	jobManager: JobManager,
 ): void {
-	server.tool(
+	server.registerTool(
 		"flee_from_entity",
-		"指定エンティティから逃走する（非同期ジョブ: 即座に jobId を返す）",
 		{
-			entityName: z
-				.string()
-				.min(1)
-				.max(64)
-				.describe('逃走対象のエンティティ名（例: "creeper", "warden"）'),
-			distance: z
-				.number()
-				.min(8)
-				.max(64)
-				.default(32)
-				.describe("逃走距離（デフォルト: 32ブロック）"),
+			description: "指定エンティティから逃走する（非同期ジョブ: 即座に jobId を返す）",
+			inputSchema: {
+				entityName: z
+					.string()
+					.min(1)
+					.max(64)
+					.describe('逃走対象のエンティティ名（例: "creeper", "warden"）'),
+				distance: z
+					.number()
+					.min(8)
+					.max(64)
+					.default(32)
+					.describe("逃走距離（デフォルト: 32ブロック）"),
+			},
 		},
 		async ({ entityName, distance }) => {
 			const bot = getBot();

--- a/packages/minecraft/src/actions/survival/food.ts
+++ b/packages/minecraft/src/actions/survival/food.ts
@@ -52,14 +52,16 @@ export function listEdibleFoods(bot: mineflayer.Bot, emergency: boolean): FoodIn
 }
 
 export function registerEatFood(server: McpServer, getBot: GetBot): void {
-	server.tool(
+	server.registerTool(
 		"eat_food",
-		"インベントリから食料を選んで食べる（空腹度を回復）",
 		{
-			emergency: z
-				.boolean()
-				.default(false)
-				.describe("緊急時のみ true（golden_apple の使用を許可）"),
+			description: "インベントリから食料を選んで食べる（空腹度を回復）",
+			inputSchema: {
+				emergency: z
+					.boolean()
+					.default(false)
+					.describe("緊急時のみ true（golden_apple の使用を許可）"),
+			},
 		},
 		async ({ emergency }) => {
 			const bot = getBot();

--- a/packages/minecraft/src/actions/survival/shelter.ts
+++ b/packages/minecraft/src/actions/survival/shelter.ts
@@ -112,16 +112,19 @@ export function registerFindShelter(
 	getBot: GetBot,
 	jobManager: JobManager,
 ): void {
-	server.tool(
+	server.registerTool(
 		"find_shelter",
-		"安全な避難場所を探して移動する（ベッド検索 → ベッド付近に移動、なければ足元を掘って緊急シェルター構築）",
 		{
-			maxDistance: z
-				.number()
-				.min(1)
-				.max(64)
-				.default(48)
-				.describe("ベッド検索範囲（デフォルト: 48）"),
+			description:
+				"安全な避難場所を探して移動する（ベッド検索 → ベッド付近に移動、なければ足元を掘って緊急シェルター構築）",
+			inputSchema: {
+				maxDistance: z
+					.number()
+					.min(1)
+					.max(64)
+					.default(48)
+					.describe("ベッド検索範囲（デフォルト: 48）"),
+			},
 		},
 		({ maxDistance }) => {
 			const bot = getBot();

--- a/packages/minecraft/src/mcp-tools.ts
+++ b/packages/minecraft/src/mcp-tools.ts
@@ -21,10 +21,9 @@ function registerObserveStateTool(
 	ctx: BotContext,
 	jobManager: JobManager,
 ): void {
-	server.tool(
+	server.registerTool(
 		"observe_state",
-		"Minecraft ボットの現在の状態を自然言語要約で取得する",
-		{},
+		{ description: "Minecraft ボットの現在の状態を自然言語要約で取得する" },
 		async () => {
 			const bot = ctx.getBot();
 			if (!bot || !bot.entity) {
@@ -69,20 +68,22 @@ function registerObserveStateTool(
 }
 
 function registerRecentEventsTool(server: McpServer, ctx: BotContext): void {
-	server.tool(
+	server.registerTool(
 		"get_recent_events",
-		"Minecraft ボットの直近イベントログをテキスト形式で取得する",
 		{
-			limit: z
-				.number()
-				.min(1)
-				.max(50)
-				.default(10)
-				.describe("取得するイベント数（デフォルト: 10、最大: 50）"),
-			importance: z
-				.enum(["low", "medium", "high"])
-				.optional()
-				.describe("最低重要度フィルタ（例: medium → medium 以上のみ）"),
+			description: "Minecraft ボットの直近イベントログをテキスト形式で取得する",
+			inputSchema: {
+				limit: z
+					.number()
+					.min(1)
+					.max(50)
+					.default(10)
+					.describe("取得するイベント数（デフォルト: 10、最大: 50）"),
+				importance: z
+					.enum(["low", "medium", "high"])
+					.optional()
+					.describe("最低重要度フィルタ（例: medium → medium 以上のみ）"),
+			},
 		},
 		({ limit, importance }) => {
 			const events = ctx.getEvents();
@@ -98,16 +99,18 @@ function registerRecentEventsTool(server: McpServer, ctx: BotContext): void {
 }
 
 function registerJobStatusTool(server: McpServer, jobManager: JobManager): void {
-	server.tool(
+	server.registerTool(
 		"get_job_status",
-		"現在のジョブ状態と直近のジョブ履歴を取得する",
 		{
-			limit: z
-				.number()
-				.min(1)
-				.max(20)
-				.default(5)
-				.describe("取得するジョブ履歴数（デフォルト: 5、最大: 20）"),
+			description: "現在のジョブ状態と直近のジョブ履歴を取得する",
+			inputSchema: {
+				limit: z
+					.number()
+					.min(1)
+					.max(20)
+					.default(5)
+					.describe("取得するジョブ履歴数（デフォルト: 5、最大: 20）"),
+			},
 		},
 		({ limit }) => {
 			const current = jobManager.getCurrentJob();
@@ -119,43 +122,42 @@ function registerJobStatusTool(server: McpServer, jobManager: JobManager): void 
 }
 
 function registerViewerUrlTool(server: McpServer, ctx: BotContext, viewerPort: number): void {
-	server.tool("get_viewer_url", "Minecraft ビューアーの URL を返す", {}, () => {
-		const bot = ctx.getBot();
-		if (!bot?.entity) {
-			return { content: [{ type: "text" as const, text: "ボット未接続" }] };
-		}
-		return {
-			content: [
-				{
-					type: "text" as const,
-					text: `http://localhost:${String(viewerPort)}`,
-				},
-			],
-		};
-	});
+	server.registerTool(
+		"get_viewer_url",
+		{ description: "Minecraft ビューアーの URL を返す" },
+		() => {
+			const bot = ctx.getBot();
+			if (!bot?.entity) {
+				return { content: [{ type: "text" as const, text: "ボット未接続" }] };
+			}
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: `http://localhost:${String(viewerPort)}`,
+					},
+				],
+			};
+		},
+	);
 }
 
 /**
- * server.tool() 呼び出しをインターセプトし、各ツールのハンドラ実行時にメトリクスを記録する
+ * server.registerTool() 呼び出しをインターセプトし、各ツールのハンドラ実行時にメトリクスを記録する
  * Proxy を使って McpServer を薄くラップすることで、個々のツール登録関数を変更せずに全ツールを計測できる
  */
 function wrapServerWithMetrics(server: McpServer, metrics: MetricsCollector): McpServer {
 	return new Proxy(server, {
 		get(target, prop, receiver) {
-			if (prop !== "tool") return Reflect.get(target, prop, receiver);
-			// oxlint-disable-next-line no-explicit-any -- McpServer.tool() は複数オーバーロードを持つため any で受ける
-			return (name: string, ...args: any[]) => {
-				const lastIdx = args.length - 1;
-				const originalHandler = args[lastIdx];
-				if (typeof originalHandler === "function") {
-					// oxlint-disable-next-line no-explicit-any -- handler の引数型はオーバーロードごとに異なる
-					args[lastIdx] = (...handlerArgs: any[]) => {
-						metrics.incrementCounter(METRIC.MC_MCP_TOOL_CALLS, { tool: name });
-						return originalHandler(...handlerArgs);
-					};
-				}
-				// oxlint-disable-next-line no-unsafe-function-type, ban-types -- target.tool の型を正確に表現できないため
-				return (target.tool as (...a: unknown[]) => unknown).call(target, name, ...args);
+			if (prop !== "registerTool") return Reflect.get(target, prop, receiver);
+			// oxlint-disable-next-line no-explicit-any -- McpServer.registerTool() のコールバック型を正確に表現できないため any で受ける
+			return (name: string, config: any, cb: (...handlerArgs: any[]) => any) => {
+				// oxlint-disable-next-line no-explicit-any -- handler の引数型はツールごとに異なる
+				const wrappedCb = (...handlerArgs: any[]) => {
+					metrics.incrementCounter(METRIC.MC_MCP_TOOL_CALLS, { tool: name });
+					return cb(...handlerArgs);
+				};
+				return target.registerTool(name, config, wrappedCb);
 			};
 		},
 	});

--- a/spec/mcp/minecraft/actions/smelt.spec.ts
+++ b/spec/mcp/minecraft/actions/smelt.spec.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
-import { registerSmeltItem } from "@vicissitude/minecraft/actions/jobs";
+import { registerSmeltItem } from "@vicissitude/minecraft/actions/smelting";
 
 type ToolHandler = (args: { itemName: string; count: number; fuelName: string }) => unknown;
 
 function captureSmeltHandler(getBot: () => unknown): ToolHandler {
 	const result: { handler: ToolHandler | null } = { handler: null };
 	const fakeServer = {
-		tool: (_name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+		registerTool: (_name: string, _config: unknown, handler: ToolHandler) => {
 			result.handler = handler;
 		},
 	};


### PR DESCRIPTION
## Summary

- `@modelcontextprotocol/sdk` v1.27.1 で deprecated となった `server.tool()` を新しい `server.registerTool()` API に全17ファイルで一括移行
- `wrapServerWithMetrics` の Proxy インターセプト対象を `tool` → `registerTool` に更新
- `jobs.ts` の `max-lines` lint 超過を解消するため smelt 関連ロジックを `smelting.ts` に分離

## Test plan

- [x] `nr validate` (fmt:check + lint + check) が 0 errors で通過（既存の 4 warnings のみ）
- [x] `nr test` の結果が移行前と同一（1005 pass, 3 fail は既存の mineflayer-pathfinder モジュール解決エラー）
- [x] `server.tool(` の使用箇所が 0 であることを grep で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)