### PR TITLE
fix(mcp): resolve merge conflict markers in core-server.ts

### DIFF
--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -263,11 +263,7 @@ function createServer(agentId: string | null): McpServer {
 		}
 	}
 
-<<<<<<< HEAD
 	registerMetaTools(server, toolDescriptions);
-=======
-	registerMetaTools(server);
->>>>>>> origin/main
 
 	return server;
 }


### PR DESCRIPTION
## Summary
- `#578` のスカッシュマージ時に残ったコンフリクトマーカーを解消
- `registerMetaTools(server, toolDescriptions)` が正しいシグネチャ（2引数版）

## Test plan
- [x] `nr fmt:check` 通過
- [x] `bun test packages/mcp/src/tools/meta.test.ts` 全9テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)