### PR TITLE
fix(listening): 睡眠時間帯遷移で clearActivity を呼びプレゼンスをクリア

### DIFF
--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -249,6 +249,10 @@ function createServer(agentId: string | null): McpServer {
 					},
 					setNowPlaying: (trackName) => setNowPlaying(db, trackName),
 				});
+			} else {
+				logger.error(
+					"[core-server] Failed to get internalStorage for listening tools — set_now_playing will be unavailable",
+				);
 			}
 		}
 	}

--- a/packages/scheduling/src/listening-scheduler.ts
+++ b/packages/scheduling/src/listening-scheduler.ts
@@ -43,6 +43,7 @@ export class ListeningScheduler {
 	private timer: ReturnType<typeof setInterval> | null = null;
 	private nowPlayingTimer: ReturnType<typeof setInterval> | null = null;
 	private running = false;
+	private wasActive = false;
 	private executePromise: Promise<void> | null = null;
 	private readonly agent: AiAgent;
 	private readonly presence: ListeningPresencePort;
@@ -97,7 +98,14 @@ export class ListeningScheduler {
 		}
 		const should = this.shouldStart();
 		this.logger.debug(`[listening] tick: shouldStart=${should}`);
-		if (!should) return;
+		if (!should) {
+			if (this.wasActive) {
+				this.presence.clearActivity();
+				this.wasActive = false;
+			}
+			return;
+		}
+		this.wasActive = true;
 
 		this.logger.info("[listening] tick started");
 		this.running = true;

--- a/spec/scheduling/listening-scheduler.spec.ts
+++ b/spec/scheduling/listening-scheduler.spec.ts
@@ -43,6 +43,12 @@ function fixedDecision(result: boolean): () => boolean {
 	return () => result;
 }
 
+/** tick ごとに異なる値を返す decision 関数 */
+function sequenceDecision(...results: boolean[]): () => boolean {
+	let idx = 0;
+	return () => results[idx++] ?? false;
+}
+
 type TickFn = { tick(): Promise<void> };
 type PollFn = { pollNowPlaying(): void };
 
@@ -275,5 +281,59 @@ describe("ListeningScheduler — 公開 API 契約", () => {
 			expect.any(String),
 			expect.objectContaining({ outcome: "error" }),
 		);
+	});
+
+	test("活動中→睡眠時間帯への遷移で clearActivity が1回呼ばれる", async () => {
+		const presence = createMockPresence();
+
+		const scheduler = new ListeningScheduler({
+			agent: createMockAgent(),
+			presence,
+			nowPlayingReader: createMockNowPlayingReader(),
+			logger: createMockLogger(),
+			shouldStart: sequenceDecision(true, false),
+		});
+		const tickFn = scheduler as unknown as TickFn;
+
+		await tickFn.tick();
+		await tickFn.tick();
+
+		expect(presence.clearActivity).toHaveBeenCalledTimes(1);
+	});
+
+	test("睡眠時間帯が続いている間は clearActivity を繰り返し呼ばない", async () => {
+		const presence = createMockPresence();
+
+		const scheduler = new ListeningScheduler({
+			agent: createMockAgent(),
+			presence,
+			nowPlayingReader: createMockNowPlayingReader(),
+			logger: createMockLogger(),
+			shouldStart: sequenceDecision(false, false),
+		});
+		const tickFn = scheduler as unknown as TickFn;
+
+		await tickFn.tick();
+		await tickFn.tick();
+
+		expect(presence.clearActivity).not.toHaveBeenCalled();
+	});
+
+	test("活動時間帯が続いている間は clearActivity を呼ばない", async () => {
+		const presence = createMockPresence();
+
+		const scheduler = new ListeningScheduler({
+			agent: createMockAgent(),
+			presence,
+			nowPlayingReader: createMockNowPlayingReader(),
+			logger: createMockLogger(),
+			shouldStart: sequenceDecision(true, true),
+		});
+		const tickFn = scheduler as unknown as TickFn;
+
+		await tickFn.tick();
+		await tickFn.tick();
+
+		expect(presence.clearActivity).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

- `ListeningScheduler` に `wasActive` フラグを追加し、活動→睡眠の遷移時のみ `clearActivity()` を呼ぶ
- `core-server` の `internalStorage` が null の場合にエラーログを出力（`set_now_playing` ツール未登録のサイレント失敗を防止）
- clearActivity の仕様テスト3件を追加（遷移時のみ呼ばれる / 連続睡眠で繰り返さない / 連続活動で呼ばない）

## Test plan

- [x] `nr test:spec` — 全1348件通過（新規3件含む）
- [x] `nr test:unit` — 全460件通過
- [x] `nr validate` — fmt:check + lint + check 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)