### PR TITLE
fix: claude-loop の send-keys 方式を廃止しスクリプト直接実行に変更

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
             REPO_DIR="$1"
             INTERVAL="$2"
             PROMPT_FILE="$REPO_DIR/.claude/prompts/cron.md"
-            cd "$REPO_DIR"
+            cd "$REPO_DIR" || exit 1
             while true; do
               echo "[$(date)] Starting claude task..."
               claude -p "$(cat "$PROMPT_FILE")" --permission-mode auto --max-budget-usd 10 || true
@@ -61,7 +61,7 @@
               exit 0
             fi
 
-            tmux new-session -d -s "$SESSION_NAME" "${claude-loop-worker} '$REPO_DIR' '$INTERVAL'"
+            tmux new-session -d -s "$SESSION_NAME" "${claude-loop-worker} \"$REPO_DIR\" \"$INTERVAL\""
             echo "Started tmux session '$SESSION_NAME' (interval: $INTERVAL)"
             echo "  Attach:  tmux attach -t $SESSION_NAME"
             echo "  Stop:    tmux kill-session -t $SESSION_NAME"


### PR DESCRIPTION
## Summary

- ループ本体を `claude-loop-worker` として別スクリプトに分離
- `tmux send-keys` を廃止し `tmux new-session -d -s ... "command"` で直接実行に変更
- worker スクリプトから `set -e` を除外（`sleep` の signal 中断でループが死ぬのを防止）

## 原因

`send-keys` で長いワンライナーを tmux に送る方式では、クォーティングの問題やシェル解釈の不整合により pane が dead になっていた。スクリプトを Nix store に独立して配置し tmux が直接実行することで、中間シェルのレイヤーを排除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)