### PR TITLE
fix: claude-loop の tmux セッションが意図せず消える問題を修正

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
               exit 0
             fi
 
-            tmux new-session -d -s "$SESSION_NAME" "cd $REPO_DIR && while true; do echo \"[\$(date)] Starting claude task...\"; claude -p \"\$(cat $PROMPT_FILE)\" --permission-mode auto --max-budget-usd 10; echo \"[\$(date)] Done. Sleeping $INTERVAL...\"; sleep $INTERVAL; done"
+            tmux new-session -d -s "$SESSION_NAME" \; set-option -t "$SESSION_NAME" remain-on-exit on \; send-keys "cd $REPO_DIR && while true; do echo \"[\$(date)] Starting claude task...\"; claude -p \"\$(cat $PROMPT_FILE)\" --permission-mode auto --max-budget-usd 10 || true; echo \"[\$(date)] Done. Sleeping $INTERVAL...\"; sleep $INTERVAL; done" Enter
             echo "Started tmux session '$SESSION_NAME' (interval: $INTERVAL)"
             echo "  Attach:  tmux attach -t $SESSION_NAME"
             echo "  Stop:    tmux kill-session -t $SESSION_NAME"


### PR DESCRIPTION
## Summary
- `remain-on-exit on` を設定し、tmux 内のプロセスが終了してもセッションを保持
- `claude` コマンド失敗時に `|| true` でループ継続を保証
- `send-keys` 方式に変更し、シェルプロセスが tmux セッションと独立して生存するように改善

## Test plan
- [ ] `nix run .#claude-loop` で起動し、tmux セッションが作成されることを確認
- [ ] `claude` コマンドが終了した後もセッションが残ることを確認
- [ ] `tmux kill-session` で正常に停止できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)