### PR TITLE
fix: claude-loop の予算上限を削減して OOM を緩和

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
             cd "$REPO_DIR" || exit 1
             while true; do
               echo "[$(date)] Starting claude task..."
-              claude -p "$(cat "$PROMPT_FILE")" --permission-mode auto --max-budget-usd 10 || true
+              claude -p "$(cat "$PROMPT_FILE")" --permission-mode auto --max-budget-usd 3 || true
               echo "[$(date)] Done. Sleeping $INTERVAL..."
               sleep "$INTERVAL"
             done


### PR DESCRIPTION
## Summary
- claude-loop の `--max-budget-usd` を 10 → 3 に削減
- OOM Killer が bun プロセスを kill していた（anon-rss ~12GB / RAM 15GB / swap 0）
- 予算を下げて実行時間を短縮し、メモリ蓄積による OOM を緩和

## Test plan
- [ ] `nix run .#claude-loop` で起動し、pane が dead にならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)