### PR TITLE
feat: AivisSpeech Engine の Docker Compose 構成を追加

### DIFF
--- a/containers/aivispeech/compose.yaml
+++ b/containers/aivispeech/compose.yaml
@@ -1,0 +1,22 @@
+# AivisSpeech Engine — Windows (Cyrene) の Docker Desktop で起動する
+# 使い方: docker compose -f containers/aivispeech/compose.yaml up -d
+
+volumes:
+  aivispeech-data:
+
+services:
+  aivispeech-engine:
+    image: ghcr.io/aivis-project/aivisspeech-engine:nvidia-latest
+    container_name: aivispeech-engine
+    ports:
+      - "10101:10101"
+    volumes:
+      - aivispeech-data:/home/user/.local/share/AivisSpeech-Engine-Dev
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Windows (Cyrene) の Docker Desktop で AivisSpeech Engine を起動するための compose ファイルを追加
- NVIDIA GPU (CUDA) 対応、named volume でモデルキャッシュを永続化
- ポート 10101 (デフォルト)

## Test plan
- [ ] Cyrene (Windows) で `docker compose -f containers/aivispeech/compose.yaml up -d` を実行
- [ ] `http://localhost:10101/docs` で API ドキュメントにアクセスできることを確認
- [ ] GPU が認識されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)