### PR TITLE
fix(spec): spec テストのログ文字列を日本語に合わせて更新

### DIFF
--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -35,7 +35,7 @@ describe("ConsolidationScheduler", () => {
 
 		expect(consolidator.consolidate).not.toHaveBeenCalled();
 		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("no active namespaces, skipping"),
+			expect.stringContaining("アクティブな namespace なし、スキップ"),
 		);
 	});
 
@@ -131,7 +131,7 @@ describe("ConsolidationScheduler", () => {
 		// 2 回目は即座に完了し、スキップログが出る
 		await second;
 		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("previous tick still running, skipping"),
+			expect.stringContaining("前回の実行がまだ進行中、スキップ"),
 		);
 
 		// 1 回目を完了させる
@@ -172,6 +172,6 @@ describe("ConsolidationScheduler", () => {
 		await tickPromise;
 		await stopPromise;
 
-		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("scheduler stopped"));
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("スケジューラ停止"));
 	});
 });

--- a/spec/scheduling/listening-scheduler.spec.ts
+++ b/spec/scheduling/listening-scheduler.spec.ts
@@ -188,7 +188,7 @@ describe("ListeningScheduler — 公開 API 契約", () => {
 
 		await second;
 		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("previous tick still running, skipping"),
+			expect.stringContaining("前回の実行がまだ進行中、スキップ"),
 		);
 
 		resolveSend({ text: "NOW_PLAYING: x - y", sessionId: "listening" });


### PR DESCRIPTION
## Summary
- `consolidation-scheduler.spec.ts` と `listening-scheduler.spec.ts` の `StringContaining` アサーションが英語ログを期待していたが、実装は 5dbc4ea で日本語化済みだったため CI が失敗していた
- 4箇所の期待値を日本語ログに合わせて更新

## Test plan
- [x] CI の test ジョブが通ること（4つの failing テストが修正される）

🤖 Generated with [Claude Code](https://claude.com/claude-code)