### PR TITLE
chore: cron.md に worktree 作業分離の手順を追加

### DIFF
--- a/.claude/prompts/cron.md
+++ b/.claude/prompts/cron.md
@@ -1,4 +1,10 @@
 `help wanted` ラベルのない最も古い open Issue を1つ選び、作業して PR を作成せよ。
 対象 Issue がなければ何もせず終了。
 
-PR 作成後、`/review` を実行し、指摘を自動修正してから `gh pr merge --squash --delete-branch` でマージせよ。
+## 作業手順
+
+1. `EnterWorktree` で worktree に入り、作業ブランチを分離する
+2. Issue の内容に従い実装・修正を行う
+3. PR 作成後、`/review` を実行し、指摘を自動修正する
+4. `gh pr merge --squash --delete-branch` でマージする
+5. `ExitWorktree` で worktree を抜ける


### PR DESCRIPTION
## Summary
- cron 実行時に `EnterWorktree`/`ExitWorktree` で作業を分離する手順を `cron.md` に追加
- main ブランチを汚さずに Issue 消化を行えるようにする

## Test plan
- [ ] cron.md の内容が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)