### PR TITLE
feat: Gateway サーバー起動 + AivisSpeech TTS 統合

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ LTM_MODEL_ID=gpt-4o
 OLLAMA_BASE_URL=http://ollama:11434
 LTM_EMBEDDING_MODEL=embeddinggemma
 
+# TTS - AivisSpeech Engine (optional)
+# AIVIS_SPEECH_URL=http://localhost:10101
+# AIVIS_SPEECH_SPEAKER_ID=0
+
 # Minecraft (optional)
 # MC_HOST=host.containers.internal
 # MC_PORT=25565

--- a/apps/discord/DEPS.md
+++ b/apps/discord/DEPS.md
@@ -18,7 +18,7 @@ graph LR
 ### bootstrap.ts
 
 - モジュール内依存: gateway/channel-config-loader, gateway/discord
-- 他モジュール依存: agent, application, infrastructure, ltm, observability, ollama, opencode, scheduling, shared, store
+- 他モジュール依存: agent, application, gateway, infrastructure, ltm, observability, ollama, opencode, scheduling, shared, store, tts
 - 外部依存: .bun, fs, path
 
 ### gateway/channel-config-loader.ts

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -8,6 +8,8 @@ import { GuildRouter } from "@vicissitude/agent/discord/router";
 import { McBrainManager } from "@vicissitude/agent/minecraft/brain-manager";
 import { SessionStore } from "@vicissitude/agent/session-store";
 import { MessageIngestionService } from "@vicissitude/application/message-ingestion-service";
+import { createGatewayServer } from "@vicissitude/gateway/server";
+import { WsConnectionManager } from "@vicissitude/gateway/ws-handler";
 import { SqliteBufferedEventStore } from "@vicissitude/infrastructure/store/sqlite-buffered-event-store";
 import { CompositeLLMAdapter } from "@vicissitude/ltm/composite-llm-adapter";
 import { LtmConversationRecorder } from "@vicissitude/ltm/conversation-recorder";
@@ -40,6 +42,7 @@ import type { StoreDb } from "@vicissitude/store/db";
 import { createDb, closeDb } from "@vicissitude/store/db";
 import { SqliteMcStatusProvider } from "@vicissitude/store/mc-status-provider";
 import { incrementEmoji } from "@vicissitude/store/queries";
+import { createAivisSpeechSynthesizer, createEmotionToTtsStyleMapper } from "@vicissitude/tts";
 import { spawn, type Subprocess } from "bun";
 
 import { ChannelConfigLoader, type ChannelConfigData } from "./gateway/channel-config-loader.ts";
@@ -408,6 +411,23 @@ export async function bootstrap(): Promise<void> {
 	const gateway = new DiscordGateway(config.discordToken, logger);
 	gateway.setHomeChannelIds(channelConfig.getHomeChannelIds());
 
+	// Gateway WebSocket server (with optional TTS)
+	const ttsSynthesizer = config.tts
+		? createAivisSpeechSynthesizer({
+				baseUrl: config.tts.baseUrl,
+				speakerId: config.tts.speakerId,
+			})
+		: undefined;
+	const ttsStyleMapper = config.tts ? createEmotionToTtsStyleMapper() : undefined;
+	const wsManager = new WsConnectionManager({
+		ttsSynthesizer,
+		ttsStyleMapper,
+	});
+	const gatewayServer = createGatewayServer(config.gatewayPort, wsManager);
+	logger.info(
+		`[bootstrap] Gateway server started (port=${config.gatewayPort}, tts=${!!config.tts})`,
+	);
+
 	// Core MCP + Minecraft MCP (start in parallel)
 	const coreReady = startCoreMcp(config, root, logger);
 	const mcReady = startMinecraftMcp(config, root, logger);
@@ -489,6 +509,7 @@ export async function bootstrap(): Promise<void> {
 			await ltmResources?.consolidationScheduler.stop();
 			heartbeatScheduler.stop();
 			gateway.stop();
+			await gatewayServer.stop();
 			mcBrainManager?.stop();
 			routingAgent.stop();
 			metrics.server.stop();

--- a/compose.yaml
+++ b/compose.yaml
@@ -71,6 +71,7 @@ services:
       - .env
     ports:
       - "127.0.0.1:9091:9091"
+      - "0.0.0.0:4001:4001" # gateway WebSocket
       - "0.0.0.0:3007:3007" # prismarine-viewer
     volumes:
       - bot-node-modules:/app/node_modules:ro

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -12,6 +12,7 @@ graph LR
   application --> shared
   apps_discord["apps/discord"] --> agent
   apps_discord["apps/discord"] --> application
+  apps_discord["apps/discord"] --> gateway
   apps_discord["apps/discord"] --> infrastructure
   apps_discord["apps/discord"] --> ltm
   apps_discord["apps/discord"] --> observability
@@ -20,6 +21,7 @@ graph LR
   apps_discord["apps/discord"] --> scheduling
   apps_discord["apps/discord"] --> shared
   apps_discord["apps/discord"] --> store
+  apps_discord["apps/discord"] --> tts
   apps_web["apps/web"] --> shared
   avatar --> shared
   gateway --> avatar
@@ -65,7 +67,7 @@ graph LR
 
 ### apps/discord
 
-- 内部依存: agent, application, infrastructure, ltm, observability, ollama, opencode, scheduling, shared, store
+- 内部依存: agent, application, gateway, infrastructure, ltm, observability, ollama, opencode, scheduling, shared, store, tts
 - 外部依存: .bun, fs, path
 - ファイル数: 4
 
@@ -85,7 +87,7 @@ graph LR
 
 - 内部依存: avatar, shared
 - 外部依存: .bun
-- ファイル数: 2
+- ファイル数: 4
 
 ### infrastructure
 
@@ -151,4 +153,4 @@ graph LR
 
 - 内部依存: shared
 - 外部依存: なし
-- ファイル数: 3
+- ファイル数: 4

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -41,6 +41,11 @@ const minecraftSchema = z.object({
 	viewerPort: safeInt,
 });
 
+const ttsSchema = z.object({
+	baseUrl: z.string(),
+	speakerId: safeInt,
+});
+
 const appConfigSchema = z.object({
 	discordToken: z.string().min(1, "DISCORD_TOKEN is required"),
 	webPort: safeInt,
@@ -62,6 +67,7 @@ const appConfigSchema = z.object({
 		providerId: z.string(),
 		modelId: z.string(),
 	}),
+	tts: ttsSchema.optional(),
 	minecraft: minecraftSchema.optional(),
 	dataDir: z.string(),
 	contextDir: z.string(),
@@ -69,6 +75,7 @@ const appConfigSchema = z.object({
 
 // ─── Types ───────────────────────────────────────────────────────
 
+export type TtsConfig = z.infer<typeof ttsSchema>;
 export type MinecraftConfig = z.infer<typeof minecraftSchema>;
 export type AppConfig = z.infer<typeof appConfigSchema>;
 
@@ -105,6 +112,12 @@ export function loadConfig(
 			providerId: env.MC_PROVIDER_ID ?? openCodeProviderId,
 			modelId: env.MC_MODEL_ID ?? env.OPENCODE_MODEL_ID ?? "big-pickle",
 		},
+		tts: env.AIVIS_SPEECH_URL
+			? {
+					baseUrl: env.AIVIS_SPEECH_URL,
+					speakerId: Number(env.AIVIS_SPEECH_SPEAKER_ID ?? "0"),
+				}
+			: undefined,
 		minecraft: env.MC_HOST
 			? {
 					host: env.MC_HOST,


### PR DESCRIPTION
## Summary

- `AppConfig` に `tts` (optional) セクションを追加（`AIVIS_SPEECH_URL`, `AIVIS_SPEECH_SPEAKER_ID` 環境変数）
- `bootstrap()` で `WsConnectionManager` に TTS 依存（`AivisSpeechSynthesizer` + `EmotionToTtsStyleMapper`）を DI し、Gateway WebSocket サーバーを起動
- `compose.yaml` で Gateway ポート (4001) を外部公開

## Test plan

- [x] `nr validate` 通過（fmt, lint, type check）
- [x] 全 1094 テスト通過
- [ ] デプロイ後に `ws://cipher:4001/ws` で WebSocket 接続確認
- [ ] `chat_input` 送信 → `audio_data` メッセージ受信確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)