### PR TITLE
test: TTS AbortSignal キャンセル時の spec テストを追加

### DIFF
--- a/spec/gateway/ws-handler.spec.ts
+++ b/spec/gateway/ws-handler.spec.ts
@@ -493,7 +493,7 @@ describe("WsConnectionManager", () => {
 			});
 
 			const messages = conn.sent.map((s) => JSON.parse(s) as ServerMessage);
-			const audioMessages = messages.filter((m): m is AudioDataMessage => m.type === "audio_data");
+			const audioMessages = messages.filter((m) => m.type === "audio_data");
 
 			expect(audioMessages).toHaveLength(0);
 		});

--- a/spec/tts/aivis-speech-synthesizer.spec.ts
+++ b/spec/tts/aivis-speech-synthesizer.spec.ts
@@ -236,7 +236,7 @@ describe("AivisSpeechSynthesizer — synthesize abort", () => {
 		const ac = new AbortController();
 		ac.abort();
 
-		// abort 済み signal を fetch に渡すと AbortError が発生するのでモック不要
+		// abort 済み signal で fetch を呼ぶと AbortError になるのでモックで再現
 		mockFetch.mockRejectedValueOnce(new DOMException("The operation was aborted.", "AbortError"));
 
 		const result = await synthesizer().synthesize("こんにちは", DEFAULT_STYLE, ac.signal);


### PR DESCRIPTION
## Summary

Closes #386

- `spec/tts/aivis-speech-synthesizer.spec.ts`: AbortSignal キャンセル時の仕様テストを2件追加
  - abort 済み signal を渡した場合に `null` を返す
  - fetch 中に signal が abort された場合に `null` を返す
- `spec/gateway/ws-handler.spec.ts`: handleClose 後の AudioDataMessage 不送信テストを追加
  - handleClose 呼び出し後に TTS 合成が完了しても AudioDataMessage は送信されない

## Test plan

- [x] `nr test:spec -- spec/tts/aivis-speech-synthesizer.spec.ts` — 全テスト通過
- [x] `nr test:spec -- spec/gateway/ws-handler.spec.ts` — 全テスト通過
- [x] `nr test:spec` — 全 998 テスト通過
- [x] `nr validate` — 型チェック・lint エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)