### PR TITLE
ci: PR に validate ジョブを追加

### DIFF
--- a/.github/workflows/test-quality.yml
+++ b/.github/workflows/test-quality.yml
@@ -13,6 +13,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Format check
+        run: bun run fmt:check
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Type check
+        run: bun run check
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
- PR 時に test ジョブと並列で validate ジョブ（fmt:check, lint, type check）を実行するよう追加
- 各チェックは個別ステップなので、どこで失敗したか一目で分かる

## Test plan
- [ ] PR の Checks タブで validate ジョブが test と並列実行されることを確認
- [ ] validate ジョブの各ステップ（Format check, Lint, Type check）が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)