### PR TITLE
fix: auto-triage の実行間隔を 1 時間に変更

### DIFF
--- a/scripts/auto-triage.ts
+++ b/scripts/auto-triage.ts
@@ -4,8 +4,8 @@ import { resolve } from "node:path";
 const PROJECT_DIR = resolve(import.meta.dirname, "..");
 const LOG_DIR = resolve(PROJECT_DIR, "logs/auto-triage");
 const MAX_BUDGET_USD = 10;
-/** 2 hours */
-const INTERVAL_SEC = 2 * 60 * 60;
+/** 1 hour */
+const INTERVAL_SEC = 1 * 60 * 60;
 
 const pad2 = (n: number) => String(n).padStart(2, "0");
 


### PR DESCRIPTION
## Summary
- auto-triage の実行間隔を 2 時間から 1 時間に短縮

## Test plan
- [x] `INTERVAL_SEC` が `1 * 60 * 60` (3600) であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)