### PR TITLE
fix(logging): ログメッセージを英語に統一

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -445,7 +445,7 @@ function setupListeningScheduler(deps: {
 	const enabled = config.listening.enabled && !!config.spotify && !!config.genius;
 	if (!enabled) {
 		logger.info(
-			"[bootstrap] Listening scheduler disabled (spotify/genius 未設定 or LISTENING_ENABLED=false)",
+			"[bootstrap] Listening scheduler disabled (spotify/genius not configured or LISTENING_ENABLED=false)",
 		);
 		return undefined;
 	}

--- a/packages/application/src/heartbeat-service.ts
+++ b/packages/application/src/heartbeat-service.ts
@@ -59,14 +59,14 @@ export class HeartbeatService {
 				const sessionKey = `${HEARTBEAT_SESSION_PREFIX}${guildKey}`;
 				const prompt = buildHeartbeatPrompt(reminders);
 				this.deps.logger.info(
-					`[heartbeat] guild=${guildKey}: ${reminders.length} 件の due リマインダーを実行`,
+					`[heartbeat] guild=${guildKey}: executing ${reminders.length} due reminder(s)`,
 				);
 
 				try {
 					await this.deps.agent.send({ sessionKey, message: prompt, guildId });
 					return reminders.map((reminder) => reminder.reminder.id);
 				} catch (error) {
-					this.deps.logger.error(`[heartbeat] guild=${guildKey} AI 実行エラー:`, error);
+					this.deps.logger.error(`[heartbeat] guild=${guildKey} AI execution error:`, error);
 					return [];
 				}
 			}),

--- a/packages/scheduling/src/consolidation-scheduler.ts
+++ b/packages/scheduling/src/consolidation-scheduler.ts
@@ -24,7 +24,9 @@ export class ConsolidationScheduler {
 
 	start(): void {
 		if (this.timer || this.initialTimer) return;
-		this.logger.info("[memory-consolidation] スケジューラ開始（30分間隔、初回5分後）");
+		this.logger.info(
+			"[memory-consolidation] scheduler started (30min interval, first tick in 5min)",
+		);
 		this.initialTimer = setTimeout(() => {
 			this.initialTimer = null;
 			void this.tick();
@@ -44,12 +46,12 @@ export class ConsolidationScheduler {
 		if (this.executePromise) {
 			await this.executePromise.catch(() => {});
 		}
-		this.logger.info("[memory-consolidation] スケジューラ停止");
+		this.logger.info("[memory-consolidation] scheduler stopped");
 	}
 
 	private async tick(): Promise<void> {
 		if (this.running) {
-			this.logger.info("[memory-consolidation] 前回の実行がまだ進行中、スキップ");
+			this.logger.info("[memory-consolidation] previous tick still running, skipping");
 			return;
 		}
 
@@ -66,7 +68,7 @@ export class ConsolidationScheduler {
 			this.metrics?.incrementCounter(METRIC.MEMORY_CONSOLIDATION_TICKS, { outcome: "success" });
 		} catch (error) {
 			this.metrics?.incrementCounter(METRIC.MEMORY_CONSOLIDATION_TICKS, { outcome: "error" });
-			this.logger.error("[memory-consolidation] tick エラー:", error);
+			this.logger.error("[memory-consolidation] tick error:", error);
 		} finally {
 			const duration = (performance.now() - start) / 1000;
 			this.metrics?.observeHistogram(METRIC.MEMORY_CONSOLIDATION_TICK_DURATION, duration);
@@ -90,7 +92,7 @@ export class ConsolidationScheduler {
 	private async executeConsolidation(): Promise<void> {
 		const namespaces = this.consolidator.getActiveNamespaces();
 		if (namespaces.length === 0) {
-			this.logger.info("[memory-consolidation] アクティブな namespace なし、スキップ");
+			this.logger.info("[memory-consolidation] no active namespaces, skipping");
 			return;
 		}
 

--- a/packages/scheduling/src/heartbeat-scheduler.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.ts
@@ -33,7 +33,7 @@ export class HeartbeatScheduler {
 
 	start(): void {
 		if (this.timer) return;
-		this.logger.info("[heartbeat] スケジューラ開始（1分間隔）");
+		this.logger.info("[heartbeat] scheduler started (1min interval)");
 		void this.tick();
 		this.timer = setInterval(() => void this.tick(), HEARTBEAT_TICK_INTERVAL_MS);
 	}
@@ -43,12 +43,12 @@ export class HeartbeatScheduler {
 			clearInterval(this.timer);
 			this.timer = null;
 		}
-		this.logger.info("[heartbeat] スケジューラ停止");
+		this.logger.info("[heartbeat] scheduler stopped");
 	}
 
 	private async tick(): Promise<void> {
 		if (this.running) {
-			this.logger.info("[heartbeat] 前回の実行がまだ進行中、スキップ");
+			this.logger.info("[heartbeat] previous tick still running, skipping");
 			return;
 		}
 
@@ -60,7 +60,7 @@ export class HeartbeatScheduler {
 			this.metrics?.incrementCounter(METRIC.HEARTBEAT_TICKS, { outcome: "success" });
 		} catch (error) {
 			this.metrics?.incrementCounter(METRIC.HEARTBEAT_TICKS, { outcome: "error" });
-			this.logger.error("[heartbeat] tick エラー:", error);
+			this.logger.error("[heartbeat] tick error:", error);
 		} finally {
 			const duration = (performance.now() - start) / 1000;
 			this.metrics?.observeHistogram(METRIC.HEARTBEAT_TICK_DURATION, duration);
@@ -91,12 +91,12 @@ export class HeartbeatScheduler {
 		const dueReminders = evaluateDueReminders(config, new Date());
 		if (dueReminders.length === 0) return false;
 		this.logger.info(
-			`[heartbeat] ${String(dueReminders.length)} 件の due リマインダー: ${dueReminders.map((d) => d.reminder.id).join(", ")}`,
+			`[heartbeat] ${String(dueReminders.length)} due reminder(s): ${dueReminders.map((d) => d.reminder.id).join(", ")}`,
 		);
 
 		const succeededIds = await this.heartbeatService.execute(dueReminders);
 		if (succeededIds.size === 0) {
-			this.logger.info("[heartbeat] 成功した Guild なし、config 更新をスキップ");
+			this.logger.info("[heartbeat] no guilds succeeded, skipping config update");
 			return true;
 		}
 
@@ -107,7 +107,7 @@ export class HeartbeatScheduler {
 			}
 		}
 		await this.configRepo.save(config);
-		this.logger.info("[heartbeat] 完了");
+		this.logger.info("[heartbeat] done");
 		return true;
 	}
 }

--- a/packages/scheduling/src/listening-scheduler.test.ts
+++ b/packages/scheduling/src/listening-scheduler.test.ts
@@ -154,7 +154,9 @@ describe("ListeningScheduler — 再入防止", () => {
 
 		// 2 回目は即座に return
 		await second;
-		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("previous tick still running"));
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining("previous tick still running"),
+		);
 
 		resolveSend({ text: "", sessionId: "listening" });
 		await first;

--- a/packages/scheduling/src/listening-scheduler.test.ts
+++ b/packages/scheduling/src/listening-scheduler.test.ts
@@ -154,7 +154,7 @@ describe("ListeningScheduler — 再入防止", () => {
 
 		// 2 回目は即座に return
 		await second;
-		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("前回の実行がまだ進行中"));
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("previous tick still running"));
 
 		resolveSend({ text: "", sessionId: "listening" });
 		await first;

--- a/packages/scheduling/src/listening-scheduler.ts
+++ b/packages/scheduling/src/listening-scheduler.ts
@@ -54,7 +54,7 @@ export class ListeningScheduler {
 
 	start(): void {
 		if (this.timer) return;
-		this.logger.info("[listening] スケジューラ開始（4分間隔）");
+		this.logger.info("[listening] scheduler started (4min interval)");
 		this.timer = setInterval(() => void this.tick(), LISTENING_TICK_INTERVAL_MS);
 	}
 
@@ -66,19 +66,19 @@ export class ListeningScheduler {
 		if (this.executePromise) {
 			await this.executePromise.catch(() => {});
 		}
-		this.logger.info("[listening] スケジューラ停止");
+		this.logger.info("[listening] scheduler stopped");
 	}
 
 	private async tick(): Promise<void> {
 		if (this.running) {
-			this.logger.info("[listening] 前回の実行がまだ進行中、スキップ");
+			this.logger.info("[listening] previous tick still running, skipping");
 			return;
 		}
 		const should = this.shouldStart();
 		this.logger.debug(`[listening] tick: shouldStart=${should}`);
 		if (!should) return;
 
-		this.logger.info("[listening] tick 開始");
+		this.logger.info("[listening] tick started");
 		this.running = true;
 		const start = performance.now();
 		const execution = this.executeTick();
@@ -88,7 +88,7 @@ export class ListeningScheduler {
 			this.metrics?.incrementCounter(METRIC.LISTENING_TICKS, { outcome: "success" });
 		} catch (error) {
 			this.metrics?.incrementCounter(METRIC.LISTENING_TICKS, { outcome: "error" });
-			this.logger.error("[listening] tick エラー:", error);
+			this.logger.error("[listening] tick error:", error);
 		} finally {
 			const duration = (performance.now() - start) / 1000;
 			this.metrics?.observeHistogram(METRIC.LISTENING_TICK_DURATION, duration);
@@ -103,7 +103,7 @@ export class ListeningScheduler {
 			message: LISTENING_PROMPT,
 		});
 		this.logger.info(
-			`[listening] agent応答 (${response.text.length}文字): ${response.text.slice(0, 200)}`,
+			`[listening] agent response (${response.text.length} chars): ${response.text.slice(0, 200)}`,
 		);
 		const match = NOW_PLAYING_RE.exec(response.text);
 		if (match) {
@@ -113,7 +113,7 @@ export class ListeningScheduler {
 				this.presence.setListeningActivity(trackName);
 			}
 		} else {
-			this.logger.warn("[listening] NOW_PLAYING が応答に含まれていません");
+			this.logger.warn("[listening] NOW_PLAYING not found in response");
 		}
 	}
 }

--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -35,7 +35,7 @@ describe("ConsolidationScheduler", () => {
 
 		expect(consolidator.consolidate).not.toHaveBeenCalled();
 		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("アクティブな namespace なし"),
+			expect.stringContaining("no active namespaces"),
 		);
 	});
 
@@ -131,7 +131,7 @@ describe("ConsolidationScheduler", () => {
 		// 2 回目は即座に完了し、スキップログが出る
 		await second;
 		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("前回の実行がまだ進行中、スキップ"),
+			expect.stringContaining("previous tick still running, skipping"),
 		);
 
 		// 1 回目を完了させる
@@ -172,6 +172,6 @@ describe("ConsolidationScheduler", () => {
 		await tickPromise;
 		await stopPromise;
 
-		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("スケジューラ停止"));
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("scheduler stopped"));
 	});
 });

--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -34,9 +34,7 @@ describe("ConsolidationScheduler", () => {
 		await (scheduler as unknown as TickFn).tick();
 
 		expect(consolidator.consolidate).not.toHaveBeenCalled();
-		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("no active namespaces"),
-		);
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("no active namespaces"));
 	});
 
 	test("アクティブギルド 1 件 → consolidate 呼び出し、success メトリクス", async () => {

--- a/spec/scheduling/listening-scheduler.spec.ts
+++ b/spec/scheduling/listening-scheduler.spec.ts
@@ -188,7 +188,7 @@ describe("ListeningScheduler — 公開 API 契約", () => {
 
 		await second;
 		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("前回の実行がまだ進行中、スキップ"),
+			expect.stringContaining("previous tick still running, skipping"),
 		);
 
 		resolveSend({ text: "NOW_PLAYING: x - y", sessionId: "listening" });


### PR DESCRIPTION
## Summary
- 日本語で書かれていたログメッセージ 25 箇所を英語に変換
- 対象: `heartbeat-service`, `listening-scheduler`, `consolidation-scheduler`, `heartbeat-scheduler`, `bootstrap`
- テストのアサーション文字列も合わせて更新（5 箇所）

## Test plan
- [x] `nr validate` 通過
- [x] `nr test` 全 1834 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)