### PR TITLE
fix: check_commands の formatEvents を Minecraft 専用 formatCommands に置き換える

### DIFF
--- a/packages/mcp/src/tools/mc-bridge-minecraft.test.ts
+++ b/packages/mcp/src/tools/mc-bridge-minecraft.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ParsedEvent } from "./event-buffer.ts";
+import { formatCommands } from "./mc-bridge-minecraft.ts";
+
+// ─── Test Helpers ────────────────────────────────────────────────
+
+function makeEvent(overrides: Partial<ParsedEvent> = {}): ParsedEvent {
+	return {
+		ts: "2024-06-15T03:00:00.000Z",
+		content: "こんにちは",
+		authorId: "user-1",
+		authorName: "Alice",
+		messageId: "msg-1",
+		...overrides,
+	};
+}
+
+// ─── 空配列 ──────────────────────────────────────────────────────
+
+describe("formatCommands", () => {
+	test("空配列は空文字列を返す", () => {
+		expect(formatCommands([])).toBe("");
+	});
+
+	// ─── JST 変換のエッジケース ──────────────────────────────────
+
+	describe("toJstString の JST 変換（formatCommands 経由）", () => {
+		test("UTC 14:59 → JST 23:59（同日）", () => {
+			const result = formatCommands([makeEvent({ ts: "2024-01-01T14:59:00.000Z" })]);
+			expect(result).toContain("[2024-01-01 23:59]");
+		});
+
+		test("UTC 15:00 → JST 翌日 00:00（日付境界）", () => {
+			const result = formatCommands([makeEvent({ ts: "2024-01-01T15:00:00.000Z" })]);
+			expect(result).toContain("[2024-01-02 00:00]");
+		});
+
+		test("年跨ぎ: UTC 2024-12-31 15:00 → JST 2025-01-01 00:00", () => {
+			const result = formatCommands([makeEvent({ ts: "2024-12-31T15:00:00.000Z" })]);
+			expect(result).toContain("[2025-01-01 00:00]");
+		});
+
+		test("月跨ぎ: UTC 2024-01-31 15:00 → JST 2024-02-01 00:00", () => {
+			const result = formatCommands([makeEvent({ ts: "2024-01-31T15:00:00.000Z" })]);
+			expect(result).toContain("[2024-02-01 00:00]");
+		});
+
+		test("月・時・分が1桁の場合にゼロパディングされる", () => {
+			// UTC 2024-03-01T00:05:00Z → JST 2024-03-01 09:05
+			const result = formatCommands([makeEvent({ ts: "2024-03-01T00:05:00.000Z" })]);
+			expect(result).toContain("[2024-03-01 09:05]");
+		});
+	});
+
+	// ─── 出力フォーマット ────────────────────────────────────────
+
+	describe("出力フォーマットの厳密な文字列一致", () => {
+		test("[YYYY-MM-DD HH:mm] authorName: content の形式で出力する", () => {
+			const result = formatCommands([
+				makeEvent({
+					ts: "2024-06-15T03:00:00.000Z",
+					authorName: "Bob",
+					content: "テスト",
+					authorId: "user-1",
+				}),
+			]);
+			// UTC 03:00 + 9h = JST 12:00
+			expect(result).toBe("[2024-06-15 12:00] Bob: <user_message>テスト</user_message>");
+		});
+
+		test("複数イベントは改行で結合される", () => {
+			const result = formatCommands([
+				makeEvent({ ts: "2024-01-01T00:00:00.000Z", authorName: "A", content: "1" }),
+				makeEvent({ ts: "2024-01-01T01:00:00.000Z", authorName: "B", content: "2" }),
+			]);
+			const lines = result.split("\n");
+			expect(lines).toHaveLength(2);
+			expect(lines[0]).toContain("A:");
+			expect(lines[1]).toContain("B:");
+		});
+	});
+
+	// ─── isUserMessage 判定 ──────────────────────────────────────
+
+	describe("isUserMessage 判定の分岐", () => {
+		test("通常ユーザーのメッセージは <user_message> タグで囲まれる", () => {
+			const result = formatCommands([makeEvent({ authorId: "user-1", content: "hello" })]);
+			expect(result).toContain("<user_message>hello</user_message>");
+		});
+
+		test("system authorId のメッセージは <user_message> タグなし", () => {
+			const result = formatCommands([makeEvent({ authorId: "system", content: "info" })]);
+			expect(result).not.toContain("<user_message>");
+			expect(result).toContain("info");
+		});
+
+		test("isBot: true のメッセージは <user_message> タグなし", () => {
+			const result = formatCommands([
+				makeEvent({
+					authorId: "bot-1",
+					content: "bot msg",
+					metadata: { isBot: true },
+				}),
+			]);
+			expect(result).not.toContain("<user_message>");
+			expect(result).toContain("bot msg");
+		});
+
+		test("isBot: false のユーザーは <user_message> タグあり", () => {
+			const result = formatCommands([
+				makeEvent({
+					authorId: "user-1",
+					content: "msg",
+					metadata: { isBot: false },
+				}),
+			]);
+			expect(result).toContain("<user_message>msg</user_message>");
+		});
+
+		test("metadata が undefined のユーザーは <user_message> タグあり", () => {
+			const result = formatCommands([
+				makeEvent({ authorId: "user-1", content: "msg", metadata: undefined }),
+			]);
+			expect(result).toContain("<user_message>msg</user_message>");
+		});
+	});
+
+	// ─── 添付ファイル ────────────────────────────────────────────
+
+	describe("添付ファイル表示", () => {
+		test("添付1件の場合、行末に [添付: 1件] が付く", () => {
+			const result = formatCommands([
+				makeEvent({
+					attachments: [{ url: "https://example.com/a.png" }],
+				}),
+			]);
+			expect(result).toEndWith("[添付: 1件]");
+		});
+
+		test("添付3件の場合、行末に [添付: 3件] が付く", () => {
+			const result = formatCommands([
+				makeEvent({
+					attachments: [
+						{ url: "https://example.com/a.png" },
+						{ url: "https://example.com/b.png" },
+						{ url: "https://example.com/c.png" },
+					],
+				}),
+			]);
+			expect(result).toEndWith("[添付: 3件]");
+		});
+
+		test("添付ファイルは content の後に続く（content と添付の間にスペース）", () => {
+			const result = formatCommands([
+				makeEvent({
+					authorId: "system",
+					content: "ログ",
+					attachments: [{ url: "https://example.com/a.png" }],
+				}),
+			]);
+			expect(result).toContain("ログ [添付: 1件]");
+		});
+
+		test("空の添付配列の場合は [添付] が付かない", () => {
+			const result = formatCommands([makeEvent({ attachments: [] })]);
+			expect(result).not.toContain("[添付");
+		});
+
+		test("attachments が undefined の場合は [添付] が付かない", () => {
+			const result = formatCommands([makeEvent({ attachments: undefined })]);
+			expect(result).not.toContain("[添付");
+		});
+	});
+
+	// ─── エラーイベント ──────────────────────────────────────────
+
+	describe("エラーイベント", () => {
+		test("_error と _raw を持つオブジェクトは [ERROR] err: raw 形式で出力する", () => {
+			const errorEvent = { _error: "invalid JSON", _raw: "{broken" } as never;
+			const result = formatCommands([errorEvent]);
+			expect(result).toBe("[ERROR] invalid JSON: {broken");
+		});
+
+		test("エラーイベントと通常イベントが混在する場合", () => {
+			const errorEvent = { _error: "parse error", _raw: "bad data" } as never;
+			const normalEvent = makeEvent({
+				ts: "2024-01-01T00:00:00.000Z",
+				authorId: "system",
+				content: "ok",
+			});
+			const result = formatCommands([errorEvent, normalEvent]);
+			const lines = result.split("\n");
+			expect(lines).toHaveLength(2);
+			expect(lines[0]).toBe("[ERROR] parse error: bad data");
+			expect(lines[1]).toContain("ok");
+		});
+	});
+});

--- a/packages/mcp/src/tools/mc-bridge-minecraft.ts
+++ b/packages/mcp/src/tools/mc-bridge-minecraft.ts
@@ -5,9 +5,51 @@ import { getSessionLockGuildId } from "@vicissitude/store/mc-bridge";
 import { appendEvent, consumeEvents } from "@vicissitude/store/queries";
 import { z } from "zod";
 
-import { MAX_BATCH_SIZE, formatEvents, parseEvents } from "./event-buffer.ts";
+import type { ParsedEvent } from "./event-buffer.ts";
+import { MAX_BATCH_SIZE, parseEvents } from "./event-buffer.ts";
 
 const MAX_REPORT_CHARS = 10_000;
+
+// ─── formatCommands ──────────────────────────────────────────────
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+function toJstString(ts: string | Date): string {
+	const utc = ts instanceof Date ? ts.getTime() : new Date(ts).getTime();
+	const jst = new Date(utc + JST_OFFSET_MS);
+	const y = jst.getUTCFullYear();
+	const mo = String(jst.getUTCMonth() + 1).padStart(2, "0");
+	const d = String(jst.getUTCDate()).padStart(2, "0");
+	const h = String(jst.getUTCHours()).padStart(2, "0");
+	const mi = String(jst.getUTCMinutes()).padStart(2, "0");
+	return `${y}-${mo}-${d} ${h}:${mi}`;
+}
+
+/** ParsedEvent 配列を Minecraft エージェント向けにフォーマットする。action ヒント・チャンネル名は含めない。 */
+export function formatCommands(events: ParsedEvent[]): string {
+	if (events.length === 0) return "";
+
+	return events
+		.map((e) => {
+			// エラーイベント
+			if ("_error" in e && "_raw" in e) {
+				const raw = (e as unknown as { _raw: string })._raw;
+				const err = (e as unknown as { _error: string })._error;
+				return `[ERROR] ${err}: ${raw}`;
+			}
+
+			const dateStr = toJstString(e.ts);
+			const isUserMessage = e.authorId !== "system" && e.metadata?.isBot !== true;
+			const content = isUserMessage ? `<user_message>${e.content}</user_message>` : e.content;
+
+			let line = `[${dateStr}] ${e.authorName}: ${content}`;
+			if (e.attachments && e.attachments.length > 0) {
+				line += ` [添付: ${e.attachments.length}件]`;
+			}
+			return line;
+		})
+		.join("\n");
+}
 
 /** Minecraft 側のブリッジツールを登録する */
 export function registerMinecraftBridgeTools(server: McpServer, deps: { db: StoreDb }): void {
@@ -67,7 +109,7 @@ export function registerMinecraftBridgeTools(server: McpServer, deps: { db: Stor
 		},
 		() => {
 			const rows = consumeEvents(db, MINECRAFT_AGENT_ID, MAX_BATCH_SIZE);
-			const text = rows.length > 0 ? formatEvents(parseEvents(rows)) : "[]";
+			const text = rows.length > 0 ? formatCommands(parseEvents(rows)) : "[]";
 			return { content: [{ type: "text" as const, text }] };
 		},
 	);

--- a/spec/mcp/tools/mc-bridge-format-commands.spec.ts
+++ b/spec/mcp/tools/mc-bridge-format-commands.spec.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ParsedEvent } from "@vicissitude/mcp/tools/event-buffer";
+/**
+ * formatCommands はまだ実装されていない。
+ * このテストは仕様を先に定義し、実装が仕様に適合することを検証する。
+ *
+ * インポートパスは実装時に確定する。暫定的に mc-bridge-minecraft から
+ * エクスポートされることを想定する。
+ */
+import { formatCommands } from "@vicissitude/mcp/tools/mc-bridge-minecraft";
+
+describe("formatCommands", () => {
+	test("空配列なら空文字列を返す", () => {
+		const result = formatCommands([]);
+		expect(result).toBe("");
+	});
+
+	test("単一のユーザーイベントを JST タイムスタンプ付きでフォーマットする", () => {
+		const events: ParsedEvent[] = [
+			{
+				ts: "2026-03-27T01:30:00.000Z",
+				content: "木を切って",
+				authorId: "user1",
+				authorName: "おかず",
+				messageId: "msg1",
+			},
+		];
+		const result = formatCommands(events);
+		// JST = UTC+9 なので 01:30 UTC -> 10:30 JST
+		expect(result).toContain("10:30");
+		expect(result).toContain("おかず");
+		expect(result).toContain("<user_message>木を切って</user_message>");
+	});
+
+	test("[action: ...] ヒントを含めない", () => {
+		const events: ParsedEvent[] = [
+			{
+				ts: "2026-03-27T00:00:00.000Z",
+				content: "テスト",
+				authorId: "user1",
+				authorName: "テスト",
+				messageId: "msg1",
+				metadata: { isMentioned: true },
+			},
+		];
+		const result = formatCommands(events);
+		expect(result).not.toContain("[action:");
+		expect(result).not.toContain("respond");
+		expect(result).not.toContain("optional");
+		expect(result).not.toContain("read_only");
+		expect(result).not.toContain("internal");
+	});
+
+	test("チャンネル名を含めない", () => {
+		const events: ParsedEvent[] = [
+			{
+				ts: "2026-03-27T00:00:00.000Z",
+				content: "テスト",
+				authorId: "user1",
+				authorName: "テスト",
+				messageId: "msg1",
+				metadata: { channelName: "general" },
+			},
+		];
+		const result = formatCommands(events);
+		expect(result).not.toContain("#general");
+		expect(result).not.toContain("general");
+	});
+
+	test("ユーザーメッセージ (authorId !== 'system' かつ isBot !== true) は <user_message> タグで囲む", () => {
+		const events: ParsedEvent[] = [
+			{
+				ts: "2026-03-27T00:00:00.000Z",
+				content: "ダイヤ掘って",
+				authorId: "user1",
+				authorName: "おかず",
+				messageId: "msg1",
+				metadata: { isBot: false },
+			},
+		];
+		const result = formatCommands(events);
+		expect(result).toContain("<user_message>ダイヤ掘って</user_message>");
+	});
+
+	test("system イベントには <user_message> タグが付かない", () => {
+		const events: ParsedEvent[] = [
+			{
+				ts: "2026-03-27T00:00:00.000Z",
+				content: "セッション開始",
+				authorId: "system",
+				authorName: "system",
+				messageId: "sys1",
+			},
+		];
+		const result = formatCommands(events);
+		expect(result).toContain("セッション開始");
+		expect(result).not.toContain("<user_message>");
+		expect(result).not.toContain("</user_message>");
+	});
+
+	test("bot イベントには <user_message> タグが付かない", () => {
+		const events: ParsedEvent[] = [
+			{
+				ts: "2026-03-27T00:00:00.000Z",
+				content: "自動応答",
+				authorId: "bot1",
+				authorName: "BotA",
+				messageId: "msg1",
+				metadata: { isBot: true },
+			},
+		];
+		const result = formatCommands(events);
+		expect(result).toContain("自動応答");
+		expect(result).not.toContain("<user_message>");
+		expect(result).not.toContain("</user_message>");
+	});
+
+	test("添付ファイルがあれば件数を表示する", () => {
+		const events: ParsedEvent[] = [
+			{
+				ts: "2026-03-27T00:00:00.000Z",
+				content: "画像送るよ",
+				authorId: "user1",
+				authorName: "テスト",
+				messageId: "msg1",
+				attachments: [{ url: "https://example.com/a.png" }, { url: "https://example.com/b.png" }],
+			},
+		];
+		const result = formatCommands(events);
+		expect(result).toContain("[添付: 2件]");
+	});
+
+	test("エラーイベントは [ERROR] 形式で出力する", () => {
+		const events = [{ _raw: "broken-data", _error: "invalid JSON" } as never];
+		const result = formatCommands(events);
+		expect(result).toContain("[ERROR]");
+		expect(result).toContain("invalid JSON");
+		expect(result).toContain("broken-data");
+	});
+
+	test("複数イベントを改行で結合する", () => {
+		const events: ParsedEvent[] = [
+			{
+				ts: "2026-03-27T00:00:00.000Z",
+				content: "1つ目",
+				authorId: "u1",
+				authorName: "A",
+				messageId: "m1",
+			},
+			{
+				ts: "2026-03-27T00:01:00.000Z",
+				content: "2つ目",
+				authorId: "u2",
+				authorName: "B",
+				messageId: "m2",
+			},
+		];
+		const result = formatCommands(events);
+		const lines = result.split("\n").filter((l) => l.trim());
+		expect(lines).toHaveLength(2);
+		expect(result).toContain("<user_message>1つ目</user_message>");
+		expect(result).toContain("<user_message>2つ目</user_message>");
+		// [action: ...] が含まれないことを再確認
+		for (const line of lines) {
+			expect(line).not.toContain("[action:");
+		}
+	});
+
+	test("タイムゾーンは JST (UTC+9) で表示する", () => {
+		// 2026-03-27T15:00:00.000Z (UTC) -> 2026-03-28 00:00 (JST)
+		const events: ParsedEvent[] = [
+			{
+				ts: "2026-03-27T15:00:00.000Z",
+				content: "深夜",
+				authorId: "user1",
+				authorName: "夜型",
+				messageId: "msg1",
+			},
+		];
+		const result = formatCommands(events);
+		expect(result).toContain("2026-03-28");
+		expect(result).toContain("00:00");
+	});
+
+	test("ユーザー・bot・system が混在する場合、ユーザーのみタグ付きである", () => {
+		const events: ParsedEvent[] = [
+			{
+				ts: "2026-03-27T00:00:00.000Z",
+				content: "こんにちは",
+				authorId: "user1",
+				authorName: "おかず",
+				messageId: "m1",
+				metadata: { isBot: false },
+			},
+			{
+				ts: "2026-03-27T00:01:00.000Z",
+				content: "自動応答",
+				authorId: "bot1",
+				authorName: "BotA",
+				messageId: "m2",
+				metadata: { isBot: true },
+			},
+			{
+				ts: "2026-03-27T00:02:00.000Z",
+				content: "通知",
+				authorId: "system",
+				authorName: "system",
+				messageId: "m3",
+			},
+		];
+		const result = formatCommands(events);
+		const lines = result.split("\n");
+
+		expect(result).toContain("<user_message>こんにちは</user_message>");
+
+		const botLine = lines.find((l) => l.includes("BotA"));
+		expect(botLine).toBeDefined();
+		expect(botLine).not.toContain("<user_message>");
+
+		const systemLine = lines.find((l) => l.includes("通知"));
+		expect(systemLine).toBeDefined();
+		expect(systemLine).not.toContain("<user_message>");
+
+		// どの行にも [action: ...] がない
+		for (const line of lines) {
+			expect(line).not.toContain("[action:");
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Minecraft 専用の `formatCommands` 関数を `mc-bridge-minecraft.ts` に新設
- `check_commands` ツールの `formatEvents` → `formatCommands` に差し替え
- `[action: ...]` ヒントとチャンネル名を出力から除外（Minecraft コンテキストで無意味なため）

Closes #311

## Changes

- `packages/mcp/src/tools/mc-bridge-minecraft.ts`: `formatCommands` 追加、`check_commands` で使用
- `spec/mcp/tools/mc-bridge-format-commands.spec.ts`: 仕様テスト 11 件追加
- `packages/mcp/src/tools/mc-bridge-minecraft.test.ts`: ユニットテスト 20 件追加

## Test plan

- [x] `nr test` — 1301 tests passed (ベースライン 1269 → +32)
- [x] `nr validate` — 型チェック・lint・フォーマット全通過
- [x] `nr test:spec` — 仕様テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)