### PR TITLE
feat: auto-triage ワークフロー

### DIFF
--- a/.claude/skills/auto-triage/SKILL.md
+++ b/.claude/skills/auto-triage/SKILL.md
@@ -1,0 +1,85 @@
+---
+description: "GitHub Issue を自動で選んで取り組み、レビュー・マージまで行う自律ワークフロー"
+user_invokable: true
+---
+
+GitHub Issue の自動トリアージ・実装・マージを一連で行うスキル。
+
+## Phase 1: Issue 選定
+
+1. `gh issue list --state open --limit 20 --json number,title,labels,createdAt` で Issue 一覧を取得
+2. `help wanted` ラベル付きの Issue は **除外** する（設計判断が必要なため）
+3. 残りの Issue から 1 つ選ぶ。優先度:
+   - `bug` ラベル > ラベルなし > `enhancement`
+   - 同優先度なら古いものを優先
+4. 選んだ Issue を `gh issue view <number>` で詳細確認
+
+## Phase 2: スコープ判定
+
+選んだ Issue の内容を分析し、以下を判定する:
+
+### 高レベル設計判断が必要な場合
+
+以下のいずれかに該当する場合は **`help wanted` ラベルを付けてスキップ** し、Phase 1 に戻って別の Issue を選ぶ:
+
+- 公開 API の破壊的変更が必要
+- 複数モジュールにまたがるアーキテクチャ変更
+- 仕様が曖昧で要件の解釈に複数の選択肢がある
+- 既存の spec テストの変更が必要（仕様変更を意味する）
+
+スキップ時は Issue にコメントを残す:
+
+```
+gh issue comment <number> --body "自動トリアージ: 設計判断が必要なため help wanted を付与しました。理由: <具体的な理由>"
+gh issue edit <number> --add-label "help wanted"
+```
+
+### 取り組める場合
+
+Phase 3 に進む。
+
+## Phase 3: 実装
+
+CLAUDE.md のワークフローに従って実装する。
+
+1. `--worktree` モードで起動されている場合、worktree のブランチをそのまま使う。手動実行の場合は `git switch -c auto/<issue-number>-<short-description>` で作業ブランチを作成
+2. Plan サブエージェントでタスク分解・スコープ特定
+3. CLAUDE.md の「タスク別の呼び出しパターン」に従い、適切なパターンで agent team を運用:
+   - 新機能: spec → verify → impl → test → verify
+   - バグ修正: spec → impl → verify
+   - リファクタ: verify → impl → verify
+4. こまめにコミット
+
+## Phase 4: レビューとマージ
+
+1. `/review` スキルを実行
+2. レビューで指摘された即修正項目を修正
+3. push して PR 作成: `gh pr create`
+4. PR をスカッシュマージ: `gh pr merge <number> --squash --delete-branch`
+
+## Phase 5: 報告
+
+実行結果をログに出力する:
+
+```
+## Auto-Triage 結果
+
+### 取り組んだ Issue
+- #<number>: <title>
+
+### スキップした Issue（help wanted 付与）
+- #<number>: <title> — 理由: <reason>
+
+### 作成した PR
+- #<number>: <title> → merged
+
+### 起票した Issue（/review で発見）
+- #<number>: <title>
+```
+
+## 制約
+
+- 1 回の実行で取り組む Issue は **1 つだけ**
+- `help wanted` をつけてスキップするのは **最大 3 回** まで。3 回スキップしたら「取り組める Issue なし」として終了
+- main ブランチに直接コミットしない。必ず作業ブランチを切る
+- マージ前に `nr validate` と `nr test` を実行し、出力を Phase 5 報告に含めること（完了宣言ルール準拠）

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ data/
 dist/
 routeTree.gen.ts
 *.vrm
+logs/

--- a/scripts/auto-triage.sh
+++ b/scripts/auto-triage.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+PROJECT_DIR="/home/ojii3/src/github.com/ojii3/vicissitude"
+LOG_DIR="${PROJECT_DIR}/logs/auto-triage"
+MAX_BUDGET_USD=10
+INTERVAL_SEC=$((2 * 60 * 60))  # 2 hours
+
+mkdir -p "$LOG_DIR"
+cd "$PROJECT_DIR"
+
+run_once() {
+  local timestamp
+  timestamp=$(date +%Y%m%d-%H%M%S)
+  local log_file="${LOG_DIR}/${timestamp}.log"
+  local json_log="${LOG_DIR}/${timestamp}.jsonl"
+
+  echo "[${timestamp}] auto-triage starting" | tee "$log_file"
+
+  # main を最新化（worktree のベースになる）
+  git fetch origin main 2>&1 | tee -a "$log_file"
+
+  # --worktree で独立したワーキングツリーで作業（main を汚さない）
+  claude -p "/auto-triage" \
+    --dangerously-skip-permissions \
+    --max-budget-usd "$MAX_BUDGET_USD" \
+    --no-session-persistence \
+    --output-format stream-json \
+    --verbose \
+    --worktree \
+    2>>"$log_file" \
+    | tee "$json_log" \
+    | jq -r --unbuffered 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' \
+    | tee -a "$log_file"
+
+  local exit_code
+  exit_code=${PIPESTATUS[0]}
+  echo "[$(date +%Y%m%d-%H%M%S)] auto-triage finished (exit: ${exit_code})" | tee -a "$log_file"
+  return "$exit_code"
+}
+
+echo "auto-triage loop: every ${INTERVAL_SEC}s ($(( INTERVAL_SEC / 3600 ))h)"
+echo "logs: ${LOG_DIR}/"
+echo "pid: $$"
+echo "---"
+
+while true; do
+  run_once || echo "[$(date +%Y%m%d-%H%M%S)] run failed (exit $?), continuing..."
+  echo "next run in ${INTERVAL_SEC}s ($(date -d "+${INTERVAL_SEC} seconds" +%H:%M))"
+  sleep "$INTERVAL_SEC"
+done


### PR DESCRIPTION
## Summary
- GitHub Issue を自動で選んで取り組み、レビュー・マージまで行う `/auto-triage` スキルを追加
- 2h おきに `claude -p --worktree` で実行する while ループスクリプト (`scripts/auto-triage.sh`)
- `--output-format stream-json` でリアルタイムログ出力、`.log` + `.jsonl` に保存

## Test plan
- [x] 手動で1回実行し、Issue #402 を選定 → PR #412 作成・マージまで成功を確認済み
- [x] `nr validate` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)