### PR TITLE
fix: spotify テストの型エラーと mock.module 汚染を修正

### DIFF
--- a/packages/mcp/src/tools/spotify.ts
+++ b/packages/mcp/src/tools/spotify.ts
@@ -4,6 +4,14 @@ import { createTrackSelector } from "@vicissitude/spotify/selector";
 import { createSpotifyClient } from "@vicissitude/spotify/spotify-client";
 import type { SpotifyTrack } from "@vicissitude/spotify/types";
 
+export interface SpotifyToolDeps {
+	getSavedTracks(limit: number, offset: number): Promise<SpotifyTrack[]>;
+	getRecentlyPlayed(limit: number): Promise<SpotifyTrack[]>;
+	getPlaylistTracks(playlistId: string): Promise<SpotifyTrack[]>;
+	getArtist(artistId: string): Promise<{ genres: string[] }>;
+	select(tracks: SpotifyTrack[]): SpotifyTrack | null;
+}
+
 export function registerSpotifyTools(
 	server: McpServer,
 	config: {
@@ -12,14 +20,20 @@ export function registerSpotifyTools(
 		refreshToken: string;
 		recommendPlaylistId?: string;
 	},
+	deps?: SpotifyToolDeps,
 ): void {
-	const auth = createSpotifyAuth({
-		clientId: config.clientId,
-		clientSecret: config.clientSecret,
-		refreshToken: config.refreshToken,
-	});
-	const client = createSpotifyClient(auth);
-	const selector = createTrackSelector();
+	const d =
+		deps ??
+		(() => {
+			const auth = createSpotifyAuth({
+				clientId: config.clientId,
+				clientSecret: config.clientSecret,
+				refreshToken: config.refreshToken,
+			});
+			const client = createSpotifyClient(auth);
+			const selector = createTrackSelector();
+			return { ...client, select: selector.select.bind(selector) };
+		})();
 
 	server.registerTool(
 		"spotify_pick_track",
@@ -31,11 +45,9 @@ export function registerSpotifyTools(
 			const tracks: SpotifyTrack[] = [];
 
 			const results = await Promise.allSettled([
-				client.getSavedTracks(50, 0),
-				client.getRecentlyPlayed(50),
-				...(config.recommendPlaylistId
-					? [client.getPlaylistTracks(config.recommendPlaylistId)]
-					: []),
+				d.getSavedTracks(50, 0),
+				d.getRecentlyPlayed(50),
+				...(config.recommendPlaylistId ? [d.getPlaylistTracks(config.recommendPlaylistId)] : []),
 			]);
 
 			const errors: string[] = [];
@@ -55,7 +67,7 @@ export function registerSpotifyTools(
 				};
 			}
 
-			const picked = selector.select(tracks);
+			const picked = d.select(tracks);
 			if (!picked) {
 				return {
 					content: [{ type: "text", text: "選曲に失敗しました。" }],
@@ -66,7 +78,7 @@ export function registerSpotifyTools(
 			let genres = picked.genres;
 			if (genres.length === 0 && picked.artistId) {
 				try {
-					const artist = await client.getArtist(picked.artistId);
+					const artist = await d.getArtist(picked.artistId);
 					genres = artist.genres;
 				} catch {
 					// genres fetch failure is non-critical

--- a/packages/spotify/src/selector.ts
+++ b/packages/spotify/src/selector.ts
@@ -1,8 +1,6 @@
 import type { SpotifyTrack } from "./types.ts";
 
-export type { TrackSelector };
-
-interface TrackSelector {
+export interface TrackSelector {
 	select(tracks: SpotifyTrack[]): SpotifyTrack | null;
 }
 

--- a/packages/spotify/src/spotify-client.ts
+++ b/packages/spotify/src/spotify-client.ts
@@ -1,9 +1,7 @@
 import type { SpotifyAuth } from "./auth.ts";
 import type { SpotifyTrack } from "./types.ts";
 
-export type { SpotifyClient };
-
-interface SpotifyClient {
+export interface SpotifyClient {
 	getSavedTracks(limit: number, offset: number): Promise<SpotifyTrack[]>;
 	getRecentlyPlayed(limit: number): Promise<SpotifyTrack[]>;
 	getPlaylistTracks(playlistId: string): Promise<SpotifyTrack[]>;

--- a/spec/mcp/tools/discord-test-helpers.ts
+++ b/spec/mcp/tools/discord-test-helpers.ts
@@ -6,7 +6,7 @@ import type { DiscordDeps } from "@vicissitude/mcp/tools/discord";
 // ─── Types ───────────────────────────────────────────────────────
 
 export type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
-export type ToolResult = { content: Array<{ type: string; text: string }> };
+export type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
 
 // ─── captureTools ────────────────────────────────────────────────
 

--- a/spec/mcp/tools/spotify-test-helpers.ts
+++ b/spec/mcp/tools/spotify-test-helpers.ts
@@ -1,15 +1,11 @@
 /* oxlint-disable no-non-null-assertion -- test helpers */
-import { mock } from "bun:test";
-
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { registerSpotifyTools } from "@vicissitude/mcp/tools/spotify";
+import type { registerSpotifyTools, SpotifyToolDeps } from "@vicissitude/mcp/tools/spotify";
 import type { SpotifyTrack } from "@vicissitude/spotify/types";
 
 import type { ToolHandler } from "./discord-test-helpers";
 
 // ─── Mutable stubs ──────────────────────────────────────────────
-// mock.module はファイルトップレベルで1回だけ呼ぶ必要がある。
-// 各テストケースでは stubs オブジェクトのプロパティを差し替えて振る舞いを変える。
 
 export const stubs = {
 	getSavedTracks: (_limit: number, _offset: number): Promise<SpotifyTrack[]> => Promise.resolve([]),
@@ -18,25 +14,6 @@ export const stubs = {
 	getArtist: (_id: string): Promise<{ genres: string[] }> => Promise.resolve({ genres: [] }),
 	select: (_tracks: SpotifyTrack[]): SpotifyTrack | null => null,
 };
-
-void mock.module("@vicissitude/spotify/auth", () => ({
-	createSpotifyAuth: () => ({ __brand: "auth" }),
-}));
-
-void mock.module("@vicissitude/spotify/spotify-client", () => ({
-	createSpotifyClient: () => ({
-		getSavedTracks: (limit: number, offset: number) => stubs.getSavedTracks(limit, offset),
-		getRecentlyPlayed: (limit: number) => stubs.getRecentlyPlayed(limit),
-		getPlaylistTracks: (id: string) => stubs.getPlaylistTracks(id),
-		getArtist: (id: string) => stubs.getArtist(id),
-	}),
-}));
-
-void mock.module("@vicissitude/spotify/selector", () => ({
-	createTrackSelector: () => ({
-		select: (tracks: SpotifyTrack[]) => stubs.select(tracks),
-	}),
-}));
 
 // ─── captureSpotifyTool ─────────────────────────────────────────
 
@@ -50,7 +27,7 @@ const defaultConfig: SpotifyConfig = {
 
 /**
  * registerSpotifyTools で登録されたツールを name → handler のマップとして取得する。
- * mock.module の後にインポートする必要があるため、動的インポートを使用。
+ * DI 経由で stubs を注入するため mock.module は不要。
  */
 export async function captureSpotifyTool(
 	overrides: Partial<SpotifyConfig> = {},
@@ -64,7 +41,15 @@ export async function captureSpotifyTool(
 		},
 	} as unknown as McpServer;
 
-	registerSpotifyTools(fakeServer, { ...defaultConfig, ...overrides });
+	const deps: SpotifyToolDeps = {
+		getSavedTracks: (limit, offset) => stubs.getSavedTracks(limit, offset),
+		getRecentlyPlayed: (limit) => stubs.getRecentlyPlayed(limit),
+		getPlaylistTracks: (id) => stubs.getPlaylistTracks(id),
+		getArtist: (id) => stubs.getArtist(id),
+		select: (tracks) => stubs.select(tracks),
+	};
+
+	registerSpotifyTools(fakeServer, { ...defaultConfig, ...overrides }, deps);
 	return { tools };
 }
 


### PR DESCRIPTION
## Summary
- `ToolResult` 型に `isError?: boolean` を追加し、`spotify.spec.ts` の型エラーを解消
- `selector.ts` / `spotify-client.ts` の `export type { ... }` を `export interface` に変更（ランタイムで見つからない問題の修正）
- `registerSpotifyTools` にオプショナル `SpotifyToolDeps` パラメータを追加し、spec テストで `mock.module` を不要に
  - `mock.module` のプロセス全体への汚染が unit テスト失敗の原因だった（#492）

## Test plan
- [ ] CI の Test Quality が全件パスすること
- [ ] CI の Type check が通ること

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)