### PR TITLE
refactor: toJstString と isErrorEvent を共有する

### DIFF
--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -88,7 +88,7 @@ export function escapeUserMessageTag(content: string): string {
 
 const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
-function toJstString(ts: string | Date): string {
+export function toJstString(ts: string | Date): string {
 	const utc = ts instanceof Date ? ts.getTime() : new Date(ts).getTime();
 	const jst = new Date(utc + JST_OFFSET_MS);
 	const y = jst.getUTCFullYear();
@@ -99,6 +99,11 @@ function toJstString(ts: string | Date): string {
 	return `${y}-${mo}-${d} ${h}:${mi}`;
 }
 
+/** parseEvents がパースに失敗したエラーイベントかどうかを判定する type guard */
+export function isErrorEvent(e: ParsedEvent): e is ParsedEvent & { _raw: string; _error: string } {
+	return "_error" in e && "_raw" in e;
+}
+
 /** ParsedEvent 配列を人間可読形式にフォーマットする */
 export function formatEvents(events: ParsedEvent[]): string {
 	if (events.length === 0) return "";
@@ -106,10 +111,8 @@ export function formatEvents(events: ParsedEvent[]): string {
 	return events
 		.map((e) => {
 			// エラーイベント
-			if ("_error" in e && "_raw" in e) {
-				const raw = (e as unknown as { _raw: string })._raw;
-				const err = (e as unknown as { _error: string })._error;
-				return `[ERROR] ${err}: ${raw}`;
+			if (isErrorEvent(e)) {
+				return `[ERROR] ${e._error}: ${e._raw}`;
 			}
 
 			const dateStr = toJstString(e.ts);

--- a/packages/mcp/src/tools/mc-bridge-minecraft.ts
+++ b/packages/mcp/src/tools/mc-bridge-minecraft.ts
@@ -6,24 +6,17 @@ import { appendEvent, consumeEvents } from "@vicissitude/store/queries";
 import { z } from "zod";
 
 import type { ParsedEvent } from "./event-buffer.ts";
-import { MAX_BATCH_SIZE, escapeUserMessageTag, parseEvents } from "./event-buffer.ts";
+import {
+	MAX_BATCH_SIZE,
+	escapeUserMessageTag,
+	isErrorEvent,
+	parseEvents,
+	toJstString,
+} from "./event-buffer.ts";
 
 const MAX_REPORT_CHARS = 10_000;
 
 // ─── formatCommands ──────────────────────────────────────────────
-
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
-
-function toJstString(ts: string | Date): string {
-	const utc = ts instanceof Date ? ts.getTime() : new Date(ts).getTime();
-	const jst = new Date(utc + JST_OFFSET_MS);
-	const y = jst.getUTCFullYear();
-	const mo = String(jst.getUTCMonth() + 1).padStart(2, "0");
-	const d = String(jst.getUTCDate()).padStart(2, "0");
-	const h = String(jst.getUTCHours()).padStart(2, "0");
-	const mi = String(jst.getUTCMinutes()).padStart(2, "0");
-	return `${y}-${mo}-${d} ${h}:${mi}`;
-}
 
 /** ParsedEvent 配列を Minecraft エージェント向けにフォーマットする。action ヒント・チャンネル名は含めない。 */
 export function formatCommands(events: ParsedEvent[]): string {
@@ -32,10 +25,8 @@ export function formatCommands(events: ParsedEvent[]): string {
 	return events
 		.map((e) => {
 			// エラーイベント
-			if ("_error" in e && "_raw" in e) {
-				const raw = (e as unknown as { _raw: string })._raw;
-				const err = (e as unknown as { _error: string })._error;
-				return `[ERROR] ${err}: ${raw}`;
+			if (isErrorEvent(e)) {
+				return `[ERROR] ${e._error}: ${e._raw}`;
 			}
 
 			const dateStr = toJstString(e.ts);


### PR DESCRIPTION
## Summary

- `event-buffer.ts` の `toJstString` を export に変更
- エラーイベント判定用の type guard `isErrorEvent()` を `event-buffer.ts` に新設・export
- `mc-bridge-minecraft.ts` の重複コード（`JST_OFFSET_MS`, `toJstString`）を削除し import に置き換え
- 両ファイルのエラーイベント処理を `isErrorEvent` に統一

Closes #346

## Test plan

- [x] 既存の `event-buffer.test.ts` (8 tests pass)
- [x] 既存の `mc-bridge-minecraft.test.ts` (22 tests pass)
- [x] 既存の `event-buffer.spec.ts` (46 tests pass)
- [x] `nr validate` (fmt, lint, type check) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)