### PR TITLE
fix: mineflayer-pathfinder の CJS named import を修正

### DIFF
--- a/packages/minecraft/src/actions/combat.ts
+++ b/packages/minecraft/src/actions/combat.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type mineflayer from "mineflayer";
-import { goals } from "mineflayer-pathfinder";
+import pathfinderPkg from "mineflayer-pathfinder";
 import type { Entity } from "prismarine-entity";
 import { z } from "zod";
 
@@ -13,6 +13,8 @@ import {
 	textResult,
 	tryStartJob,
 } from "./shared.ts";
+
+const { goals } = pathfinderPkg;
 
 /** 武器の優先度リスト（上位ほど優先） */
 const WEAPON_PRIORITY: string[] = [

--- a/packages/minecraft/src/actions/jobs.ts
+++ b/packages/minecraft/src/actions/jobs.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Logger } from "@vicissitude/shared/types";
 import type mineflayer from "mineflayer";
-import { goals } from "mineflayer-pathfinder";
+import pathfinderPkg from "mineflayer-pathfinder";
 import type { Recipe } from "prismarine-recipe";
 import { z } from "zod";
 
@@ -14,6 +14,8 @@ import {
 	textResult,
 	tryStartJob,
 } from "./shared.ts";
+
+const { goals } = pathfinderPkg;
 
 const MAX_CRAFT_COUNT = 64;
 

--- a/packages/minecraft/src/actions/movement.ts
+++ b/packages/minecraft/src/actions/movement.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type mineflayer from "mineflayer";
-import { goals } from "mineflayer-pathfinder";
+import pathfinderPkg from "mineflayer-pathfinder";
 import type { Entity } from "prismarine-entity";
 import { z } from "zod";
 
@@ -13,6 +13,8 @@ import {
 	textResult,
 	tryStartJob,
 } from "./shared.ts";
+
+const { goals } = pathfinderPkg;
 
 const MAX_COLLECT_COUNT = 64;
 

--- a/packages/minecraft/src/actions/shared.ts
+++ b/packages/minecraft/src/actions/shared.ts
@@ -1,7 +1,9 @@
 import type mineflayer from "mineflayer";
-import { Movements } from "mineflayer-pathfinder";
+import pathfinderPkg from "mineflayer-pathfinder";
 
 import type { JobExecutor, JobManager } from "../job-manager.ts";
+
+const { Movements } = pathfinderPkg;
 
 export type GetBot = () => mineflayer.Bot | null;
 export type TextResult = { content: { type: "text"; text: string }[] };

--- a/packages/minecraft/src/actions/smelting.ts
+++ b/packages/minecraft/src/actions/smelting.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type mineflayer from "mineflayer";
 import type { Furnace } from "mineflayer";
-import { goals } from "mineflayer-pathfinder";
+import pathfinderPkg from "mineflayer-pathfinder";
 import { z } from "zod";
 
 import type { JobManager } from "../job-manager.ts";
@@ -12,6 +12,8 @@ import {
 	textResult,
 	tryStartJob,
 } from "./shared.ts";
+
+const { goals } = pathfinderPkg;
 
 const SMELT_TIMEOUT_PER_ITEM_MS = 12_000;
 const SMELT_TIMEOUT_BUFFER_MS = 5_000;

--- a/packages/minecraft/src/actions/survival/escape.ts
+++ b/packages/minecraft/src/actions/survival/escape.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { goals } from "mineflayer-pathfinder";
+import pathfinderPkg from "mineflayer-pathfinder";
 import { z } from "zod";
 
 import { findPerceivedEntityByName } from "../../bot-queries.ts";
@@ -11,6 +11,8 @@ import {
 	textResult,
 	tryStartJob,
 } from "../shared.ts";
+
+const { goals } = pathfinderPkg;
 
 export function registerFleeFromEntity(
 	server: McpServer,

--- a/packages/minecraft/src/actions/survival/shelter.ts
+++ b/packages/minecraft/src/actions/survival/shelter.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type mineflayer from "mineflayer";
-import { goals } from "mineflayer-pathfinder";
+import pathfinderPkg from "mineflayer-pathfinder";
 import { Vec3 } from "vec3";
 import { z } from "zod";
 
@@ -13,6 +13,8 @@ import {
 	textResult,
 	tryStartJob,
 } from "../shared.ts";
+
+const { goals } = pathfinderPkg;
 
 /** 天井を塞ぐのに適したソリッドブロックの候補（優先度順） */
 const SHELTER_BLOCK_NAMES = new Set([


### PR DESCRIPTION
## Summary

- `mineflayer-pathfinder` は CJS モジュールだが、named import (`{ Movements }`, `{ goals }`) を使用していたため Bun が ESM named export として解決できず 3 件のテストが `SyntaxError` で失敗していた
- 7ファイルで named import を default import + destructuring に統一変更
- `bot-connection.ts` の既存パターン (`import pathfinder from "mineflayer-pathfinder"`) と整合

## Test plan

- [x] `nr test` — 1094 pass, 0 fail
- [x] `nr validate` — fmt:check, lint (0 errors), tsgo すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)