### PR TITLE
fix: compacted 後にセッション監視を即座に再開する

### DIFF
--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -124,18 +124,19 @@ export class AgentRunner implements AiAgent {
 				this.sessionWatch = null;
 				if (signal.aborted) return;
 				this.handleSessionEnd(event);
-				// eslint-disable-next-line no-await-in-loop -- rotation only happens after session end
-				await this.rotateSessionIfExpired();
 				if (event.type === "cancelled") return;
 
 				// compacted: セッションはまだ生きており LLM がポーリングを続けているため、
 				// waitForEvents を挟まず即座にセッション監視を再開する。
-				// waitForEvents を挟むと、LLM が先にイベントを消費してしまい応答が失われる。
+				// rotateSessionIfExpired もスキップする（セッション削除すると rewatch が空振りする）。
 				if (event.type === "compacted") {
 					this.rewatchSession(signal);
 					delay = INITIAL_RECONNECT_DELAY_MS;
 					continue;
 				}
+
+				// eslint-disable-next-line no-await-in-loop -- rotation only happens after session end
+				await this.rotateSessionIfExpired();
 
 				if (event.type !== "error") {
 					delay = INITIAL_RECONNECT_DELAY_MS;
@@ -199,7 +200,10 @@ export class AgentRunner implements AiAgent {
 	/** compacted 後にイベントストリームだけ再購読する（セッションは生存中） */
 	private rewatchSession(signal: AbortSignal): void {
 		const sessionId = this.sessionStore.get(this.profile.name, `__polling__:${this.agentId}`);
-		if (!sessionId) return;
+		if (!sessionId) {
+			this.logger.warn(`[${this.profile.name}:${this.agentId}] rewatch skipped: no session`);
+			return;
+		}
 		this.logger.info(`[${this.profile.name}:${this.agentId}] re-watching after compaction`);
 		this.sessionWatch = this.sessionPort.waitForSessionIdle(sessionId, signal);
 	}


### PR DESCRIPTION
## Summary

- セッション compaction 後、`AgentRunner` が `waitForEvents` で新規イベントを待つ状態に遷移していたが、OpenCode セッション自体はまだ生存しており LLM が `wait_for_events` MCP ツールでイベントを先に消費してしまうため、メイン側の `hasEvents` が常に false になり応答が完全に失われるバグを修正
- compacted 後は `waitForSessionIdle` で即座にイベントストリームを再購読し、セッション監視を継続するようにした

## Root Cause

1. セッション compaction → `promptAsyncAndWatchSession` が `{ type: "compacted" }` を返す
2. `AgentRunner` が `waitForEvents` に遷移（新規イベント待ち）
3. しかし OpenCode セッションは生存中で LLM が `wait_for_events` を呼び続けている
4. 新規イベントが buffered されると LLM が先に消費 → メイン側は検知不能
5. compaction でコンテキストが劣化した LLM はイベントを消費しても適切に応答しない

## Test plan

- [x] `nr validate` — 0 errors
- [x] `nr test` — 1316 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)