### PR TITLE
docs(readme): リスニングスケジューラ仕様を現行実装に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ MCP サーバー経由で各種操作を提供する。
 | ゲーム通信   | mc-bridge    | mc_report, check_commands                                                                             |
 | ゲーム記憶   | mc-bridge    | mc_read_goals, mc_update_goals, mc_read_progress, mc_update_progress, mc_read_skills, mc_record_skill |
 | 選曲         | core         | spotify_pick_track                                                                                    |
+| プレゼンス   | core         | set_now_playing                                                                                       |
 | 歌詞取得     | core         | fetch_lyrics                                                                                          |
 | 聴取記録     | core         | save_listening_fact                                                                                   |
 
@@ -112,20 +113,10 @@ OpenCode SDK 組み込み: `webfetch`
 
 ### 3.9 音楽リスニングスケジューラ
 
-- 専用スケジューラ（`ListeningScheduler`）が一定間隔（4 分）で tick し、時間帯別確率に基づき「選曲 → 曲理解 → 感想生成 → プレゼンス更新」のパイプラインを起動する。
-- パイプラインの実体は専用 AiAgent（`listeningRouter`）で、ツール（`spotify_pick_track`, `fetch_lyrics`, `save_listening_fact`）を orchestrate する。セッションキーは `"listening"` で固定。
-- 時間帯別確率（JST、1 tick あたり）:
-
-| 時間帯   | 基準確率        |
-| -------- | --------------- |
-| 2-7 時   | 0（聴かない）   |
-| 7-9 時   | 低（~0.15）     |
-| 9-18 時  | 中（~0.35）     |
-| 18-24 時 | 高（~0.60）     |
-| 0-2 時   | 中〜高（~0.50） |
-
-- ジッター: 基準確率 ± 0.1 の範囲で毎 tick ゆらぎを加える（2-7 時帯を除く）。同一パターンの反復を避ける。
-- プレゼンス表示: 選曲が成功したら Discord の `ActivityType.Listening` で `<曲名> - <アーティスト名>` を表示する。次の選曲が行われるまでそのまま継続（KISS）。
+- 専用スケジューラ（`ListeningScheduler`）が一定間隔（4 分）で tick し、活動時間帯判定に基づき「選曲 → 曲理解 → 感想生成 → プレゼンス更新」のパイプラインを起動する。
+- パイプラインの実体は専用 AiAgent（`listeningRouter`）で、ツール（`spotify_pick_track`, `set_now_playing`, `fetch_lyrics`, `save_listening_fact`）を orchestrate する。セッションキーは `"listening"` で固定。
+- 活動時間帯判定（JST）: 睡眠帯（2:00-7:00）は起動しない。それ以外の時間帯（7:00-翌 2:00）は毎 tick 起動する。
+- プレゼンス表示: エージェントが `set_now_playing` MCP ツールで `<曲名> - <アーティスト名>` を store の `now_playing` テーブルに書き込む。スケジューラが 10 秒間隔でポーリングし、未消費のエントリがあれば Discord の `ActivityType.Listening` に設定する。次の選曲が行われるまでそのまま継続。
 - チャット応答・Minecraft タスクと独立に動作する。
 
 ### 3.10 エラー応答


### PR DESCRIPTION
## Summary

- 3.4節ツール構成表に `set_now_playing` を追加
- 3.9節の時間帯別確率テーブル+ジッターを活動時間帯 on/off 判定に置換
- 3.9節のプレゼンス更新フローを MCP ツール→store→ポーリング方式に更新

Closes #567

## Test plan

- [x] ドキュメントのみの変更のため、コード変更なし
- [x] 現行実装（`listening-schedule.ts`, `listening-scheduler.ts`, `listening.ts`）と記述が一致することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)