### PR TITLE
docs: README に check_commands ツールの記載を追加する (#362)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ TypeScript + Bun で動作し、OpenCode を推論エンジンとして使用す
 
 MCP サーバー経由で各種操作を提供する。
 
-| カテゴリ     | MCP サーバー | 主要ツール                                         |
-| ------------ | ------------ | -------------------------------------------------- |
-| チャット     | discord      | send_message, reply, add_reaction, read_messages   |
-| コード実行   | code-exec    | execute_code                                       |
-| スケジュール | schedule     | list_reminders, add_reminder                       |
-| 記憶（短期） | memory       | read_memory, update_memory, read_soul              |
-| 記憶（長期） | memory       | memory_retrieve, memory_get_facts                  |
-| ゲーム操作   | minecraft    | observe_state, follow_player, go_to, collect_block |
-| ゲーム通信   | mc-bridge    | mc_report, mc_read_goals, mc_update_goals          |
+| カテゴリ     | MCP サーバー | 主要ツール                                                |
+| ------------ | ------------ | --------------------------------------------------------- |
+| チャット     | discord      | send_message, reply, add_reaction, read_messages          |
+| コード実行   | code-exec    | execute_code                                              |
+| スケジュール | schedule     | list_reminders, add_reminder                              |
+| 記憶（短期） | memory       | read_memory, update_memory, read_soul                     |
+| 記憶（長期） | memory       | memory_retrieve, memory_get_facts                         |
+| ゲーム操作   | minecraft    | observe_state, follow_player, go_to, collect_block        |
+| ゲーム通信   | mc-bridge    | mc_report, mc_read_goals, mc_update_goals, check_commands |
 
 OpenCode SDK 組み込み: `webfetch`, `websearch`
 


### PR DESCRIPTION
## Summary

- MCP ツール一覧テーブルの mc-bridge 行に `check_commands` を追記

Closes #362

## Test plan

- [x] `nr validate` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)