### PR TITLE
test: discord.ts ツール群の仕様テスト追加

### DIFF
--- a/spec/mcp/tools/discord.spec.ts
+++ b/spec/mcp/tools/discord.spec.ts
@@ -54,7 +54,6 @@ function createDiscordClientStub(): DiscordDeps["discordClient"] {
 										attachments: createFakeAttachments([]),
 									},
 								];
-								fakeCollection.map = Array.prototype.map.bind(fakeCollection);
 								return Promise.resolve(fakeCollection);
 							}
 							// messages.fetch(messageId) は単一メッセージを返す
@@ -123,7 +122,6 @@ function createClientStubWithImageAttachments(): DiscordDeps["discordClient"] {
 									]),
 								},
 							];
-							msgs.map = Array.prototype.map.bind(msgs);
 							return Promise.resolve(msgs);
 						},
 					},


### PR DESCRIPTION
## Summary

- `spec/mcp/tools/discord.spec.ts` を新規作成し、discord.ts の6ツール（send_message, reply, add_reaction, send_typing, read_messages, list_channels）の公開API契約をブラックボックステストで検証
- 感情推定は `discord-emotion.spec.ts` でカバー済みのため除外
- 14テスト全パス、型チェック・lint・フォーマットもクリア

## Test plan

- [x] `nr test:spec` — 全995テストパス
- [x] `nr validate` — fmt/lint/check パス

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)