### PR TITLE
fix(ci): bun.lock に listening ワークスペースを追加

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,9 @@
         "discord.js": "^14.19.3",
       },
     },
+    "packages/listening": {
+      "name": "@vicissitude/listening",
+    },
     "packages/mcp": {
       "name": "@vicissitude/mcp",
       "dependencies": {
@@ -607,6 +610,8 @@
     "@vicissitude/gateway": ["@vicissitude/gateway@workspace:packages/gateway"],
 
     "@vicissitude/infrastructure": ["@vicissitude/infrastructure@workspace:packages/infrastructure"],
+
+    "@vicissitude/listening": ["@vicissitude/listening@workspace:packages/listening"],
 
     "@vicissitude/mcp": ["@vicissitude/mcp@workspace:packages/mcp"],
 


### PR DESCRIPTION
## Summary
- `packages/listening` ワークスペース追加時に `bun.lock` が更新されておらず、CI の `--frozen-lockfile` が失敗していた
- `bun install` で lockfile を再生成

## Test plan
- [ ] CI の `bun install --frozen-lockfile` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)