### PR TITLE
fix: deploy スクリプトの podman-compose rm を down に置換

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"test:quality:flake": "bun scripts/test-quality-flake.ts",
 		"deps:graph": "depcruise packages/*/src apps/*/src --config .dependency-cruiser.mjs --output-type json | bun scripts/generate-deps-md.ts && oxfmt docs/DEPS.md 'packages/*/DEPS.md' 'apps/*/DEPS.md'",
 		"validate": "bun run fmt:check && bun run lint && bun run check",
-		"deploy": "podman-compose rm -f -s installer builder bot 2>/dev/null; podman-compose up -d && echo 'Deployed: podman-compose logs -f to follow logs'",
+		"deploy": "podman-compose down installer builder bot 2>/dev/null; podman-compose up -d && echo 'Deployed: podman-compose logs -f to follow logs'",
 		"auto-triage": "bun scripts/auto-triage.ts",
 		"auto-triage:once": "claude -p /auto-triage --dangerously-skip-permissions --max-budget-usd 10 --no-session-persistence --worktree"
 	},

--- a/packages/mcp/DEPS.md
+++ b/packages/mcp/DEPS.md
@@ -50,6 +50,7 @@ graph LR
 
 ### tool-metrics.ts
 
+- 他モジュール依存: shared
 - 外部依存: @modelcontextprotocol/sdk/server/mcp.js
 
 ### tools/discord.ts


### PR DESCRIPTION
## Summary

- `podman-compose rm` は存在しないサブコマンドのため、`podman-compose down` に置換
- `down` はサービス指定でコンテナの停止＋削除を行う

## Test plan

- [x] `nr deploy` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)