### PR TITLE
fix(mcp): #502 memory tools の internal namespace 対応

### DIFF
--- a/apps/web/DEPS.md
+++ b/apps/web/DEPS.md
@@ -13,6 +13,9 @@ graph LR
   lib_audio_player["lib/audio-player"]
   lib_ws_client["lib/ws-client"]
   main.tsx --> index.css
+  main.tsx --> routeTree.gen
+  routeTree.gen --> routes___root.tsx["routes/__root.tsx"]
+  routeTree.gen --> routes_index.tsx["routes/index.tsx"]
   routes___root.tsx["routes/__root.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_avatar_VrmViewer.tsx["components/avatar/VrmViewer.tsx"]
   routes_index.tsx["routes/index.tsx"] --> components_chat_ChatPanel.tsx["components/chat/ChatPanel.tsx"]
@@ -46,8 +49,12 @@ graph LR
 
 ### main.tsx.ts
 
-- モジュール内依存: index.css
-- 外部依存: ./routeTree.gen, .bun
+- モジュール内依存: index.css, routeTree.gen
+- 外部依存: .bun
+
+### routeTree.gen.ts
+
+- モジュール内依存: routes/\_\_root.tsx, routes/index.tsx
 
 ### routes/\_\_root.tsx.ts
 

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -87,8 +87,8 @@ graph LR
 ### apps/web
 
 - 内部依存: shared
-- 外部依存: ./routeTree.gen, .bun, three/addons/loaders/GLTFLoader.js
-- ファイル数: 9
+- 外部依存: .bun, three/addons/loaders/GLTFLoader.js
+- ファイル数: 10
 
 ### avatar
 

--- a/packages/mcp/src/tools/memory.ts
+++ b/packages/mcp/src/tools/memory.ts
@@ -27,12 +27,10 @@ export function registerMemoryTools(
 	boundNamespace?: MemoryNamespace,
 ): void {
 	const { getOrCreateMemory } = deps;
-	const boundGuildId =
-		boundNamespace?.surface === "discord-guild" ? boundNamespace.guildId : undefined;
-
 	function resolveNamespace(guildIdInput: string | undefined): MemoryNamespace | null {
+		if (boundNamespace) return boundNamespace;
 		if (guildIdInput) return discordGuildNamespace(guildIdInput);
-		return boundNamespace ?? null;
+		return null;
 	}
 
 	server.registerTool(
@@ -41,7 +39,7 @@ export function registerMemoryTools(
 			description:
 				"クエリに関連する長期記憶をハイブリッド検索（テキスト＋ベクトル＋FSRS リランキング）で取得する",
 			inputSchema: {
-				...(boundGuildId ? {} : { guild_id: guildIdSchema }),
+				...(boundNamespace ? {} : { guild_id: guildIdSchema }),
 				query: z.string().min(1).describe("検索クエリ"),
 				limit: z.number().min(1).max(50).optional().describe("最大取得件数（デフォルト: 10）"),
 			},
@@ -51,7 +49,7 @@ export function registerMemoryTools(
 				const ns = resolveNamespace(guild_id);
 				if (!ns) {
 					return {
-						content: [{ type: "text" as const, text: "Error: guild_id is required" }],
+						content: [{ type: "text" as const, text: "Error: namespace could not be resolved" }],
 						isError: true,
 					};
 				}
@@ -103,7 +101,7 @@ export function registerMemoryTools(
 		{
 			description: "蓄積されたファクト（意味記憶）一覧を取得する",
 			inputSchema: {
-				...(boundGuildId ? {} : { guild_id: guildIdSchema }),
+				...(boundNamespace ? {} : { guild_id: guildIdSchema }),
 				category: z
 					.enum([
 						"identity",
@@ -138,7 +136,7 @@ export function registerMemoryTools(
 				const ns = resolveNamespace(guild_id);
 				if (!ns) {
 					return {
-						content: [{ type: "text" as const, text: "Error: guild_id is required" }],
+						content: [{ type: "text" as const, text: "Error: namespace could not be resolved" }],
 						isError: true,
 					};
 				}

--- a/packages/shared/src/namespace.ts
+++ b/packages/shared/src/namespace.ts
@@ -73,6 +73,9 @@ export function resolveNamespaceFromAgentId(
 	if (m?.[1] && GUILD_ID_RE.test(m[1])) {
 		return { surface: "discord-guild", guildId: m[1] };
 	}
+	if (/^internal(?::.+)?$/.test(agentId)) {
+		return INTERNAL_NAMESPACE;
+	}
 	return null;
 }
 

--- a/spec/memory/namespace.spec.ts
+++ b/spec/memory/namespace.spec.ts
@@ -45,7 +45,7 @@
  *   // agent_id → namespace の解決
  *   //   "discord:heartbeat:{guildId}" → discord-guild
  *   //   "discord:{guildId}"           → discord-guild
- *   //   "internal:*" 等（未定義）     → null（呼び出し元で fallback）
+ *   //   "internal:*" / "internal"     → internal
  *   export function resolveNamespaceFromAgentId(
  *     agentId: string | null | undefined,
  *   ): MemoryNamespace | null;
@@ -173,6 +173,18 @@ describe("resolveNamespaceFromAgentId", () => {
 		expect(resolveNamespaceFromAgentId("discord:heartbeat:abc")).toBeNull();
 		expect(resolveNamespaceFromAgentId("discord:../malicious")).toBeNull();
 	});
+
+	it("'internal:listening' を INTERNAL_NAMESPACE に解決する", () => {
+		expect(resolveNamespaceFromAgentId("internal:listening")).toEqual(INTERNAL_NAMESPACE);
+	});
+
+	it("'internal:any-suffix' を INTERNAL_NAMESPACE に解決する", () => {
+		expect(resolveNamespaceFromAgentId("internal:any-suffix")).toEqual(INTERNAL_NAMESPACE);
+	});
+
+	it("'internal'（suffix なし）を INTERNAL_NAMESPACE に解決する", () => {
+		expect(resolveNamespaceFromAgentId("internal")).toEqual(INTERNAL_NAMESPACE);
+	});
 });
 
 describe("defaultSubject", () => {
@@ -226,13 +238,11 @@ describe("core-server adapter 契約（resolveNamespaceFromAgentId fallback）",
 		}
 	});
 
-	it("将来の internal agent_id（仮）→ boundNamespace は設定、boundGuildId は undefined", () => {
-		// 現状 resolveNamespaceFromAgentId は internal を解決しないため、
-		// この契約は INTERNAL_NAMESPACE を直接与えた場合の挙動を検証する。
-		const ns: MemoryNamespace = INTERNAL_NAMESPACE;
-		const boundNamespace = ns;
-		const boundGuildId = ns.surface === "discord-guild" ? ns.guildId : undefined;
-
+	it("internal agent_id → boundNamespace は INTERNAL_NAMESPACE, boundGuildId は undefined", () => {
+		const ns = resolveNamespaceFromAgentId("internal:listening");
+		expect(ns).not.toBeNull();
+		const boundNamespace = ns ?? undefined;
+		const boundGuildId = ns?.surface === "discord-guild" ? ns.guildId : undefined;
 		expect(boundNamespace).toEqual(INTERNAL_NAMESPACE);
 		expect(boundGuildId).toBeUndefined();
 	});
@@ -256,6 +266,36 @@ describe("recorder subject 導出契約（defaultSubject）", () => {
 		// HUA_SELF_SUBJECT は validateUserId の制約を満たす
 		expect(HUA_SELF_SUBJECT.length).toBeGreaterThan(0);
 		expect(HUA_SELF_SUBJECT.length).toBeLessThanOrEqual(256);
+	});
+});
+
+describe("registerMemoryTools: boundNamespace による guild_id スキーマ省略契約", () => {
+	// これらは registerMemoryTools の inputSchema 生成ロジックの契約。
+	// 実際のスキーマ検証は integration test のスコープ。
+
+	// 契約 1: boundNamespace が INTERNAL_NAMESPACE の場合、
+	//   guild_id フィールドは inputSchema に含まれない。
+	//   → 内部エージェントは guild_id を指定せずに memory ツールを呼べる。
+
+	// 契約 2: boundNamespace が discordGuildNamespace("123") の場合、
+	//   guild_id フィールドは inputSchema に含まれない。
+	//   → guild-bound なエージェントも guild_id を省略できる。
+
+	// 契約 3: boundNamespace が undefined の場合、
+	//   guild_id が必須フィールドとして inputSchema に含まれる。
+	//   → unbound なエージェントは guild_id を明示的に指定する必要がある。
+
+	it("boundNamespace の有無で guild_id スキーマが切り替わる前提条件", () => {
+		// INTERNAL_NAMESPACE は discord-guild ではないので boundGuildId は undefined
+		const internalBoundGuildId =
+			INTERNAL_NAMESPACE.surface === "discord-guild" ? INTERNAL_NAMESPACE.guildId : undefined;
+		expect(internalBoundGuildId).toBeUndefined();
+
+		// discord-guild namespace は boundGuildId が設定される
+		const discordNs = discordGuildNamespace("123");
+		const discordBoundGuildId =
+			discordNs.surface === "discord-guild" ? discordNs.guildId : undefined;
+		expect(discordBoundGuildId).toBe("123");
 	});
 });
 


### PR DESCRIPTION
## Summary

- `resolveNamespaceFromAgentId` に `internal:*` / `internal` パターンを追加し、`INTERNAL_NAMESPACE` に解決するようにした
- `registerMemoryTools` の `guild_id` スキーマ省略判定を `boundGuildId` から `boundNamespace` ベースに変更（internal namespace bound 時に不要な `guild_id` が要求されなくなる）
- `resolveNamespace` 関数を `boundNamespace` 優先に変更
- エラーメッセージを `"Error: guild_id is required"` → `"Error: namespace could not be resolved"` に汎用化

Closes #502

## Test plan

- [x] `nr test` — 全 1761 テスト PASS
- [x] `nr validate` — fmt:check + lint + check 通過
- [x] `spec/memory/namespace.spec.ts` に internal namespace 仕様テスト追加（4件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)