### PR TITLE
docs: README の Memory 分離セクションに internal namespace を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ OpenCode SDK 組み込み: `webfetch`, `websearch`
 
 - 人格共通: `IDENTITY.md`, `SOUL.md`, `DISCORD.md`, `HEARTBEAT.md`, `TOOLS-CORE.md`, `TOOLS-CODE.md`, `TOOLS-MINECRAFT.md` は全テナントで共有。
 - 記憶分離: `MEMORY.md`, `LESSONS.md` はテナントごとに分離（オーバーレイ方式）。
-- Memory 分離: テナントごとに独立した DB。
+- Memory 分離: `MemoryNamespace` により namespace 単位で独立した DB を持つ。
+  - `discord-guild`: Discord ギルドごとの記憶。DB パス: `guilds/{guildId}/memory.db`
+  - `internal`: ふあ本人の内部記憶（ギルドに属さない自己の気づき等）。DB パス: `internal/memory.db`
 - テナント間で会話内容・メンバー情報・教訓が漏洩しない。
 
 ### 3.7 記憶システム

--- a/apps/discord/DEPS.md
+++ b/apps/discord/DEPS.md
@@ -23,11 +23,11 @@ graph LR
 
 - モジュール内依存: config, gateway/channel-config-loader, gateway/discord, port-allocator
 - 他モジュール依存: agent, application, gateway, infrastructure, memory, observability, ollama, opencode, scheduling, shared, store, tts
-- 外部依存: .bun, fs, path
+- 外部依存: ../../../node_modules/.bun/@types+bun@1.3.9/node_modules/@types/bun/index.d.ts, fs, path
 
 ### config.ts
 
-- 外部依存: .bun, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, path
 
 ### gateway/channel-config-loader.ts
 
@@ -36,7 +36,7 @@ graph LR
 ### gateway/discord.ts
 
 - 他モジュール依存: infrastructure, shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js
 
 ### index.ts
 

--- a/apps/web/DEPS.md
+++ b/apps/web/DEPS.md
@@ -13,9 +13,6 @@ graph LR
   lib_audio_player["lib/audio-player"]
   lib_ws_client["lib/ws-client"]
   main.tsx --> index.css
-  main.tsx --> routeTree.gen
-  routeTree.gen --> routes___root.tsx["routes/__root.tsx"]
-  routeTree.gen --> routes_index.tsx["routes/index.tsx"]
   routes___root.tsx["routes/__root.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_avatar_VrmViewer.tsx["components/avatar/VrmViewer.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_chat_ChatPanel.tsx["components/chat/ChatPanel.tsx"]
@@ -27,13 +24,13 @@ graph LR
 ### components/avatar/VrmViewer.tsx.ts
 
 - 他モジュール依存: shared
-- 外部依存: .bun, three/addons/loaders/GLTFLoader.js
+- 外部依存: ../../../node_modules/.bun/three@0.183.2/node_modules/three/build/three.cjs, @pixiv/three-vrm, @react-three/drei, @react-three/fiber, react, three/addons/loaders/GLTFLoader.js
 
 ### components/chat/ChatPanel.tsx.ts
 
 - モジュール内依存: lib/audio-player, lib/ws-client
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: react
 
 ### index.css.ts
 
@@ -49,23 +46,19 @@ graph LR
 
 ### main.tsx.ts
 
-- モジュール内依存: index.css, routeTree.gen
-- 外部依存: .bun
-
-### routeTree.gen.ts
-
-- モジュール内依存: routes/\_\_root.tsx, routes/index.tsx
+- モジュール内依存: index.css
+- 外部依存: ./routeTree.gen, @tanstack/react-router, react, react-dom/client
 
 ### routes/\_\_root.tsx.ts
 
-- 外部依存: .bun
+- 外部依存: @tanstack/react-router
 
 ### routes/index.tsx.ts
 
 - モジュール内依存: components/avatar/VrmViewer.tsx, components/chat/ChatPanel.tsx
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: @tanstack/react-router, react
 
 ### vite-env.d.ts
 
-- 外部依存: .bun
+- 外部依存: vite/client

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -65,7 +65,7 @@ graph LR
 ### agent
 
 - 内部依存: minecraft, observability, opencode, shared, store
-- 外部依存: .bun, path
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, path
 - ファイル数: 19
 
 ### application
@@ -77,14 +77,14 @@ graph LR
 ### apps/discord
 
 - 内部依存: agent, application, gateway, infrastructure, memory, observability, ollama, opencode, scheduling, shared, store, tts
-- 外部依存: .bun, fs, path
+- 外部依存: ../../../node_modules/.bun/@types+bun@1.3.9/node_modules/@types/bun/index.d.ts, ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, fs, path
 - ファイル数: 6
 
 ### apps/web
 
 - 内部依存: shared
-- 外部依存: .bun, three/addons/loaders/GLTFLoader.js
-- ファイル数: 10
+- 外部依存: ../../../node_modules/.bun/three@0.183.2/node_modules/three/build/three.cjs, ./routeTree.gen, @pixiv/three-vrm, @react-three/drei, @react-three/fiber, @tanstack/react-router, react, react-dom/client, three/addons/loaders/GLTFLoader.js, vite/client
+- ファイル数: 9
 
 ### avatar
 
@@ -95,31 +95,31 @@ graph LR
 ### gateway
 
 - 内部依存: avatar, observability, shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/elysia@1.4.28/node_modules/elysia/dist/index.js
 - ファイル数: 4
 
 ### infrastructure
 
 - 内部依存: application, shared, store
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js
 - ファイル数: 6
 
 ### mcp
 
 - 内部依存: agent, infrastructure, memory, minecraft, observability, ollama, scheduling, shared, spotify, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, @modelcontextprotocol/sdk/server/webStandardStreamableHttp.js, fs, path
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, @modelcontextprotocol/sdk/server/webStandardStreamableHttp.js, fs, path
 - ファイル数: 16
 
 ### memory
 
 - 内部依存: ollama, shared
-- 外部依存: bun:sqlite, fs, path
+- 外部依存: bun:sqlite, fs
 - ファイル数: 33
 
 ### minecraft
 
 - 内部依存: mcp, observability, shared, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, path
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/prismarine-viewer@1.33.0/node_modules/prismarine-viewer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js, path, prismarine-entity, prismarine-recipe, vec3
 - ファイル数: 31
 
 ### observability
@@ -143,13 +143,13 @@ graph LR
 ### scheduling
 
 - 内部依存: application, observability, shared
-- 外部依存: .bun, fs, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, fs, path
 - ファイル数: 7
 
 ### shared
 
 - 内部依存: なし
-- 外部依存: .bun, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, path
 - ファイル数: 16
 
 ### spotify
@@ -161,7 +161,7 @@ graph LR
 ### store
 
 - 内部依存: shared
-- 外部依存: .bun, bun:sqlite, fs, path
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/bun-sqlite/index.js, ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs, ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/sqlite-core/index.js, bun:sqlite, fs, path
 - ファイル数: 13
 
 ### tts

--- a/packages/agent/DEPS.md
+++ b/packages/agent/DEPS.md
@@ -54,7 +54,7 @@ graph LR
 ### emotion/estimator.ts
 
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs
 
 ### mcp-config.ts
 
@@ -94,4 +94,4 @@ graph LR
 ### session-store.ts
 
 - 他モジュール依存: store
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs

--- a/packages/gateway/DEPS.md
+++ b/packages/gateway/DEPS.md
@@ -15,7 +15,7 @@ graph LR
 ### server.ts
 
 - モジュール内依存: ws-handler
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/elysia@1.4.28/node_modules/elysia/dist/index.js
 
 ### ws-handler.ts
 

--- a/packages/infrastructure/DEPS.md
+++ b/packages/infrastructure/DEPS.md
@@ -16,7 +16,7 @@ graph LR
 ### discord/attachment-mapper.ts
 
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js
 
 ### discord/url-rewriter.ts
 

--- a/packages/mcp/DEPS.md
+++ b/packages/mcp/DEPS.md
@@ -32,13 +32,13 @@ graph LR
 
 ### code-exec-server.ts
 
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, @modelcontextprotocol/sdk/server/stdio.js
 
 ### core-server.ts
 
 - モジュール内依存: http-server, tool-metrics, tools/discord, tools/event-buffer, tools/mc-bridge-discord, tools/memory, tools/schedule, tools/spotify
 - 他モジュール依存: agent, memory, observability, ollama, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, fs
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js, @modelcontextprotocol/sdk/server/mcp.js, fs
 
 ### http-server.ts
 
@@ -59,38 +59,38 @@ graph LR
 
 - モジュール内依存: tools/event-buffer
 - 他モジュール依存: infrastructure, shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, fs, path
+- 外部依存: ../../../node_modules/.bun/discord.js@14.25.1/node_modules/discord.js/src/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, fs, path
 
 ### tools/event-buffer.ts
 
 - 他モジュール依存: shared, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### tools/mc-bridge-discord.ts
 
 - 他モジュール依存: minecraft, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### tools/mc-bridge-minecraft.ts
 
 - モジュール内依存: tools/event-buffer
 - 他モジュール依存: minecraft, store
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### tools/mc-memory.ts
 
 - モジュール内依存: memory-helpers
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, fs, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, fs, path
 
 ### tools/memory.ts
 
 - 他モジュール依存: memory
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### tools/schedule.ts
 
 - 他モジュール依存: scheduling, shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js, fs, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, fs, path
 
 ### tools/spotify.ts
 

--- a/packages/memory/DEPS.md
+++ b/packages/memory/DEPS.md
@@ -104,7 +104,7 @@ graph LR
 
 - モジュール内依存: consolidation, episode, episodic, llm-port, namespace, segmenter, storage
 - 他モジュール依存: shared
-- 外部依存: fs, path
+- 外部依存: fs
 
 ### episode.ts
 

--- a/packages/minecraft/DEPS.md
+++ b/packages/minecraft/DEPS.md
@@ -88,12 +88,12 @@ graph LR
 ### actions/combat.ts
 
 - モジュール内依存: actions/shared, bot-queries, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, prismarine-entity
 
 ### actions/exploration.ts
 
 - モジュール内依存: actions/shared, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/explore-tools.ts
 
@@ -108,43 +108,43 @@ graph LR
 ### actions/interaction.ts
 
 - モジュール内依存: actions/shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, vec3
 
 ### actions/jobs.ts
 
 - モジュール内依存: actions/shared, error-context, job-manager
 - 他モジュール依存: shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, prismarine-recipe
 
 ### actions/movement.ts
 
 - モジュール内依存: actions/shared, bot-queries, error-context, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, prismarine-entity
 
 ### actions/queries.ts
 
 - モジュール内依存: actions/shared, bot-queries
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/shared.ts
 
 - モジュール内依存: job-manager
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js
 
 ### actions/smelting.ts
 
 - モジュール内依存: actions/shared, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/survival/escape.ts
 
 - モジュール内依存: actions/shared, bot-queries, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/survival/food.ts
 
 - モジュール内依存: actions/shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### actions/survival/index.ts
 
@@ -154,7 +154,7 @@ graph LR
 ### actions/survival/shelter.ts
 
 - モジュール内依存: actions/shared, job-manager
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js, vec3
 
 ### auto-notifier.ts
 
@@ -165,27 +165,27 @@ graph LR
 
 - モジュール内依存: bot-context, bot-queries, constants, helpers
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, ../../../node_modules/.bun/prismarine-viewer@1.33.0/node_modules/prismarine-viewer/index.js, prismarine-entity
 
 ### bot-context.ts
 
 - モジュール内依存: helpers
 - 他モジュール依存: observability, shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js
 
 ### bot-queries.ts
 
 - モジュール内依存: helpers
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, prismarine-entity, vec3
 
 ### constants.ts
 
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs
 
 ### error-context.ts
 
 - モジュール内依存: bot-queries, helpers
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js
 
 ### helpers.ts
 
@@ -213,12 +213,12 @@ graph LR
 
 - モジュール内依存: actions/index, bot-context, bot-queries, job-manager, state-summary, stuck-recovery
 - 他モジュール依存: observability, shared
-- 外部依存: .bun, @modelcontextprotocol/sdk/server/mcp.js
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, @modelcontextprotocol/sdk/server/mcp.js
 
 ### reactive-layer.ts
 
 - モジュール内依存: actions/survival/food, bot-context, helpers
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/mineflayer-pathfinder@2.4.5/node_modules/mineflayer-pathfinder/index.js, ../../../node_modules/.bun/mineflayer@4.35.0/node_modules/mineflayer/index.js, prismarine-entity
 
 ### server.ts
 

--- a/packages/scheduling/DEPS.md
+++ b/packages/scheduling/DEPS.md
@@ -23,7 +23,7 @@ graph LR
 
 - モジュール内依存: heartbeat-helpers
 - 他モジュール依存: shared
-- 外部依存: .bun, fs, path
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs, fs, path
 
 ### heartbeat-helpers.ts
 

--- a/packages/shared/DEPS.md
+++ b/packages/shared/DEPS.md
@@ -27,7 +27,7 @@ graph LR
 
 ### emotion.ts
 
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs
 
 ### functions.ts
 
@@ -44,7 +44,7 @@ graph LR
 ### tts.ts
 
 - モジュール内依存: emotion
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs
 
 ### types.ts
 
@@ -53,4 +53,4 @@ graph LR
 ### ws-protocol.ts
 
 - モジュール内依存: emotion
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/zod@4.3.6/node_modules/zod/index.cjs

--- a/packages/store/DEPS.md
+++ b/packages/store/DEPS.md
@@ -23,7 +23,7 @@ graph LR
 ### db.ts
 
 - モジュール内依存: schema
-- 外部依存: .bun, bun:sqlite, fs, path
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/bun-sqlite/index.js, bun:sqlite, fs, path
 
 ### event-buffer.ts
 
@@ -33,19 +33,19 @@ graph LR
 ### mc-bridge.ts
 
 - モジュール内依存: db, schema
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs
 
 ### mood-store.ts
 
 - モジュール内依存: db, schema
 - 他モジュール依存: shared
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs
 
 ### queries.ts
 
 - モジュール内依存: db, schema
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/index.cjs
 
 ### schema.ts
 
-- 外部依存: .bun
+- 外部依存: ../../../node_modules/.bun/drizzle-orm@0.45.1/node_modules/drizzle-orm/sqlite-core/index.js


### PR DESCRIPTION
## Summary

- §3.6 マルチテナント分離の Memory 分離記述を更新
- `MemoryNamespace` の 2 バリアント（`discord-guild` / `internal`）を明記
- 各 namespace の DB パスルール（`guilds/{guildId}/memory.db`, `internal/memory.db`）を追記

Closes #500

## Test plan

- [x] ドキュメント変更のみ（コード変更なし）
- [x] 実装（`packages/shared/src/namespace.ts`）と整合性を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)