### PR TITLE
fix: v<0, a>0, d=0 の感情マッピングで happy になるバグを修正

### DIFF
--- a/apps/web/DEPS.md
+++ b/apps/web/DEPS.md
@@ -13,9 +13,6 @@ graph LR
   lib_audio_player["lib/audio-player"]
   lib_ws_client["lib/ws-client"]
   main.tsx --> index.css
-  main.tsx --> routeTree.gen
-  routeTree.gen --> routes___root.tsx["routes/__root.tsx"]
-  routeTree.gen --> routes_index.tsx["routes/index.tsx"]
   routes___root.tsx["routes/__root.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_avatar_VrmViewer.tsx["components/avatar/VrmViewer.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_chat_ChatPanel.tsx["components/chat/ChatPanel.tsx"]
@@ -49,12 +46,8 @@ graph LR
 
 ### main.tsx.ts
 
-- モジュール内依存: index.css, routeTree.gen
-- 外部依存: .bun
-
-### routeTree.gen.ts
-
-- モジュール内依存: routes/\_\_root.tsx, routes/index.tsx
+- モジュール内依存: index.css
+- 外部依存: ./routeTree.gen, .bun
 
 ### routes/\_\_root.tsx.ts
 

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -81,8 +81,8 @@ graph LR
 ### apps/web
 
 - 内部依存: shared
-- 外部依存: .bun, three/addons/loaders/GLTFLoader.js
-- ファイル数: 10
+- 外部依存: ./routeTree.gen, .bun, three/addons/loaders/GLTFLoader.js
+- ファイル数: 9
 
 ### avatar
 

--- a/packages/avatar/src/emotion-to-expression-mapper.ts
+++ b/packages/avatar/src/emotion-to-expression-mapper.ts
@@ -9,7 +9,7 @@ import type { EmotionToExpressionMapper } from "@vicissitude/shared/ports";
  * 2. neutral:   |V| < 0.2 && |A| < 0.2 && |D| < 0.2
  * 3. happy:     V > 0, A > 0
  * 4. relaxed:   V > 0, A < 0
- * 5. angry:     V < 0, A > 0, D > 0
+ * 5. angry:     V < 0, A > 0, D >= 0
  * 6. fear:      V < 0, A > 0, D < 0
  * 7. sad:       V < 0, A < 0
  * fallback:     neutral
@@ -53,8 +53,8 @@ function mapPrimaryExpression(v: number, a: number, d: number): VrmExpressionWei
 	if (v > 0 && a < 0) {
 		return { expression: "relaxed", weight: computeWeight(v, Math.abs(a), Math.abs(d)) };
 	}
-	if (v < 0 && a > 0 && d > 0) {
-		return { expression: "angry", weight: computeWeight(Math.abs(v), a, d) };
+	if (v < 0 && a > 0 && d >= 0) {
+		return { expression: "angry", weight: computeWeight(Math.abs(v), a, Math.abs(d)) };
 	}
 	if (v < 0 && a > 0 && d < 0) {
 		return { expression: "fear", weight: computeWeight(Math.abs(v), a, Math.abs(d)) };

--- a/packages/shared/src/emotion.ts
+++ b/packages/shared/src/emotion.ts
@@ -106,7 +106,7 @@ export function describeEmotion(emotion: Emotion): string {
 		label = "嬉しい";
 	} else if (v > 0 && a < 0) {
 		label = "リラックスした";
-	} else if (v < 0 && a > 0 && d > 0) {
+	} else if (v < 0 && a > 0 && d >= 0) {
 		label = "怒っている";
 	} else if (v < 0 && a > 0 && d < 0) {
 		label = "怖がっている";

--- a/spec/avatar/emotion-to-expression-mapper.spec.ts
+++ b/spec/avatar/emotion-to-expression-mapper.spec.ts
@@ -35,6 +35,11 @@ describe("EmotionToExpressionMapper — expression selection", () => {
 		expect(result.expression).toBe("fear");
 	});
 
+	it("angry: V < 0, A > 0, D = 0 のとき angry を返す", () => {
+		const result = mapper().mapToExpression(createEmotion(-0.5, 0.4, 0));
+		expect(result.expression).toBe("angry");
+	});
+
 	it("sad: V < 0, A < 0 のとき sad を返す", () => {
 		const result = mapper().mapToExpression(createEmotion(-0.6, -0.5, 0.1));
 		expect(result.expression).toBe("sad");

--- a/spec/shared/emotion-describe.spec.ts
+++ b/spec/shared/emotion-describe.spec.ts
@@ -31,6 +31,13 @@ describe("describeEmotion", () => {
 		});
 	});
 
+	describe("angry (V < 0, A > 0, D = 0)", () => {
+		it("D = 0 でも怒り系の記述を返す", () => {
+			const result = describeEmotion(createEmotion(-0.5, 0.5, 0));
+			expect(result).toContain("怒");
+		});
+	});
+
 	describe("sad (V < 0, A < 0)", () => {
 		it("悲しい系の記述を返す", () => {
 			const result = describeEmotion(createEmotion(-0.5, -0.5, -0.3));


### PR DESCRIPTION
## Summary

- `mapPrimaryExpression` と `describeEmotion` の条件 `d > 0` を `d >= 0` に変更
- `v < 0, a > 0, d = 0` のケースで angry にマッピングされるようにした
- 再現テスト（spec テスト）を両モジュールに追加

Closes #321

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `packages/avatar/src/emotion-to-expression-mapper.ts` | `d > 0` → `d >= 0` + コメント更新 |
| `packages/shared/src/emotion.ts` | `d > 0` → `d >= 0` |
| `spec/avatar/emotion-to-expression-mapper.spec.ts` | 再現テスト追加 |
| `spec/shared/emotion-describe.spec.ts` | 再現テスト追加 |

## Test plan

- [x] `nr test:spec` — 1001 pass, 0 fail
- [x] `nr test` — 1351 pass, 0 fail
- [x] `nr validate` — lint warning のみ（既存）、型エラーは apps/web の既存エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)