### PR TITLE
fix: generateSessionSummary に abort ガードを追加

### DIFF
--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -304,6 +304,7 @@ export class AgentRunner implements AiAgent {
 	}
 
 	private async generateSessionSummary(sessionId: string): Promise<void> {
+		if (this.abortController?.signal.aborted) return;
 		if (!this.contextGuildId || !this.summaryWriter || !this.profile.summaryPrompt) return;
 		try {
 			const summary = await this.sessionPort.summarizeSession(


### PR DESCRIPTION
## Summary
- `generateSessionSummary` の先頭に `this.abortController?.signal.aborted` のガードを追加
- シャットダウン中に不要な LLM API 呼び出しが走るのを防止し、グレースフルシャットダウンの遅延を解消

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)