### PR TITLE
refactor(mcp): remove unreachable null guard for internalStorage

### DIFF
--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -232,28 +232,22 @@ function createServer(agentId: string | null): McpServer {
 
 		if (process.env.GENIUS_ACCESS_TOKEN) {
 			const geniusClient = new GeniusClient(process.env.GENIUS_ACCESS_TOKEN);
-			// internal namespace の MemoryStorage を確保
+			// getOrCreateMemory は必ず memoryStorages にエントリを挿入するため non-null
 			getOrCreateMemory(INTERNAL_NAMESPACE);
-			const internalStorage = memoryStorages.get(namespaceKey(INTERNAL_NAMESPACE));
-			if (internalStorage) {
-				const listeningMemory = new ListeningMemory(internalStorage, {
-					embed: (text) => ollama.embed(text),
-				});
-				registerListeningTools(server, {
-					fetchLyrics: (title, artist) => geniusClient.fetchLyrics(title, artist),
-					saveListening: async (record) => {
-						await listeningMemory.saveListening({
-							track: record.track,
-							impression: record.impression,
-							listenedAt: record.listenedAt,
-						});
-					},
-				});
-			} else {
-				logger.error(
-					"[core-server] Failed to get internalStorage for listening tools — fetch_lyrics/save_listening_fact will be unavailable",
-				);
-			}
+			const internalStorage = memoryStorages.get(namespaceKey(INTERNAL_NAMESPACE))!;
+			const listeningMemory = new ListeningMemory(internalStorage, {
+				embed: (text) => ollama.embed(text),
+			});
+			registerListeningTools(server, {
+				fetchLyrics: (title, artist) => geniusClient.fetchLyrics(title, artist),
+				saveListening: async (record) => {
+					await listeningMemory.saveListening({
+						track: record.track,
+						impression: record.impression,
+						listenedAt: record.listenedAt,
+					});
+				},
+			});
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `core-server.ts` L252-256 の到達不能な `else` ブランチ（`internalStorage` が null の場合のエラーログ）を削除
- `getOrCreateMemory()` は必ず `memoryStorages` にエントリを挿入するため、直後の `.get()` は常に non-null
- `!` 非null アサーションで意図を明示

Closes #570

## Test plan
- [x] `nr test:spec` — 全 1344 テスト通過
- [x] `nr test:unit` — 全 440 テスト通過（既存の `vec3` 依存エラー 1 件は無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)