### PR TITLE
feat: ActionState に eating 型を追加する (#430)

### DIFF
--- a/apps/web/DEPS.md
+++ b/apps/web/DEPS.md
@@ -13,9 +13,6 @@ graph LR
   lib_audio_player["lib/audio-player"]
   lib_ws_client["lib/ws-client"]
   main.tsx --> index.css
-  main.tsx --> routeTree.gen
-  routeTree.gen --> routes___root.tsx["routes/__root.tsx"]
-  routeTree.gen --> routes_index.tsx["routes/index.tsx"]
   routes___root.tsx["routes/__root.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_avatar_VrmViewer.tsx["components/avatar/VrmViewer.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_chat_ChatPanel.tsx["components/chat/ChatPanel.tsx"]
@@ -49,12 +46,8 @@ graph LR
 
 ### main.tsx.ts
 
-- モジュール内依存: index.css, routeTree.gen
-- 外部依存: .bun
-
-### routeTree.gen.ts
-
-- モジュール内依存: routes/\_\_root.tsx, routes/index.tsx
+- モジュール内依存: index.css
+- 外部依存: ./routeTree.gen, .bun
 
 ### routes/\_\_root.tsx.ts
 

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -81,8 +81,8 @@ graph LR
 ### apps/web
 
 - 内部依存: shared
-- 外部依存: .bun, three/addons/loaders/GLTFLoader.js
-- ファイル数: 10
+- 外部依存: ./routeTree.gen, .bun, three/addons/loaders/GLTFLoader.js
+- ファイル数: 9
 
 ### avatar
 

--- a/packages/minecraft/src/helpers.ts
+++ b/packages/minecraft/src/helpers.ts
@@ -3,6 +3,7 @@ export type Importance = "low" | "medium" | "high" | "critical";
 export interface ActionState {
 	type:
 		| "idle"
+		| "eating"
 		| "following"
 		| "moving"
 		| "collecting"
@@ -133,6 +134,9 @@ export function formatActionState(action: ActionState): string {
 	switch (action.type) {
 		case "idle":
 			return "待機中";
+		case "eating":
+			base = `${action.target ?? "?"} を食事中`;
+			break;
 		case "following":
 			base = `${action.target ?? "?"} を追従中`;
 			break;

--- a/packages/minecraft/src/reactive-layer.ts
+++ b/packages/minecraft/src/reactive-layer.ts
@@ -187,7 +187,7 @@ export class ReactiveLayer {
 			if (item === undefined) continue;
 
 			this.cancelJobIfNeeded();
-			this.ctx.setActionState({ type: "idle", target: food.name });
+			this.ctx.setActionState({ type: "eating", target: food.name });
 
 			try {
 				// oxlint-disable-next-line no-await-in-loop -- 最初にマッチした食料を1つ食べて即 return する

--- a/packages/shared/DEPS.md
+++ b/packages/shared/DEPS.md
@@ -12,7 +12,7 @@ graph LR
   ports --> emotion
   ports --> tts
   ports --> ws_protocol["ws-protocol"]
-  tts
+  tts --> emotion
   types --> emotion
   ws_protocol["ws-protocol"] --> emotion
 ```
@@ -37,6 +37,7 @@ graph LR
 
 ### tts.ts
 
+- モジュール内依存: emotion
 - 外部依存: .bun
 
 ### types.ts

--- a/spec/mcp/minecraft/helpers.spec.ts
+++ b/spec/mcp/minecraft/helpers.spec.ts
@@ -134,4 +134,12 @@ describe("formatActionState", () => {
 		expect(formatActionState({ type: "smelting", target: "raw_iron", progress: "精錬中..." })).toBe(
 			"raw_iron を精錬中 (精錬中...)",
 		));
+	test("eating", () =>
+		expect(formatActionState({ type: "eating", target: "cooked_beef" })).toBe(
+			"cooked_beef を食事中",
+		));
+	test("eating with progress", () =>
+		expect(
+			formatActionState({ type: "eating", target: "cooked_beef", progress: "消費中..." }),
+		).toBe("cooked_beef を食事中 (消費中...)"));
 });


### PR DESCRIPTION
## Summary
- `ActionState.type` の union に `"eating"` を追加
- `formatActionState` に `case "eating":` を追加し、`"○○ を食事中"` と表示
- `handleEat` で `type: "idle"` → `type: "eating"` に変更

Closes #430

## Test plan
- [x] `nr test:spec` — 全 1100 件通過（eating の新規2件含む）
- [x] `nr test` — 全 1412 件通過
- [x] `nr validate` — fmt:check, lint 通過（既存警告のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)