### PR TITLE
fix(observability): respond スキップ検知と自動セッションローテーション

### DIFF
--- a/packages/agent/src/discord/discord-agent.ts
+++ b/packages/agent/src/discord/discord-agent.ts
@@ -7,7 +7,7 @@ import type {
 } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
 import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
-import { getHeartbeat } from "@vicissitude/store/queries";
+import { consumeRotationRequest, getHeartbeat } from "@vicissitude/store/queries";
 
 import { mcpServerConfigs } from "../mcp-config.ts";
 import { AgentRunner } from "../runner.ts";
@@ -55,7 +55,10 @@ export class DiscordAgent extends AgentRunner {
 			metrics: deps.metrics,
 			contextGuildId: deps.guildId,
 			summaryWriter: deps.summaryWriter,
-			heartbeatReader: { getLastSeenAt: (id) => getHeartbeat(deps.db, id) },
+			heartbeatReader: {
+				getLastSeenAt: (id) => getHeartbeat(deps.db, id),
+				consumeRotationRequest: (id) => consumeRotationRequest(deps.db, id),
+			},
 		});
 	}
 }

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -151,8 +151,7 @@ export class AgentRunner implements AiAgent {
 			}
 
 			// MCP 側からのローテーション要求をチェック（respond スキップ閾値超過時に書き込まれる）
-			const rotationTs =
-				this.heartbeatReader?.consumeRotationRequest?.(this.agentId) ?? null;
+			const rotationTs = this.heartbeatReader?.consumeRotationRequest?.(this.agentId) ?? null;
 			if (rotationTs !== null) {
 				this.logger.warn(
 					`[${this.profile.name}:${this.agentId}] MCP respond-skip rotation request detected (requested at ${rotationTs}), rotating session`,

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -24,6 +24,8 @@ const DEFAULT_HANG_TIMEOUT_MS = 600_000;
 /** MCP プロセスが書き込むハートビートを読み取るポート */
 export interface HeartbeatReader {
 	getLastSeenAt(agentId: string): number | undefined;
+	/** MCP 側からのローテーション要求を消費する。要求があればタイムスタンプを返し、DB 側はリセットする */
+	consumeRotationRequest?(agentId: string): number | null;
 }
 
 export interface RunnerDeps {
@@ -142,6 +144,23 @@ export class AgentRunner implements AiAgent {
 				this.requestSessionRotation().catch((err) => {
 					this.logger.error(
 						`[${this.profile.name}:${this.agentId}] hang recovery rotation failed`,
+						err,
+					);
+				});
+				return;
+			}
+
+			// MCP 側からのローテーション要求をチェック（respond スキップ閾値超過時に書き込まれる）
+			const rotationTs =
+				this.heartbeatReader?.consumeRotationRequest?.(this.agentId) ?? null;
+			if (rotationTs !== null) {
+				this.logger.warn(
+					`[${this.profile.name}:${this.agentId}] MCP respond-skip rotation request detected (requested at ${rotationTs}), rotating session`,
+				);
+				this.lastWaitForEventsAt = Date.now();
+				this.requestSessionRotation().catch((err) => {
+					this.logger.error(
+						`[${this.profile.name}:${this.agentId}] respond-skip recovery rotation failed`,
 						err,
 					);
 				});

--- a/packages/mcp/src/tools/discord.test.ts
+++ b/packages/mcp/src/tools/discord.test.ts
@@ -268,7 +268,7 @@ describe("triggerEmotionEstimation の分岐ロジック", () => {
 describe("SkipTracker 連携", () => {
 	test("send_message が skipTracker.markResponded() を呼び pendingResponse を false にする", async () => {
 		const skipTracker = createSkipTracker();
-		skipTracker.markPending();
+		skipTracker.markPending("respond");
 
 		const tools = captureTools({
 			discordClient: createDiscordClientStub(),
@@ -282,7 +282,7 @@ describe("SkipTracker 連携", () => {
 
 	test("reply が skipTracker.markResponded() を呼び pendingResponse を false にする", async () => {
 		const skipTracker = createSkipTracker();
-		skipTracker.markPending();
+		skipTracker.markPending("respond");
 
 		const tools = captureTools({
 			discordClient: createDiscordClientStub(),

--- a/packages/mcp/src/tools/event-buffer.test.ts
+++ b/packages/mcp/src/tools/event-buffer.test.ts
@@ -107,7 +107,7 @@ describe("wait_for_events × SkipTracker", () => {
 		const db = createTestDb();
 		const skipTracker = createSkipTracker();
 		const logger = createMockLogger();
-		skipTracker.markPending();
+		skipTracker.markPending("optional");
 
 		const tools = captureEventBufferTools({ db, agentId: "agent-1", skipTracker, logger });
 		const waitForEvents = tools.get("wait_for_events")!;

--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -4,7 +4,12 @@ import { describeEmotion, isNeutralEmotion } from "@vicissitude/shared/emotion";
 import type { MoodReader } from "@vicissitude/shared/ports";
 import type { Attachment, Logger } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
-import { consumeEvents, hasEvents, requestRotation, touchHeartbeat } from "@vicissitude/store/queries";
+import {
+	consumeEvents,
+	hasEvents,
+	requestRotation,
+	touchHeartbeat,
+} from "@vicissitude/store/queries";
 import { z } from "zod";
 
 export interface RecentMessage {
@@ -420,7 +425,11 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 						logger?.error(
 							`[event-buffer] 連続respondスキップが閾値(${RESPOND_SKIP_ROTATION_THRESHOLD})に達しました。セッションローテーションを要求します`,
 						);
-						requestRotation(db, agentId);
+						try {
+							requestRotation(db, agentId);
+						} catch (err) {
+							logger?.error("[event-buffer] requestRotation failed", err);
+						}
 					}
 				} else if (skipTracker.consecutiveSkips >= 3) {
 					logger?.warn(msg);

--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -4,7 +4,7 @@ import { describeEmotion, isNeutralEmotion } from "@vicissitude/shared/emotion";
 import type { MoodReader } from "@vicissitude/shared/ports";
 import type { Attachment, Logger } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
-import { consumeEvents, hasEvents, touchHeartbeat } from "@vicissitude/store/queries";
+import { consumeEvents, hasEvents, requestRotation, touchHeartbeat } from "@vicissitude/store/queries";
 import { z } from "zod";
 
 export interface RecentMessage {
@@ -23,14 +23,24 @@ export interface SkipTracker {
 	readonly pendingSince: number;
 	/** 連続スキップ回数 */
 	readonly consecutiveSkips: number;
-	markPending(): void;
+	/** 連続で respond イベントがスキップされた回数 */
+	readonly consecutiveRespondSkips: number;
+	/** pending 中のイベントに含まれる最も優先度の高い ActionHint。pending でなければ null */
+	readonly pendingHint: ActionHint | null;
+	markPending(hint: ActionHint): void;
 	/** スキップとして記録してから応答済みにする（consecutiveSkips はインクリメントされる） */
 	markSkipped(): void;
 	markResponded(): void;
 }
 
 export function createSkipTracker(): SkipTracker {
-	const state = { pending: false, pendingSince: 0, consecutiveSkips: 0 };
+	const state = {
+		pending: false,
+		pendingSince: 0,
+		consecutiveSkips: 0,
+		consecutiveRespondSkips: 0,
+		pendingHint: null as ActionHint | null,
+	};
 	return {
 		get pendingResponse() {
 			return state.pending;
@@ -41,22 +51,38 @@ export function createSkipTracker(): SkipTracker {
 		get consecutiveSkips() {
 			return state.consecutiveSkips;
 		},
-		markPending() {
+		get consecutiveRespondSkips() {
+			return state.consecutiveRespondSkips;
+		},
+		get pendingHint() {
+			return state.pendingHint;
+		},
+		markPending(hint: ActionHint) {
 			state.pending = true;
 			state.pendingSince = Date.now();
+			state.pendingHint = hint;
 		},
 		markSkipped() {
 			state.consecutiveSkips += 1;
+			if (state.pendingHint === "respond") {
+				state.consecutiveRespondSkips += 1;
+			}
 			state.pending = false;
 			state.pendingSince = 0;
+			state.pendingHint = null;
 		},
 		markResponded() {
 			state.pending = false;
 			state.pendingSince = 0;
 			state.consecutiveSkips = 0;
+			state.consecutiveRespondSkips = 0;
+			state.pendingHint = null;
 		},
 	};
 }
+
+/** 連続 respond スキップでセッションローテーションを要求する閾値 */
+export const RESPOND_SKIP_ROTATION_THRESHOLD = 2;
 
 export interface EventBufferDeps {
 	db: StoreDb;
@@ -308,6 +334,26 @@ async function fetchRecentMessagesContext(
 	return { type: "text", text: context };
 }
 
+const HINT_PRIORITY: Record<ActionHint, number> = {
+	respond: 3,
+	optional: 2,
+	read_only: 1,
+	internal: 0,
+};
+
+/** EventOrError 配列から最も優先度の高い ActionHint を返す */
+export function highestPriorityHint(events: EventOrError[]): ActionHint {
+	let best: ActionHint = "internal";
+	for (const e of events) {
+		if (isErrorEvent(e)) continue;
+		const hint = classifyActionHint(e);
+		if (HINT_PRIORITY[hint] > HINT_PRIORITY[best]) {
+			best = hint;
+		}
+	}
+	return best;
+}
+
 /** 文字列配列の各値の出現回数を返す */
 function countValues(values: string[]): Record<string, number> {
 	const counts: Record<string, number> = {};
@@ -344,7 +390,10 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 		}
 		const moodContent = buildMoodContent(moodReader, moodKey);
 		if (moodContent) content.unshift(moodContent);
-		skipTracker?.markPending();
+		if (skipTracker) {
+			const highestHint = highestPriorityHint(events);
+			skipTracker.markPending(highestHint);
+		}
 		return { content };
 	}
 
@@ -362,9 +411,18 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 
 			if (skipTracker?.pendingResponse) {
 				const elapsed = Date.now() - skipTracker.pendingSince;
+				const skippedHint = skipTracker.pendingHint;
 				skipTracker.markSkipped();
-				const msg = `[event-buffer] 前回のイベントに対する応答がスキップされました (経過=${elapsed}ms, 連続スキップ=${skipTracker.consecutiveSkips}回)`;
-				if (skipTracker.consecutiveSkips >= 3) {
+				const msg = `[event-buffer] 前回のイベントに対する応答がスキップされました (hint=${skippedHint}, 経過=${elapsed}ms, 連続スキップ=${skipTracker.consecutiveSkips}回, 連続respondスキップ=${skipTracker.consecutiveRespondSkips}回)`;
+				if (skippedHint === "respond") {
+					logger?.error(msg);
+					if (skipTracker.consecutiveRespondSkips >= RESPOND_SKIP_ROTATION_THRESHOLD) {
+						logger?.error(
+							`[event-buffer] 連続respondスキップが閾値(${RESPOND_SKIP_ROTATION_THRESHOLD})に達しました。セッションローテーションを要求します`,
+						);
+						requestRotation(db, agentId);
+					}
+				} else if (skipTracker.consecutiveSkips >= 3) {
 					logger?.warn(msg);
 				} else {
 					logger?.info(msg);

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -65,7 +65,8 @@ CREATE TABLE IF NOT EXISTS mood_state (
 
 CREATE TABLE IF NOT EXISTS agent_heartbeat (
 	agent_id TEXT PRIMARY KEY,
-	last_seen_at INTEGER NOT NULL
+	last_seen_at INTEGER NOT NULL,
+	rotation_requested_at INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS mc_session_lock (
@@ -109,6 +110,21 @@ function migrateDb(sqlite: Database): void {
 		}
 		if (!columns.some((c) => c.name === "connected_at")) {
 			sqlite.exec("ALTER TABLE mc_session_lock ADD COLUMN connected_at INTEGER");
+		}
+	}
+
+	// agent_heartbeat: rotation_requested_at カラム追加
+	const hasHeartbeat = sqlite
+		.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='agent_heartbeat'")
+		.get();
+	if (hasHeartbeat) {
+		const columns = sqlite.prepare("PRAGMA table_info(agent_heartbeat)").all() as {
+			name: string;
+		}[];
+		if (!columns.some((c) => c.name === "rotation_requested_at")) {
+			sqlite.exec(
+				"ALTER TABLE agent_heartbeat ADD COLUMN rotation_requested_at INTEGER NOT NULL DEFAULT 0",
+			);
 		}
 	}
 

--- a/packages/store/src/queries.ts
+++ b/packages/store/src/queries.ts
@@ -119,31 +119,30 @@ export function getHeartbeat(db: StoreDb, agentId: string): number | undefined {
 	return row?.lastSeenAt;
 }
 
-/** MCP 側からセッションローテーションを要求する */
+/** MCP 側からセッションローテーションを要求する。行が存在しない場合は no-op（touchHeartbeat で先に作成されている前提） */
 export function requestRotation(db: StoreDb, agentId: string): void {
 	const now = Date.now();
-	db.insert(agentHeartbeat)
-		.values({ agentId, lastSeenAt: now, rotationRequestedAt: now })
-		.onConflictDoUpdate({
-			target: agentHeartbeat.agentId,
-			set: { rotationRequestedAt: now },
-		})
+	db.update(agentHeartbeat)
+		.set({ rotationRequestedAt: now })
+		.where(eq(agentHeartbeat.agentId, agentId))
 		.run();
 }
 
 /** ローテーション要求を消費する。要求があった場合はタイムスタンプを返し 0 にリセットする */
 export function consumeRotationRequest(db: StoreDb, agentId: string): number | null {
-	const row = db
-		.select({ rotationRequestedAt: agentHeartbeat.rotationRequestedAt })
-		.from(agentHeartbeat)
-		.where(eq(agentHeartbeat.agentId, agentId))
-		.get();
-	if (!row || row.rotationRequestedAt === 0) return null;
-	db.update(agentHeartbeat)
-		.set({ rotationRequestedAt: 0 })
-		.where(eq(agentHeartbeat.agentId, agentId))
-		.run();
-	return row.rotationRequestedAt;
+	return db.transaction((tx) => {
+		const row = tx
+			.select({ rotationRequestedAt: agentHeartbeat.rotationRequestedAt })
+			.from(agentHeartbeat)
+			.where(eq(agentHeartbeat.agentId, agentId))
+			.get();
+		if (!row || row.rotationRequestedAt === 0) return null;
+		tx.update(agentHeartbeat)
+			.set({ rotationRequestedAt: 0 })
+			.where(eq(agentHeartbeat.agentId, agentId))
+			.run();
+		return row.rotationRequestedAt;
+	});
 }
 
 /** 使用頻度トップ N の絵文字を返す */

--- a/packages/store/src/queries.ts
+++ b/packages/store/src/queries.ts
@@ -119,6 +119,33 @@ export function getHeartbeat(db: StoreDb, agentId: string): number | undefined {
 	return row?.lastSeenAt;
 }
 
+/** MCP 側からセッションローテーションを要求する */
+export function requestRotation(db: StoreDb, agentId: string): void {
+	const now = Date.now();
+	db.insert(agentHeartbeat)
+		.values({ agentId, lastSeenAt: now, rotationRequestedAt: now })
+		.onConflictDoUpdate({
+			target: agentHeartbeat.agentId,
+			set: { rotationRequestedAt: now },
+		})
+		.run();
+}
+
+/** ローテーション要求を消費する。要求があった場合はタイムスタンプを返し 0 にリセットする */
+export function consumeRotationRequest(db: StoreDb, agentId: string): number | null {
+	const row = db
+		.select({ rotationRequestedAt: agentHeartbeat.rotationRequestedAt })
+		.from(agentHeartbeat)
+		.where(eq(agentHeartbeat.agentId, agentId))
+		.get();
+	if (!row || row.rotationRequestedAt === 0) return null;
+	db.update(agentHeartbeat)
+		.set({ rotationRequestedAt: 0 })
+		.where(eq(agentHeartbeat.agentId, agentId))
+		.run();
+	return row.rotationRequestedAt;
+}
+
 /** 使用頻度トップ N の絵文字を返す */
 export function getTopEmojis(
 	db: StoreDb,

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -39,6 +39,8 @@ export const moodState = sqliteTable("mood_state", {
 export const agentHeartbeat = sqliteTable("agent_heartbeat", {
 	agentId: text("agent_id").primaryKey(),
 	lastSeenAt: integer("last_seen_at").notNull(),
+	/** MCP 側からセッションローテーションを要求するフラグ（タイムスタンプ、0 = 要求なし） */
+	rotationRequestedAt: integer("rotation_requested_at").notNull().default(0),
 });
 
 /** MC セッション排他ロックテーブル（最大1行） */

--- a/spec/mcp/tools/event-buffer.spec.ts
+++ b/spec/mcp/tools/event-buffer.spec.ts
@@ -8,6 +8,7 @@ import {
 	formatEventMetadata,
 	formatEvents,
 	formatRecentMessages,
+	highestPriorityHint,
 	isErrorEvent,
 	parseEvents,
 	pollEvents,
@@ -199,6 +200,49 @@ describe("classifyActionHint", () => {
 			metadata: { isMentioned: true },
 		};
 		expect(classifyActionHint(event)).toBe("internal");
+	});
+});
+
+describe("highestPriorityHint", () => {
+	test("respond が1つでもあれば respond を返す", () => {
+		const events = [
+			{ ts: "t", content: "a", authorId: "u1", authorName: "A", messageId: "m1" },
+			{
+				ts: "t",
+				content: "b",
+				authorId: "u2",
+				authorName: "B",
+				messageId: "m2",
+				metadata: { isMentioned: true },
+			},
+		];
+		expect(highestPriorityHint(events)).toBe("respond");
+	});
+
+	test("respond がなく optional があれば optional を返す", () => {
+		const events = [
+			{ ts: "t", content: "a", authorId: "u1", authorName: "A", messageId: "m1" },
+		];
+		expect(highestPriorityHint(events)).toBe("optional");
+	});
+
+	test("internal のみなら internal を返す", () => {
+		const events = [
+			{ ts: "t", content: "sys", authorId: "system", authorName: "system", messageId: "s1" },
+		];
+		expect(highestPriorityHint(events)).toBe("internal");
+	});
+
+	test("空配列なら internal を返す", () => {
+		expect(highestPriorityHint([])).toBe("internal");
+	});
+
+	test("エラーイベントは無視して残りから判定する", () => {
+		const events = [
+			{ _raw: "broken", _error: "invalid JSON" },
+			{ ts: "t", content: "a", authorId: "u1", authorName: "A", messageId: "m1" },
+		];
+		expect(highestPriorityHint(events)).toBe("optional");
 	});
 });
 
@@ -650,7 +694,7 @@ describe("createSkipTracker", () => {
 
 	test("markPending() で true にした後、markResponded() で false に戻る", () => {
 		const tracker = createSkipTracker();
-		tracker.markPending();
+		tracker.markPending("optional");
 		expect(tracker.pendingResponse).toBe(true);
 
 		tracker.markResponded();
@@ -659,7 +703,7 @@ describe("createSkipTracker", () => {
 
 	test("markResponded() を連続で呼んでも pendingResponse は false のまま", () => {
 		const tracker = createSkipTracker();
-		tracker.markPending();
+		tracker.markPending("optional");
 		tracker.markResponded();
 		tracker.markResponded();
 		expect(tracker.pendingResponse).toBe(false);
@@ -683,13 +727,13 @@ describe("createSkipTracker", () => {
 
 	test("markPending() で pendingSince が 0 より大きい値にセットされる", () => {
 		const tracker = createSkipTracker();
-		tracker.markPending();
+		tracker.markPending("optional");
 		expect(tracker.pendingSince).toBeGreaterThan(0);
 	});
 
 	test("markSkipped() で consecutiveSkips がインクリメントされ、pendingResponse が false になる", () => {
 		const tracker = createSkipTracker();
-		tracker.markPending();
+		tracker.markPending("optional");
 		expect(tracker.pendingResponse).toBe(true);
 
 		tracker.markSkipped();
@@ -700,15 +744,15 @@ describe("createSkipTracker", () => {
 	test("markSkipped() → markSkipped() の連続呼び出しでカウントが累積する", () => {
 		const tracker = createSkipTracker();
 
-		tracker.markPending();
+		tracker.markPending("optional");
 		tracker.markSkipped();
 		expect(tracker.consecutiveSkips).toBe(1);
 
-		tracker.markPending();
+		tracker.markPending("optional");
 		tracker.markSkipped();
 		expect(tracker.consecutiveSkips).toBe(2);
 
-		tracker.markPending();
+		tracker.markPending("optional");
 		tracker.markSkipped();
 		expect(tracker.consecutiveSkips).toBe(3);
 	});
@@ -716,20 +760,20 @@ describe("createSkipTracker", () => {
 	test("markResponded() が consecutiveSkips を 0 にリセットする", () => {
 		const tracker = createSkipTracker();
 
-		tracker.markPending();
+		tracker.markPending("optional");
 		tracker.markSkipped();
-		tracker.markPending();
+		tracker.markPending("optional");
 		tracker.markSkipped();
 		expect(tracker.consecutiveSkips).toBe(2);
 
-		tracker.markPending();
+		tracker.markPending("optional");
 		tracker.markResponded();
 		expect(tracker.consecutiveSkips).toBe(0);
 	});
 
 	test("markSkipped() で pendingSince が 0 にリセットされる", () => {
 		const tracker = createSkipTracker();
-		tracker.markPending();
+		tracker.markPending("optional");
 		expect(tracker.pendingSince).toBeGreaterThan(0);
 
 		tracker.markSkipped();
@@ -738,11 +782,77 @@ describe("createSkipTracker", () => {
 
 	test("markResponded() で pendingSince が 0 にリセットされる", () => {
 		const tracker = createSkipTracker();
-		tracker.markPending();
+		tracker.markPending("optional");
 		expect(tracker.pendingSince).toBeGreaterThan(0);
 
 		tracker.markResponded();
 		expect(tracker.pendingSince).toBe(0);
+	});
+
+	test("初期状態は consecutiveRespondSkips === 0", () => {
+		const tracker = createSkipTracker();
+		expect(tracker.consecutiveRespondSkips).toBe(0);
+	});
+
+	test("respond hint でスキップすると consecutiveRespondSkips がインクリメントされる", () => {
+		const tracker = createSkipTracker();
+		tracker.markPending("respond");
+		tracker.markSkipped();
+		expect(tracker.consecutiveRespondSkips).toBe(1);
+		expect(tracker.consecutiveSkips).toBe(1);
+	});
+
+	test("optional hint でスキップしても consecutiveRespondSkips は増えない", () => {
+		const tracker = createSkipTracker();
+		tracker.markPending("optional");
+		tracker.markSkipped();
+		expect(tracker.consecutiveRespondSkips).toBe(0);
+		expect(tracker.consecutiveSkips).toBe(1);
+	});
+
+	test("respond → respond の連続スキップでカウントが累積する", () => {
+		const tracker = createSkipTracker();
+
+		tracker.markPending("respond");
+		tracker.markSkipped();
+		tracker.markPending("respond");
+		tracker.markSkipped();
+		expect(tracker.consecutiveRespondSkips).toBe(2);
+	});
+
+	test("respond → optional のスキップでは consecutiveRespondSkips が累積しない", () => {
+		const tracker = createSkipTracker();
+
+		tracker.markPending("respond");
+		tracker.markSkipped();
+		expect(tracker.consecutiveRespondSkips).toBe(1);
+
+		tracker.markPending("optional");
+		tracker.markSkipped();
+		expect(tracker.consecutiveRespondSkips).toBe(1);
+		expect(tracker.consecutiveSkips).toBe(2);
+	});
+
+	test("markResponded() で consecutiveRespondSkips が 0 にリセットされる", () => {
+		const tracker = createSkipTracker();
+		tracker.markPending("respond");
+		tracker.markSkipped();
+		expect(tracker.consecutiveRespondSkips).toBe(1);
+
+		tracker.markPending("optional");
+		tracker.markResponded();
+		expect(tracker.consecutiveRespondSkips).toBe(0);
+	});
+
+	test("pendingHint は markPending に渡した値を反映する", () => {
+		const tracker = createSkipTracker();
+		expect(tracker.pendingHint).toBeNull();
+
+		tracker.markPending("respond");
+		expect(tracker.pendingHint).toBe("respond");
+
+		tracker.markSkipped();
+		expect(tracker.pendingHint).toBeNull();
 	});
 });
 

--- a/spec/mcp/tools/event-buffer.spec.ts
+++ b/spec/mcp/tools/event-buffer.spec.ts
@@ -220,9 +220,7 @@ describe("highestPriorityHint", () => {
 	});
 
 	test("respond がなく optional があれば optional を返す", () => {
-		const events = [
-			{ ts: "t", content: "a", authorId: "u1", authorName: "A", messageId: "m1" },
-		];
+		const events = [{ ts: "t", content: "a", authorId: "u1", authorName: "A", messageId: "m1" }];
 		expect(highestPriorityHint(events)).toBe("optional");
 	});
 


### PR DESCRIPTION
## Summary

- LLM が `wait_for_events` で respond イベント（メンション）を消費後、`send_message` を呼ばずに無応答になる問題に対処
- SkipTracker に ActionHint 対応を追加し、respond スキップを ERROR ログで検知可能に
- 連続 respond スキップが閾値(2)に達すると、SQLite 経由で Runner にセッションローテーションを要求し自動回復

### 根本原因

1. hang detection が `mcpHeartbeat`（`wait_for_events` ポーリング中に定期更新）で常にリセットされ、応答しない LLM を検知できなかった
2. skip tracker が respond/optional を区別しておらず、メンション無応答が埋もれていた

### 変更内容

| ファイル | 変更 |
|---------|------|
| `event-buffer.ts` | SkipTracker に `pendingHint`, `consecutiveRespondSkips` 追加。respond スキップ時に ERROR ログ + rotation request |
| `runner.ts` | HeartbeatReader に `consumeRotationRequest` 追加。hang timer で rotation request を消費して自動ローテーション |
| `schema.ts` / `db.ts` | `agent_heartbeat` テーブルに `rotation_requested_at` カラム追加（マイグレーション付き） |
| `queries.ts` | `requestRotation` / `consumeRotationRequest` クエリ追加 |
| `discord-agent.ts` | `consumeRotationRequest` を HeartbeatReader に配線 |

## Test plan

- [x] `nr check` — 型チェック pass
- [x] `nr lint` — 0 errors
- [x] `nr test` — 全 1834 テスト pass
- [x] `spec/mcp/tools/event-buffer.spec.ts` に `consecutiveRespondSkips`, `pendingHint`, `highestPriorityHint` の spec 追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)