### PR TITLE
fix: describeEmotion の fallback を mapFallback と整合させる

### DIFF
--- a/packages/shared/src/emotion.ts
+++ b/packages/shared/src/emotion.ts
@@ -112,6 +112,14 @@ export function describeEmotion(emotion: Emotion): string {
 		label = "怖がっている";
 	} else if (v < 0 && a < 0) {
 		label = "悲しい";
+	} else if (a > 0 && d > 0) {
+		label = "怒っている";
+	} else if (a > 0 && d < 0) {
+		label = "怖がっている";
+	} else if (a > 0) {
+		label = "嬉しい";
+	} else if (a < 0) {
+		label = "悲しい";
 	} else {
 		label = "穏やかな";
 	}

--- a/spec/shared/emotion-describe.spec.ts
+++ b/spec/shared/emotion-describe.spec.ts
@@ -100,4 +100,33 @@ describe("describeEmotion", () => {
 			expect(typeof result).toBe("string");
 		});
 	});
+
+	// ─── fallback（主要ルール非該当の境界ケース） ────────────────
+
+	describe("fallback（主要ルール非該当の境界ケース）", () => {
+		it("a > 0, d > 0 → 怒り系の記述を返す (angry fallback)", () => {
+			const result = describeEmotion(createEmotion(0, 0.5, 0.5));
+			expect(result).toContain("怒");
+		});
+
+		it("a > 0, d < 0 → 恐怖系の記述を返す (fear fallback)", () => {
+			const result = describeEmotion(createEmotion(0, 0.5, -0.5));
+			expect(result).toContain("怖");
+		});
+
+		it("a > 0, d = 0 → 嬉しい系の記述を返す (happy fallback)", () => {
+			const result = describeEmotion(createEmotion(0, 0.5, 0));
+			expect(result).toContain("嬉しい");
+		});
+
+		it("a < 0, d = 0 → 悲しい系の記述を返す (sad fallback)", () => {
+			const result = describeEmotion(createEmotion(0, -0.5, 0));
+			expect(result).toContain("悲しい");
+		});
+
+		it("a = 0, d > 0 → 穏やか系の記述を返す (neutral fallback)", () => {
+			const result = describeEmotion(createEmotion(0, 0, 0.5));
+			expect(result).toContain("穏やか");
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- `describeEmotion()` の fallback（主要ルール非該当の境界ケース）を `emotion-to-expression-mapper` の `mapFallback` と同等のロジックに変更
- fallback 境界ケースの仕様テスト5件を追加

Closes #319

## Test plan

- [x] `nr test:spec` — 917 pass / 0 fail
- [x] `nr test:unit` — 312 pass / 0 fail
- [x] `nr check` — パス
- [x] `nr lint` — 新規エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)