### PR TITLE
fix(lint): enable unbound-method rule (Phase 2)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -63,7 +63,7 @@
 		"typescript/no-unsafe-return": "error",
 		"typescript/strict-boolean-expressions": "off",
 		"typescript/no-confusing-void-expression": "off",
-		"typescript/unbound-method": "off",
+		"typescript/unbound-method": "error",
 		"typescript/await-thenable": "error"
 	},
 	"overrides": [
@@ -97,7 +97,8 @@
 					{ "max": 300, "skipBlankLines": true, "skipComments": true }
 				],
 				"eslint/max-params": "off",
-				"import/max-dependencies": "off"
+				"import/max-dependencies": "off",
+				"typescript/unbound-method": "off"
 			}
 		},
 		{

--- a/packages/minecraft/src/bot-context.ts
+++ b/packages/minecraft/src/bot-context.ts
@@ -14,12 +14,12 @@ export interface BotEvent {
 const MAX_EVENTS = 100;
 
 export interface BotContext {
-	getBot(): mineflayer.Bot | null;
-	setBot(bot: mineflayer.Bot | null): void;
-	getEvents(): BotEvent[];
-	pushEvent(kind: string, description: string, importance: Importance): void;
-	getActionState(): ActionState;
-	setActionState(state: ActionState): void;
+	getBot: () => mineflayer.Bot | null;
+	setBot: (bot: mineflayer.Bot | null) => void;
+	getEvents: () => BotEvent[];
+	pushEvent: (kind: string, description: string, importance: Importance) => void;
+	getActionState: () => ActionState;
+	setActionState: (state: ActionState) => void;
 }
 
 const BOT_EVENT_KINDS = new Set(["spawn", "death", "kicked", "disconnect"]);

--- a/packages/minecraft/src/bot-context.ts
+++ b/packages/minecraft/src/bot-context.ts
@@ -14,12 +14,12 @@ export interface BotEvent {
 const MAX_EVENTS = 100;
 
 export interface BotContext {
-	getBot: () => mineflayer.Bot | null;
-	setBot: (bot: mineflayer.Bot | null) => void;
-	getEvents: () => BotEvent[];
-	pushEvent: (kind: string, description: string, importance: Importance) => void;
-	getActionState: () => ActionState;
-	setActionState: (state: ActionState) => void;
+	getBot(): mineflayer.Bot | null;
+	setBot(bot: mineflayer.Bot | null): void;
+	getEvents(): BotEvent[];
+	pushEvent(kind: string, description: string, importance: Importance): void;
+	getActionState(): ActionState;
+	setActionState(state: ActionState): void;
 }
 
 const BOT_EVENT_KINDS = new Set(["spawn", "death", "kicked", "disconnect"]);

--- a/packages/minecraft/src/server.ts
+++ b/packages/minecraft/src/server.ts
@@ -92,7 +92,11 @@ const connection = createBotConnection(
 	logger,
 );
 
-const jobManager = new JobManager(ctx.pushEvent, ctx.setActionState, mcCollector);
+const jobManager = new JobManager(
+	ctx.pushEvent.bind(ctx),
+	ctx.setActionState.bind(ctx),
+	mcCollector,
+);
 
 const reactiveLayer = new ReactiveLayer(ctx, {
 	onCancelJob: () => jobManager.cancelCurrentJob(),

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -249,7 +249,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 			},
 		});
 		this.client = result.client;
-		this.closeServer = result.server.close;
+		this.closeServer = result.server.close.bind(result.server);
 		this.logger?.info(`[opencode] client initialized (port=${this.config.port})`);
 		return this.client;
 	}


### PR DESCRIPTION
## Summary
- `.oxlintrc.json`: `typescript/unbound-method` を `off` → `error` に変更
- テストファイル (`*.test.ts`, `*.spec.ts`, `**/test-helpers.ts`) は overrides で `off`
- `packages/minecraft/src/server.ts`: `ctx.pushEvent` / `ctx.setActionState` を `.bind(ctx)` でバインド
- `packages/opencode/src/session-adapter.ts`: `result.server.close` を `.bind(result.server)` でバインド

Closes #585

## Test plan
- [x] `nr lint` で `unbound-method` 違反が 0 件であること
- [x] `nr test` で既存テストが全て通ること（既存の `vec3` パッケージ不足エラー以外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)