### PR TITLE
fix(observability): agent 無応答時の診断ログ追加

### DIFF
--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -164,6 +164,9 @@ export class AgentRunner implements AiAgent {
 				await this.ensureSessionStarted(signal);
 				if (!this.sessionWatch) {
 					if (signal.aborted) return;
+					this.logger.warn(
+						`[${this.profile.name}:${this.agentId}] ensureSessionStarted returned without sessionWatch (not aborted)`,
+					);
 					continue;
 				}
 
@@ -171,9 +174,15 @@ export class AgentRunner implements AiAgent {
 				// sessionWatch は通常返らない。返るのは session.error / session.compacted /
 				// signal abort / stream タイムアウト（5分間イベントなし）のいずれか。
 				// セッションの異常検知は hang detection timer (startHangDetectionTimer) が担う。
+				this.logger.info(
+					`[${this.profile.name}:${this.agentId}] sessionWatch started, waiting for session end event...`,
+				);
 				// eslint-disable-next-line no-await-in-loop -- monitor the active session until it ends
 				const event = await this.sessionWatch;
 				this.sessionWatch = null;
+				this.logger.info(
+					`[${this.profile.name}:${this.agentId}] sessionWatch resolved: type=${event.type}${event.type === "error" ? ` message=${event.message}` : ""}`,
+				);
 				if (signal.aborted) return;
 				this.handleSessionEnd(event);
 				if (event.type === "cancelled") return;
@@ -220,6 +229,9 @@ export class AgentRunner implements AiAgent {
 			this.lastRotationRequestAt &&
 			now - this.lastRotationRequestAt < this.minRotationIntervalMs
 		) {
+			this.logger.debug(
+				`[${this.profile.name}:${this.agentId}] session rotation throttled (${now - this.lastRotationRequestAt}ms since last)`,
+			);
 			return;
 		}
 		this.lastRotationRequestAt = now;
@@ -291,19 +303,31 @@ export class AgentRunner implements AiAgent {
 	private async ensureSessionStarted(signal: AbortSignal): Promise<void> {
 		if (this.sessionWatch) return;
 		if (this.hasStartedSession && this.profile.restartPolicy === "immediate") {
-			this.logger.info(`[${this.profile.name}:${this.agentId}] restarting long-lived session`);
+			this.logger.info(
+				`[${this.profile.name}:${this.agentId}] restarting long-lived session (restartPolicy=immediate)`,
+			);
 			await this.startLongLivedSession(signal);
 			return;
 		}
 
-		this.logger.info(`[${this.profile.name}:${this.agentId}] waiting for events...`);
+		this.logger.info(
+			`[${this.profile.name}:${this.agentId}] waiting for events... (hasStartedSession=${this.hasStartedSession}, restartPolicy=${this.profile.restartPolicy})`,
+		);
 		this.lastWaitForEventsAt = Date.now();
 		await this.eventBuffer.waitForEvents(signal);
 		this.lastWaitForEventsAt = Date.now();
-		if (signal.aborted) return;
+		if (signal.aborted) {
+			this.logger.info(`[${this.profile.name}:${this.agentId}] waitForEvents aborted`);
+			return;
+		}
 		this.logger.info(`[${this.profile.name}:${this.agentId}] events detected, starting session`);
 		await this.startLongLivedSession(signal);
-		if (signal.aborted || !this.sessionWatch) return;
+		if (signal.aborted || !this.sessionWatch) {
+			this.logger.warn(
+				`[${this.profile.name}:${this.agentId}] startLongLivedSession failed (aborted=${signal.aborted}, sessionWatch=${!!this.sessionWatch})`,
+			);
+			return;
+		}
 		this.hasStartedSession = true;
 	}
 

--- a/packages/mcp/src/tools/event-buffer.test.ts
+++ b/packages/mcp/src/tools/event-buffer.test.ts
@@ -118,6 +118,8 @@ describe("wait_for_events × SkipTracker", () => {
 		expect(logger.info).toHaveBeenCalledTimes(1);
 		// タイムアウト時は pendingResponse をセットしないので false のまま
 		expect(skipTracker.pendingResponse).toBe(false);
+		// 1回スキップされたことが記録される
+		expect(skipTracker.consecutiveSkips).toBe(1);
 	});
 
 	test("タイムアウト時は pendingResponse をセットしない", async () => {

--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -308,8 +308,6 @@ async function fetchRecentMessagesContext(
 	return { type: "text", text: context };
 }
 
-// ─── helpers ─────────────────────────────────────────────────────
-
 /** 文字列配列の各値の出現回数を返す */
 function countValues(values: string[]): Record<string, number> {
 	const counts: Record<string, number> = {};
@@ -365,10 +363,12 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 			if (skipTracker?.pendingResponse) {
 				const elapsed = Date.now() - skipTracker.pendingSince;
 				skipTracker.markSkipped();
-				const level = skipTracker.consecutiveSkips >= 3 ? "warn" : "info";
-				logger?.[level](
-					`[event-buffer] 前回のイベントに対する応答がスキップされました (経過=${elapsed}ms, 連続スキップ=${skipTracker.consecutiveSkips}回)`,
-				);
+				const msg = `[event-buffer] 前回のイベントに対する応答がスキップされました (経過=${elapsed}ms, 連続スキップ=${skipTracker.consecutiveSkips}回)`;
+				if (skipTracker.consecutiveSkips >= 3) {
+					logger?.warn(msg);
+				} else {
+					logger?.info(msg);
+				}
 			}
 
 			const immediate = consumeEvents(db, agentId, MAX_BATCH_SIZE);

--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -19,21 +19,41 @@ export type RecentMessagesFetcher = (channelId: string) => Promise<RecentMessage
 
 export interface SkipTracker {
 	readonly pendingResponse: boolean;
+	/** pending になった時刻（ms）。pending でなければ 0 */
+	readonly pendingSince: number;
+	/** 連続スキップ回数 */
+	readonly consecutiveSkips: number;
 	markPending(): void;
+	/** スキップとして記録してから応答済みにする（consecutiveSkips はインクリメントされる） */
+	markSkipped(): void;
 	markResponded(): void;
 }
 
 export function createSkipTracker(): SkipTracker {
-	const state = { pending: false };
+	const state = { pending: false, pendingSince: 0, consecutiveSkips: 0 };
 	return {
 		get pendingResponse() {
 			return state.pending;
 		},
+		get pendingSince() {
+			return state.pendingSince;
+		},
+		get consecutiveSkips() {
+			return state.consecutiveSkips;
+		},
 		markPending() {
 			state.pending = true;
+			state.pendingSince = Date.now();
+		},
+		markSkipped() {
+			state.consecutiveSkips += 1;
+			state.pending = false;
+			state.pendingSince = 0;
 		},
 		markResponded() {
 			state.pending = false;
+			state.pendingSince = 0;
+			state.consecutiveSkips = 0;
 		},
 	};
 }
@@ -288,6 +308,15 @@ async function fetchRecentMessagesContext(
 	return { type: "text", text: context };
 }
 
+// ─── helpers ─────────────────────────────────────────────────────
+
+/** 文字列配列の各値の出現回数を返す */
+function countValues(values: string[]): Record<string, number> {
+	const counts: Record<string, number> = {};
+	for (const v of values) counts[v] = (counts[v] ?? 0) + 1;
+	return counts;
+}
+
 // ─── registerEventBufferTools ────────────────────────────────────
 
 function buildMoodContent(moodReader: MoodReader | undefined, agentId: string): TextContent | null {
@@ -334,13 +363,21 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 			touchHeartbeat(db, agentId);
 
 			if (skipTracker?.pendingResponse) {
-				logger?.info("[event-buffer] 前回のイベントに対する応答がスキップされました");
-				skipTracker.markResponded();
+				const elapsed = Date.now() - skipTracker.pendingSince;
+				skipTracker.markSkipped();
+				const level = skipTracker.consecutiveSkips >= 3 ? "warn" : "info";
+				logger?.[level](
+					`[event-buffer] 前回のイベントに対する応答がスキップされました (経過=${elapsed}ms, 連続スキップ=${skipTracker.consecutiveSkips}回)`,
+				);
 			}
 
 			const immediate = consumeEvents(db, agentId, MAX_BATCH_SIZE);
 			if (immediate.length > 0) {
 				const events = parseEvents(immediate);
+				const hints = events.map((e) => (isErrorEvent(e) ? "error" : classifyActionHint(e)));
+				logger?.info(
+					`[event-buffer] ${events.length}件のイベントを即時消費 (hints=${JSON.stringify(countValues(hints))})`,
+				);
 				return buildResponseContent(events);
 			}
 
@@ -357,8 +394,13 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 			const deadline = Date.now() + timeout_seconds * 1000;
 			const result = await pollEvents(db, agentId, deadline, { onPoll });
 			if (result === null) {
+				logger?.debug(`[event-buffer] タイムアウト (${timeout_seconds}s)`);
 				return { content: [{ type: "text" as const, text: "イベントなし（タイムアウト）" }] };
 			}
+			const hints = result.map((e) => (isErrorEvent(e) ? "error" : classifyActionHint(e)));
+			logger?.info(
+				`[event-buffer] ${result.length}件のイベントをポーリング消費 (hints=${JSON.stringify(countValues(hints))})`,
+			);
 			return buildResponseContent(result);
 		},
 	);

--- a/packages/store/src/event-buffer.ts
+++ b/packages/store/src/event-buffer.ts
@@ -12,6 +12,9 @@ export class SqliteEventBuffer implements EventBuffer {
 
 	append(event: BufferedEvent): void {
 		appendEvent(this.db, this.agentId, JSON.stringify(event));
+		this.logger?.debug(
+			`[event-buffer:${this.agentId}] append: author=${event.authorName} content=${event.content.slice(0, 80)}`,
+		);
 	}
 
 	waitForEvents(signal: AbortSignal): Promise<void> {


### PR DESCRIPTION
## Summary

- Discord agent がメッセージ受信後に応答しない問題の原因調査用ログを追加
- `wait_for_events` MCP ツール: 消費イベント数と action hint 内訳を記録
- `SkipTracker`: 連続スキップ回数・経過時間を記録し、3回以上連続で warn レベルに昇格
- `SqliteEventBuffer`: イベント追加時のデバッグログ
- `AgentRunner`: セッション状態遷移の詳細ログ（sessionWatch の開始/終了/分岐パス）

## Background

ログ分析で判明した問題:
- `lastWaitForEvents` が 46〜82 時間前のまま（MCP heartbeat は正常）
- `前回のイベントに対する応答がスキップされました` が繰り返し発生
- LLM がイベントを受け取っても Discord に応答を返していない可能性が高い

現状のログでは「何が起きたか」は分かるが「なぜ応答しなかったか」の特定が困難。このPRで追加するログにより、次回発生時に根本原因を特定可能にする。

## Test plan

- [x] `nr test:unit` — 489 pass, 0 fail
- [x] `nr test:spec` — 1325 pass, 0 fail
- [x] `nr validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)