### PR TITLE
feat: ホームスレッド常駐機能

### DIFF
--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -3,7 +3,9 @@
 	"private": true,
 	"module": "src/index.ts",
 	"exports": {
-		"./config": "./src/config.ts"
+		"./config": "./src/config.ts",
+		"./gateway/discord": "./src/gateway/discord.ts",
+		"./gateway/channel-config-loader": "./src/gateway/channel-config-loader.ts"
 	},
 	"dependencies": {
 		"discord.js": "^14.25.1",

--- a/apps/discord/src/gateway/discord.test.ts
+++ b/apps/discord/src/gateway/discord.test.ts
@@ -1,0 +1,312 @@
+/* oxlint-disable require-await, no-constructor-return, typescript/no-floating-promises -- テスト用モック */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+import { Events } from "discord.js";
+
+import { DiscordGateway } from "./discord";
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+function createMockClient() {
+	const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+
+	const mockClient = {
+		user: { id: "bot-user-id", tag: "TestBot#0001" },
+		login: mock(async () => {}),
+		destroy: mock(() => {}),
+		once: mock((event: string, cb: (...args: unknown[]) => void) => {
+			if (event === (Events.ClientReady as string)) {
+				cb(mockClient);
+			}
+		}),
+		on: mock((event: string, cb: (...args: unknown[]) => void) => {
+			const existing = listeners.get(event) ?? [];
+			existing.push(cb);
+			listeners.set(event, existing);
+		}),
+		channels: {
+			fetch: mock((id: string) => Promise.resolve(channelStore.get(id) ?? null)),
+		},
+	};
+
+	function emit(event: string, ...args: unknown[]) {
+		for (const cb of listeners.get(event) ?? []) {
+			cb(...args);
+		}
+	}
+
+	const channelStore = new Map<string, unknown>();
+	function registerChannel(id: string, channel: unknown) {
+		channelStore.set(id, channel);
+	}
+
+	return { mockClient, emit, registerChannel };
+}
+
+function createMockThreadChannel(id: string) {
+	return {
+		id,
+		isThread: () => true,
+		join: mock(async () => {}),
+		setArchived: mock(async () => {}),
+	};
+}
+
+type LogLevel = "info" | "warn" | "error";
+
+function createSpyLogger() {
+	const calls: { level: LogLevel; args: unknown[] }[] = [];
+	return {
+		logger: {
+			info: (...args: unknown[]) => calls.push({ level: "info", args }),
+			warn: (...args: unknown[]) => calls.push({ level: "warn", args }),
+			error: (...args: unknown[]) => calls.push({ level: "error", args }),
+		},
+		calls,
+		warnCalls: () => calls.filter((c) => c.level === "warn"),
+	};
+}
+
+// ─── Client コンストラクタをモックで差し替える ───────────────────
+
+let currentMockClient: ReturnType<typeof createMockClient>;
+
+mock.module("discord.js", () => {
+	// oxlint-disable-next-line typescript/no-require-imports
+	const actual = require("discord.js");
+	return {
+		...actual,
+		// oxlint-disable-next-line no-constructor-return, typescript/no-extraneous-class
+		Client: class MockedClient {
+			constructor() {
+				const { mockClient } = currentMockClient;
+				return mockClient as unknown;
+			}
+		},
+	};
+});
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe("DiscordGateway - スレッドロジック ユニットテスト", () => {
+	let gateway: DiscordGateway;
+	let mockSetup: ReturnType<typeof createMockClient>;
+	let logSpy: ReturnType<typeof createSpyLogger>;
+
+	beforeEach(() => {
+		mockSetup = createMockClient();
+		currentMockClient = mockSetup;
+		logSpy = createSpyLogger();
+		gateway = new DiscordGateway("fake-token", logSpy.logger);
+	});
+
+	afterEach(() => {
+		gateway.stop();
+	});
+
+	// ─── joinIfThread エッジケース ────────────────────────────────
+
+	describe("joinIfThread: fetch が null を返す場合", () => {
+		it("join() は呼ばれず、エラーも発生しない", async () => {
+			// channelStore に登録しない → fetch は null を返す
+			gateway.setHomeChannelIds(["nonexistent-id"]);
+			await gateway.start();
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
+
+			// warn ログが出ていないことを確認（null は正常パス、try 内で静かにスキップ）
+			const warns = logSpy.warnCalls();
+			const joinWarn = warns.find((w) => String(w.args[0]).includes("failed to join home thread"));
+			expect(joinWarn).toBeUndefined();
+		});
+	});
+
+	describe("joinIfThread: fetch がスレッドでないチャンネルを返す場合", () => {
+		it("join() は呼ばれない", async () => {
+			const normalChannel = {
+				id: "text-channel-1",
+				isThread: () => false,
+				join: mock(async () => {}),
+			};
+			mockSetup.registerChannel("text-channel-1", normalChannel);
+
+			gateway.setHomeChannelIds(["text-channel-1"]);
+			await gateway.start();
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
+
+			expect(normalChannel.join).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("joinIfThread: fetch が例外をスローする場合", () => {
+		it("warn ログを出力し、クラッシュしない", async () => {
+			mockSetup.mockClient.channels.fetch = mock(() =>
+				Promise.reject(new Error("Unknown Channel")),
+			);
+
+			gateway.setHomeChannelIds(["deleted-thread-id"]);
+			await gateway.start();
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
+
+			const warns = logSpy.warnCalls();
+			const joinWarn = warns.find((w) =>
+				String(w.args[0]).includes("failed to join home thread deleted-thread-id"),
+			);
+			expect(joinWarn).toBeDefined();
+		});
+	});
+
+	describe("joinIfThread: isThread プロパティが存在しないチャンネルの場合", () => {
+		it("join() は呼ばれず、エラーも発生しない", async () => {
+			const weirdChannel = { id: "weird-channel" };
+			mockSetup.registerChannel("weird-channel", weirdChannel);
+
+			gateway.setHomeChannelIds(["weird-channel"]);
+			await gateway.start();
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
+
+			// クラッシュしないことの確認（join が存在しないので呼ばれない）
+			const warns = logSpy.warnCalls();
+			const joinWarn = warns.find((w) => String(w.args[0]).includes("failed to join home thread"));
+			expect(joinWarn).toBeUndefined();
+		});
+	});
+
+	describe("joinIfThread: join() が失敗する場合", () => {
+		it("warn ログを出力し、クラッシュしない", async () => {
+			const failingThread = {
+				id: "thread-join-fail",
+				isThread: () => true,
+				join: mock(() => Promise.reject(new Error("Missing Permissions"))),
+			};
+			mockSetup.registerChannel("thread-join-fail", failingThread);
+
+			gateway.setHomeChannelIds(["thread-join-fail"]);
+			await gateway.start();
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
+
+			expect(failingThread.join).toHaveBeenCalled();
+			const warns = logSpy.warnCalls();
+			const joinWarn = warns.find((w) =>
+				String(w.args[0]).includes("failed to join home thread thread-join-fail"),
+			);
+			expect(joinWarn).toBeDefined();
+		});
+	});
+
+	describe("joinIfThread: 複数のホームチャンネルIDに対してそれぞれ fetch する", () => {
+		it("全IDについて channels.fetch が呼ばれる", async () => {
+			const thread1 = createMockThreadChannel("t1");
+			const thread2 = createMockThreadChannel("t2");
+			mockSetup.registerChannel("t1", thread1);
+			mockSetup.registerChannel("t2", thread2);
+
+			gateway.setHomeChannelIds(["t1", "t2"]);
+			await gateway.start();
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
+
+			expect(thread1.join).toHaveBeenCalled();
+			expect(thread2.join).toHaveBeenCalled();
+		});
+	});
+
+	// ─── registerThreadUpdateHandler エッジケース ─────────────────
+
+	describe("registerThreadUpdateHandler: archived が false の場合", () => {
+		it("setArchived は呼ばれない", async () => {
+			const threadId = "home-thread-1";
+			gateway.setHomeChannelIds([threadId]);
+			await gateway.start();
+
+			const unarchivedThread = {
+				id: threadId,
+				archived: false,
+				setArchived: mock(async () => {}),
+			};
+
+			mockSetup.emit(Events.ThreadUpdate, {}, unarchivedThread);
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(unarchivedThread.setArchived).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("registerThreadUpdateHandler: setArchived が失敗する場合", () => {
+		it("warn ログを出力し、クラッシュしない", async () => {
+			const threadId = "home-thread-2";
+			gateway.setHomeChannelIds([threadId]);
+			await gateway.start();
+
+			const failingThread = {
+				id: threadId,
+				archived: true,
+				setArchived: mock(() => Promise.reject(new Error("Missing Permissions"))),
+			};
+
+			mockSetup.emit(Events.ThreadUpdate, {}, failingThread);
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(failingThread.setArchived).toHaveBeenCalledWith(false);
+			const warns = logSpy.warnCalls();
+			const unarchiveWarn = warns.find((w) =>
+				String(w.args[0]).includes("failed to unarchive home thread"),
+			);
+			expect(unarchiveWarn).toBeDefined();
+		});
+	});
+
+	describe("registerThreadUpdateHandler: ホーム以外のスレッドがアーカイブされた場合", () => {
+		it("setArchived は呼ばれない", async () => {
+			gateway.setHomeChannelIds(["home-thread-1"]);
+			await gateway.start();
+
+			const otherThread = {
+				id: "other-thread",
+				archived: true,
+				setArchived: mock(async () => {}),
+			};
+
+			mockSetup.emit(Events.ThreadUpdate, {}, otherThread);
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(otherThread.setArchived).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("registerThreadUpdateHandler: homeChannelIds が空の場合", () => {
+		it("どのスレッドに対しても setArchived は呼ばれない", async () => {
+			gateway.setHomeChannelIds([]);
+			await gateway.start();
+
+			const thread = {
+				id: "any-thread",
+				archived: true,
+				setArchived: mock(async () => {}),
+			};
+
+			mockSetup.emit(Events.ThreadUpdate, {}, thread);
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(thread.setArchived).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/apps/discord/src/gateway/discord.ts
+++ b/apps/discord/src/gateway/discord.ts
@@ -67,12 +67,15 @@ export class DiscordGateway {
 
 		this.registerMessageHandler(client);
 		this.registerReactionHandler(client);
+		this.registerThreadUpdateHandler(client);
 
 		this.logger.info(
 			`[discord] connecting... (homeChannels=${this.homeChannelIds.size}, handler=${!!this.handler}, homeHandler=${!!this.homeChannelHandler})`,
 		);
 		await client.login(this.token);
 		this.client = client;
+
+		this.joinHomeThreads(client);
 	}
 
 	stop(): void {
@@ -140,6 +143,38 @@ export class DiscordGateway {
 		for (const match of message.content.matchAll(CUSTOM_EMOJI_RE)) {
 			const name = match[1];
 			if (name) this.emojiUsedHandler(message.guildId, name);
+		}
+	}
+
+	private registerThreadUpdateHandler(client: Client): void {
+		client.on(Events.ThreadUpdate, (_oldThread, newThread) => {
+			if (!this.homeChannelIds.has(newThread.id)) return;
+			if (!newThread.archived) return;
+			newThread.setArchived(false).catch((err) => {
+				this.logger.warn("[discord] failed to unarchive home thread:", err);
+			});
+		});
+	}
+
+	private joinHomeThreads(client: Client): void {
+		for (const id of this.homeChannelIds) {
+			void this.joinIfThread(client, id);
+		}
+	}
+
+	private async joinIfThread(client: Client, id: string): Promise<void> {
+		try {
+			const channel = await client.channels.fetch(id);
+			if (
+				channel &&
+				"isThread" in channel &&
+				typeof channel.isThread === "function" &&
+				channel.isThread()
+			) {
+				await (channel as { join: () => Promise<unknown> }).join();
+			}
+		} catch (err) {
+			this.logger.warn(`[discord] failed to join home thread ${id}:`, err);
 		}
 	}
 

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -118,7 +118,7 @@ graph LR
 
 - 内部依存: mcp, observability, shared, store
 - 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, path
-- ファイル数: 27
+- ファイル数: 30
 
 ### observability
 

--- a/packages/minecraft/DEPS.md
+++ b/packages/minecraft/DEPS.md
@@ -9,12 +9,17 @@ graph LR
   actions_combat["actions/combat"] --> actions_shared["actions/shared"]
   actions_combat["actions/combat"] --> bot_queries["bot-queries"]
   actions_combat["actions/combat"] --> job_manager["job-manager"]
-  actions_index["actions/index"] --> actions_combat["actions/combat"]
+  actions_exploration["actions/exploration"] --> actions_shared["actions/shared"]
+  actions_exploration["actions/exploration"] --> job_manager["job-manager"]
+  actions_explore_tools["actions/explore-tools"] --> actions_combat["actions/combat"]
+  actions_explore_tools["actions/explore-tools"] --> actions_exploration["actions/exploration"]
+  actions_explore_tools["actions/explore-tools"] --> actions_queries["actions/queries"]
+  actions_explore_tools["actions/explore-tools"] --> actions_smelting["actions/smelting"]
+  actions_index["actions/index"] --> actions_explore_tools["actions/explore-tools"]
   actions_index["actions/index"] --> actions_interaction["actions/interaction"]
   actions_index["actions/index"] --> actions_jobs["actions/jobs"]
   actions_index["actions/index"] --> actions_movement["actions/movement"]
   actions_index["actions/index"] --> actions_shared["actions/shared"]
-  actions_index["actions/index"] --> actions_smelting["actions/smelting"]
   actions_index["actions/index"] --> actions_survival_index["actions/survival/index"]
   actions_index["actions/index"] --> job_manager["job-manager"]
   actions_interaction["actions/interaction"] --> actions_shared["actions/shared"]
@@ -23,6 +28,7 @@ graph LR
   actions_movement["actions/movement"] --> actions_shared["actions/shared"]
   actions_movement["actions/movement"] --> bot_queries["bot-queries"]
   actions_movement["actions/movement"] --> job_manager["job-manager"]
+  actions_queries["actions/queries"] --> actions_shared["actions/shared"]
   actions_shared["actions/shared"] --> job_manager["job-manager"]
   actions_smelting["actions/smelting"] --> actions_shared["actions/shared"]
   actions_smelting["actions/smelting"] --> job_manager["job-manager"]
@@ -79,9 +85,18 @@ graph LR
 - モジュール内依存: actions/shared, bot-queries, job-manager
 - 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
 
+### actions/exploration.ts
+
+- モジュール内依存: actions/shared, job-manager
+- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+
+### actions/explore-tools.ts
+
+- モジュール内依存: actions/combat, actions/exploration, actions/queries, actions/smelting
+
 ### actions/index.ts
 
-- モジュール内依存: actions/combat, actions/interaction, actions/jobs, actions/movement, actions/shared, actions/smelting, actions/survival/index, job-manager
+- モジュール内依存: actions/explore-tools, actions/interaction, actions/jobs, actions/movement, actions/shared, actions/survival/index, job-manager
 - 他モジュール依存: shared
 - 外部依存: @modelcontextprotocol/sdk/server/mcp.js
 
@@ -99,6 +114,11 @@ graph LR
 ### actions/movement.ts
 
 - モジュール内依存: actions/shared, bot-queries, job-manager
+- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+
+### actions/queries.ts
+
+- モジュール内依存: actions/shared
 - 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/shared.ts

--- a/spec/discord/gateway/discord-gateway-thread.spec.ts
+++ b/spec/discord/gateway/discord-gateway-thread.spec.ts
@@ -1,0 +1,377 @@
+/* oxlint-disable require-await, no-constructor-return, typescript/no-floating-promises -- テスト用モック */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { IncomingMessage } from "@vicissitude/shared/types";
+import { Collection, Events } from "discord.js";
+
+import { DiscordGateway } from "../../../apps/discord/src/gateway/discord";
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+/** discord.js の Client をモックし、イベントリスナーを手動で発火できるようにする */
+function createMockClient() {
+	const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+
+	const mockClient = {
+		user: { id: "bot-user-id", tag: "TestBot#0001" },
+		login: mock(async () => {}),
+		destroy: mock(() => {}),
+		once: mock((event: string, cb: (...args: unknown[]) => void) => {
+			if (event === (Events.ClientReady as string)) {
+				cb(mockClient);
+			}
+		}),
+		on: mock((event: string, cb: (...args: unknown[]) => void) => {
+			const existing = listeners.get(event) ?? [];
+			existing.push(cb);
+			listeners.set(event, existing);
+		}),
+		channels: {
+			fetch: mock((id: string) => Promise.resolve(channelStore.get(id) ?? null)),
+		},
+	};
+
+	function emit(event: string, ...args: unknown[]) {
+		for (const cb of listeners.get(event) ?? []) {
+			cb(...args);
+		}
+	}
+
+	const channelStore = new Map<string, unknown>();
+	function registerChannel(id: string, channel: unknown) {
+		channelStore.set(id, channel);
+	}
+
+	return { mockClient, emit, registerChannel };
+}
+
+/** 通常チャンネルのメッセージを作成するヘルパー */
+function createMockMessage(overrides: {
+	channelId: string;
+	authorId?: string;
+	isThread?: boolean;
+	parentId?: string | null;
+	guildId?: string;
+	content?: string;
+}) {
+	const isThread = overrides.isThread ?? false;
+	return {
+		id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+		author: {
+			id: overrides.authorId ?? "user-123",
+			username: "testuser",
+			displayName: "Test User",
+			bot: false,
+		},
+		member: { displayName: "Test User" },
+		channel: {
+			id: overrides.channelId,
+			name: "test-channel",
+			isThread: () => isThread,
+			parentId: isThread ? (overrides.parentId ?? null) : null,
+			sendTyping: mock(async () => {}),
+			send: mock(async () => {}),
+		},
+		guildId: overrides.guildId ?? "guild-1",
+		content: overrides.content ?? "hello",
+		mentions: { has: () => false },
+		createdAt: new Date(),
+		attachments: new Collection(),
+		react: mock(async () => {}),
+		reply: mock(async () => {}),
+	};
+}
+
+/** ホームスレッド用のモックチャンネル（join / setArchived を持つ） */
+function createMockThreadChannel(
+	id: string,
+	opts: { archived?: boolean; parentId?: string | null } = {},
+) {
+	return {
+		id,
+		isThread: () => true,
+		parentId: opts.parentId ?? null,
+		archived: opts.archived ?? false,
+		join: mock(async () => {}),
+		setArchived: mock(async () => {}),
+	};
+}
+
+function createSilentLogger() {
+	return {
+		info: () => {},
+		error: () => {},
+		warn: () => {},
+	};
+}
+
+// ─── Client コンストラクタをモックで差し替える ───────────────────
+
+let currentMockClient: ReturnType<typeof createMockClient>;
+
+mock.module("discord.js", () => {
+	// oxlint-disable-next-line typescript/no-require-imports
+	const actual = require("discord.js");
+	return {
+		...actual,
+		// oxlint-disable-next-line no-constructor-return, typescript/no-extraneous-class
+		Client: class MockedClient {
+			constructor() {
+				const { mockClient } = currentMockClient;
+				return mockClient as unknown;
+			}
+		},
+	};
+});
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe("DiscordGateway - ホームスレッド常駐", () => {
+	let gateway: DiscordGateway;
+	let mockSetup: ReturnType<typeof createMockClient>;
+
+	beforeEach(() => {
+		mockSetup = createMockClient();
+		currentMockClient = mockSetup;
+		gateway = new DiscordGateway("fake-token", createSilentLogger());
+	});
+
+	afterEach(() => {
+		gateway.stop();
+	});
+
+	// ─── 1. ホーム判定 ───────────────────────────────────────────
+
+	describe("ホーム判定: スレッドIDが直接登録されている場合", () => {
+		it("スレッドIDが homeChannelIds に含まれる場合、そのスレッドのメッセージはホーム扱いになる", async () => {
+			const threadId = "thread-001";
+			gateway.setHomeChannelIds([threadId]);
+
+			const homeMessages: IncomingMessage[] = [];
+			gateway.onHomeChannelMessage(async (msg) => {
+				homeMessages.push(msg);
+			});
+
+			await gateway.start();
+
+			const message = createMockMessage({
+				channelId: threadId,
+				isThread: true,
+				parentId: "some-other-channel",
+			});
+
+			mockSetup.emit(Events.MessageCreate, message);
+
+			// イベントハンドラは非同期なので少し待つ
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(homeMessages).toHaveLength(1);
+			expect(homeMessages[0]?.channelId).toBe(threadId);
+		});
+
+		it("スレッドIDが homeChannelIds に含まれない場合、ホーム扱いにならない", async () => {
+			gateway.setHomeChannelIds(["other-channel"]);
+
+			const homeMessages: IncomingMessage[] = [];
+			gateway.onHomeChannelMessage(async (msg) => {
+				homeMessages.push(msg);
+			});
+			gateway.onMessage(async (msg) => {
+				void msg;
+			});
+
+			await gateway.start();
+
+			const message = createMockMessage({
+				channelId: "thread-not-home",
+				isThread: true,
+				parentId: "unrelated-parent",
+			});
+
+			mockSetup.emit(Events.MessageCreate, message);
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(homeMessages).toHaveLength(0);
+		});
+	});
+
+	// ─── 2. 自動 join ───────────────────────────────────────────
+
+	describe("自動 join: start() 後にホームスレッドへ join する", () => {
+		it("homeChannelIds のうちスレッドであるものに join() が呼ばれる", async () => {
+			const threadChannel = createMockThreadChannel("thread-home-1");
+			mockSetup.registerChannel("thread-home-1", threadChannel);
+
+			gateway.setHomeChannelIds(["thread-home-1", "normal-channel-1"]);
+			await gateway.start();
+
+			// start() 完了後、スレッドへの join が非同期で行われることを待つ
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
+
+			expect(threadChannel.join).toHaveBeenCalled();
+		});
+
+		it("通常チャンネル（スレッドでないもの）には join() を呼ばない", async () => {
+			const normalChannel = {
+				id: "normal-channel-1",
+				isThread: () => false,
+				join: mock(async () => {}),
+			};
+			mockSetup.registerChannel("normal-channel-1", normalChannel);
+
+			const threadChannel = createMockThreadChannel("thread-home-1");
+			mockSetup.registerChannel("thread-home-1", threadChannel);
+
+			gateway.setHomeChannelIds(["normal-channel-1", "thread-home-1"]);
+			await gateway.start();
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
+
+			expect(normalChannel.join).not.toHaveBeenCalled();
+			expect(threadChannel.join).toHaveBeenCalled();
+		});
+	});
+
+	// ─── 3. アーカイブ復帰 ──────────────────────────────────────
+
+	describe("アーカイブ復帰: ホームスレッドがアーカイブされた場合に自動解除する", () => {
+		it("ホームスレッドがアーカイブされたとき、setArchived(false) が呼ばれる", async () => {
+			const threadId = "thread-home-1";
+			gateway.setHomeChannelIds([threadId]);
+			await gateway.start();
+
+			const archivedThread = createMockThreadChannel(threadId, { archived: true });
+
+			// ThreadUpdate イベントを発火（oldThread, newThread）
+			mockSetup.emit(Events.ThreadUpdate, {}, archivedThread);
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(archivedThread.setArchived).toHaveBeenCalledWith(false);
+		});
+
+		it("ホームスレッド以外がアーカイブされても setArchived は呼ばれない", async () => {
+			gateway.setHomeChannelIds(["thread-home-1"]);
+			await gateway.start();
+
+			const otherThread = createMockThreadChannel("thread-other", { archived: true });
+
+			mockSetup.emit(Events.ThreadUpdate, {}, otherThread);
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(otherThread.setArchived).not.toHaveBeenCalled();
+		});
+
+		it("ホームスレッドがアーカイブ解除された場合（archived=false）は何もしない", async () => {
+			const threadId = "thread-home-1";
+			gateway.setHomeChannelIds([threadId]);
+			await gateway.start();
+
+			const unarchivedThread = createMockThreadChannel(threadId, { archived: false });
+
+			mockSetup.emit(Events.ThreadUpdate, {}, unarchivedThread);
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(unarchivedThread.setArchived).not.toHaveBeenCalled();
+		});
+	});
+
+	// ─── 4. 既存動作の維持 ──────────────────────────────────────
+
+	describe("既存動作の維持: ホームチャンネル配下スレッドのホーム判定", () => {
+		it("ホームチャンネル配下のスレッドは引き続きホーム扱いになる", async () => {
+			const parentChannelId = "home-channel-1";
+			gateway.setHomeChannelIds([parentChannelId]);
+
+			const homeMessages: IncomingMessage[] = [];
+			gateway.onHomeChannelMessage(async (msg) => {
+				homeMessages.push(msg);
+			});
+
+			await gateway.start();
+
+			const message = createMockMessage({
+				channelId: "child-thread-in-home",
+				isThread: true,
+				parentId: parentChannelId,
+			});
+
+			mockSetup.emit(Events.MessageCreate, message);
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(homeMessages).toHaveLength(1);
+		});
+
+		it("ホームチャンネル自体のメッセージもホーム扱いになる", async () => {
+			const channelId = "home-channel-1";
+			gateway.setHomeChannelIds([channelId]);
+
+			const homeMessages: IncomingMessage[] = [];
+			gateway.onHomeChannelMessage(async (msg) => {
+				homeMessages.push(msg);
+			});
+
+			await gateway.start();
+
+			const message = createMockMessage({
+				channelId,
+				isThread: false,
+			});
+
+			mockSetup.emit(Events.MessageCreate, message);
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(homeMessages).toHaveLength(1);
+		});
+
+		it("スレッドIDとチャンネルIDの両方を homeChannelIds に登録できる", async () => {
+			const channelId = "home-channel-1";
+			const threadId = "standalone-thread-1";
+			gateway.setHomeChannelIds([channelId, threadId]);
+
+			const homeMessages: IncomingMessage[] = [];
+			gateway.onHomeChannelMessage(async (msg) => {
+				homeMessages.push(msg);
+			});
+
+			await gateway.start();
+
+			// チャンネルからのメッセージ
+			const channelMsg = createMockMessage({
+				channelId,
+				isThread: false,
+			});
+			mockSetup.emit(Events.MessageCreate, channelMsg);
+
+			// スレッドからのメッセージ
+			const threadMsg = createMockMessage({
+				channelId: threadId,
+				isThread: true,
+				parentId: "unrelated-parent",
+			});
+			mockSetup.emit(Events.MessageCreate, threadMsg);
+
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 50);
+			});
+
+			expect(homeMessages).toHaveLength(2);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- channels.json の `channelId` にスレッドIDを指定することで、スレッドでもホームチャンネルと同様にメンションなしで常駐可能に
- `start()` 後にホームスレッドへ自動 join（スレッドメッセージ受信に必要）
- `ThreadUpdate` イベント監視によるホームスレッドのアーカイブ自動解除
- `isHomeMessage()` の変更は不要（既存の `homeChannelIds.has(message.channel.id)` でスレッドIDもマッチ）

## 使い方

`data/context/channels.json` にスレッドエントリを追加するだけ（既存フォーマットのまま）:

```json
{
  "channelId": "<スレッドID>",
  "guildId": "<ギルドID>",
  "guildName": "...",
  "channelName": "...",
  "role": "home"
}
```

## Test plan

- [x] 仕様テスト 10件 pass (`spec/discord/gateway/discord-gateway-thread.spec.ts`)
- [x] ユニットテスト 10件 pass (`apps/discord/src/gateway/discord.test.ts`)
- [x] 既存テスト 1473件 全 pass
- [x] 実装コードに型エラー・lintエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)