### PR TITLE
refactor: findNearestHostile の戻り値型を HostileTarget 型に抽出する (#433)

### DIFF
--- a/packages/minecraft/src/reactive-layer.ts
+++ b/packages/minecraft/src/reactive-layer.ts
@@ -16,6 +16,11 @@ const DEFAULT_FLEE_DISTANCE = 8;
 /** 拡張距離が適用される mob */
 const EXTENDED_DISTANCE_MOBS = new Set(["creeper", "warden"]);
 
+type HostileTarget = {
+	entity: { position: { distanceTo: (pos: unknown) => number }; name?: string };
+	distance: number;
+};
+
 export interface ReactiveLayerOptions {
 	/** hostile mob スキャンの最小間隔（ms）。デフォルト: 1000 */
 	scanIntervalMs?: number;
@@ -123,15 +128,9 @@ export class ReactiveLayer {
 		}
 	}
 
-	private findNearestHostile(bot: mineflayer.Bot): {
-		entity: { position: { distanceTo: (pos: unknown) => number }; name?: string };
-		distance: number;
-	} | null {
+	private findNearestHostile(bot: mineflayer.Bot): HostileTarget | null {
 		const botPos = bot.entity.position;
-		let nearest: {
-			entity: { position: { distanceTo: (pos: unknown) => number }; name?: string };
-			distance: number;
-		} | null = null;
+		let nearest: HostileTarget | null = null;
 
 		for (const entity of Object.values(bot.entities)) {
 			const e = entity as {
@@ -171,13 +170,7 @@ export class ReactiveLayer {
 		}
 	}
 
-	private async handleFlee(
-		bot: mineflayer.Bot,
-		hostile: {
-			entity: { position: { distanceTo: (pos: unknown) => number }; name?: string };
-			distance: number;
-		},
-	): Promise<void> {
+	private async handleFlee(bot: mineflayer.Bot, hostile: HostileTarget): Promise<void> {
 		this.cancelJobIfNeeded();
 		this.ctx.setActionState({ type: "fleeing", target: hostile.entity.name });
 


### PR DESCRIPTION
## Summary

- `findNearestHostile` の戻り値・`nearest` 変数・`handleFlee` 引数に3箇所重複していたインライン型を `HostileTarget` 型エイリアスに抽出
- ランタイム動作に変更なし（純粋な DRY リファクタ）

Closes #433

## Test plan

- [x] `nr check` — 今回の変更に起因する型エラーなし
- [x] `bun test spec/mcp/minecraft/reactive-layer.spec.ts` — 33テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)