### PR TITLE
fix(lint): replace non-null assertion with runtime guard

### DIFF
--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -232,9 +232,10 @@ function createServer(agentId: string | null): McpServer {
 
 		if (process.env.GENIUS_ACCESS_TOKEN) {
 			const geniusClient = new GeniusClient(process.env.GENIUS_ACCESS_TOKEN);
-			// getOrCreateMemory は必ず memoryStorages にエントリを挿入するため non-null
 			getOrCreateMemory(INTERNAL_NAMESPACE);
-			const internalStorage = memoryStorages.get(namespaceKey(INTERNAL_NAMESPACE))!;
+			const internalStorage = memoryStorages.get(namespaceKey(INTERNAL_NAMESPACE));
+			if (!internalStorage)
+				throw new Error("unreachable: getOrCreateMemory failed to populate memoryStorages");
 			const listeningMemory = new ListeningMemory(internalStorage, {
 				embed: (text) => ollama.embed(text),
 			});


### PR DESCRIPTION
## Summary
- `packages/mcp/src/core-server.ts` の `memoryStorages.get()!` を non-null assertion (`!`) から明示的なランタイムガードに置換
- `no-non-null-assertion` lint ルール違反を解消し、main の CI を修正

## Test plan
- [ ] CI の lint ステップが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)