### PR TITLE
spec(store,agent): requestRotation / consumeRotationRequest / rotation request 検知の spec 追加 (#559)

### DIFF
--- a/spec/agent/hang-detection.spec.ts
+++ b/spec/agent/hang-detection.spec.ts
@@ -380,6 +380,140 @@ describe("AgentRunner ハング検知と自動ローテーション", () => {
 		});
 	});
 
+	describe("heartbeatReader.consumeRotationRequest によるローテーション要求検知", () => {
+		test("getLastSeenAt が alive でも consumeRotationRequest が非 null ならローテーションが発生する", async () => {
+			const rotationSpy = mock(() => Promise.resolve());
+			const sessionStore = createSessionStore("existing-session-id");
+
+			const eventBuffer = createEventBuffer(() => new Promise(() => {}));
+			const sessionPort = createSimpleSessionPort();
+
+			// heartbeatReader: alive だがローテーション要求あり
+			let rotationConsumed = false;
+			const heartbeatReader = {
+				getLastSeenAt: mock(() => Date.now()),
+				consumeRotationRequest: mock(() => {
+					if (!rotationConsumed) {
+						rotationConsumed = true;
+						return Date.now();
+					}
+					return null;
+				}),
+			};
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "agent-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				hangTimeoutMs: 100,
+				heartbeatReader,
+			});
+			runner.sleepSpy = () => Promise.resolve();
+			activeRunners.add(runner);
+
+			runner.requestSessionRotation = rotationSpy;
+			runner.ensurePolling();
+
+			await Bun.sleep(250);
+
+			// alive なのでハング検知はされないが、consumeRotationRequest 経由でローテーションが発生する
+			expect(rotationSpy).toHaveBeenCalledTimes(1);
+			expect(heartbeatReader.consumeRotationRequest).toHaveBeenCalled();
+
+			runner.stop();
+		});
+
+		test("consumeRotationRequest 消費後は再度ローテーションが発生しない", async () => {
+			const rotationSpy = mock(() => Promise.resolve());
+			const sessionStore = createSessionStore("existing-session-id");
+
+			const eventBuffer = createEventBuffer(() => new Promise(() => {}));
+			const sessionPort = createSimpleSessionPort();
+
+			// 1 回だけ要求を返し、以降は null
+			let consumed = false;
+			const heartbeatReader = {
+				getLastSeenAt: mock(() => Date.now()),
+				consumeRotationRequest: mock(() => {
+					if (!consumed) {
+						consumed = true;
+						return Date.now();
+					}
+					return null;
+				}),
+			};
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "agent-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				hangTimeoutMs: 100,
+				heartbeatReader,
+			});
+			runner.sleepSpy = () => Promise.resolve();
+			activeRunners.add(runner);
+
+			runner.requestSessionRotation = rotationSpy;
+			runner.ensurePolling();
+
+			// 十分待って複数回 interval が発火する
+			await Bun.sleep(250);
+
+			// 消費型なので 1 回だけローテーションが発生する
+			expect(rotationSpy).toHaveBeenCalledTimes(1);
+
+			runner.stop();
+		});
+
+		test("consumeRotationRequest が未実装（undefined）の場合、ローテーションは発生しない", async () => {
+			const rotationSpy = mock(() => Promise.resolve());
+			const sessionStore = createSessionStore("existing-session-id");
+
+			const eventBuffer = createEventBuffer(() => new Promise(() => {}));
+			const sessionPort = createSimpleSessionPort();
+
+			// consumeRotationRequest を持たない heartbeatReader
+			const heartbeatReader = {
+				getLastSeenAt: mock(() => Date.now()),
+			};
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "agent-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				hangTimeoutMs: 100,
+				heartbeatReader,
+			});
+			runner.sleepSpy = () => Promise.resolve();
+			activeRunners.add(runner);
+
+			runner.requestSessionRotation = rotationSpy;
+			runner.ensurePolling();
+
+			await Bun.sleep(250);
+
+			// heartbeat は alive、consumeRotationRequest は undefined なのでローテーションは発生しない
+			expect(rotationSpy).not.toHaveBeenCalled();
+
+			runner.stop();
+		});
+	});
+
 	describe("RunnerDeps の hangTimeoutMs 設定", () => {
 		test("hangTimeoutMs を明示的に設定できる", () => {
 			const sessionStore = createSessionStore();

--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -35,7 +35,7 @@ describe("ConsolidationScheduler", () => {
 
 		expect(consolidator.consolidate).not.toHaveBeenCalled();
 		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("アクティブな namespace なし"),
+			expect.stringContaining("no active namespaces, skipping"),
 		);
 	});
 
@@ -131,7 +131,7 @@ describe("ConsolidationScheduler", () => {
 		// 2 回目は即座に完了し、スキップログが出る
 		await second;
 		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("前回の実行がまだ進行中、スキップ"),
+			expect.stringContaining("previous tick still running, skipping"),
 		);
 
 		// 1 回目を完了させる
@@ -172,6 +172,6 @@ describe("ConsolidationScheduler", () => {
 		await tickPromise;
 		await stopPromise;
 
-		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("スケジューラ停止"));
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("scheduler stopped"));
 	});
 });

--- a/spec/scheduling/listening-scheduler.spec.ts
+++ b/spec/scheduling/listening-scheduler.spec.ts
@@ -188,7 +188,7 @@ describe("ListeningScheduler — 公開 API 契約", () => {
 
 		await second;
 		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("前回の実行がまだ進行中、スキップ"),
+			expect.stringContaining("previous tick still running, skipping"),
 		);
 
 		resolveSend({ text: "NOW_PLAYING: x - y", sessionId: "listening" });

--- a/spec/store/db.spec.ts
+++ b/spec/store/db.spec.ts
@@ -4,11 +4,13 @@ import {
 	appendEvent,
 	consumeNextEvent,
 	consumeEvents,
+	consumeRotationRequest,
 	deleteSession,
 	getHeartbeat,
 	getSession,
 	getTopEmojis,
 	incrementEmoji,
+	requestRotation,
 	saveSession,
 	touchHeartbeat,
 } from "@vicissitude/store/queries";
@@ -205,6 +207,62 @@ describe("store", () => {
 			touchHeartbeat(db, "agent-1");
 			const second = getHeartbeat(db, "agent-1");
 			expect(second).toBeGreaterThanOrEqual(first ?? 0);
+		});
+
+		test("requestRotation を呼ぶと rotation_requested_at が設定される", () => {
+			const db = createTestDb();
+			touchHeartbeat(db, "agent-1");
+			requestRotation(db, "agent-1");
+			const ts = consumeRotationRequest(db, "agent-1");
+			expect(ts).toBeTypeOf("number");
+			expect(ts).toBeGreaterThan(0);
+		});
+
+		test("consumeRotationRequest を呼ぶとタイムスタンプが返り DB 側が 0 にリセットされる", () => {
+			const db = createTestDb();
+			touchHeartbeat(db, "agent-1");
+			requestRotation(db, "agent-1");
+			const ts = consumeRotationRequest(db, "agent-1");
+			expect(ts).toBeTypeOf("number");
+			expect(ts).toBeGreaterThan(0);
+
+			// DB 側はリセットされている
+			const after = consumeRotationRequest(db, "agent-1");
+			expect(after).toBeNull();
+		});
+
+		test("consumeRotationRequest を連続で呼ぶと 2 回目以降は null を返す", () => {
+			const db = createTestDb();
+			touchHeartbeat(db, "agent-1");
+			requestRotation(db, "agent-1");
+
+			const first = consumeRotationRequest(db, "agent-1");
+			expect(first).toBeTypeOf("number");
+			expect(first).toBeGreaterThan(0);
+
+			const second = consumeRotationRequest(db, "agent-1");
+			expect(second).toBeNull();
+
+			const third = consumeRotationRequest(db, "agent-1");
+			expect(third).toBeNull();
+		});
+
+		test("ローテーション要求がない状態で consumeRotationRequest を呼ぶと null を返す", () => {
+			const db = createTestDb();
+			touchHeartbeat(db, "agent-1");
+			const result = consumeRotationRequest(db, "agent-1");
+			expect(result).toBeNull();
+		});
+
+		test("行が存在しない場合に consumeRotationRequest を呼ぶと null を返す", () => {
+			const db = createTestDb();
+			const result = consumeRotationRequest(db, "nonexistent-agent");
+			expect(result).toBeNull();
+		});
+
+		test("行が存在しない場合に requestRotation を呼んでもエラーにならない", () => {
+			const db = createTestDb();
+			expect(() => requestRotation(db, "nonexistent-agent")).not.toThrow();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- `spec/store/db.spec.ts`: `requestRotation`, `consumeRotationRequest` の 6 テストケース追加
- `spec/agent/hang-detection.spec.ts`: rotation request 検知の 3 テストケース追加
- `spec/scheduling`: ログメッセージ英語化への追従（4箇所修正）

## Test plan

- [x] `nr test:spec` — 1354 pass / 0 fail
- [x] `nr validate` — lint エラーは既存の問題のみ（今回の変更とは無関係）

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)