### PR TITLE
refactor: agentId プレフィックス判定ロジックの一元化 (#551)

### DIFF
--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -10,9 +10,9 @@ import {
 	INTERNAL_NAMESPACE,
 	type MemoryNamespace,
 	namespaceKey,
+	parseAgentId,
 	resolveMemoryDbDir,
 	resolveMemoryDbPath,
-	resolveNamespaceFromAgentId,
 } from "@vicissitude/memory/namespace";
 import { Retrieval } from "@vicissitude/memory/retrieval";
 import { SemanticMemory } from "@vicissitude/memory/semantic-memory";
@@ -153,7 +153,13 @@ function createServer(agentId: string | null): McpServer {
 	const rawServer = new McpServer({ name: "core", version: "1.0.0" });
 	const server = wrapServerWithMetrics(rawServer, { metrics: metricsCollector, logger });
 
-	const boundNamespace = resolveNamespaceFromAgentId(agentId) ?? undefined;
+	const parsed = parseAgentId(agentId);
+	const boundNamespace: MemoryNamespace | undefined =
+		parsed?.platform === "discord"
+			? { surface: "discord-guild", guildId: parsed.guildId }
+			: parsed?.platform === "internal"
+				? INTERNAL_NAMESPACE
+				: undefined;
 	if (agentId && !boundNamespace) {
 		logger.warn(
 			`[core-server] agent_id=${agentId} did not resolve to a known namespace — tools require explicit guild_id`,
@@ -207,7 +213,7 @@ function createServer(agentId: string | null): McpServer {
 	registerMemoryTools(server, { getOrCreateMemory }, boundNamespace);
 	registerDiscordBridgeTools(server, { db }, boundGuildId);
 
-	const isListeningAgent = agentId?.startsWith("discord:listening:");
+	const isListeningAgent = parsed?.platform === "discord" && parsed.role === "listening";
 	if (
 		isListeningAgent &&
 		process.env.SPOTIFY_CLIENT_ID &&

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -13,6 +13,7 @@ import {
 	parseAgentId,
 	resolveMemoryDbDir,
 	resolveMemoryDbPath,
+	resolveNamespaceFromAgentId,
 } from "@vicissitude/memory/namespace";
 import { Retrieval } from "@vicissitude/memory/retrieval";
 import { SemanticMemory } from "@vicissitude/memory/semantic-memory";
@@ -155,11 +156,7 @@ function createServer(agentId: string | null): McpServer {
 
 	const parsed = parseAgentId(agentId);
 	const boundNamespace: MemoryNamespace | undefined =
-		parsed?.platform === "discord"
-			? { surface: "discord-guild", guildId: parsed.guildId }
-			: parsed?.platform === "internal"
-				? INTERNAL_NAMESPACE
-				: undefined;
+		resolveNamespaceFromAgentId(agentId) ?? undefined;
 	if (agentId && !boundNamespace) {
 		logger.warn(
 			`[core-server] agent_id=${agentId} did not resolve to a known namespace — tools require explicit guild_id`,

--- a/packages/memory/src/namespace.ts
+++ b/packages/memory/src/namespace.ts
@@ -16,8 +16,11 @@ export {
 	HUA_SELF_SUBJECT,
 	INTERNAL_NAMESPACE,
 	namespaceKey,
+	parseAgentId,
 	resolveMemoryDbDir,
 	resolveMemoryDbPath,
 	resolveNamespaceFromAgentId,
+	type DiscordAgentRole,
 	type MemoryNamespace,
+	type ParsedAgentId,
 } from "@vicissitude/shared/namespace";

--- a/packages/shared/src/namespace.ts
+++ b/packages/shared/src/namespace.ts
@@ -60,6 +60,32 @@ export function namespaceKey(namespace: MemoryNamespace): string {
 	}
 }
 
+/** Discord agentId のエージェント種別 */
+export type DiscordAgentRole = "polling" | "heartbeat" | "listening";
+
+/** agentId のパース結果 */
+export type ParsedAgentId =
+	| { readonly platform: "discord"; readonly role: DiscordAgentRole; readonly guildId: string }
+	| { readonly platform: "internal" }
+	| null;
+
+/**
+ * agentId を解析してプラットフォーム・ロール・guildId を返す。
+ * 未知のプレフィックス・null/undefined/空文字・不正形式は null を返す。
+ */
+export function parseAgentId(agentId: string | null | undefined): ParsedAgentId {
+	if (!agentId) return null;
+	if (/^internal(?::.+)?$/.test(agentId)) {
+		return { platform: "internal" };
+	}
+	const m = agentId.match(/^discord:(?:(heartbeat|listening):)?(.+)$/);
+	if (m?.[2] && GUILD_ID_RE.test(m[2])) {
+		const role: DiscordAgentRole = (m[1] as DiscordAgentRole) ?? "polling";
+		return { platform: "discord", role, guildId: m[2] };
+	}
+	return null;
+}
+
 /**
  * agent_id から namespace を解決する。
  * 未知のプレフィックス・null/undefined/空文字・不正形式は null を返す
@@ -68,15 +94,14 @@ export function namespaceKey(namespace: MemoryNamespace): string {
 export function resolveNamespaceFromAgentId(
 	agentId: string | null | undefined,
 ): MemoryNamespace | null {
-	if (!agentId) return null;
-	const m = agentId.match(/^discord:(?:heartbeat:|listening:)?(.+)$/);
-	if (m?.[1] && GUILD_ID_RE.test(m[1])) {
-		return { surface: "discord-guild", guildId: m[1] };
+	const parsed = parseAgentId(agentId);
+	if (!parsed) return null;
+	switch (parsed.platform) {
+		case "discord":
+			return { surface: "discord-guild", guildId: parsed.guildId };
+		case "internal":
+			return INTERNAL_NAMESPACE;
 	}
-	if (/^internal(?::.+)?$/.test(agentId)) {
-		return INTERNAL_NAMESPACE;
-	}
-	return null;
 }
 
 /**

--- a/packages/shared/src/namespace.ts
+++ b/packages/shared/src/namespace.ts
@@ -80,7 +80,7 @@ export function parseAgentId(agentId: string | null | undefined): ParsedAgentId 
 	}
 	const m = agentId.match(/^discord:(?:(heartbeat|listening):)?(.+)$/);
 	if (m?.[2] && GUILD_ID_RE.test(m[2])) {
-		const role: DiscordAgentRole = (m[1] as DiscordAgentRole) ?? "polling";
+		const role = (m[1] ?? "polling") as DiscordAgentRole;
 		return { platform: "discord", role, guildId: m[2] };
 	}
 	return null;


### PR DESCRIPTION
## Summary
- `parseAgentId()` を `shared/namespace` に追加し、agentId のパースを single source of truth に集約
- `resolveNamespaceFromAgentId()` を `parseAgentId()` のラッパーにリファクタ（公開 API 維持）
- `core-server.ts` の `isListeningAgent` 判定を `startsWith` から `parseAgentId` ベースの型安全な判定に変更
- `DiscordAgentRole`, `ParsedAgentId` 型を export

## Test plan
- [x] 既存 namespace spec テスト全 32 件通過
- [x] 全 spec テスト 1325 件通過
- [x] validate (fmt:check + lint + check) 通過
- [ ] CI 通過

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)