### PR TITLE
fix: discord.ts ツールアウトプットの言語を英語に統一し description を改善 (#407)

### DIFF
--- a/packages/mcp/src/tools/discord.ts
+++ b/packages/mcp/src/tools/discord.ts
@@ -14,12 +14,12 @@ const ALLOWED_FILE_DIRS = ["/tmp/vicissitude-screenshots"];
 function validateFilePath(filePath: string): void {
 	const absolute = path.resolve(filePath);
 	if (!existsSync(absolute)) {
-		throw new Error(`ファイルが見つかりません: ${filePath}`);
+		throw new Error(`File not found: ${filePath}`);
 	}
 	const resolved = realpathSync(absolute);
 	const allowed = ALLOWED_FILE_DIRS.some((dir) => resolved.startsWith(dir + "/"));
 	if (!allowed) {
-		throw new Error(`許可されていないファイルパスです: ${filePath}`);
+		throw new Error(`File path not allowed: ${filePath}`);
 	}
 }
 
@@ -113,11 +113,12 @@ export function registerDiscordTools(
 	server.registerTool(
 		"send_message",
 		{
-			description: "Send a message to a Discord channel (optionally with a file attachment)",
+			description:
+				"Send a message to a Discord channel (optionally with a file attachment). Also clears any active typing indicator.",
 			inputSchema: {
 				channel_id: z.string(),
 				content: z.string(),
-				file_path: z.string().optional().describe("添付するファイルのパス"),
+				file_path: z.string().optional().describe("Path to a file to attach"),
 			},
 		},
 		async ({ channel_id, content, file_path }) => {
@@ -139,12 +140,12 @@ export function registerDiscordTools(
 		"reply",
 		{
 			description:
-				"Reply to a specific message in a Discord channel (optionally with a file attachment)",
+				"Reply to a specific message in a Discord channel (optionally with a file attachment). Also clears any active typing indicator.",
 			inputSchema: {
 				channel_id: z.string(),
 				message_id: z.string(),
 				content: z.string(),
-				file_path: z.string().optional().describe("添付するファイルのパス"),
+				file_path: z.string().optional().describe("Path to a file to attach"),
 			},
 		},
 		async ({ channel_id, message_id, content, file_path }) => {
@@ -189,7 +190,7 @@ export function registerDiscordTools(
 			const messages = await channel.messages.fetch({ limit });
 			const formatted = messages.map((m) => {
 				const imageUrls = filterImageUrls(m.attachments);
-				const imageText = imageUrls.length > 0 ? ` [画像: ${imageUrls.join(", ")}]` : "";
+				const imageText = imageUrls.length > 0 ? ` [images: ${imageUrls.join(", ")}]` : "";
 				return `[${m.author.tag}] ${m.content}${imageText}`;
 			});
 			return { content: [{ type: "text", text: formatted.join("\n") }] };
@@ -205,7 +206,7 @@ export function registerDiscordTools(
 		async ({ guild_id }: { guild_id?: string }) => {
 			const gid = boundGuildId ?? guild_id;
 			if (!gid) {
-				return { content: [{ type: "text" as const, text: "エラー: guild_id が必要です" }] };
+				return { content: [{ type: "text" as const, text: "Error: guild_id is required" }] };
 			}
 			const guild = await discordClient.guilds.fetch(gid);
 			const channels = await guild.channels.fetch();

--- a/spec/mcp/tools/discord.spec.ts
+++ b/spec/mcp/tools/discord.spec.ts
@@ -161,7 +161,7 @@ describe("read_messages", () => {
 		expect(result.content[0]!.text).toContain("[user#1234] hello world");
 	});
 
-	test("画像添付がある場合は [画像: url] を表示する", async () => {
+	test("画像添付がある場合は [images: url] を表示する", async () => {
 		const { tools } = captureTools({
 			discordClient: createClientStubWithImageAttachments(),
 		});
@@ -173,7 +173,7 @@ describe("read_messages", () => {
 		})) as ToolResult;
 
 		expect(result.content[0]!.text).toContain("[user#5678] 写真だよ");
-		expect(result.content[0]!.text).toContain("[画像: https://cdn.example.com/img.png]");
+		expect(result.content[0]!.text).toContain("[images: https://cdn.example.com/img.png]");
 	});
 
 	test("複数画像添付がある場合はカンマ区切りでまとめて表示する", async () => {
@@ -189,7 +189,7 @@ describe("read_messages", () => {
 
 		expect(result.content[0]!.text).toContain("[user#9999] 複数画像だよ");
 		expect(result.content[0]!.text).toContain(
-			"[画像: https://cdn.example.com/img1.png, https://cdn.example.com/img2.jpg]",
+			"[images: https://cdn.example.com/img1.png, https://cdn.example.com/img2.jpg]",
 		);
 	});
 });


### PR DESCRIPTION
## Summary

- discord.ts 内の日本語エラーメッセージ・describe を英語に統一（6箇所）
- `send_message` / `reply` の description に typing indicator 自動クリアの補足を追加
- spec テストの期待値を更新

Closes #407

## Test plan

- [x] `bun test spec/mcp/tools/discord.spec.ts` — 16 pass, 0 fail
- [x] `bun test packages/mcp/src/tools/discord.test.ts` — 10 pass, 0 fail
- [x] `nr validate` — 変更対象ファイルにエラーなし（既存の無関係な lint エラーのみ）

## 関連 Issue

- #447: 他ツールファイル（schedule.ts, memory.ts, mc-bridge-discord.ts）の同様の言語統一（レビューで発見、別 Issue として起票）

🤖 Generated with [Claude Code](https://claude.com/claude-code)