### PR TITLE
refactor(mcp): createFakeServer をテストヘルパーに共通化

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -17,7 +17,8 @@
 		"./tools/schedule": "./src/tools/schedule.ts",
 		"./tools/spotify": "./src/tools/spotify.ts",
 		"./tools/listening": "./src/tools/listening.ts",
-		"./tools/meta": "./src/tools/meta.ts"
+		"./tools/meta": "./src/tools/meta.ts",
+		"./tools/meta-test-helpers": "./src/tools/meta-test-helpers.ts"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.1",

--- a/packages/mcp/src/tools/meta-test-helpers.ts
+++ b/packages/mcp/src/tools/meta-test-helpers.ts
@@ -1,0 +1,39 @@
+/* oxlint-disable no-non-null-assertion -- test helpers */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export type ToolHandler = (args: Record<string, unknown>) => unknown;
+export type ToolResult = { content: Array<{ type: string; text: string }> };
+
+/**
+ * registerTool 呼び出しをキャプチャする fakeServer を作成し、
+ * toolDescriptions に登録済みツール情報を保持する。
+ */
+export function createFakeServer(): {
+	server: McpServer;
+	tools: Map<string, ToolHandler>;
+	toolDescriptions: Map<string, string | undefined>;
+} {
+	const tools = new Map<string, ToolHandler>();
+	const toolDescriptions = new Map<string, string | undefined>();
+
+	const fakeServer = {
+		registerTool(name: string, config: { description?: string }, handler: ToolHandler) {
+			tools.set(name, handler);
+			toolDescriptions.set(name, config.description);
+		},
+	} as unknown as McpServer;
+
+	return { server: fakeServer, tools, toolDescriptions };
+}
+
+/**
+ * fakeServer にダミーツールを registerTool 経由で登録する。
+ * spec テストが内部プロパティに直接アクセスしないようにする。
+ */
+export function registerDummyTool(server: McpServer, name: string, description?: string): void {
+	(
+		server as unknown as {
+			registerTool: (n: string, c: { description?: string }, h: ToolHandler) => void;
+		}
+	).registerTool(name, { description }, () => ({ content: [] }));
+}

--- a/packages/mcp/src/tools/meta.test.ts
+++ b/packages/mcp/src/tools/meta.test.ts
@@ -4,31 +4,9 @@ import { describe, expect, test } from "bun:test";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { registerMetaTools } from "./meta";
-
-// ─── Types ───────────────────────────────────────────────────────
-
-type ToolHandler = (args: Record<string, unknown>) => unknown;
-type ToolResult = { content: Array<{ type: string; text: string }> };
+import { createFakeServer, type ToolHandler, type ToolResult } from "./meta-test-helpers";
 
 // ─── Helpers ─────────────────────────────────────────────────────
-
-function createFakeServer(): {
-	server: McpServer;
-	tools: Map<string, ToolHandler>;
-	toolDescriptions: Map<string, string | undefined>;
-} {
-	const tools = new Map<string, ToolHandler>();
-	const toolDescriptions = new Map<string, string | undefined>();
-
-	const fakeServer = {
-		registerTool(name: string, config: { description?: string }, handler: ToolHandler) {
-			tools.set(name, handler);
-			toolDescriptions.set(name, config.description);
-		},
-	} as unknown as McpServer;
-
-	return { server: fakeServer, tools, toolDescriptions };
-}
 
 function callListTools(
 	server: McpServer,

--- a/spec/mcp/tools/meta.spec.ts
+++ b/spec/mcp/tools/meta.spec.ts
@@ -1,49 +1,12 @@
 /* oxlint-disable no-non-null-assertion -- test assertions */
 import { describe, expect, test } from "bun:test";
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerMetaTools } from "@vicissitude/mcp/tools/meta";
-
-// ─── Types ───────────────────────────────────────────────────────
-
-type ToolHandler = (args: Record<string, unknown>) => unknown;
-type ToolResult = { content: Array<{ type: string; text: string }> };
-
-// ─── Helpers ─────────────────────────────────────────────────────
-
-/**
- * registerTool 呼び出しをキャプチャする fakeServer を作成し、
- * toolDescriptions に登録済みツール情報を保持する。
- */
-function createFakeServer(): {
-	server: McpServer;
-	tools: Map<string, ToolHandler>;
-	toolDescriptions: Map<string, string | undefined>;
-} {
-	const tools = new Map<string, ToolHandler>();
-	const toolDescriptions = new Map<string, string | undefined>();
-
-	const fakeServer = {
-		registerTool(name: string, config: { description?: string }, handler: ToolHandler) {
-			tools.set(name, handler);
-			toolDescriptions.set(name, config.description);
-		},
-	} as unknown as McpServer;
-
-	return { server: fakeServer, tools, toolDescriptions };
-}
-
-/**
- * fakeServer にダミーツールを registerTool 経由で登録する。
- * spec テストが内部プロパティに直接アクセスしないようにする。
- */
-function registerDummyTool(server: McpServer, name: string, description?: string): void {
-	(
-		server as unknown as {
-			registerTool: (n: string, c: { description?: string }, h: ToolHandler) => void;
-		}
-	).registerTool(name, { description }, () => ({ content: [] }));
-}
+import {
+	createFakeServer,
+	registerDummyTool,
+	type ToolResult,
+} from "@vicissitude/mcp/tools/meta-test-helpers";
 
 // ─── Tests ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `meta.spec.ts` と `meta.test.ts` で重複していた `createFakeServer`, `registerDummyTool`, `ToolHandler`, `ToolResult` を `packages/mcp/src/tools/meta-test-helpers.ts` に抽出
- 依存方向を正しく保つため、ヘルパーは `packages/mcp` 側に配置し、`spec` からはパッケージエイリアス `@vicissitude/mcp/tools/meta-test-helpers` 経由でインポート

Closes #577

## Test plan
- [x] `bun test spec/mcp/tools/meta.spec.ts packages/mcp/src/tools/meta.test.ts` — 全16テスト通過
- [x] `nr fmt:check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)