### PR TITLE
fix: MockedClient コンストラクタの型エラーを修正

### DIFF
--- a/apps/discord/src/gateway/discord.test.ts
+++ b/apps/discord/src/gateway/discord.test.ts
@@ -80,7 +80,7 @@ mock.module("discord.js", () => {
 		Client: class MockedClient {
 			constructor() {
 				const { mockClient } = currentMockClient;
-				return mockClient as unknown;
+				return mockClient as unknown as MockedClient;
 			}
 		},
 	};

--- a/spec/discord/gateway/discord-gateway-thread.spec.ts
+++ b/spec/discord/gateway/discord-gateway-thread.spec.ts
@@ -118,7 +118,7 @@ mock.module("discord.js", () => {
 		Client: class MockedClient {
 			constructor() {
 				const { mockClient } = currentMockClient;
-				return mockClient as unknown;
+				return mockClient as unknown as MockedClient;
 			}
 		},
 	};


### PR DESCRIPTION
## Summary
- `discord.test.ts` と `discord-gateway-thread.spec.ts` の MockedClient コンストラクタで `return mockClient as unknown` を `return mockClient as unknown as MockedClient` に修正
- tsgo の型チェックで `Type 'unknown' is not assignable to type 'MockedClient'` エラーが発生していた

## Test plan
- [ ] CI の Type check ステップが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)