### PR TITLE
fix: Minecraft Kick 理由のログ出力を修正

### DIFF
--- a/packages/minecraft/src/bot-connection.ts
+++ b/packages/minecraft/src/bot-connection.ts
@@ -129,9 +129,10 @@ function registerCoreEvents(
 	b.on("chat", (username: string, message: string) => {
 		if (username !== b.username) ctx.pushEvent("chat", `<${username}> ${message}`, "medium");
 	});
-	b.on("kicked", (reason: string) => {
-		logger.warn(`[minecraft] Kicked: ${reason}`);
-		ctx.pushEvent("kicked", `Kicked: ${reason}`, "high");
+	b.on("kicked", (reason: string | Record<string, unknown>) => {
+		const text = typeof reason === "string" ? reason : JSON.stringify(reason);
+		logger.warn(`[minecraft] Kicked: ${text}`);
+		ctx.pushEvent("kicked", `Kicked: ${text}`, "high");
 	});
 	b.on("entityHurt", (entity: Entity) => {
 		if (entity === b.entity) ctx.pushEvent("damage", "Bot took damage", "medium");


### PR DESCRIPTION
## Summary
- mineflayer の `kicked` イベントの `reason` が Chat Component オブジェクトの場合、`[object Object]` としてログ出力されていた問題を修正
- オブジェクトの場合は `JSON.stringify()` でシリアライズしてから出力するように変更

## Test plan
- [x] `nr validate` 通過（型チェック・lint・フォーマット）

🤖 Generated with [Claude Code](https://claude.com/claude-code)