### PR TITLE
fix: Ollama の GIN リクエストログを抑制する

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -102,6 +102,7 @@ services:
     entrypoint: ["/entrypoint.sh"]
     environment:
       MEMORY_EMBEDDING_MODEL: ${MEMORY_EMBEDDING_MODEL:-embeddinggemma}
+      GIN_MODE: release
     volumes:
       - ollama-data:/root/.ollama
       - ./containers/ollama/entrypoint.sh:/entrypoint.sh:ro


### PR DESCRIPTION
## Summary
- Ollama コンテナに `GIN_MODE: release` を設定し、healthcheck 由来の大量の `[GIN]` リクエストログを抑制

## Test plan
- [ ] `podman compose up -d ollama` で反映後、`podman compose logs ollama` に `[GIN]` ログが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)