### PR TITLE
feat: EmotionEstimator の LLM ポート配線 (#315)

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -319,6 +319,7 @@ async function startCoreMcp(config: AppConfig, root: string, logger: Logger): Pr
 		MEMORY_EMBEDDING_MODEL: config.memory.embeddingModel,
 		MEMORY_DATA_DIR: resolve(config.dataDir, "memory"),
 		DATA_DIR: resolve(root, "data"),
+		EMOTION_CHAT_MODEL: process.env.EMOTION_CHAT_MODEL ?? "gemma3",
 	};
 
 	const coreProcess = spawn({

--- a/bun.lock
+++ b/bun.lock
@@ -95,8 +95,10 @@
       "name": "@vicissitude/mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@vicissitude/agent": "workspace:*",
         "@vicissitude/minecraft": "workspace:*",
         "@vicissitude/observability": "workspace:*",
+        "@vicissitude/ollama": "workspace:*",
         "@vicissitude/scheduling": "workspace:*",
         "@vicissitude/shared": "workspace:*",
         "discord.js": "^14.25.1",
@@ -127,6 +129,9 @@
     },
     "packages/ollama": {
       "name": "@vicissitude/ollama",
+      "dependencies": {
+        "@vicissitude/shared": "workspace:*",
+      },
     },
     "packages/opencode": {
       "name": "@vicissitude/opencode",

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -32,6 +32,7 @@ graph LR
   infrastructure --> application
   infrastructure --> shared
   infrastructure --> store
+  mcp --> agent
   mcp --> infrastructure
   mcp --> memory
   mcp --> minecraft
@@ -63,7 +64,7 @@ graph LR
 
 - 内部依存: minecraft, observability, opencode, shared, store
 - 外部依存: .bun, path
-- ファイル数: 18
+- ファイル数: 19
 
 ### application
 
@@ -103,7 +104,7 @@ graph LR
 
 ### mcp
 
-- 内部依存: infrastructure, memory, minecraft, observability, ollama, scheduling, shared, store
+- 内部依存: agent, infrastructure, memory, minecraft, observability, ollama, scheduling, shared, store
 - 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, @modelcontextprotocol/sdk/server/webStandardStreamableHttp.js, fs, path
 - ファイル数: 15
 
@@ -129,7 +130,7 @@ graph LR
 
 - 内部依存: なし
 - 外部依存: なし
-- ファイル数: 2
+- ファイル数: 4
 
 ### opencode
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -12,7 +12,8 @@
 		"./minecraft/brain-manager": "./src/minecraft/brain-manager.ts",
 		"./minecraft/minecraft-agent": "./src/minecraft/minecraft-agent.ts",
 		"./discord/profile": "./src/discord/profile.ts",
-		"./minecraft/context-builder": "./src/minecraft/context-builder.ts"
+		"./minecraft/context-builder": "./src/minecraft/context-builder.ts",
+		"./emotion/estimator": "./src/emotion/estimator.ts"
 	},
 	"dependencies": {
 		"@vicissitude/minecraft": "workspace:*",

--- a/packages/agent/src/emotion/estimator.ts
+++ b/packages/agent/src/emotion/estimator.ts
@@ -1,11 +1,11 @@
 import { EmotionSchema, NEUTRAL_EMOTION } from "@vicissitude/shared/emotion";
-import type { EmotionAnalysisInput, EmotionAnalysisResult, EmotionAnalyzer } from "@vicissitude/shared/ports";
+import type {
+	EmotionAnalysisInput,
+	EmotionAnalysisResult,
+	EmotionAnalyzer,
+	LlmPromptPort,
+} from "@vicissitude/shared/ports";
 import { z } from "zod";
-
-/** 軽量 LLM 呼び出しポート。テキストを送り、応答テキストを受け取る */
-export interface LlmPromptPort {
-	prompt(text: string): Promise<string>;
-}
 
 const ANALYSIS_PROMPT = `Analyze the emotional tone of the following text and return a JSON object with these fields:
 - valence: pleasure (+1) to displeasure (-1)

--- a/packages/mcp/DEPS.md
+++ b/packages/mcp/DEPS.md
@@ -35,7 +35,7 @@ graph LR
 ### core-server.ts
 
 - モジュール内依存: http-server, tool-metrics, tools/discord, tools/event-buffer, tools/mc-bridge-discord, tools/memory, tools/schedule
-- 他モジュール依存: memory, observability, ollama, store
+- 他モジュール依存: agent, memory, observability, ollama, store
 - 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, fs, path
 
 ### http-server.ts

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -17,8 +17,10 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.1",
+		"@vicissitude/agent": "workspace:*",
 		"@vicissitude/minecraft": "workspace:*",
 		"@vicissitude/observability": "workspace:*",
+		"@vicissitude/ollama": "workspace:*",
 		"@vicissitude/scheduling": "workspace:*",
 		"@vicissitude/shared": "workspace:*",
 		"discord.js": "^14.25.1",

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "fs";
 import { resolve } from "path";
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { EmotionEstimator } from "@vicissitude/agent/emotion/estimator";
 import { EpisodicMemory } from "@vicissitude/memory/episodic";
 import type { MemoryLlmPort } from "@vicissitude/memory/llm-port";
 import { Retrieval } from "@vicissitude/memory/retrieval";
@@ -10,6 +11,7 @@ import { MemoryStorage } from "@vicissitude/memory/storage";
 import { ConsoleLogger } from "@vicissitude/observability/logger";
 import { METRIC } from "@vicissitude/observability/metrics";
 import { OllamaEmbeddingAdapter } from "@vicissitude/ollama";
+import { OllamaChatAdapter } from "@vicissitude/ollama/ollama-chat-adapter";
 import { closeDb, createDb } from "@vicissitude/store/db";
 import { SqliteMoodStore } from "@vicissitude/store/mood-store";
 import { Client, GatewayIntentBits } from "discord.js";
@@ -32,6 +34,7 @@ const CORE_MCP_PORT = Number(process.env.CORE_MCP_PORT ?? "4095");
 const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://ollama:11434";
 const MEMORY_EMBEDDING_MODEL = process.env.MEMORY_EMBEDDING_MODEL ?? "embeddinggemma";
 const MEMORY_DATA_DIR = process.env.MEMORY_DATA_DIR ?? "data/memory";
+const EMOTION_CHAT_MODEL = process.env.EMOTION_CHAT_MODEL ?? "gemma3";
 const DATA_DIR = process.env.DATA_DIR ?? "data";
 
 if (!process.env.DISCORD_TOKEN) {
@@ -64,6 +67,8 @@ const moodStore = new SqliteMoodStore(db);
 // --- Memory (embed-only — consolidation runs in the main process) ---
 
 const ollama = new OllamaEmbeddingAdapter(OLLAMA_BASE_URL, MEMORY_EMBEDDING_MODEL);
+const ollamaChat = new OllamaChatAdapter(OLLAMA_BASE_URL, EMOTION_CHAT_MODEL);
+const emotionEstimator = new EmotionEstimator(ollamaChat);
 
 /** MemoryLlmPort that only supports embed — chat/chatStructured throw since they are unused here */
 const embedOnlyLlm: MemoryLlmPort = {
@@ -168,6 +173,7 @@ function createServer(agentId: string | null): McpServer {
 			memory,
 			moodReader: moodStore,
 			moodWriter: moodStore,
+			emotionAnalyzer: emotionEstimator,
 			typingSender,
 		});
 	} else {

--- a/packages/ollama/DEPS.md
+++ b/packages/ollama/DEPS.md
@@ -6,10 +6,15 @@
 
 ```mermaid
 graph LR
+  ollama_chat_adapter["ollama-chat-adapter"]
   ollama_embedding_adapter["ollama-embedding-adapter"]
 ```
 
 ## ファイル別依存一覧
+
+### ollama-chat-adapter.ts
+
+- 依存なし
 
 ### ollama-embedding-adapter.ts
 

--- a/packages/ollama/package.json
+++ b/packages/ollama/package.json
@@ -2,6 +2,7 @@
 	"name": "@vicissitude/ollama",
 	"private": true,
 	"exports": {
-		".": "./src/ollama-embedding-adapter.ts"
+		".": "./src/ollama-embedding-adapter.ts",
+		"./ollama-chat-adapter": "./src/ollama-chat-adapter.ts"
 	}
 }

--- a/packages/ollama/src/ollama-chat-adapter.test.ts
+++ b/packages/ollama/src/ollama-chat-adapter.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { OllamaChatAdapter } from "./ollama-chat-adapter";
+
+describe("OllamaChatAdapter internals", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	function captureFetch() {
+		let capturedUrl: URL | string = "";
+		let capturedInit: RequestInit | undefined;
+		globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+			capturedUrl = input as URL | string;
+			capturedInit = init;
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: () => Promise.resolve({ response: "ok" }),
+			} as Response);
+		}) as typeof fetch;
+		return { url: () => capturedUrl, init: () => capturedInit };
+	}
+
+	it("AbortSignal.timeout(30_000) をリクエストに設定する", async () => {
+		const captured = captureFetch();
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+		await adapter.prompt("test");
+
+		const signal = captured.init()?.signal;
+		expect(signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("baseUrl に末尾スラッシュがあっても正しい URL を構築する", async () => {
+		const captured = captureFetch();
+		const adapter = new OllamaChatAdapter("http://localhost:11434/", "gemma3");
+		await adapter.prompt("test");
+
+		expect(captured.url().toString()).toBe("http://localhost:11434/api/generate");
+	});
+
+	it("stream: false をリクエストボディに含める", async () => {
+		const captured = captureFetch();
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+		await adapter.prompt("test");
+
+		const body = JSON.parse(captured.init()?.body as string);
+		expect(body.stream).toBe(false);
+	});
+
+	it("空文字列の response を正常に返す", async () => {
+		globalThis.fetch = (() =>
+			Promise.resolve({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: () => Promise.resolve({ response: "" }),
+			} as Response)) as unknown as typeof fetch;
+
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+		const result = await adapter.prompt("test");
+		expect(result).toBe("");
+	});
+
+	it("response が null の場合 TypeError をスローする", async () => {
+		globalThis.fetch = (() =>
+			Promise.resolve({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: () => Promise.resolve({ response: null }),
+			} as Response)) as unknown as typeof fetch;
+
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+		await expect(adapter.prompt("test")).rejects.toBeInstanceOf(TypeError);
+	});
+
+	it("response が数値の場合 TypeError をスローする", async () => {
+		globalThis.fetch = (() =>
+			Promise.resolve({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: () => Promise.resolve({ response: 42 }),
+			} as Response)) as unknown as typeof fetch;
+
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+		await expect(adapter.prompt("test")).rejects.toBeInstanceOf(TypeError);
+		await expect(adapter.prompt("test")).rejects.toThrow("no response field");
+	});
+
+	it("HTTP エラーメッセージにステータスコードとステータステキストを含む", async () => {
+		globalThis.fetch = (() =>
+			Promise.resolve({
+				ok: false,
+				status: 404,
+				statusText: "Not Found",
+				json: () => Promise.resolve({}),
+			} as Response)) as unknown as typeof fetch;
+
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+		await expect(adapter.prompt("test")).rejects.toThrow("404 Not Found");
+	});
+
+	it("コンストラクタで渡した model がリクエストボディに反映される", async () => {
+		const captured = captureFetch();
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "llama3.2");
+		await adapter.prompt("test");
+
+		const body = JSON.parse(captured.init()?.body as string);
+		expect(body.model).toBe("llama3.2");
+	});
+});

--- a/packages/ollama/src/ollama-chat-adapter.ts
+++ b/packages/ollama/src/ollama-chat-adapter.ts
@@ -1,0 +1,27 @@
+/** Ollama HTTP API generate adapter */
+export class OllamaChatAdapter {
+	constructor(
+		private readonly baseUrl: string,
+		private readonly model: string,
+	) {}
+
+	async prompt(text: string): Promise<string> {
+		const url = new URL("/api/generate", this.baseUrl);
+		const response = await fetch(url, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ model: this.model, prompt: text, stream: false }),
+			signal: AbortSignal.timeout(30_000),
+		});
+
+		if (!response.ok) {
+			throw new Error(`Ollama generate failed: ${response.status} ${response.statusText}`);
+		}
+
+		const data = (await response.json()) as { response?: string };
+		if (typeof data.response !== "string") {
+			throw new TypeError("Ollama generate returned no response field");
+		}
+		return data.response;
+	}
+}

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -2,6 +2,16 @@ import type { Emotion, VrmExpressionWeight } from "./emotion";
 import type { TtsResult, TtsStyleParams } from "./tts";
 import type { BodyAnimationPreset, ClientMessage, ServerMessage } from "./ws-protocol";
 
+// ─── LlmPromptPort ──────────────────────────────────────────────
+//
+// 軽量 LLM 呼び出しポート。テキストを送り、応答テキストを受け取る。
+// EmotionEstimator などの内部コンポーネントが利用する。
+
+/** 軽量 LLM 呼び出しポート。テキストを送り、応答テキストを受け取る */
+export interface LlmPromptPort {
+	prompt(text: string): Promise<string>;
+}
+
 // ─── EmotionToExpressionMapper ─────────────────────────────────
 //
 // VAD → VRM Expression マッピングのポート。

--- a/packages/store/src/mood-store.ts
+++ b/packages/store/src/mood-store.ts
@@ -13,11 +13,7 @@ export class SqliteMoodStore implements MoodReader, MoodWriter {
 	constructor(private readonly db: StoreDb) {}
 
 	getMood(agentId: string): Emotion {
-		const row = this.db
-			.select()
-			.from(moodState)
-			.where(eq(moodState.agentId, agentId))
-			.get();
+		const row = this.db.select().from(moodState).where(eq(moodState.agentId, agentId)).get();
 
 		if (!row) return NEUTRAL_EMOTION;
 		if (Date.now() - row.updatedAt >= MOOD_TTL_MS) return NEUTRAL_EMOTION;

--- a/spec/mcp/tools/event-buffer-mood.spec.ts
+++ b/spec/mcp/tools/event-buffer-mood.spec.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerEventBufferTools } from "@vicissitude/mcp/tools/event-buffer";
 import { createEmotion, NEUTRAL_EMOTION } from "@vicissitude/shared/emotion";
 import type { Emotion } from "@vicissitude/shared/emotion";
 import type { MoodReader } from "@vicissitude/shared/ports";
-import { registerEventBufferTools } from "@vicissitude/mcp/tools/event-buffer";
 import { appendEvent } from "@vicissitude/store/queries";
 import { createTestDb } from "@vicissitude/store/test-helpers";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createStubMoodReader(mood: Emotion): MoodReader {
 	return {

--- a/spec/ollama/ollama-chat-adapter.spec.ts
+++ b/spec/ollama/ollama-chat-adapter.spec.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from "bun:test";
+/**
+ * OllamaChatAdapter 仕様テスト
+ *
+ * OllamaChatAdapter は Ollama /api/generate エンドポイントを叩く軽量アダプタで、
+ * LlmPromptPort を実装する。EmotionEstimator の DI 配線に使用される。
+ */
+
+// NOTE: OllamaChatAdapter はまだ実装されていないため、
+// パッケージエクスポートが追加され次第インポートパスを更新する。
+// 現時点では直接ファイルパスでインポートする想定。
+import { OllamaChatAdapter } from "@vicissitude/ollama/ollama-chat-adapter";
+
+function mockFetch(response: { ok: boolean; status?: number; statusText?: string; body: unknown }) {
+	globalThis.fetch = (() =>
+		Promise.resolve({
+			ok: response.ok,
+			status: response.status ?? (response.ok ? 200 : 500),
+			statusText: response.statusText ?? (response.ok ? "OK" : "Internal Server Error"),
+			json: () => Promise.resolve(response.body),
+		} as Response)) as unknown as typeof fetch;
+}
+
+describe("OllamaChatAdapter", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("正常レスポンスの response フィールドを返す", async () => {
+		mockFetch({ ok: true, body: { response: "感情分析結果: positive" } });
+
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+		const result = await adapter.prompt("テスト入力");
+
+		expect(result).toBe("感情分析結果: positive");
+	});
+
+	it("/api/generate に正しいリクエストボディで POST する", async () => {
+		let capturedUrl: string | URL = "";
+		let capturedInit: RequestInit | undefined;
+
+		globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+			capturedUrl = input as string | URL;
+			capturedInit = init;
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: () => Promise.resolve({ response: "ok" }),
+			} as Response);
+		}) as typeof fetch;
+
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+		await adapter.prompt("分析してください");
+
+		expect(capturedUrl.toString()).toBe("http://localhost:11434/api/generate");
+		expect(capturedInit?.method).toBe("POST");
+		expect(capturedInit?.headers).toEqual({ "Content-Type": "application/json" });
+		expect(JSON.parse(capturedInit?.body as string)).toEqual({
+			model: "gemma3",
+			prompt: "分析してください",
+			stream: false,
+		});
+	});
+
+	it("HTTP エラー時にエラーをスローする", async () => {
+		mockFetch({ ok: false, status: 503, statusText: "Service Unavailable", body: {} });
+
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+
+		await expect(adapter.prompt("hello")).rejects.toThrow(/503/);
+	});
+
+	it("レスポンスに response フィールドがない場合にエラーをスローする", async () => {
+		mockFetch({ ok: true, body: {} });
+
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+
+		await expect(adapter.prompt("hello")).rejects.toThrow();
+	});
+});

--- a/spec/store/mood-store.spec.ts
+++ b/spec/store/mood-store.spec.ts
@@ -7,7 +7,9 @@ import { createTestDb } from "@vicissitude/store/test-helpers";
 // SqliteMoodStore は MoodReader & MoodWriter を実装する想定。
 // テストでは実装クラスをインポートして検証する。
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-type SqliteMoodStoreModule = { SqliteMoodStore: new (...args: unknown[]) => MoodReader & MoodWriter };
+type SqliteMoodStoreModule = {
+	SqliteMoodStore: new (...args: unknown[]) => MoodReader & MoodWriter;
+};
 
 async function importMoodStore(): Promise<SqliteMoodStoreModule> {
 	return (await import("@vicissitude/store/mood-store")) as SqliteMoodStoreModule;


### PR DESCRIPTION
## Summary

- `LlmPromptPort` を `shared/ports` に移動し、ポート集約パターンに統一
- Ollama `/api/generate` を叩く軽量アダプタ `OllamaChatAdapter` を新規作成
- `core-server.ts` で OllamaChatAdapter → EmotionEstimator → registerEventBufferTools の DI 配線を完了
- `bootstrap.ts` で `EMOTION_CHAT_MODEL` 環境変数を MCP 子プロセスに伝搬

## Test plan

- [x] 仕様テスト `spec/ollama/ollama-chat-adapter.spec.ts` (4 pass)
- [x] ユニットテスト `packages/ollama/src/ollama-chat-adapter.test.ts` (8 pass)
- [x] 全テスト 1190 pass / 0 fail
- [x] `nr check` (tsgo --noEmit) PASS
- [x] `nr fmt` PASS

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)