### PR TITLE
feat: await-thenable ルールを有効化する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -64,7 +64,7 @@
 		"typescript/strict-boolean-expressions": "off",
 		"typescript/no-confusing-void-expression": "off",
 		"typescript/unbound-method": "off",
-		"typescript/await-thenable": "off"
+		"typescript/await-thenable": "error"
 	},
 	"overrides": [
 		{

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -549,7 +549,7 @@ export async function bootstrap(): Promise<void> {
 			routingAgent.stop();
 			metrics.server.stop();
 			await factReader.close();
-			await memoryResources?.chatAdapter.close();
+			memoryResources?.chatAdapter.close();
 			await memoryResources?.recorder.close();
 			coreProcess.kill();
 			mcProcess?.kill();

--- a/packages/minecraft/src/actions/combat.ts
+++ b/packages/minecraft/src/actions/combat.ts
@@ -119,8 +119,7 @@ async function attackLoop(ctx: AttackContext): Promise<void> {
 		if (bot.entity.position.distanceTo(target.position) > ATTACK_RANGE) continue;
 
 		try {
-			// oxlint-disable-next-line no-await-in-loop -- 攻撃は順次実行が必須
-			await bot.attack(target);
+			bot.attack(target);
 			hits++;
 			updateProgress(`${String(hits)}/${String(maxHits)} 攻撃 (武器: ${weapon})`);
 		} catch {

--- a/spec/agent/discord/context-builder.spec.ts
+++ b/spec/agent/discord/context-builder.spec.ts
@@ -149,16 +149,16 @@ describe("ContextBuilder", () => {
 	});
 
 	describe("guildId バリデーション", () => {
-		it("不正な guildId（パストラバーサル）でエラーをスローする", async () => {
+		it("不正な guildId（パストラバーサル）でエラーをスローする", () => {
 			const { baseDir, overlayDir } = createTmpDirs();
 			const builder = new ContextBuilder(overlayDir, baseDir);
-			await expect(builder.build("../../../etc")).rejects.toThrow("Invalid guildId");
+			expect(builder.build("../../../etc")).rejects.toThrow("Invalid guildId");
 		});
 
-		it("不正な guildId（英字）でエラーをスローする", async () => {
+		it("不正な guildId（英字）でエラーをスローする", () => {
 			const { baseDir, overlayDir } = createTmpDirs();
 			const builder = new ContextBuilder(overlayDir, baseDir);
-			await expect(builder.build("abc")).rejects.toThrow("Invalid guildId");
+			expect(builder.build("abc")).rejects.toThrow("Invalid guildId");
 		});
 
 		it("正しい guildId（数字のみ）は通る", async () => {

--- a/spec/agent/discord/router.spec.ts
+++ b/spec/agent/discord/router.spec.ts
@@ -38,11 +38,11 @@ describe("GuildRouter", () => {
 		expect(agentB.send).not.toHaveBeenCalled();
 	});
 
-	it("guildId 未指定 + defaultAgent なしの場合にエラーがスローされる", async () => {
+	it("guildId 未指定 + defaultAgent なしの場合にエラーがスローされる", () => {
 		const router = new GuildRouter(new Map());
 
 		const opts: SendOptions = { sessionKey: "key", message: "hello" };
-		await expect(router.send(opts)).rejects.toThrow("GuildRouter requires guildId");
+		expect(router.send(opts)).rejects.toThrow("GuildRouter requires guildId");
 	});
 
 	it("guildId 未指定 + defaultAgent ありの場合に defaultAgent に委譲される", async () => {
@@ -56,15 +56,13 @@ describe("GuildRouter", () => {
 		expect(defaultAgent.send).toHaveBeenCalledTimes(1);
 	});
 
-	it("未登録の guildId の場合にエラーがスローされる", async () => {
+	it("未登録の guildId の場合にエラーがスローされる", () => {
 		const agentA = createMockAgent("a");
 		const agents = new Map<string, AiAgent>([["guild-a", agentA]]);
 		const router = new GuildRouter(agents);
 
 		const opts: SendOptions = { sessionKey: "key", message: "hello", guildId: "guild-unknown" };
-		await expect(router.send(opts)).rejects.toThrow(
-			"No agent registered for guildId: guild-unknown",
-		);
+		expect(router.send(opts)).rejects.toThrow("No agent registered for guildId: guild-unknown");
 	});
 
 	it("stop() が全エージェントに伝播される", () => {

--- a/spec/core/functions.spec.ts
+++ b/spec/core/functions.spec.ts
@@ -279,15 +279,15 @@ describe("withTimeout", () => {
 		expect(result).toBe("ok");
 	});
 
-	test("rejects with timeout error when promise takes too long", async () => {
+	test("rejects with timeout error when promise takes too long", () => {
 		const slow = new Promise<string>((resolve) => {
 			setTimeout(() => resolve("late"), 500);
 		});
-		await expect(withTimeout(slow, 10, "timed out")).rejects.toThrow("timed out");
+		expect(withTimeout(slow, 10, "timed out")).rejects.toThrow("timed out");
 	});
 
-	test("propagates original error when promise rejects before timeout", async () => {
+	test("propagates original error when promise rejects before timeout", () => {
 		const failing = Promise.reject(new Error("original"));
-		await expect(withTimeout(failing, 1000, "timed out")).rejects.toThrow("original");
+		expect(withTimeout(failing, 1000, "timed out")).rejects.toThrow("original");
 	});
 });

--- a/spec/memory/chat-adapter.spec.ts
+++ b/spec/memory/chat-adapter.spec.ts
@@ -59,13 +59,11 @@ describe("chatStructured", () => {
 		expect(port.createSession).toHaveBeenCalledTimes(2);
 	});
 
-	it("should throw a clear error when retry limit is exceeded with empty responses", async () => {
+	it("should throw a clear error when retry limit is exceeded with empty responses", () => {
 		const port = createMockSessionPort([{ text: "" }, { text: "" }, { text: "" }]);
 		const adapter = new MemoryChatAdapter(port, "provider", "model", noopLogger);
 
-		await expect(adapter.chatStructured(messages, validSchema)).rejects.toThrow(
-			/empty.*response|retry/i,
-		);
+		expect(adapter.chatStructured(messages, validSchema)).rejects.toThrow(/empty.*response|retry/i);
 	});
 });
 

--- a/spec/memory/consolidation.spec.ts
+++ b/spec/memory/consolidation.spec.ts
@@ -619,7 +619,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 		await storage.saveEpisode(userId, episode);
 
 		const pipeline = new ConsolidationPipeline(createInvalidLLM("not an object"), storage);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("Expected object");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("Expected object");
 	});
 
 	test("rejects response without facts array", async () => {
@@ -627,7 +627,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 		await storage.saveEpisode(userId, episode);
 
 		const pipeline = new ConsolidationPipeline(createInvalidLLM({}), storage);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("Expected facts array");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("Expected facts array");
 	});
 
 	test("rejects fact with invalid action", async () => {
@@ -647,7 +647,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 			}),
 			storage,
 		);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("action");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("action");
 	});
 
 	test("rejects fact with invalid category", async () => {
@@ -667,7 +667,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 			}),
 			storage,
 		);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("category");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("category");
 	});
 
 	test("rejects fact with empty fact string", async () => {
@@ -687,7 +687,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 			}),
 			storage,
 		);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("fact");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("fact");
 	});
 
 	test("rejects reinforce action without existingFactId", async () => {
@@ -707,7 +707,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 			}),
 			storage,
 		);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("existingFactId");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("existingFactId");
 	});
 
 	test("rejects fact with non-array keywords", async () => {
@@ -727,7 +727,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 			}),
 			storage,
 		);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("keywords");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("keywords");
 	});
 
 	test("rejects update action without existingFactId", async () => {
@@ -747,7 +747,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 			}),
 			storage,
 		);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("existingFactId");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("existingFactId");
 	});
 
 	test("rejects invalidate action without existingFactId", async () => {
@@ -767,7 +767,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 			}),
 			storage,
 		);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("existingFactId");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("existingFactId");
 	});
 
 	test("rejects null element in facts array", async () => {
@@ -780,7 +780,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 			}),
 			storage,
 		);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("expected object");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("expected object");
 	});
 
 	test("rejects non-string keyword element", async () => {
@@ -800,7 +800,7 @@ describe("ConsolidationPipeline — schema validation", () => {
 			}),
 			storage,
 		);
-		await expect(pipeline.consolidate(userId)).rejects.toThrow("keywords[0]: expected string");
+		expect(pipeline.consolidate(userId)).rejects.toThrow("keywords[0]: expected string");
 	});
 });
 

--- a/spec/memory/conversation-recorder.spec.ts
+++ b/spec/memory/conversation-recorder.spec.ts
@@ -48,9 +48,9 @@ const sampleMessage = {
 };
 
 describe("MemoryConversationRecorder", () => {
-	test("record() で guildId が非数字 → Error throw", async () => {
+	test("record() で guildId が非数字 → Error throw", () => {
 		const recorder = createRecorder();
-		await expect(recorder.record("abc", sampleMessage)).rejects.toThrow("Invalid guildId: abc");
+		expect(recorder.record("abc", sampleMessage)).rejects.toThrow("Invalid guildId: abc");
 	});
 
 	test("record() で segmenter.addMessage 呼び出し確認", async () => {

--- a/spec/memory/retrieval.spec.ts
+++ b/spec/memory/retrieval.spec.ts
@@ -239,7 +239,7 @@ describe("Retrieval — edge cases", () => {
 	});
 
 	test("throws on empty userId", async () => {
-		await expect(retrieval.retrieve("", "query")).rejects.toThrow("userId must not be empty");
+		expect(retrieval.retrieve("", "query")).rejects.toThrow("userId must not be empty");
 	});
 
 	test("empty query returns empty results without calling embed", async () => {

--- a/spec/memory/segmenter.spec.ts
+++ b/spec/memory/segmenter.spec.ts
@@ -369,9 +369,7 @@ describe("Segmenter — schema validation", () => {
 		});
 
 		await segmenter.addMessage(userId, makeMessage("first"));
-		await expect(segmenter.addMessage(userId, makeMessage("trigger"))).rejects.toThrow(
-			"Expected object",
-		);
+		expect(segmenter.addMessage(userId, makeMessage("trigger"))).rejects.toThrow("Expected object");
 	});
 
 	test("rejects response without segments array", async () => {
@@ -382,7 +380,7 @@ describe("Segmenter — schema validation", () => {
 		});
 
 		await segmenter.addMessage(userId, makeMessage("first"));
-		await expect(segmenter.addMessage(userId, makeMessage("trigger"))).rejects.toThrow(
+		expect(segmenter.addMessage(userId, makeMessage("trigger"))).rejects.toThrow(
 			"Expected segments array",
 		);
 	});
@@ -397,7 +395,7 @@ describe("Segmenter — schema validation", () => {
 		);
 
 		await segmenter.addMessage(userId, makeMessage("first"));
-		await expect(segmenter.addMessage(userId, makeMessage("trigger"))).rejects.toThrow("title");
+		expect(segmenter.addMessage(userId, makeMessage("trigger"))).rejects.toThrow("title");
 	});
 
 	test.each([
@@ -449,9 +447,7 @@ describe("Segmenter — schema validation", () => {
 		);
 
 		await segmenter.addMessage(userId, makeMessage("first"));
-		await expect(segmenter.addMessage(userId, makeMessage("trigger"))).rejects.toThrow(
-			"startIndex",
-		);
+		expect(segmenter.addMessage(userId, makeMessage("trigger"))).rejects.toThrow("startIndex");
 	});
 });
 
@@ -478,7 +474,7 @@ describe("Segmenter — maxQueueSize", () => {
 		await segmenter.addMessage(userId, makeMessage("msg 2"));
 		await segmenter.addMessage(userId, makeMessage("msg 3"));
 
-		await expect(segmenter.addMessage(userId, makeMessage("msg 4"))).rejects.toThrow(
+		expect(segmenter.addMessage(userId, makeMessage("msg 4"))).rejects.toThrow(
 			"exceeds maximum size",
 		);
 	});
@@ -515,6 +511,6 @@ describe("Segmenter — edge cases", () => {
 		});
 
 		await segmenter.addMessage(userId, makeMessage("first"));
-		await expect(segmenter.addMessage(userId, makeMessage("trigger"))).rejects.toThrow("endIndex");
+		expect(segmenter.addMessage(userId, makeMessage("trigger"))).rejects.toThrow("endIndex");
 	});
 });

--- a/spec/memory/storage.spec.ts
+++ b/spec/memory/storage.spec.ts
@@ -116,7 +116,7 @@ describe("MemoryStorage — episodic memory", () => {
 
 	test("saveEpisode throws on userId mismatch", async () => {
 		const ep = makeEpisode({ userId: "user-1" });
-		await expect(storage.saveEpisode("user-2", ep)).rejects.toThrow("does not match");
+		expect(storage.saveEpisode("user-2", ep)).rejects.toThrow("does not match");
 	});
 });
 
@@ -222,7 +222,7 @@ describe("MemoryStorage — semantic memory", () => {
 
 	test("saveFact throws on userId mismatch", async () => {
 		const fact = makeFact({ userId: "user-1" });
-		await expect(storage.saveFact("user-2", fact)).rejects.toThrow("does not match");
+		expect(storage.saveFact("user-2", fact)).rejects.toThrow("does not match");
 	});
 });
 
@@ -393,7 +393,7 @@ describe("MemoryStorage — updateFact edge cases", () => {
 	});
 
 	test("updateFact on nonexistent fact does not throw", async () => {
-		await expect(
+		expect(
 			storage.updateFact(userId, "nonexistent-id", { fact: "Updated fact" }),
 		).resolves.toBeUndefined();
 	});
@@ -799,7 +799,7 @@ describe("MemoryStorage — embedding dimension validation", () => {
 		const ep1 = makeEpisode({ embedding: [0.1, 0.2, 0.3] });
 		const ep2 = makeEpisode({ embedding: [0.4, 0.5, 0.6] });
 		await storage.saveEpisode(userId, ep1);
-		await expect(storage.saveEpisode(userId, ep2)).resolves.toBeUndefined();
+		expect(storage.saveEpisode(userId, ep2)).resolves.toBeUndefined();
 	});
 
 	test("throws on episode dimension mismatch", async () => {
@@ -807,7 +807,7 @@ describe("MemoryStorage — embedding dimension validation", () => {
 		await storage.saveEpisode(userId, ep1);
 
 		const ep2 = makeEpisode({ embedding: [0.1, 0.2] });
-		await expect(storage.saveEpisode(userId, ep2)).rejects.toThrow(
+		expect(storage.saveEpisode(userId, ep2)).rejects.toThrow(
 			"Embedding dimension mismatch: expected 3, got 2",
 		);
 	});
@@ -817,7 +817,7 @@ describe("MemoryStorage — embedding dimension validation", () => {
 		await storage.saveEpisode(userId, ep);
 
 		const fact = makeFact({ embedding: [0.1, 0.2, 0.3, 0.4, 0.5] });
-		await expect(storage.saveFact(userId, fact)).rejects.toThrow(
+		expect(storage.saveFact(userId, fact)).rejects.toThrow(
 			"Embedding dimension mismatch: expected 3, got 5",
 		);
 	});
@@ -827,7 +827,7 @@ describe("MemoryStorage — embedding dimension validation", () => {
 		await storage.saveFact(userId, fact);
 
 		const ep = makeEpisode({ embedding: [0.1, 0.2, 0.3] });
-		await expect(storage.saveEpisode(userId, ep)).rejects.toThrow("Embedding dimension mismatch");
+		expect(storage.saveEpisode(userId, ep)).rejects.toThrow("Embedding dimension mismatch");
 	});
 
 	test("resetEmbeddingMeta backfills from existing data", async () => {
@@ -840,7 +840,7 @@ describe("MemoryStorage — embedding dimension validation", () => {
 		expect(storage.getEmbeddingDimension()).toBe(3);
 
 		const ep2 = makeEpisode({ embedding: [0.1, 0.2] });
-		await expect(storage.saveEpisode(userId, ep2)).rejects.toThrow("Embedding dimension mismatch");
+		expect(storage.saveEpisode(userId, ep2)).rejects.toThrow("Embedding dimension mismatch");
 	});
 
 	test("getEmbeddingDimension returns null when no data stored", () => {
@@ -852,14 +852,14 @@ describe("MemoryStorage — embedding dimension validation", () => {
 		await storage.saveEpisode(userId, ep1);
 
 		const ep2 = makeEpisode({ embedding: [] });
-		await expect(storage.saveEpisode(userId, ep2)).resolves.toBeUndefined();
+		expect(storage.saveEpisode(userId, ep2)).resolves.toBeUndefined();
 	});
 
 	test("updateFact throws on embedding dimension mismatch", async () => {
 		const fact = makeFact({ embedding: [0.1, 0.2, 0.3] });
 		await storage.saveFact(userId, fact);
 
-		await expect(storage.updateFact(userId, fact.id, { embedding: [0.1, 0.2] })).rejects.toThrow(
+		expect(storage.updateFact(userId, fact.id, { embedding: [0.1, 0.2] })).rejects.toThrow(
 			"Embedding dimension mismatch: expected 3, got 2",
 		);
 	});
@@ -868,7 +868,7 @@ describe("MemoryStorage — embedding dimension validation", () => {
 		const fact = makeFact({ embedding: [0.1, 0.2, 0.3] });
 		await storage.saveFact(userId, fact);
 
-		await expect(
+		expect(
 			storage.updateFact(userId, fact.id, { embedding: [0.4, 0.5, 0.6] }),
 		).resolves.toBeUndefined();
 	});
@@ -877,9 +877,7 @@ describe("MemoryStorage — embedding dimension validation", () => {
 		const fact = makeFact({ embedding: [0.1, 0.2, 0.3] });
 		await storage.saveFact(userId, fact);
 
-		await expect(
-			storage.updateFact(userId, fact.id, { fact: "Updated text" }),
-		).resolves.toBeUndefined();
+		expect(storage.updateFact(userId, fact.id, { fact: "Updated text" })).resolves.toBeUndefined();
 	});
 
 	test("search does not create embedding_meta on empty DB", async () => {
@@ -894,7 +892,7 @@ describe("MemoryStorage — embedding dimension validation", () => {
 		await storage.saveEpisode(userId, ep);
 
 		// Search with dim=2 should throw
-		await expect(storage.searchEpisodesByEmbedding(userId, [0.1, 0.2], 10)).rejects.toThrow(
+		expect(storage.searchEpisodesByEmbedding(userId, [0.1, 0.2], 10)).rejects.toThrow(
 			"Embedding dimension mismatch",
 		);
 	});
@@ -925,7 +923,7 @@ describe("MemoryStorage — legacy DB upgrade (backfill from existing data)", ()
 		storage.resetEmbeddingMeta();
 
 		const ep2 = makeEpisode({ embedding: [0.1, 0.2, 0.3, 0.4, 0.5] });
-		await expect(storage.saveEpisode(userId, ep2)).rejects.toThrow(
+		expect(storage.saveEpisode(userId, ep2)).rejects.toThrow(
 			"Embedding dimension mismatch: expected 3, got 5",
 		);
 	});

--- a/spec/observability/instrumented-agent.spec.ts
+++ b/spec/observability/instrumented-agent.spec.ts
@@ -50,7 +50,7 @@ describe("InstrumentedAiAgent", () => {
 		);
 	});
 
-	it("エラー時に counter が outcome=error でインクリメントされる", async () => {
+	it("エラー時に counter が outcome=error でインクリメントされる", () => {
 		const collector = createSetup();
 		const inner = {
 			send: mock((): Promise<AgentResponse> => Promise.reject(new Error("fail"))),
@@ -58,7 +58,7 @@ describe("InstrumentedAiAgent", () => {
 		};
 		const agent = new InstrumentedAiAgent(inner, collector, "polling");
 
-		await expect(agent.send({ sessionKey: "system:heartbeat:g1", message: "hi" })).rejects.toThrow(
+		expect(agent.send({ sessionKey: "system:heartbeat:g1", message: "hi" })).rejects.toThrow(
 			"fail",
 		);
 

--- a/spec/ollama/ollama-chat-adapter.spec.ts
+++ b/spec/ollama/ollama-chat-adapter.spec.ts
@@ -65,19 +65,19 @@ describe("OllamaChatAdapter", () => {
 		});
 	});
 
-	it("HTTP エラー時にエラーをスローする", async () => {
+	it("HTTP エラー時にエラーをスローする", () => {
 		mockFetch({ ok: false, status: 503, statusText: "Service Unavailable", body: {} });
 
 		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
 
-		await expect(adapter.prompt("hello")).rejects.toThrow(/503/);
+		expect(adapter.prompt("hello")).rejects.toThrow(/503/);
 	});
 
-	it("レスポンスに response フィールドがない場合にエラーをスローする", async () => {
+	it("レスポンスに response フィールドがない場合にエラーをスローする", () => {
 		mockFetch({ ok: true, body: {} });
 
 		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
 
-		await expect(adapter.prompt("hello")).rejects.toThrow();
+		expect(adapter.prompt("hello")).rejects.toThrow();
 	});
 });

--- a/spec/ollama/ollama-embedding-adapter.spec.ts
+++ b/spec/ollama/ollama-embedding-adapter.spec.ts
@@ -56,21 +56,19 @@ describe("OllamaEmbeddingAdapter", () => {
 		});
 	});
 
-	it("should throw on HTTP error", async () => {
+	it("should throw on HTTP error", () => {
 		mockFetch({ ok: false, status: 503, statusText: "Service Unavailable", body: {} });
 
 		const adapter = new OllamaEmbeddingAdapter("http://localhost:11434", "nomic-embed-text");
 
-		await expect(adapter.embed("hello")).rejects.toThrow(
-			"Ollama embed failed: 503 Service Unavailable",
-		);
+		expect(adapter.embed("hello")).rejects.toThrow("Ollama embed failed: 503 Service Unavailable");
 	});
 
-	it("should throw when embeddings array is empty", async () => {
+	it("should throw when embeddings array is empty", () => {
 		mockFetch({ ok: true, body: { embeddings: [] } });
 
 		const adapter = new OllamaEmbeddingAdapter("http://localhost:11434", "nomic-embed-text");
 
-		await expect(adapter.embed("hello")).rejects.toThrow("Ollama embed returned no embeddings");
+		expect(adapter.embed("hello")).rejects.toThrow("Ollama embed returned no embeddings");
 	});
 });


### PR DESCRIPTION
## Summary

closes #352

- `.oxlintrc.json` で `typescript/await-thenable` を `off` → `error` に変更
- 実装コード（2箇所）: `bootstrap.ts` の `chatAdapter.close()`、`combat.ts` の `bot.attack()` は `void` 返却のため不要な `await` を削除
- テストコード（45箇所、12ファイル）: bun:test の `expect().rejects`/`expect().resolves` は Thenable ではなく同期処理のため `await` を除去。`await` 不要になったテスト関数から `async` も除去

### 調査結果

- bun:test の `rejects`/`resolves` はランタイムで `.then` メソッドを持たない（非 Thenable）
- `await` の有無に関わらずテスト結果は同一（検証済み）
- Jest と異なり bun:test 固有の実装

## Test plan

- [x] `nr validate` — 0 errors
- [x] `nr test` — 1319 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)