### PR TITLE
fix: auto-triage に watchdog タイムアウトを追加

### DIFF
--- a/apps/web/DEPS.md
+++ b/apps/web/DEPS.md
@@ -13,6 +13,9 @@ graph LR
   lib_audio_player["lib/audio-player"]
   lib_ws_client["lib/ws-client"]
   main.tsx --> index.css
+  main.tsx --> routeTree.gen
+  routeTree.gen --> routes___root.tsx["routes/__root.tsx"]
+  routeTree.gen --> routes_index.tsx["routes/index.tsx"]
   routes___root.tsx["routes/__root.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_avatar_VrmViewer.tsx["components/avatar/VrmViewer.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_chat_ChatPanel.tsx["components/chat/ChatPanel.tsx"]
@@ -46,8 +49,12 @@ graph LR
 
 ### main.tsx.ts
 
-- モジュール内依存: index.css
-- 外部依存: ./routeTree.gen, .bun
+- モジュール内依存: index.css, routeTree.gen
+- 外部依存: .bun
+
+### routeTree.gen.ts
+
+- モジュール内依存: routes/\_\_root.tsx, routes/index.tsx
 
 ### routes/\_\_root.tsx.ts
 

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -81,8 +81,8 @@ graph LR
 ### apps/web
 
 - 内部依存: shared
-- 外部依存: ./routeTree.gen, .bun, three/addons/loaders/GLTFLoader.js
-- ファイル数: 9
+- 外部依存: .bun, three/addons/loaders/GLTFLoader.js
+- ファイル数: 10
 
 ### avatar
 

--- a/scripts/auto-triage.ts
+++ b/scripts/auto-triage.ts
@@ -6,6 +6,8 @@ const LOG_DIR = resolve(PROJECT_DIR, "logs/auto-triage");
 const MAX_BUDGET_USD = 10;
 /** 1 hour */
 const INTERVAL_SEC = 1 * 60 * 60;
+/** 30 minutes — kill claude if no stdout output for this duration */
+const STALL_TIMEOUT_MS = 30 * 60 * 1000;
 
 const pad2 = (n: number) => String(n).padStart(2, "0");
 
@@ -84,6 +86,21 @@ async function runOnce(): Promise<number> {
 		},
 	);
 
+	// Watchdog: stdout が一定時間途絶えたらプロセスを強制終了
+	let lastOutputAt = Date.now();
+	let stalled = false;
+	const watchdog = setInterval(() => {
+		if (Date.now() - lastOutputAt > STALL_TIMEOUT_MS) {
+			stalled = true;
+			tee(
+				`[${formatTimestamp()}] watchdog: no output for ${String(STALL_TIMEOUT_MS / 60000)}min, killing claude (pid: ${String(proc.pid)})`,
+				logFile,
+			);
+			proc.kill("SIGTERM");
+			clearInterval(watchdog);
+		}
+	}, 60_000);
+
 	// stderr → logFile に追記（バックグラウンド）
 	const stderrDone = (async () => {
 		for await (const chunk of proc.stderr as AsyncIterable<Uint8Array>) {
@@ -95,6 +112,7 @@ async function runOnce(): Promise<number> {
 	const decoder = new TextDecoder();
 	let buffer = "";
 	for await (const chunk of proc.stdout as AsyncIterable<Uint8Array>) {
+		lastOutputAt = Date.now();
 		buffer += decoder.decode(chunk, { stream: true });
 		let newlineIdx: number;
 		while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
@@ -120,9 +138,11 @@ async function runOnce(): Promise<number> {
 		}
 	}
 
+	clearInterval(watchdog);
 	await stderrDone;
 	const exitCode = await proc.exited;
-	tee(`[${formatTimestamp()}] auto-triage finished (exit: ${String(exitCode)})`, logFile);
+	const suffix = stalled ? " (killed by watchdog)" : "";
+	tee(`[${formatTimestamp()}] auto-triage finished (exit: ${String(exitCode)})${suffix}`, logFile);
 	return exitCode;
 }
 


### PR DESCRIPTION
## Summary
- auto-triage の claude プロセスが TeamDelete の無限ループで 3 時間以上ハングする問題を修正
- stdout の最終出力時刻を追跡し、30 分間出力がなければ SIGTERM で強制終了する watchdog を追加
- ログに watchdog による kill を記録

## 背景
`--worktree` モードで起動した claude が、spec-agent のシャットダウン待ちで `TeamDelete` を無限リトライし、プロセスがハングしていた。タスク自体は完了済みだが、親ループの次のサイクルがブロックされていた。

## Test plan
- [x] 既存の auto-triage ループが正常に動作することを確認
- [x] watchdog が正常終了時にクリーンアップされることを確認（`clearInterval`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)