### PR TITLE
fix: createServer が Proxy ではなく rawServer を返していた問題を修正

### DIFF
--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -208,7 +208,7 @@ function createServer(agentId: string | null): McpServer {
 	registerMemoryTools(server, { getOrCreateMemory }, boundGuildId);
 	registerDiscordBridgeTools(server, { db }, boundGuildId);
 
-	return rawServer;
+	return server;
 }
 
 // --- Start HTTP Server ---


### PR DESCRIPTION
## Summary
- `packages/mcp/src/core-server.ts` の `createServer()` で `wrapServerWithMetrics` が返す Proxy を破棄して `rawServer` を返していた問題を修正
- `return rawServer` → `return server` に変更し、メトリクス Proxy が呼び出し元に正しく渡されるようにした

Closes #469

## Test plan
- [x] `nr validate` 通過（既存の lint エラーは変更外のファイル）
- [x] `nr test` 通過（既存の `vec3` 依存エラーは変更外）
- [x] `nr check` 通過（既存の型エラーは `apps/web` と `packages/minecraft` の依存関係問題）
- [x] correctness-reviewer: 問題なし
- [x] design-reviewer: 問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)