### PR TITLE
fix: entrypoint で Ollama の GIN リクエストログをフィルタする

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -102,7 +102,6 @@ services:
     entrypoint: ["/entrypoint.sh"]
     environment:
       MEMORY_EMBEDDING_MODEL: ${MEMORY_EMBEDDING_MODEL:-embeddinggemma}
-      GIN_MODE: release
     volumes:
       - ollama-data:/root/.ollama
       - ./containers/ollama/entrypoint.sh:/entrypoint.sh:ro

--- a/containers/ollama/entrypoint.sh
+++ b/containers/ollama/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-# Ollama サーバーをバックグラウンドで起動
-ollama serve &
+# Ollama サーバーをバックグラウンドで起動（GIN リクエストログを除外）
+ollama serve 2>&1 | grep -v '^\[GIN\]' &
 SERVE_PID=$!
 
 # サーバー起動をポーリングで待機（最大 60 秒）


### PR DESCRIPTION
## Summary
- `GIN_MODE=release` は Ollama が内部で上書きするため効果なし (#324 の修正)
- entrypoint.sh で `grep -v '^\[GIN\]'` によりログをフィルタする方式に変更
- compose.yaml から不要な `GIN_MODE` を削除

## Test plan
- [x] `podman compose logs ollama` に `[GIN]` ログが出ないことを確認済み
- [x] bot が正常に起動することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)