### PR TITLE
chore: allow Edit, Read ツールを許可リストに追加する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
 		"CLAUDE_CODE_DISABLE_1M_CONTEXT": 1
 	},
 	"permissions": {
-		"allow": ["Bash"]
+		"allow": ["Bash", "Edit", "Read"]
 	},
 	"teammateMode": "in-process",
 	"hooks": {


### PR DESCRIPTION
## Summary
- `.claude/settings.json` の `permissions.allow` に `Edit` と `Read` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)