### PR TITLE
fix: BED_MATERIAL_PATTERN から bed を除去し wool|planks に変更 (#460)

### DIFF
--- a/apps/discord/DEPS.md
+++ b/apps/discord/DEPS.md
@@ -23,11 +23,11 @@ graph LR
 
 - モジュール内依存: config, gateway/channel-config-loader, gateway/discord, port-allocator
 - 他モジュール依存: agent, application, gateway, infrastructure, memory, observability, ollama, opencode, scheduling, shared, store, tts
-- 外部依存: .bun, fs, path
+- 外部依存: ../../../node_modules/.bun/@types+bun@1.3.9/node_modules/@types/bun/index.d.ts, fs, path
 
 ### config.ts
 
-- 外部依存: .bun, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, path
 
 ### gateway/channel-config-loader.ts
 
@@ -36,7 +36,7 @@ graph LR
 ### gateway/discord.ts
 
 - 他モジュール依存: infrastructure, shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js
 
 ### index.ts
 

--- a/apps/web/DEPS.md
+++ b/apps/web/DEPS.md
@@ -24,13 +24,13 @@ graph LR
 ### components/avatar/VrmViewer.tsx.ts
 
 - 他モジュール依存: shared
-- 外部依存: .bun, three/addons/loaders/GLTFLoader.js
+- 外部依存: ../../../node_modules/.bun/three@0.183.2/node_modules/three/build/three.cjs, @pixiv/three-vrm, @react-three/drei, @react-three/fiber, react, three/addons/loaders/GLTFLoader.js
 
 ### components/chat/ChatPanel.tsx.ts
 
 - モジュール内依存: lib/audio-player, lib/ws-client
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: react
 
 ### index.css.ts
 
@@ -47,18 +47,18 @@ graph LR
 ### main.tsx.ts
 
 - モジュール内依存: index.css
-- 外部依存: ./routeTree.gen, .bun
+- 外部依存: ./routeTree.gen, @tanstack/react-router, react, react-dom/client
 
 ### routes/\_\_root.tsx.ts
 
-- 外部依存: .bun
+- 外部依存: @tanstack/react-router
 
 ### routes/index.tsx.ts
 
 - モジュール内依存: components/avatar/VrmViewer.tsx, components/chat/ChatPanel.tsx
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: @tanstack/react-router, react
 
 ### vite-env.d.ts
 
-- 外部依存: .bun
+- 外部依存: vite/client

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -63,7 +63,7 @@ graph LR
 ### agent
 
 - 内部依存: minecraft, observability, opencode, shared, store
-- 外部依存: .bun, path
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, path
 - ファイル数: 19
 
 ### application
@@ -75,13 +75,13 @@ graph LR
 ### apps/discord
 
 - 内部依存: agent, application, gateway, infrastructure, memory, observability, ollama, opencode, scheduling, shared, store, tts
-- 外部依存: .bun, fs, path
+- 外部依存: ../../../node_modules/.bun/@types+bun@1.3.9/node_modules/@types/bun/index.d.ts, ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, fs, path
 - ファイル数: 6
 
 ### apps/web
 
 - 内部依存: shared
-- 外部依存: ./routeTree.gen, .bun, three/addons/loaders/GLTFLoader.js
+- 外部依存: ../../../node_modules/.bun/three@0.183.2/node_modules/three/build/three.cjs, ./routeTree.gen, @pixiv/three-vrm, @react-three/drei, @react-three/fiber, @tanstack/react-router, react, react-dom/client, three/addons/loaders/GLTFLoader.js, vite/client
 - ファイル数: 9
 
 ### avatar
@@ -93,19 +93,19 @@ graph LR
 ### gateway
 
 - 内部依存: avatar, observability, shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/elysia@1.4.28/node_modules/elysia/dist/index.js
 - ファイル数: 4
 
 ### infrastructure
 
 - 内部依存: application, shared, store
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js
 - ファイル数: 6
 
 ### mcp
 
 - 内部依存: agent, infrastructure, memory, minecraft, observability, ollama, scheduling, shared, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, @modelcontextprotocol/sdk/server/webStandardStreamableHttp.js, fs, path
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, @modelcontextprotocol/sdk/server/webStandardStreamableHttp.js, fs, path
 - ファイル数: 15
 
 ### memory
@@ -117,8 +117,8 @@ graph LR
 ### minecraft
 
 - 内部依存: mcp, observability, shared, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, path
-- ファイル数: 30
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/prismarine-viewer@1.33.0/node_modules/prismarine-viewer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, path, prismarine-entity, prismarine-recipe, vec3
+- ファイル数: 31
 
 ### observability
 
@@ -141,19 +141,19 @@ graph LR
 ### scheduling
 
 - 内部依存: application, observability, shared
-- 外部依存: .bun, fs, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, fs, path
 - ファイル数: 7
 
 ### shared
 
 - 内部依存: なし
-- 外部依存: .bun, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, path
 - ファイル数: 14
 
 ### store
 
 - 内部依存: shared
-- 外部依存: .bun, bun:sqlite, fs, path
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/bun-sqlite/index.js, ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs, ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/sqlite-core/index.js, bun:sqlite, fs, path
 - ファイル数: 13
 
 ### tts

--- a/packages/agent/DEPS.md
+++ b/packages/agent/DEPS.md
@@ -54,7 +54,7 @@ graph LR
 ### emotion/estimator.ts
 
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs
 
 ### mcp-config.ts
 
@@ -94,4 +94,4 @@ graph LR
 ### session-store.ts
 
 - 他モジュール依存: store
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs

--- a/packages/gateway/DEPS.md
+++ b/packages/gateway/DEPS.md
@@ -15,7 +15,7 @@ graph LR
 ### server.ts
 
 - モジュール内依存: ws-handler
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/elysia@1.4.28/node_modules/elysia/dist/index.js
 
 ### ws-handler.ts
 

--- a/packages/infrastructure/DEPS.md
+++ b/packages/infrastructure/DEPS.md
@@ -16,7 +16,7 @@ graph LR
 ### discord/attachment-mapper.ts
 
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js
 
 ### discord/url-rewriter.ts
 

--- a/packages/mcp/DEPS.md
+++ b/packages/mcp/DEPS.md
@@ -30,13 +30,13 @@ graph LR
 
 ### code-exec-server.ts
 
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js
 
 ### core-server.ts
 
 - モジュール内依存: http-server, tool-metrics, tools/discord, tools/event-buffer, tools/mc-bridge-discord, tools/memory, tools/schedule
 - 他モジュール依存: agent, memory, observability, ollama, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, fs, path
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js, @modelcontextprotocol/sdk/server/mcp.js, fs, path
 
 ### http-server.ts
 
@@ -56,35 +56,35 @@ graph LR
 
 - モジュール内依存: tools/event-buffer
 - 他モジュール依存: infrastructure, shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, fs, path
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, fs, path
 
 ### tools/event-buffer.ts
 
 - 他モジュール依存: shared, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### tools/mc-bridge-discord.ts
 
 - 他モジュール依存: minecraft, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### tools/mc-bridge-minecraft.ts
 
 - モジュール内依存: tools/event-buffer
 - 他モジュール依存: minecraft, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### tools/mc-memory.ts
 
 - モジュール内依存: memory-helpers
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, fs, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, fs, path
 
 ### tools/memory.ts
 
 - 他モジュール依存: memory
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### tools/schedule.ts
 
 - 他モジュール依存: scheduling, shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, fs, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, fs, path

--- a/packages/minecraft/DEPS.md
+++ b/packages/minecraft/DEPS.md
@@ -24,11 +24,14 @@ graph LR
   actions_index["actions/index"] --> job_manager["job-manager"]
   actions_interaction["actions/interaction"] --> actions_shared["actions/shared"]
   actions_jobs["actions/jobs"] --> actions_shared["actions/shared"]
+  actions_jobs["actions/jobs"] --> error_context["error-context"]
   actions_jobs["actions/jobs"] --> job_manager["job-manager"]
   actions_movement["actions/movement"] --> actions_shared["actions/shared"]
   actions_movement["actions/movement"] --> bot_queries["bot-queries"]
+  actions_movement["actions/movement"] --> error_context["error-context"]
   actions_movement["actions/movement"] --> job_manager["job-manager"]
   actions_queries["actions/queries"] --> actions_shared["actions/shared"]
+  actions_queries["actions/queries"] --> bot_queries["bot-queries"]
   actions_shared["actions/shared"] --> job_manager["job-manager"]
   actions_smelting["actions/smelting"] --> actions_shared["actions/shared"]
   actions_smelting["actions/smelting"] --> job_manager["job-manager"]
@@ -51,6 +54,8 @@ graph LR
   bot_context["bot-context"] --> helpers
   bot_queries["bot-queries"] --> helpers
   constants
+  error_context["error-context"] --> bot_queries["bot-queries"]
+  error_context["error-context"] --> helpers
   helpers
   http_server["http-server"]
   job_manager["job-manager"] --> helpers
@@ -83,12 +88,12 @@ graph LR
 ### actions/combat.ts
 
 - モジュール内依存: actions/shared, bot-queries, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, prismarine-entity
 
 ### actions/exploration.ts
 
 - モジュール内依存: actions/shared, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/explore-tools.ts
 
@@ -103,43 +108,43 @@ graph LR
 ### actions/interaction.ts
 
 - モジュール内依存: actions/shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, vec3
 
 ### actions/jobs.ts
 
-- モジュール内依存: actions/shared, job-manager
+- モジュール内依存: actions/shared, error-context, job-manager
 - 他モジュール依存: shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, prismarine-recipe
 
 ### actions/movement.ts
 
-- モジュール内依存: actions/shared, bot-queries, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- モジュール内依存: actions/shared, bot-queries, error-context, job-manager
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, prismarine-entity
 
 ### actions/queries.ts
 
-- モジュール内依存: actions/shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- モジュール内依存: actions/shared, bot-queries
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/shared.ts
 
 - モジュール内依存: job-manager
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js
 
 ### actions/smelting.ts
 
 - モジュール内依存: actions/shared, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/survival/escape.ts
 
 - モジュール内依存: actions/shared, bot-queries, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/survival/food.ts
 
 - モジュール内依存: actions/shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/survival/index.ts
 
@@ -149,7 +154,7 @@ graph LR
 ### actions/survival/shelter.ts
 
 - モジュール内依存: actions/shared, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, vec3
 
 ### auto-notifier.ts
 
@@ -160,22 +165,27 @@ graph LR
 
 - モジュール内依存: bot-context, bot-queries, constants, helpers
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/prismarine-viewer@1.33.0/node_modules/prismarine-viewer/index.js, prismarine-entity
 
 ### bot-context.ts
 
 - モジュール内依存: helpers
 - 他モジュール依存: observability, shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js
 
 ### bot-queries.ts
 
 - モジュール内依存: helpers
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, prismarine-entity, vec3
 
 ### constants.ts
 
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs
+
+### error-context.ts
+
+- モジュール内依存: bot-queries, helpers
+- 外部依存: ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js
 
 ### helpers.ts
 
@@ -203,12 +213,12 @@ graph LR
 
 - モジュール内依存: actions/index, bot-context, bot-queries, job-manager, state-summary, stuck-recovery
 - 他モジュール依存: observability, shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### reactive-layer.ts
 
 - モジュール内依存: actions/survival/food, bot-context, helpers
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, prismarine-entity
 
 ### server.ts
 

--- a/packages/minecraft/src/error-context.ts
+++ b/packages/minecraft/src/error-context.ts
@@ -3,8 +3,8 @@ import type mineflayer from "mineflayer";
 import { getNearbyBlockCounts } from "./bot-queries.ts";
 import { getOreHint } from "./helpers.ts";
 
-/** ベッド素材となりうるブロック名のパターン */
-const BED_MATERIAL_PATTERN = /wool|bed/i;
+/** ベッド素材となりうるブロック名のパターン（wool, planks） */
+const BED_MATERIAL_PATTERN = /wool|planks/i;
 
 /** 採集失敗時のコンテキスト文字列を生成する（3行以内） */
 export function buildCollectBlockContext(bot: mineflayer.Bot, blockName: string): string {
@@ -48,7 +48,7 @@ export function buildSleepContext(bot: mineflayer.Bot): string {
 		top5.length > 0 ? top5.map(([name, count]) => `${name}x${String(count)}`).join(", ") : "なし";
 
 	const hasBedMaterial = [...counts.keys()].some((name) => BED_MATERIAL_PATTERN.test(name));
-	const bedInfo = hasBedMaterial ? "ベッド素材（wool）あり" : "ベッド素材なし";
+	const bedInfo = hasBedMaterial ? "ベッド素材（wool/planks）あり" : "ベッド素材なし";
 
 	return [`周辺ブロック: ${nearbyText}`, bedInfo].join("\n");
 }

--- a/packages/scheduling/DEPS.md
+++ b/packages/scheduling/DEPS.md
@@ -23,7 +23,7 @@ graph LR
 
 - モジュール内依存: heartbeat-helpers
 - 他モジュール依存: shared
-- 外部依存: .bun, fs, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, fs, path
 
 ### heartbeat-helpers.ts
 

--- a/packages/shared/DEPS.md
+++ b/packages/shared/DEPS.md
@@ -25,7 +25,7 @@ graph LR
 
 ### emotion.ts
 
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs
 
 ### functions.ts
 
@@ -38,7 +38,7 @@ graph LR
 ### tts.ts
 
 - モジュール内依存: emotion
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs
 
 ### types.ts
 
@@ -47,4 +47,4 @@ graph LR
 ### ws-protocol.ts
 
 - モジュール内依存: emotion
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs

--- a/packages/store/DEPS.md
+++ b/packages/store/DEPS.md
@@ -23,7 +23,7 @@ graph LR
 ### db.ts
 
 - モジュール内依存: schema
-- 外部依存: .bun, bun:sqlite, fs, path
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/bun-sqlite/index.js, bun:sqlite, fs, path
 
 ### event-buffer.ts
 
@@ -33,19 +33,19 @@ graph LR
 ### mc-bridge.ts
 
 - モジュール内依存: db, schema
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs
 
 ### mood-store.ts
 
 - モジュール内依存: db, schema
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs
 
 ### queries.ts
 
 - モジュール内依存: db, schema
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs
 
 ### schema.ts
 
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/sqlite-core/index.js

--- a/spec/mcp/minecraft/error-context.spec.ts
+++ b/spec/mcp/minecraft/error-context.spec.ts
@@ -218,6 +218,37 @@ describe("buildSleepContext", () => {
 		expect(result).toMatch(/wool|羊毛|bed|ベッド/i);
 	});
 
+	test("周辺ブロックが red_bed のみの場合、ベッド素材ありと誤判定されないこと", async () => {
+		const fn = await getFn();
+		// blockAt が red_bed を返すモック（ベッドブロック自体は素材ではない）
+		const bot = {
+			entity: { position: { x: 0, y: 64, z: 0 } },
+			registry: { biomes: { 1: { name: "plains" } } },
+			world: { getBiome: mock(() => 1) },
+			inventory: { items: mock(() => []) },
+			blockAt: mock(() => ({ name: "red_bed" })),
+		} as never;
+		const result = fn(bot);
+		// 「素材」+「あり」の組み合わせが含まれないこと（「ベッド素材なし」が含まれること）
+		expect(result).toMatch(/素材.*なし/);
+		expect(result).not.toMatch(/素材.*あり/);
+	});
+
+	test("周辺ブロックに oak_planks がある場合、ベッド素材ありの情報が含まれること", async () => {
+		const fn = await getFn();
+		// blockAt が oak_planks を返すモック（ベッド素材として有効）
+		const bot = {
+			entity: { position: { x: 0, y: 64, z: 0 } },
+			registry: { biomes: { 1: { name: "plains" } } },
+			world: { getBiome: mock(() => 1) },
+			inventory: { items: mock(() => []) },
+			blockAt: mock(() => ({ name: "oak_planks" })),
+		} as never;
+		const result = fn(bot);
+		// ベッド素材（planks）の情報が含まれること
+		expect(result).toMatch(/素材.*あり|planks/i);
+	});
+
 	test("戻り値が3行以内であること", async () => {
 		const fn = await getFn();
 		const bot = makeBot();


### PR DESCRIPTION
## Summary
- `BED_MATERIAL_PATTERN` の正規表現を `/wool|bed/i` から `/wool|planks/i` に変更
- `red_bed` 等のベッドブロック名にマッチして「ベッド素材あり」と誤判定される問題を修正
- 再現テスト（red_bed 偽陽性テスト、oak_planks 正常系テスト）を追加

## Test plan
- [x] `nr test:spec` — 1142 pass / 0 fail
- [x] `nr test` — 1507 pass / 0 fail
- [x] `nr validate` — lint 0 errors, fmt OK

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)