### PR TITLE
refactor: ポート割り当てロジックを port-allocator に一元化する (#395)

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -527,7 +527,7 @@ export async function bootstrap(): Promise<void> {
 		logger,
 		metrics: metrics.collector,
 		agentIdPrefix: "discord:heartbeat",
-		portOffset: ports.heartbeat(0) - config.opencode.basePort,
+		portOffset: ports.heartbeatOffset,
 	});
 	const firstHeartbeatAgent = heartbeatAgents.values().next().value as AiAgent | undefined;
 	if (!firstHeartbeatAgent) {

--- a/apps/discord/src/port-allocator.ts
+++ b/apps/discord/src/port-allocator.ts
@@ -2,14 +2,18 @@ export interface PortLayout {
 	guild(index: number): number;
 	minecraft(): number;
 	heartbeat(index: number): number;
+	/** createGuildAgents の portOffset に渡す相対オフセット */
+	heartbeatOffset: number;
 	memory(): number;
 }
 
 export function createPortLayout(basePort: number, guildCount: number): PortLayout {
+	const heartbeatOffset = guildCount + 1;
 	return {
 		guild: (index) => basePort + index,
 		minecraft: () => basePort + guildCount,
-		heartbeat: (index) => basePort + guildCount + 1 + index,
+		heartbeat: (index) => basePort + heartbeatOffset + index,
+		heartbeatOffset,
 		memory: () => basePort - 2,
 	};
 }

--- a/spec/core/port-allocator.spec.ts
+++ b/spec/core/port-allocator.spec.ts
@@ -23,6 +23,10 @@ describe("createPortLayout", () => {
 		expect(ports.heartbeat(2)).toBe(4102);
 	});
 
+	test("heartbeatOffset returns guildCount + 1", () => {
+		expect(ports.heartbeatOffset).toBe(4);
+	});
+
 	test("memory() returns basePort - 2", () => {
 		expect(ports.memory()).toBe(4094);
 	});


### PR DESCRIPTION
## Summary
- `bootstrap.ts` 内に分散していた4箇所のポート計算 (guild, minecraft, heartbeat, memory) を `createPortLayout` ユーティリティに抽出
- `setupMemoryRecording` の `memoryPort` を引数化し、ポート知識を関数から除去
- `heartbeatOffset` プロパティにより `createGuildAgents` との接続を明確化

Closes #395

## Test plan
- [x] `nr test:spec` — 1069件全パス（新規 port-allocator spec 6件含む）
- [x] `nr validate` — 新規エラーなし（既存の minecraft 型エラーのみ）
- [x] `nr test` — 1417件パス、既存の vec3 エラー1件のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)