### PR TITLE
fix(ci): format issues in test files

### DIFF
--- a/packages/scheduling/src/listening-scheduler.test.ts
+++ b/packages/scheduling/src/listening-scheduler.test.ts
@@ -154,7 +154,9 @@ describe("ListeningScheduler — 再入防止", () => {
 
 		// 2 回目は即座に return
 		await second;
-		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("previous tick still running"));
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining("previous tick still running"),
+		);
 
 		resolveSend({ text: "", sessionId: "listening" });
 		await first;

--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -34,9 +34,7 @@ describe("ConsolidationScheduler", () => {
 		await (scheduler as unknown as TickFn).tick();
 
 		expect(consolidator.consolidate).not.toHaveBeenCalled();
-		expect(logger.info).toHaveBeenCalledWith(
-			expect.stringContaining("no active namespaces"),
-		);
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("no active namespaces"));
 	});
 
 	test("アクティブギルド 1 件 → consolidate 呼び出し、success メトリクス", async () => {


### PR DESCRIPTION
## Summary
- `oxfmt` で 2 ファイルのフォーマットを修正
  - `packages/scheduling/src/listening-scheduler.test.ts`
  - `spec/scheduling/consolidation-scheduler.spec.ts`

## Test plan
- [ ] CI の Format check が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)