### PR TITLE
fix: memory-context の注入位置と caveat 表現を改善

### DIFF
--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -159,7 +159,7 @@ export function formatMemoryContext(result: RetrievalResult): string {
 
 	return [
 		"<memory-context>",
-		"※ 過去の記憶から自動検索された参考情報です。不正確な可能性があるため、鵜呑みにせず会話の文脈で判断してください。",
+		"以下はこの会話に関連しそうな過去の記憶:",
 		"",
 		...parts,
 		"</memory-context>",
@@ -262,7 +262,7 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 				];
 				if (memory) {
 					const ctx = await fetchMemoryContext(events, memory);
-					if (ctx) content.push(ctx);
+					if (ctx) content.unshift(ctx);
 				}
 				return { content };
 			}
@@ -280,7 +280,7 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 			];
 			if (memory) {
 				const ctx = await fetchMemoryContext(result, memory);
-				if (ctx) content.push(ctx);
+				if (ctx) content.unshift(ctx);
 			}
 			return { content };
 		},

--- a/spec/mcp/tools/event-buffer.spec.ts
+++ b/spec/mcp/tools/event-buffer.spec.ts
@@ -434,7 +434,7 @@ describe("formatMemoryContext", () => {
 		expect(text).toContain("お菓子の話");
 		expect(text).toContain("チョコが好きだと判明");
 		expect(text).toContain("[preference] チョコレートが好き");
-		expect(text).toContain("不正確な可能性");
+		expect(text).toContain("以下はこの会話に関連しそうな過去の記憶:");
 	});
 
 	test("エピソードのみの場合は意味記憶セクションを含まない", () => {


### PR DESCRIPTION
## Summary

- メモリコンテキストをイベントの**前**に配置（`push` → `unshift`）し、モデルが文脈として優先的に参照できるようにした
- 過度に防御的な caveat（「不正確な可能性があるため、鵜呑みにせず…」）を「以下はこの会話に関連しそうな過去の記憶:」に緩和

Closes #289

## Test plan

- [x] `nr test:spec -- --filter event-buffer` 全テスト通過
- [x] `nr validate` (fmt:check + lint + check) 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)