### PR TITLE
fix: setupMemoryRecording の max-params 違反を修正

### DIFF
--- a/apps/discord/DEPS.md
+++ b/apps/discord/DEPS.md
@@ -9,17 +9,19 @@ graph LR
   bootstrap --> config
   bootstrap --> gateway_channel_config_loader["gateway/channel-config-loader"]
   bootstrap --> gateway_discord["gateway/discord"]
+  bootstrap --> port_allocator["port-allocator"]
   config
   gateway_channel_config_loader["gateway/channel-config-loader"]
   gateway_discord["gateway/discord"]
   index --> bootstrap
+  port_allocator["port-allocator"]
 ```
 
 ## ファイル別依存一覧
 
 ### bootstrap.ts
 
-- モジュール内依存: config, gateway/channel-config-loader, gateway/discord
+- モジュール内依存: config, gateway/channel-config-loader, gateway/discord, port-allocator
 - 他モジュール依存: agent, application, gateway, infrastructure, memory, observability, ollama, opencode, scheduling, shared, store, tts
 - 外部依存: .bun, fs, path
 
@@ -40,3 +42,7 @@ graph LR
 
 - モジュール内依存: bootstrap
 - 他モジュール依存: observability
+
+### port-allocator.ts
+
+- 依存なし

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -209,15 +209,17 @@ interface MemoryResources {
 export function setupMemoryRecording(
 	config: AppConfig,
 	logger: Logger,
-	memoryPort: number,
-	metricsCollector?: PrometheusCollector,
-	embeddingAdapter?: OllamaEmbeddingAdapter,
+	opts: {
+		memoryPort: number;
+		metricsCollector?: PrometheusCollector;
+		embeddingAdapter?: OllamaEmbeddingAdapter;
+	},
 ): MemoryResources | undefined {
 	const dataDir = resolve(config.dataDir, "memory");
 
 	try {
 		const memorySessionPort = new OpencodeSessionAdapter({
-			port: memoryPort,
+			port: opts.memoryPort,
 			mcpServers: {},
 			builtinTools: OPENCODE_ALL_TOOLS_DISABLED,
 		});
@@ -229,13 +231,17 @@ export function setupMemoryRecording(
 		);
 
 		const ollama =
-			embeddingAdapter ??
+			opts.embeddingAdapter ??
 			new OllamaEmbeddingAdapter(config.memory.ollamaBaseUrl, config.memory.embeddingModel);
 		const llm = new CompositeLLMAdapter(chatAdapter, ollama);
 		const recorder = new MemoryConversationRecorder(llm, dataDir);
-		const consolidationScheduler = new ConsolidationScheduler(recorder, logger, metricsCollector);
+		const consolidationScheduler = new ConsolidationScheduler(
+			recorder,
+			logger,
+			opts.metricsCollector,
+		);
 
-		logger.info(`[bootstrap] Memory auto-recording enabled (port=${memoryPort})`);
+		logger.info(`[bootstrap] Memory auto-recording enabled (port=${opts.memoryPort})`);
 		return { chatAdapter, recorder, consolidationScheduler };
 	} catch (err) {
 		logger.error("[bootstrap] Memory auto-recording init failed, continuing without memory", err);
@@ -483,13 +489,11 @@ export async function bootstrap(): Promise<void> {
 	});
 
 	// Memory recording
-	const memoryResources = setupMemoryRecording(
-		config,
-		logger,
-		ports.memory(),
-		metrics.collector,
-		ollamaEmbedding,
-	);
+	const memoryResources = setupMemoryRecording(config, logger, {
+		memoryPort: ports.memory(),
+		metricsCollector: metrics.collector,
+		embeddingAdapter: ollamaEmbedding,
+	});
 	const ingestionService = new MessageIngestionService({
 		eventStore: new SqliteBufferedEventStore(db),
 		logger,

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -76,7 +76,7 @@ graph LR
 
 - 内部依存: agent, application, gateway, infrastructure, memory, observability, ollama, opencode, scheduling, shared, store, tts
 - 外部依存: .bun, fs, path
-- ファイル数: 5
+- ファイル数: 6
 
 ### apps/web
 


### PR DESCRIPTION
## Summary
- PR #442 で追加された `memoryPort` パラメータにより `setupMemoryRecording` の引数が5個になり、`eslint(max-params)` ルール（最大4個）に違反していた
- `memoryPort`, `metricsCollector`, `embeddingAdapter` をオプションオブジェクトにまとめて修正

## Test plan
- [x] `nr validate` (fmt:check + lint + type check) 通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)