### PR TITLE
fix: collect_block が 0 個採集でも「完了」になるバグを修正

### DIFF
--- a/packages/minecraft/src/actions/movement.ts
+++ b/packages/minecraft/src/actions/movement.ts
@@ -61,8 +61,10 @@ async function executeCollectBlock(
 		collected++;
 		updateProgress(`${String(collected)}/${String(count)} 採集済み`);
 	}
-	if (collected === 0 && !signal.aborted) {
-		throw new Error(`${String(maxDistance)} ブロック以内に対象ブロックが見つかりません`);
+	if (collected < count && !signal.aborted) {
+		throw new Error(
+			`${String(collected)}/${String(count)} 個採集 — ${String(maxDistance)} ブロック以内に追加の対象ブロックが見つかりません`,
+		);
 	}
 }
 


### PR DESCRIPTION
## Summary

- `executeCollectBlock` で `findPerceivedBlock` が対象ブロックを見つけられない場合、0 個採集のまま正常 resolve していたため、JobManager が「完了」と記録していた
- MC エージェントはこの誤った成功報告により「採集成功→クラフト失敗（材料なし）」のループに陥り、インベントリが空のまま進行不能になっていた
- 0 個採集時にエラーをスローし、ジョブを「失敗」として記録するよう修正

## Test plan

- [x] `nr validate` 通過
- [x] `nr test` 全 1130 テスト通過
- [ ] デプロイ後に MC エージェントが oak_log 不在時に「失敗」と認識し、別の行動を取ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)