### PR TITLE
fix: deepslate 鉱石バリアントを getOreHint で対応 (#459)

### DIFF
--- a/packages/minecraft/src/helpers.ts
+++ b/packages/minecraft/src/helpers.ts
@@ -235,7 +235,10 @@ export const ORE_Y_DISTRIBUTION: Record<string, { minY: number; maxY: number }> 
 
 // 鉱石名からY座標ヒント文字列を返す。鉱石でなければ null
 export function getOreHint(blockName: string): string | null {
-	const entry = ORE_Y_DISTRIBUTION[blockName];
+	const normalized = blockName.startsWith("deepslate_")
+		? blockName.slice("deepslate_".length)
+		: blockName;
+	const entry = ORE_Y_DISTRIBUTION[normalized];
 	if (!entry) return null;
 	return `${blockName} は Y=${String(entry.minY)}〜${String(entry.maxY)} に分布`;
 }

--- a/spec/mcp/minecraft/helpers.spec.ts
+++ b/spec/mcp/minecraft/helpers.spec.ts
@@ -154,6 +154,35 @@ describe("getOreHint", () => {
 		expect(getOreHint("dirt")).toBeNull();
 	});
 
+	test("deepslate_diamond_ore でヒント文字列が返ること", () => {
+		const hint = getOreHint("deepslate_diamond_ore");
+		expect(hint).not.toBeNull();
+		expect(typeof hint).toBe("string");
+	});
+
+	test("deepslate_iron_ore でヒント文字列が返ること", () => {
+		const hint = getOreHint("deepslate_iron_ore");
+		expect(hint).not.toBeNull();
+		expect(typeof hint).toBe("string");
+	});
+
+	test("deepslate バリアントで返されるヒントに Y 座標範囲が含まれること", () => {
+		const deepslateOres = [
+			"deepslate_diamond_ore",
+			"deepslate_iron_ore",
+			"deepslate_gold_ore",
+			"deepslate_lapis_ore",
+			"deepslate_redstone_ore",
+			"deepslate_emerald_ore",
+			"deepslate_copper_ore",
+		];
+		for (const ore of deepslateOres) {
+			const hint = getOreHint(ore);
+			expect(hint).not.toBeNull();
+			expect(hint).toMatch(/Y/i);
+		}
+	});
+
 	test("すべての主要鉱石でヒントが返ること", () => {
 		const ores = [
 			"diamond_ore",


### PR DESCRIPTION
## Summary
- `getOreHint` で `deepslate_` プレフィックスを除去してから `ORE_Y_DISTRIBUTION` テーブルを参照するように修正
- `deepslate_diamond_ore` 等の深岩版鉱石でもヒント文字列が返るようになった
- deepslate バリアント 7 種の仕様テストを追加

## Test plan
- [x] `nr test` 全 1510 テスト通過
- [x] `nr test:spec` 全 1145 仕様テスト通過
- [x] `nr validate` 今回の変更に関するエラーなし

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)