### PR TITLE
feat: primary agent の temperature を 0.7 に設定

### DIFF
--- a/packages/agent/src/discord/discord-agent.ts
+++ b/packages/agent/src/discord/discord-agent.ts
@@ -38,6 +38,7 @@ export class DiscordAgent extends AgentRunner {
 				port: deps.opencodePort,
 				mcpServers: profile.mcpServers,
 				builtinTools: profile.builtinTools,
+				temperature: 0.7,
 				logger: deps.logger,
 			}),
 			eventBuffer: new SqliteEventBuffer(deps.db, agentId, deps.logger),

--- a/packages/agent/src/minecraft/minecraft-agent.ts
+++ b/packages/agent/src/minecraft/minecraft-agent.ts
@@ -40,6 +40,7 @@ export class MinecraftAgent extends AgentRunner {
 				port: deps.opencodePort,
 				mcpServers: profile.mcpServers,
 				builtinTools: profile.builtinTools,
+				temperature: 0.7,
 				logger: deps.logger,
 			}),
 			eventBuffer: deps.eventBuffer,

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -29,6 +29,7 @@ export interface OpencodeSessionAdapterConfig {
 	/** `{ enabled: boolean }` は SDK の設定スキーマが許容する無効化用のフォールバック型 */
 	mcpServers: Record<string, McpLocalConfig | McpRemoteConfig | { enabled: boolean }>;
 	builtinTools: Record<string, boolean>;
+	temperature?: number;
 	clientFactory?: typeof createOpencode;
 	logger?: Logger;
 }
@@ -174,6 +175,9 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 			config: {
 				mcp: this.config.mcpServers,
 				tools: this.config.builtinTools,
+				agent: this.config.temperature != null
+					? { build: { temperature: this.config.temperature } }
+					: undefined,
 			},
 		});
 		this.client = result.client;


### PR DESCRIPTION
## Summary
- `OpencodeSessionAdapterConfig` に `temperature` オプションを追加
- SDK の `config.agent.build.temperature` として渡すよう `getClient()` を修正
- Discord / Minecraft 両エージェントに `temperature: 0.7` を適用

## Test plan
- [x] `nr check` 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)