### PR TITLE
docs: README の MCP ツール一覧テーブルを実装と整合させる (#369)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ MCP サーバー経由で各種操作を提供する。
 
 | カテゴリ     | MCP サーバー | 主要ツール                                                                                            |
 | ------------ | ------------ | ----------------------------------------------------------------------------------------------------- |
-| チャット     | discord      | send_message, reply, add_reaction, read_messages                                                      |
+| チャット     | core         | send_message, reply, add_reaction, read_messages, list_channels, send_typing                          |
+| イベント     | core         | wait_for_events                                                                                       |
 | コード実行   | code-exec    | execute_code                                                                                          |
-| スケジュール | schedule     | list_reminders, add_reminder                                                                          |
-| 記憶（短期） | memory       | read_memory, update_memory, read_soul                                                                 |
-| 記憶（長期） | memory       | memory_retrieve, memory_get_facts                                                                     |
-| ゲーム操作   | minecraft    | observe_state, follow_player, go_to, collect_block                                                    |
+| スケジュール | core         | list_reminders, add_reminder, update_reminder, remove_reminder                                        |
+| 記憶         | core         | memory_retrieve, memory_get_facts                                                                     |
+| ゲーム委譲   | core         | minecraft_delegate, minecraft_status, minecraft_start_session, minecraft_stop_session                 |
+| ゲーム操作   | minecraft    | observe_state, follow_player, go_to, collect_block, attack_entity, craft_item 等                      |
 | ゲーム通信   | mc-bridge    | mc_report, check_commands                                                                             |
 | ゲーム記憶   | mc-bridge    | mc_read_goals, mc_update_goals, mc_read_progress, mc_update_progress, mc_read_skills, mc_record_skill |
 


### PR DESCRIPTION
## Summary

- 実装に存在しない「記憶（短期）」行（`read_memory`, `update_memory`, `read_soul`）を削除
- MCP サーバー名を実際の名前（`core`, `code-exec`, `minecraft`, `mc-bridge`）に修正
- 未記載ツールを追記: `send_typing`, `list_channels`, `wait_for_events`, `update_reminder`, `remove_reminder`, `minecraft_delegate` 等
- 新カテゴリ「イベント」「ゲーム委譲」を追加

Closes #369

## Test plan

- [x] `nr validate` 全パス
- [x] 全ツール名を実装コードと照合済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)