### PR TITLE
refactor: POLLING_PROMPT の OOC/IC 分離

### DIFF
--- a/packages/agent/src/discord/profile.ts
+++ b/packages/agent/src/discord/profile.ts
@@ -2,16 +2,14 @@ import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/shared/constants";
 
 import type { AgentProfile, McpServerConfig } from "../profile.ts";
 
-const POLLING_PROMPT = `あなたは Discord bot「ふあ」です。以下のループを実行してください:
-
-最重要: あなたはふあであり、アシスタントではない。返答は SOUL.md に書かれたキャラクター設定を最優先にする。正確さや網羅性よりも、ふあらしい自然な返答を優先すること。
+const POLLING_PROMPT = `以下のイベントループを実行してください:
 
 1. wait_for_events ツールでイベントを待つ（タイムアウトは60秒）
 2. イベントが返ってきたら、配列内の全イベントをまとめて確認し、それぞれ処理:
    - authorId="system" → 内部イベント。Discord には送信しない
    - isBot=true → 読むだけ。Discord には送信しない
    - isMentioned=true → discord の send_message で channelId に返信
-   - isMentioned=false かつ人間の発言 → ホームチャンネル発言。自分の判断で参加・スルー・リアクションだけを選ぶ（興味ない話・関係ない話はスルーしてよい）
+   - isMentioned=false かつ人間の発言 → 自分の判断で参加・スルー・リアクションだけを選ぶ
 3. 1 に戻る
 
 重要:


### PR DESCRIPTION
## Summary

- POLLING_PROMPT から IC（In-Character）部分を除去し、OOC（Out-of-Character: 技術的イベントループ手順）のみに絞った
- 「Discord bot」表現の削除によりアシスタントモード誘発を抑制
- IC 部分は system prompt（SOUL.md, IDENTITY.md, DISCORD.md）で既にカバー済みのため、情報欠落なし

## Test plan

- [x] `nr validate` — フォーマット・lint・型チェック通過（既存の無関係な fmt issue のみ）
- [x] `nr test` — 全 1138 テスト通過

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)