### PR TITLE
fix: spec ファイルの lint エラーを修正

### DIFF
--- a/apps/web/DEPS.md
+++ b/apps/web/DEPS.md
@@ -13,9 +13,6 @@ graph LR
   lib_audio_player["lib/audio-player"]
   lib_ws_client["lib/ws-client"]
   main.tsx --> index.css
-  main.tsx --> routeTree.gen
-  routeTree.gen --> routes___root.tsx["routes/__root.tsx"]
-  routeTree.gen --> routes_index.tsx["routes/index.tsx"]
   routes___root.tsx["routes/__root.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_avatar_VrmViewer.tsx["components/avatar/VrmViewer.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_chat_ChatPanel.tsx["components/chat/ChatPanel.tsx"]
@@ -49,12 +46,8 @@ graph LR
 
 ### main.tsx.ts
 
-- モジュール内依存: index.css, routeTree.gen
-- 外部依存: .bun
-
-### routeTree.gen.ts
-
-- モジュール内依存: routes/\_\_root.tsx, routes/index.tsx
+- モジュール内依存: index.css
+- 外部依存: ./routeTree.gen, .bun
 
 ### routes/\_\_root.tsx.ts
 

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -81,8 +81,8 @@ graph LR
 ### apps/web
 
 - 内部依存: shared
-- 外部依存: .bun, three/addons/loaders/GLTFLoader.js
-- ファイル数: 10
+- 外部依存: ./routeTree.gen, .bun, three/addons/loaders/GLTFLoader.js
+- ファイル数: 9
 
 ### avatar
 
@@ -118,7 +118,7 @@ graph LR
 
 - 内部依存: mcp, observability, shared, store
 - 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, path
-- ファイル数: 27
+- ファイル数: 30
 
 ### observability
 

--- a/packages/minecraft/DEPS.md
+++ b/packages/minecraft/DEPS.md
@@ -9,12 +9,17 @@ graph LR
   actions_combat["actions/combat"] --> actions_shared["actions/shared"]
   actions_combat["actions/combat"] --> bot_queries["bot-queries"]
   actions_combat["actions/combat"] --> job_manager["job-manager"]
-  actions_index["actions/index"] --> actions_combat["actions/combat"]
+  actions_exploration["actions/exploration"] --> actions_shared["actions/shared"]
+  actions_exploration["actions/exploration"] --> job_manager["job-manager"]
+  actions_explore_tools["actions/explore-tools"] --> actions_combat["actions/combat"]
+  actions_explore_tools["actions/explore-tools"] --> actions_exploration["actions/exploration"]
+  actions_explore_tools["actions/explore-tools"] --> actions_queries["actions/queries"]
+  actions_explore_tools["actions/explore-tools"] --> actions_smelting["actions/smelting"]
+  actions_index["actions/index"] --> actions_explore_tools["actions/explore-tools"]
   actions_index["actions/index"] --> actions_interaction["actions/interaction"]
   actions_index["actions/index"] --> actions_jobs["actions/jobs"]
   actions_index["actions/index"] --> actions_movement["actions/movement"]
   actions_index["actions/index"] --> actions_shared["actions/shared"]
-  actions_index["actions/index"] --> actions_smelting["actions/smelting"]
   actions_index["actions/index"] --> actions_survival_index["actions/survival/index"]
   actions_index["actions/index"] --> job_manager["job-manager"]
   actions_interaction["actions/interaction"] --> actions_shared["actions/shared"]
@@ -23,6 +28,7 @@ graph LR
   actions_movement["actions/movement"] --> actions_shared["actions/shared"]
   actions_movement["actions/movement"] --> bot_queries["bot-queries"]
   actions_movement["actions/movement"] --> job_manager["job-manager"]
+  actions_queries["actions/queries"] --> actions_shared["actions/shared"]
   actions_shared["actions/shared"] --> job_manager["job-manager"]
   actions_smelting["actions/smelting"] --> actions_shared["actions/shared"]
   actions_smelting["actions/smelting"] --> job_manager["job-manager"]
@@ -79,9 +85,18 @@ graph LR
 - モジュール内依存: actions/shared, bot-queries, job-manager
 - 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
 
+### actions/exploration.ts
+
+- モジュール内依存: actions/shared, job-manager
+- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+
+### actions/explore-tools.ts
+
+- モジュール内依存: actions/combat, actions/exploration, actions/queries, actions/smelting
+
 ### actions/index.ts
 
-- モジュール内依存: actions/combat, actions/interaction, actions/jobs, actions/movement, actions/shared, actions/smelting, actions/survival/index, job-manager
+- モジュール内依存: actions/explore-tools, actions/interaction, actions/jobs, actions/movement, actions/shared, actions/survival/index, job-manager
 - 他モジュール依存: shared
 - 外部依存: @modelcontextprotocol/sdk/server/mcp.js
 
@@ -99,6 +114,11 @@ graph LR
 ### actions/movement.ts
 
 - モジュール内依存: actions/shared, bot-queries, job-manager
+- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+
+### actions/queries.ts
+
+- モジュール内依存: actions/shared
 - 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/shared.ts

--- a/spec/mcp/minecraft/exploration.spec.ts
+++ b/spec/mcp/minecraft/exploration.spec.ts
@@ -91,13 +91,12 @@ function makeBot(options?: { blocksByName?: Record<string, { id: number }> }) {
 // 仕様テスト: MCP ツール登録関数を直接テストする
 // GetBot 型: () => mineflayer.Bot | null
 type GetBot = () => ReturnType<typeof makeBot> | null;
+const nullBot: GetBot = () => null;
 
 // 登録関数の型定義（実装前の仕様）
 type RegisterSearchForBlock = (server: McpServer, getBot: GetBot, jobManager: JobManager) => void;
 
 type RegisterExploreDirection = (server: McpServer, getBot: GetBot, jobManager: JobManager) => void;
-
-const nullBot: GetBot = () => null;
 
 // ---------------------------------------------------------------------------
 // search_for_block 仕様テスト
@@ -128,7 +127,6 @@ describe("search_for_block", () => {
 		const registerSearchForBlock = await getRegisterFn();
 		const { server, getTool } = makeMockServer();
 		const { jobManager } = makeMockJobManager();
-
 		registerSearchForBlock(server, nullBot as never, jobManager);
 
 		const tool = getTool("search_for_block");
@@ -214,7 +212,6 @@ describe("explore_direction", () => {
 		const registerExploreDirection = await getRegisterFn();
 		const { server, getTool } = makeMockServer();
 		const { jobManager } = makeMockJobManager();
-
 		registerExploreDirection(server, nullBot as never, jobManager);
 
 		const tool = getTool("explore_direction");

--- a/spec/mcp/minecraft/queries.spec.ts
+++ b/spec/mcp/minecraft/queries.spec.ts
@@ -65,6 +65,7 @@ function makeBot(options?: {
 // ---------------------------------------------------------------------------
 
 type GetBot = () => ReturnType<typeof makeBot> | null;
+const nullBot: GetBot = () => null;
 
 type RegisterNearbyBlocks = (server: McpServer, getBot: GetBot) => void;
 type RegisterCraftableItems = (server: McpServer, getBot: GetBot) => void;
@@ -74,8 +75,6 @@ function textOf(result: unknown): string {
 	const r = result as { content: { text: string }[] };
 	return r.content[0]?.text ?? "";
 }
-
-const nullBot: GetBot = () => null;
 
 // ---------------------------------------------------------------------------
 // nearby_blocks 仕様テスト
@@ -101,7 +100,6 @@ describe("nearby_blocks", () => {
 	test("ボット未接続時にエラーメッセージを返すこと", async () => {
 		const registerNearbyBlocks = await getRegisterFn();
 		const { server, getTool } = makeMockServer();
-
 		registerNearbyBlocks(server, nullBot as never);
 
 		const tool = getTool("nearby_blocks");
@@ -169,7 +167,6 @@ describe("craftable_items", () => {
 	test("ボット未接続時にエラーメッセージを返すこと", async () => {
 		const registerCraftableItems = await getRegisterFn();
 		const { server, getTool } = makeMockServer();
-
 		registerCraftableItems(server, nullBot as never);
 
 		const tool = getTool("craftable_items");
@@ -239,7 +236,6 @@ describe("get_biome", () => {
 	test("ボット未接続時にエラーメッセージを返すこと", async () => {
 		const registerGetBiome = await getRegisterFn();
 		const { server, getTool } = makeMockServer();
-
 		registerGetBiome(server, nullBot as never);
 
 		const tool = getTool("get_biome");


### PR DESCRIPTION
## Summary
- 空ファイル (`spec/minecraft/exploration.spec.ts`, `spec/minecraft/queries.spec.ts`) を削除
- `consistent-function-scoping` lint エラー: テスト内の `getBot: GetBot = () => null` をファイルスコープの `nullGetBot` 定数に抽出

## Test plan
- [x] `nr lint` — エラー 0 件
- [x] `nr test` — 1453 テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)