### PR TITLE
improve: check_commands の空イベント時フォールバック文字列を改善する (#347)

### DIFF
--- a/packages/mcp/src/tools/mc-bridge-minecraft.ts
+++ b/packages/mcp/src/tools/mc-bridge-minecraft.ts
@@ -98,11 +98,11 @@ export function registerMinecraftBridgeTools(server: McpServer, deps: { db: Stor
 		"check_commands",
 		{
 			description:
-				"Discord 側からの指示を確認する。指示があれば消費して返し、なければ空配列を返す。ブロッキングしない。",
+				"Discord 側からの指示を確認する。指示があれば消費して返し、なければ「新しい指示はありません」を返す。ブロッキングしない。",
 		},
 		() => {
 			const rows = consumeEvents(db, MINECRAFT_AGENT_ID, MAX_BATCH_SIZE);
-			const text = rows.length > 0 ? formatCommands(parseEvents(rows)) : "[]";
+			const text = rows.length > 0 ? formatCommands(parseEvents(rows)) : "新しい指示はありません";
 			return { content: [{ type: "text" as const, text }] };
 		},
 	);

--- a/spec/mcp/tools/mc-bridge-integration.spec.ts
+++ b/spec/mcp/tools/mc-bridge-integration.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { MAX_BATCH_SIZE } from "@vicissitude/mcp/tools/event-buffer";
+import { registerMinecraftBridgeTools } from "@vicissitude/mcp/tools/mc-bridge-minecraft";
 import { MINECRAFT_AGENT_ID } from "@vicissitude/minecraft/constants";
 import {
 	getSessionLockGuildId,
@@ -152,5 +154,29 @@ describe("check_commands データアクセス層テスト", () => {
 		// 2回目の消費では空配列が返る
 		const secondBatch = consumeEvents(db, MINECRAFT_AGENT_ID, MAX_BATCH_SIZE);
 		expect(secondBatch).toEqual([]);
+	});
+});
+
+describe("check_commands ツール結合テスト", () => {
+	test("イベントがない場合、返却テキストが「新しい指示はありません」である", () => {
+		const db = createTestDb();
+
+		// registerMinecraftBridgeTools が登録するハンドラをキャプチャする
+		type ToolHandler = () => { content: { type: string; text: string }[] };
+		const handlers = new Map<string, ToolHandler>();
+		const mockServer = {
+			registerTool: (name: string, _schema: unknown, handler: ToolHandler) => {
+				handlers.set(name, handler);
+			},
+		} as unknown as McpServer;
+
+		registerMinecraftBridgeTools(mockServer, { db });
+
+		const checkCommands = handlers.get("check_commands");
+		if (!checkCommands) throw new Error("check_commands handler not found");
+
+		const result = checkCommands();
+		expect(result.content).toHaveLength(1);
+		expect(result.content[0]?.text).toBe("新しい指示はありません");
 	});
 });


### PR DESCRIPTION
## Summary

- `check_commands` ツールがイベントなしの場合に返す文字列を `"[]"` から `"新しい指示はありません"` に変更
- ツールの description を合わせて更新（「空配列を返す」→「"新しい指示はありません" を返す」）
- 結合テストに空イベント時のフォールバック文字列検証を追加

## Test plan

- [x] `nr test:spec` — 973 pass / 0 fail
- [x] `nr validate` — fmt:check + lint (0 error) + check 全パス

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)