### PR TITLE
fix: watchdog に SIGKILL フォールバックを追加

### DIFF
--- a/scripts/auto-triage.ts
+++ b/scripts/auto-triage.ts
@@ -97,6 +97,17 @@ async function runOnce(): Promise<number> {
 				logFile,
 			);
 			proc.kill("SIGTERM");
+			// SIGTERM が無視された場合に備え、10 秒後に SIGKILL で強制終了
+			setTimeout(() => {
+				try {
+					// プロセス生存チェック（signal 0 は kill せず存在確認のみ）
+					process.kill(proc.pid, 0);
+					tee(`[${formatTimestamp()}] watchdog: SIGTERM ignored, sending SIGKILL`, logFile);
+					proc.kill("SIGKILL");
+				} catch {
+					// already dead
+				}
+			}, 10_000);
 			clearInterval(watchdog);
 		}
 	}, 60_000);


### PR DESCRIPTION
## Summary
- SIGTERM 送信後、プロセスが 10 秒以内に終了しない場合 SIGKILL で強制終了するフォールバックを追加
- `process.kill(pid, 0)` でプロセス生存を確認し、生きている場合のみ SIGKILL を送信

## 背景
PR #439 で追加した watchdog は SIGTERM のみだったが、claude プロセスが SIGTERM を無視した場合、stdout の `for await` ループが永久にブロックする問題がレビューで指摘された。

## Test plan
- [x] `nr validate` 通過（0 errors）

🤖 Generated with [Claude Code](https://claude.com/claude-code)