### PR TITLE
test: creeper/warden の拡張逃走距離 (16ブロック) の spec カバレッジを追加 (#432)

### DIFF
--- a/spec/mcp/minecraft/reactive-layer.spec.ts
+++ b/spec/mcp/minecraft/reactive-layer.spec.ts
@@ -324,6 +324,78 @@ describe("ReactiveLayer", () => {
 			expect(failEvents.length).toBeGreaterThanOrEqual(1);
 			expect(failEvents.at(0)?.importance).toBe("high");
 		});
+
+		test("creeper が 16 ブロック以内にいる場合は逃走がトリガーされる", async () => {
+			const creeper = createHostileEntity("creeper", 15);
+			const ctx = createStubContext();
+			const bot = createFakeBot({
+				health: 20,
+				entities: { "entity-1": creeper },
+			});
+			ctx.setBot(bot as unknown as ReturnType<BotContext["getBot"]>);
+
+			const layer = new ReactiveLayer(ctx);
+			layer.attach();
+			await layer.tick();
+			layer.detach();
+
+			const fleeEvents = ctx.events.filter((e) => e.kind === "reactive_flee");
+			expect(fleeEvents.length).toBeGreaterThanOrEqual(1);
+		});
+
+		test("creeper が 16 ブロックより遠くにいる場合は逃走しない", async () => {
+			const creeper = createHostileEntity("creeper", 17);
+			const ctx = createStubContext();
+			const bot = createFakeBot({
+				health: 20,
+				entities: { "entity-1": creeper },
+			});
+			ctx.setBot(bot as unknown as ReturnType<BotContext["getBot"]>);
+
+			const layer = new ReactiveLayer(ctx);
+			layer.attach();
+			await layer.tick();
+			layer.detach();
+
+			const fleeEvents = ctx.events.filter((e) => e.kind === "reactive_flee");
+			expect(fleeEvents).toHaveLength(0);
+		});
+
+		test("warden が 16 ブロック以内にいる場合は逃走がトリガーされる", async () => {
+			const warden = createHostileEntity("warden", 15);
+			const ctx = createStubContext();
+			const bot = createFakeBot({
+				health: 20,
+				entities: { "entity-1": warden },
+			});
+			ctx.setBot(bot as unknown as ReturnType<BotContext["getBot"]>);
+
+			const layer = new ReactiveLayer(ctx);
+			layer.attach();
+			await layer.tick();
+			layer.detach();
+
+			const fleeEvents = ctx.events.filter((e) => e.kind === "reactive_flee");
+			expect(fleeEvents.length).toBeGreaterThanOrEqual(1);
+		});
+
+		test("zombie が 8 ブロックより遠く 16 ブロック以内にいる場合は逃走しない（8 ブロック閾値の確認）", async () => {
+			const zombie = createHostileEntity("zombie", 12);
+			const ctx = createStubContext();
+			const bot = createFakeBot({
+				health: 20,
+				entities: { "entity-1": zombie },
+			});
+			ctx.setBot(bot as unknown as ReturnType<BotContext["getBot"]>);
+
+			const layer = new ReactiveLayer(ctx);
+			layer.attach();
+			await layer.tick();
+			layer.detach();
+
+			const fleeEvents = ctx.events.filter((e) => e.kind === "reactive_flee");
+			expect(fleeEvents).toHaveLength(0);
+		});
 	});
 
 	// =======================================================================


### PR DESCRIPTION
## Summary

- creeper/warden に対する `EXTENDED_FLEE_DISTANCE = 16` の仕様テスト4件を `reactive-layer.spec.ts` に追加
- 一般 hostile mob (zombie) の `DEFAULT_FLEE_DISTANCE = 8` との境界値テストも追加

Closes #432

## Test plan

- [x] `nr test:spec -- spec/mcp/minecraft/reactive-layer.spec.ts` で追加した4テストがパスすることを確認
- [x] 既存テストに影響がないことを確認
- [x] `nr validate` で今回の変更による新規 lint エラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)