### PR TITLE
fix: consolidation プロンプトにカテゴリ定義を追加

### DIFF
--- a/packages/memory/src/consolidation.ts
+++ b/packages/memory/src/consolidation.ts
@@ -212,7 +212,15 @@ For each fact, decide the appropriate action:
 
 Each fact must have:
 - action: One of "new", "reinforce", "update", "invalidate"
-- category: One of "identity", "preference", "interest", "personality", "relationship", "experience", "goal", "guideline"
+- category: One of the following 8 categories:
+  - "identity": Name, location, occupation, age, demographic facts
+  - "preference": Likes, dislikes, favorites, rankings
+  - "interest": Topics, hobbies, domains the person engages with
+  - "personality": Communication style, emotional tendencies, traits
+  - "relationship": Dynamics between participants, shared references, routines
+  - "experience": Skills, past events, professional background
+  - "goal": Desires, plans, aspirations
+  - "guideline": How the assistant should behave — rules, tone preferences, conditional instructions given by the user. NOT general advice or knowledge shared in conversation.
 - fact: A concise statement of the fact
 - keywords: 1-5 relevant keywords
 - existingFactId: Required for "reinforce", "update", "invalidate" actions
@@ -223,7 +231,11 @@ ${formatExistingFacts(existingFacts)}
 </existing_facts>
 
 Rules:
-- Only extract facts that are clearly stated or strongly implied
+- Only extract facts that are persistent and high-value. Apply these tests:
+  - Persistence: Will this still be true in 6 months?
+  - Specificity: Does it contain concrete, searchable information?
+  - Utility: Can this help predict future needs or behavior?
+- Do NOT extract: temporary emotions, single-conversation reactions, vague statements, or context-dependent information
 - Do not speculate or infer beyond what the conversation supports
 - Each fact MUST include an explicit subject (who or what the fact is about). Write facts as complete sentences with a clear subject, e.g. "Alice prefers dark mode", "Tokyo is hot in summer", "The user enjoys hiking"
 - When speaker names are available (shown as role(name)), use those names as subjects. Otherwise use "The user" or "The assistant"


### PR DESCRIPTION
## Summary

- consolidation プロンプトに plast-mem 準拠の 8 カテゴリ定義を追加
- 特に `guideline` を「アシスタントの行動ルール」に限定する説明を追加
- ファクト抽出の品質基準（Persistence/Specificity/Utility テスト）を追加

## Background

既存の guideline ファクトに「ルナが語った NDA ルール」「デバッグは疲れる」等、アシスタントの行動ルールではない情報が大量に混入していた。原因はプロンプトにカテゴリの定義がなく、LLM が「guideline」を広く解釈していたため。

ref: https://github.com/moeru-ai/plast-mem

## Related Issues

- #326 Predict-Calibrate Learning の導入検討
- #327 ファクト抽出の品質フィルタ強化
- #328 embedding 重複排除の導入
- #329 guideline ファクトの retrieval 優先度付け

## Test plan

- [x] `nr test:spec -- --grep consolidation` 全通
- [x] `nr check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)