### PR TITLE
test: discord spec にエッジケースのテストを追加する (#408)

### DIFF
--- a/spec/mcp/tools/discord-test-helpers.ts
+++ b/spec/mcp/tools/discord-test-helpers.ts
@@ -117,7 +117,33 @@ export function createClientStubWithoutSendTyping(): DiscordDeps["discordClient"
 	} as unknown as DiscordDeps["discordClient"];
 }
 
-/** 画像添付ありのメッセージを返すスタブ */
+/** react() が reject するスタブ（無効な絵文字等） */
+export function createClientStubWithReactError(): DiscordDeps["discordClient"] {
+	const error = new Error("Unknown Emoji");
+	return {
+		channels: {
+			fetch: () =>
+				Promise.resolve({
+					isTextBased: () => true,
+					send: () => Promise.resolve({ id: "msg-1" }),
+					messages: {
+						fetch: (idOrOptions: unknown) => {
+							if (typeof idOrOptions === "object" && idOrOptions !== null) {
+								return Promise.resolve([]);
+							}
+							return Promise.resolve({
+								id: "msg-1",
+								reply: () => Promise.resolve({ id: "reply-msg-1" }),
+								react: () => Promise.reject(error),
+							});
+						},
+					},
+				}),
+		},
+	} as unknown as DiscordDeps["discordClient"];
+}
+
+/** 画像添付ありのメッセージを返すスタブ（1枚） */
 export function createClientStubWithImageAttachments(): DiscordDeps["discordClient"] {
 	return {
 		channels: {
@@ -133,6 +159,34 @@ export function createClientStubWithImageAttachments(): DiscordDeps["discordClie
 									content: "写真だよ",
 									attachments: createFakeAttachments([
 										{ url: "https://cdn.example.com/img.png", contentType: "image/png" },
+									]),
+								},
+							];
+							return Promise.resolve(msgs);
+						},
+					},
+				}),
+		},
+	} as unknown as DiscordDeps["discordClient"];
+}
+
+/** 複数画像添付ありのメッセージを返すスタブ */
+export function createClientStubWithMultipleImageAttachments(): DiscordDeps["discordClient"] {
+	return {
+		channels: {
+			fetch: () =>
+				Promise.resolve({
+					isTextBased: () => true,
+					send: () => Promise.resolve({ id: "msg-1" }),
+					messages: {
+						fetch: (_opts: unknown) => {
+							const msgs = [
+								{
+									author: { tag: "user#9999" },
+									content: "複数画像だよ",
+									attachments: createFakeAttachments([
+										{ url: "https://cdn.example.com/img1.png", contentType: "image/png" },
+										{ url: "https://cdn.example.com/img2.jpg", contentType: "image/jpeg" },
 									]),
 								},
 							];

--- a/spec/mcp/tools/discord.spec.ts
+++ b/spec/mcp/tools/discord.spec.ts
@@ -4,6 +4,8 @@ import { describe, expect, test } from "bun:test";
 import {
 	captureTools,
 	createClientStubWithImageAttachments,
+	createClientStubWithMultipleImageAttachments,
+	createClientStubWithReactError,
 	createClientStubWithoutSendTyping,
 	createDiscordClientStub,
 	type ToolResult,
@@ -135,6 +137,15 @@ describe("add_reaction", () => {
 
 		expect(result.content[0]!.text).toBe("Reacted with 👍");
 	});
+
+	test("react() が失敗した場合は例外がそのまま throw される", () => {
+		const { tools } = captureTools({ discordClient: createClientStubWithReactError() });
+		const addReaction = tools.get("add_reaction")!;
+
+		expect(
+			addReaction({ channel_id: "ch-1", message_id: "msg-1", emoji: "invalid" }),
+		).rejects.toThrow("Unknown Emoji");
+	});
 });
 
 describe("read_messages", () => {
@@ -163,6 +174,23 @@ describe("read_messages", () => {
 
 		expect(result.content[0]!.text).toContain("[user#5678] 写真だよ");
 		expect(result.content[0]!.text).toContain("[画像: https://cdn.example.com/img.png]");
+	});
+
+	test("複数画像添付がある場合はカンマ区切りでまとめて表示する", async () => {
+		const { tools } = captureTools({
+			discordClient: createClientStubWithMultipleImageAttachments(),
+		});
+		const readMessages = tools.get("read_messages")!;
+
+		const result = (await readMessages({
+			channel_id: "ch-1",
+			limit: 10,
+		})) as ToolResult;
+
+		expect(result.content[0]!.text).toContain("[user#9999] 複数画像だよ");
+		expect(result.content[0]!.text).toContain(
+			"[画像: https://cdn.example.com/img1.png, https://cdn.example.com/img2.jpg]",
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

- `read_messages`: 複数画像添付がカンマ区切りでまとめて表示されることを検証するテストを追加
- `add_reaction`: `react()` 失敗時に例外がそのまま伝播することを検証するテストを追加
- テストヘルパーに `createClientStubWithReactError()` と `createClientStubWithMultipleImageAttachments()` を追加

Closes #408

## Test plan

- [x] `nr test:spec` — 全 1032 テストパス（既存 1030 + 新規 2）
- [x] `bunx oxlint --type-aware spec/mcp/tools/discord.spec.ts` — エラー 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)