### PR TITLE
chore: settings.json のインデントをタブに統一

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,23 +1,23 @@
 {
-  "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": 1,
-    "CLAUDE_CODE_DISABLE_1M_CONTEXT": 1
-  },
-  "permissions": {
-    "allow": ["Bash"]
-  },
-  "teammateMode": "in-process",
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "FILE=$(jq -r '.tool_input.file_path' 2>/dev/null) && oxfmt \"$FILE\" 2>/dev/null; exit 0"
-          }
-        ]
-      }
-    ]
-  }
+	"env": {
+		"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": 1,
+		"CLAUDE_CODE_DISABLE_1M_CONTEXT": 1
+	},
+	"permissions": {
+		"allow": ["Bash"]
+	},
+	"teammateMode": "in-process",
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "Edit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "FILE=$(jq -r '.tool_input.file_path' 2>/dev/null) && oxfmt \"$FILE\" 2>/dev/null; exit 0"
+					}
+				]
+			}
+		]
+	}
 }


### PR DESCRIPTION
## Summary
- `.claude/settings.json` のインデントをスペースからタブに統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)