### PR TITLE
feat: consolidation に embedding 重複排除 (dedup) を導入する (#328)

### DIFF
--- a/packages/memory/DEPS.md
+++ b/packages/memory/DEPS.md
@@ -17,6 +17,7 @@ graph LR
   consolidation --> storage
   consolidation --> types
   consolidation --> utils
+  consolidation --> vector_math["vector-math"]
   conversation_recorder["conversation-recorder"] --> consolidation
   conversation_recorder["conversation-recorder"] --> episode
   conversation_recorder["conversation-recorder"] --> episodic
@@ -94,7 +95,7 @@ graph LR
 
 ### consolidation.ts
 
-- モジュール内依存: episode, episodic, llm-port, semantic-fact, storage, types, utils
+- モジュール内依存: episode, episodic, llm-port, semantic-fact, storage, types, utils, vector-math
 
 ### conversation-recorder.ts
 

--- a/packages/memory/src/consolidation.test.ts
+++ b/packages/memory/src/consolidation.test.ts
@@ -351,3 +351,64 @@ describe("ConsolidationPipeline PCL", () => {
 		});
 	});
 });
+
+describe("ConsolidationPipeline dedup", () => {
+	test("dedup fires: identical embedding on action 'new' reinforces existing fact instead", async () => {
+		const storage = new MemoryStorage();
+		// embed returns same vector as the existing fact -> cosine similarity = 1.0
+		const llm = createSpyLLM({
+			structuredResponse: validOutput([
+				{ action: "new", category: "preference", fact: "Likes TypeScript", keywords: ["ts"] },
+			]),
+		});
+		const pipeline = new ConsolidationPipeline(llm, storage);
+
+		const existingFact = makeFact(storage);
+		const episode = makeEpisode(storage);
+
+		const result = await pipeline.consolidate(userId);
+
+		// dedup should have triggered: reinforce instead of new
+		expect(result.reinforced).toBe(1);
+		expect(result.newFacts).toBe(0);
+
+		// Existing fact's sourceEpisodicIds should include the new episode's id
+		const facts = await storage.getFacts(userId);
+		const updated = facts.find((f) => f.id === existingFact.id);
+		expect(updated).toBeDefined();
+		expect(updated!.sourceEpisodicIds).toContain(episode.id);
+
+		// No new fact should have been created
+		expect(facts.filter((f) => f.invalidAt === null)).toHaveLength(1);
+		storage.close();
+	});
+
+	test("dedup does not fire: different embedding on action 'new' creates new fact", async () => {
+		const storage = new MemoryStorage();
+		// embed returns a very different vector -> low cosine similarity
+		const llm: SpyLLM = {
+			...createSpyLLM({
+				structuredResponse: validOutput([
+					{ action: "new", category: "interest", fact: "Enjoys cooking", keywords: ["cooking"] },
+				]),
+			}),
+			embed: async () => [0.9, -0.1, 0.0],
+		};
+		const pipeline = new ConsolidationPipeline(llm, storage);
+
+		// existing fact with embedding [0.1, 0.2, 0.3]
+		makeFact(storage);
+		makeEpisode(storage);
+
+		const result = await pipeline.consolidate(userId);
+
+		// No dedup: should be a new fact
+		expect(result.newFacts).toBe(1);
+		expect(result.reinforced).toBe(0);
+
+		// Two facts total
+		const facts = await storage.getFacts(userId);
+		expect(facts.filter((f) => f.invalidAt === null)).toHaveLength(2);
+		storage.close();
+	});
+});

--- a/packages/memory/src/consolidation.ts
+++ b/packages/memory/src/consolidation.ts
@@ -8,6 +8,7 @@ import type { MemoryStorage } from "./storage.ts";
 import type { ConsolidationAction, FactCategory } from "./types.ts";
 import { CONSOLIDATION_ACTIONS, FACT_CATEGORIES } from "./types.ts";
 import { escapeXmlContent, validateUserId } from "./utils.ts";
+import { cosineSimilarity } from "./vector-math.ts";
 
 /** Result of a consolidation run */
 export interface ConsolidationResult {
@@ -36,6 +37,9 @@ interface ActionContext {
 	existingFacts: SemanticFact[];
 	now: Date;
 }
+const DEDUPE_THRESHOLD = 0.95;
+const DUPLICATE_CANDIDATE_LIMIT = 5;
+
 /** Consolidation pipeline — converts episodes into semantic facts */
 export class ConsolidationPipeline {
 	constructor(
@@ -139,35 +143,47 @@ export class ConsolidationPipeline {
 	): Promise<void> {
 		for (const extracted of facts) {
 			// eslint-disable-next-line no-await-in-loop -- sequential writes required
-			const applied = await this.dispatchAction(ctx, extracted);
-			if (applied) {
-				incrementResult(result, extracted.action);
+			const actualAction = await this.dispatchAction(ctx, extracted);
+			if (actualAction) {
+				incrementResult(result, actualAction);
 			}
 		}
 	}
 
 	/** Dispatch a single extracted fact action to the appropriate handler */
-	private async dispatchAction(ctx: ActionContext, extracted: ExtractedFact): Promise<boolean> {
+	private async dispatchAction(
+		ctx: ActionContext,
+		extracted: ExtractedFact,
+	): Promise<ConsolidationAction | null> {
 		switch (extracted.action) {
 			case "new": {
-				await this.applyNew(ctx, extracted);
-				return true;
+				return this.applyNew(ctx, extracted);
 			}
 			case "reinforce": {
-				return this.applyReinforce(ctx, extracted);
+				return (await this.applyReinforce(ctx, extracted)) ? "reinforce" : null;
 			}
 			case "update": {
-				return this.applyUpdate(ctx, extracted);
+				return (await this.applyUpdate(ctx, extracted)) ? "update" : null;
 			}
 			case "invalidate": {
-				return this.applyInvalidate(ctx, extracted);
+				return (await this.applyInvalidate(ctx, extracted)) ? "invalidate" : null;
 			}
 		}
 	}
 
-	/** Create a new fact with embedding */
-	private async applyNew(ctx: ActionContext, extracted: ExtractedFact): Promise<void> {
+	/** Create a new fact with embedding, or dedup if a near-duplicate exists */
+	private async applyNew(
+		ctx: ActionContext,
+		extracted: ExtractedFact,
+	): Promise<ConsolidationAction> {
 		const embedding = await this.llm.embed(extracted.fact);
+		const duplicate = await this.findDuplicate(ctx.userId, embedding);
+		if (duplicate) {
+			await this.storage.updateFact(ctx.userId, duplicate.id, {
+				sourceEpisodicIds: [...duplicate.sourceEpisodicIds, ctx.episodeId],
+			});
+			return "reinforce";
+		}
 		const fact = createFact({
 			userId: ctx.userId,
 			category: extracted.category,
@@ -177,6 +193,22 @@ export class ConsolidationPipeline {
 			embedding,
 		});
 		await this.storage.saveFact(ctx.userId, fact);
+		return "new";
+	}
+
+	/** Find an existing fact whose embedding is near-duplicate of the given one */
+	private async findDuplicate(userId: string, embedding: number[]): Promise<SemanticFact | null> {
+		const candidates = await this.storage.searchFactsByEmbedding(
+			userId,
+			embedding,
+			DUPLICATE_CANDIDATE_LIMIT,
+		);
+		for (const candidate of candidates) {
+			if (cosineSimilarity(embedding, candidate.embedding) >= DEDUPE_THRESHOLD) {
+				return candidate;
+			}
+		}
+		return null;
 	}
 
 	/** Reinforce an existing fact by adding sourceEpisodicId */

--- a/spec/memory/consolidation.spec.ts
+++ b/spec/memory/consolidation.spec.ts
@@ -130,7 +130,16 @@ describe("ConsolidationPipeline — new facts", () => {
 			],
 		};
 
-		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
+		// Each embed call returns an orthogonal vector to avoid embedding dedup between facts
+		const distinctEmbeddings = [
+			[1, 0, 0],
+			[0, 1, 0],
+			[0, 0, 1],
+		];
+		let embedCount = 0;
+		const llm = createMockLLM({ structuredResponse: llmResponse });
+		llm.embed = async (_text: string) => distinctEmbeddings[embedCount++] ?? [0, 0, 1];
+		const pipeline = new ConsolidationPipeline(llm, storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.newFacts).toBe(2);
@@ -351,7 +360,16 @@ describe("ConsolidationPipeline — multiple episodes", () => {
 			],
 		};
 
-		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
+		// Each embed call returns an orthogonal vector to avoid embedding dedup between episodes
+		const distinctEmbeddings = [
+			[1, 0, 0],
+			[0, 1, 0],
+			[0, 0, 1],
+		];
+		let embedCount = 0;
+		const llm = createMockLLM({ structuredResponse: llmResponse });
+		llm.embed = async (_text: string) => distinctEmbeddings[embedCount++] ?? [0, 0, 1];
+		const pipeline = new ConsolidationPipeline(llm, storage);
 		const result = await pipeline.consolidate(userId);
 
 		expect(result.processedEpisodes).toBe(2);
@@ -861,7 +879,8 @@ function createPCLMockLLM(opts: {
 			return schema.parse(calibrateResponse);
 		},
 		async embed(_text: string): Promise<number[]> {
-			return [0.1, 0.2, 0.3];
+			// Use a vector far from typical existing-fact embeddings to avoid embedding dedup
+			return [0.9, -0.1, 0.0];
 		},
 	};
 
@@ -1036,5 +1055,136 @@ describe("ConsolidationPipeline — Predict-Calibrate Learning", () => {
 		expect(result.reinforced).toBe(1);
 		expect(result.updated).toBe(0);
 		expect(result.invalidated).toBe(0);
+	});
+});
+
+describe("ConsolidationPipeline — embedding dedup", () => {
+	let storage: MemoryStorage;
+
+	beforeEach(() => {
+		storage = new MemoryStorage(":memory:");
+	});
+
+	afterEach(() => {
+		storage.close();
+	});
+
+	test("dedup triggers when new fact embedding matches existing fact (cosine >= 0.95)", async () => {
+		// Pre-existing fact with embedding [0.1, 0.2, 0.3]
+		const existingFact = createFact({
+			userId,
+			category: "preference",
+			fact: "User likes TypeScript",
+			keywords: ["typescript"],
+			sourceEpisodicIds: ["ep-old"],
+			embedding: [0.1, 0.2, 0.3],
+		});
+		await storage.saveFact(userId, existingFact);
+
+		const episode = makeEpisode();
+		await storage.saveEpisode(userId, episode);
+
+		// LLM returns action: "new", but embed returns [0.1, 0.2, 0.3] (identical to existing)
+		// → cosine similarity = 1.0 → dedup should trigger
+		const llmResponse: ConsolidationOutput = {
+			facts: [
+				{
+					action: "new",
+					category: "preference",
+					fact: "User enjoys TypeScript",
+					keywords: ["typescript"],
+				},
+			],
+		};
+
+		const llm = createMockLLM({
+			structuredResponse: llmResponse,
+			embedding: [0.1, 0.2, 0.3],
+		});
+		const pipeline = new ConsolidationPipeline(llm, storage);
+		const result = await pipeline.consolidate(userId);
+
+		// Should count as reinforced, not new
+		expect(result.reinforced).toBe(1);
+		expect(result.newFacts).toBe(0);
+
+		// No new fact created; existing fact's sourceEpisodicIds updated
+		const facts = await storage.getFacts(userId);
+		expect(facts).toHaveLength(1);
+		expect(facts[0]!.id).toBe(existingFact.id);
+		expect(facts[0]!.sourceEpisodicIds).toContain("ep-old");
+		expect(facts[0]!.sourceEpisodicIds).toContain(episode.id);
+	});
+
+	test("dedup does not trigger when embeddings are sufficiently different", async () => {
+		const existingFact = createFact({
+			userId,
+			category: "preference",
+			fact: "User likes TypeScript",
+			keywords: ["typescript"],
+			sourceEpisodicIds: ["ep-old"],
+			embedding: [0.1, 0.2, 0.3],
+		});
+		await storage.saveFact(userId, existingFact);
+
+		const episode = makeEpisode();
+		await storage.saveEpisode(userId, episode);
+
+		const llmResponse: ConsolidationOutput = {
+			facts: [
+				{
+					action: "new",
+					category: "interest",
+					fact: "User is interested in cooking",
+					keywords: ["cooking"],
+				},
+			],
+		};
+
+		// embed returns a very different vector → low cosine similarity → no dedup
+		const llm = createMockLLM({
+			structuredResponse: llmResponse,
+			embedding: [0.9, -0.1, 0.0],
+		});
+		const pipeline = new ConsolidationPipeline(llm, storage);
+		const result = await pipeline.consolidate(userId);
+
+		// Normal new fact creation
+		expect(result.newFacts).toBe(1);
+		expect(result.reinforced).toBe(0);
+
+		const facts = await storage.getFacts(userId);
+		expect(facts).toHaveLength(2);
+	});
+
+	test("no dedup when no existing facts exist", async () => {
+		const episode = makeEpisode();
+		await storage.saveEpisode(userId, episode);
+
+		const llmResponse: ConsolidationOutput = {
+			facts: [
+				{
+					action: "new",
+					category: "preference",
+					fact: "User likes TypeScript",
+					keywords: ["typescript"],
+				},
+			],
+		};
+
+		const llm = createMockLLM({
+			structuredResponse: llmResponse,
+			embedding: [0.1, 0.2, 0.3],
+		});
+		const pipeline = new ConsolidationPipeline(llm, storage);
+		const result = await pipeline.consolidate(userId);
+
+		// Normal new fact creation — nothing to dedup against
+		expect(result.newFacts).toBe(1);
+		expect(result.reinforced).toBe(0);
+
+		const facts = await storage.getFacts(userId);
+		expect(facts).toHaveLength(1);
+		expect(facts[0]!.sourceEpisodicIds).toEqual([episode.id]);
 	});
 });


### PR DESCRIPTION
## Summary

- LLM が `action: "new"` を返した場合に、embedding ベースの重複チェックをフォールバックとして追加
- 新ファクトの embedding と既存ファクトのコサイン類似度が **≥ 0.95** なら、新規作成せず `reinforce` 相当の動作（`sourceEpisodicIds` にエピソード ID を追加）
- `DEDUPE_THRESHOLD = 0.95`, `DUPLICATE_CANDIDATE_LIMIT = 5` で制御
- `dispatchAction` の戻り値を `ConsolidationAction | null` に変更し、dedup 時は `reinforced` カウントに加算

## Test plan

- [x] 仕様テスト 3 件追加（dedup 発動・非発動・既存ファクトなし）
- [x] ユニットテスト 2 件追加（dedup 発動・非発動）
- [x] 既存テストの mock embedding を調整（dedup が干渉しないように）
- [x] `nr validate` 通過（fmt:check + lint + check）
- [x] `nr test` 全 1248 テスト通過

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)