### PR TITLE
docs: README の mc-bridge ツール一覧に mc_read_progress 等4ツールを追記する (#367)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,16 @@ TypeScript + Bun で動作し、OpenCode を推論エンジンとして使用す
 
 MCP サーバー経由で各種操作を提供する。
 
-| カテゴリ     | MCP サーバー | 主要ツール                                                |
-| ------------ | ------------ | --------------------------------------------------------- |
-| チャット     | discord      | send_message, reply, add_reaction, read_messages          |
-| コード実行   | code-exec    | execute_code                                              |
-| スケジュール | schedule     | list_reminders, add_reminder                              |
-| 記憶（短期） | memory       | read_memory, update_memory, read_soul                     |
-| 記憶（長期） | memory       | memory_retrieve, memory_get_facts                         |
-| ゲーム操作   | minecraft    | observe_state, follow_player, go_to, collect_block        |
-| ゲーム通信   | mc-bridge    | mc_report, mc_read_goals, mc_update_goals, check_commands |
+| カテゴリ     | MCP サーバー | 主要ツール                                                                                            |
+| ------------ | ------------ | ----------------------------------------------------------------------------------------------------- |
+| チャット     | discord      | send_message, reply, add_reaction, read_messages                                                      |
+| コード実行   | code-exec    | execute_code                                                                                          |
+| スケジュール | schedule     | list_reminders, add_reminder                                                                          |
+| 記憶（短期） | memory       | read_memory, update_memory, read_soul                                                                 |
+| 記憶（長期） | memory       | memory_retrieve, memory_get_facts                                                                     |
+| ゲーム操作   | minecraft    | observe_state, follow_player, go_to, collect_block                                                    |
+| ゲーム通信   | mc-bridge    | mc_report, check_commands                                                                             |
+| ゲーム記憶   | mc-bridge    | mc_read_goals, mc_update_goals, mc_read_progress, mc_update_progress, mc_read_skills, mc_record_skill |
 
 OpenCode SDK 組み込み: `webfetch`, `websearch`
 


### PR DESCRIPTION
## Summary

- mc-bridge 行を「ゲーム通信」（mc_report, check_commands）と「ゲーム記憶」（mc_read_goals, mc_update_goals, mc_read_progress, mc_update_progress, mc_read_skills, mc_record_skill）の2行に分割
- 未記載だった4ツールを追記し、mc-bridge の全8ツールを網羅

Closes #367

## Test plan

- [x] `nr validate` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)