### PR TITLE
chore: auto-triage の npm scripts を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
 		"test:quality:flake": "bun scripts/test-quality-flake.ts",
 		"deps:graph": "depcruise packages/*/src apps/*/src --config .dependency-cruiser.mjs --output-type json | bun scripts/generate-deps-md.ts && oxfmt docs/DEPS.md 'packages/*/DEPS.md' 'apps/*/DEPS.md'",
 		"validate": "bun run fmt:check && bun run lint && bun run check",
-		"deploy": "podman-compose rm -f -s installer builder bot 2>/dev/null; podman-compose up -d && echo 'Deployed: podman-compose logs -f to follow logs'"
+		"deploy": "podman-compose rm -f -s installer builder bot 2>/dev/null; podman-compose up -d && echo 'Deployed: podman-compose logs -f to follow logs'",
+		"auto-triage": "bash scripts/auto-triage.sh",
+		"auto-triage:once": "claude -p /auto-triage --dangerously-skip-permissions --max-budget-usd 10 --no-session-persistence --worktree"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.1",


### PR DESCRIPTION
## Summary
- `nr auto-triage` — 2h ループで自動実行
- `nr auto-triage:once` — 1回だけ実行（テスト用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)