### PR TITLE
refactor(design): Phase 0 基盤整備 — JST重複統一・型修正・IF正規化

### DIFF
--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -25,7 +25,7 @@ const DEFAULT_HANG_TIMEOUT_MS = 600_000;
 export interface HeartbeatReader {
 	getLastSeenAt(agentId: string): number | undefined;
 	/** MCP 側からのローテーション要求を消費する。要求があればタイムスタンプを返し、DB 側はリセットする */
-	consumeRotationRequest?(agentId: string): number | null;
+	consumeRotationRequest(agentId: string): number | null;
 }
 
 export interface RunnerDeps {
@@ -151,7 +151,7 @@ export class AgentRunner implements AiAgent {
 			}
 
 			// MCP 側からのローテーション要求をチェック（respond スキップ閾値超過時に書き込まれる）
-			const rotationTs = this.heartbeatReader?.consumeRotationRequest?.(this.agentId) ?? null;
+			const rotationTs = this.heartbeatReader?.consumeRotationRequest(this.agentId) ?? null;
 			if (rotationTs !== null) {
 				this.logger.warn(
 					`[${this.profile.name}:${this.agentId}] MCP respond-skip rotation request detected (requested at ${rotationTs}), rotating session`,

--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable max-lines -- event-buffer tools + polling + formatting helpers are tightly coupled */
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { describeEmotion, isNeutralEmotion } from "@vicissitude/shared/emotion";
+import { formatTimestamp } from "@vicissitude/shared/functions";
 import type { MoodReader } from "@vicissitude/shared/ports";
 import type { Attachment, Logger } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
@@ -165,19 +166,6 @@ export function escapeUserMessageTag(content: string): string {
 
 // ─── formatEvents ────────────────────────────────────────────────
 
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
-
-export function toJstString(ts: string | Date): string {
-	const utc = ts instanceof Date ? ts.getTime() : new Date(ts).getTime();
-	const jst = new Date(utc + JST_OFFSET_MS);
-	const y = jst.getUTCFullYear();
-	const mo = String(jst.getUTCMonth() + 1).padStart(2, "0");
-	const d = String(jst.getUTCDate()).padStart(2, "0");
-	const h = String(jst.getUTCHours()).padStart(2, "0");
-	const mi = String(jst.getUTCMinutes()).padStart(2, "0");
-	return `${y}-${mo}-${d} ${h}:${mi}`;
-}
-
 /** parseEvents がパースに失敗したエラーイベントかどうかを判定する type guard */
 export function isErrorEvent(e: EventOrError): e is ErrorEvent {
 	return "_error" in e && "_raw" in e;
@@ -194,7 +182,7 @@ export function formatEvents(events: EventOrError[]): string {
 				return `[ERROR] ${e._error}: ${e._raw}`;
 			}
 
-			const dateStr = toJstString(e.ts);
+			const dateStr = formatTimestamp(new Date(e.ts));
 			const channel = e.metadata?.channelName ? ` #${e.metadata.channelName}` : "";
 			const hint = classifyActionHint(e);
 			const extras: string[] = [];
@@ -247,7 +235,7 @@ export function formatRecentMessages(channelMessages: Map<string, RecentMessage[
 		if (messages.length === 0) continue;
 		const lines: string[] = [`## #${channelName}`];
 		for (const msg of messages) {
-			const dateStr = toJstString(msg.timestamp);
+			const dateStr = formatTimestamp(msg.timestamp);
 			let line = `[${dateStr} JST] ${msg.authorName}: ${msg.content}`;
 			if (msg.reactions.length > 0) {
 				const reactionStr = msg.reactions.map((r) => `${r.emoji}×${r.count}`).join(" ");

--- a/packages/mcp/src/tools/mc-bridge-minecraft.ts
+++ b/packages/mcp/src/tools/mc-bridge-minecraft.ts
@@ -1,18 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { MINECRAFT_AGENT_ID } from "@vicissitude/minecraft/constants";
+import { formatTimestamp } from "@vicissitude/shared/functions";
 import type { StoreDb } from "@vicissitude/store/db";
 import { getSessionLockGuildId } from "@vicissitude/store/mc-bridge";
 import { appendEvent, consumeEvents } from "@vicissitude/store/queries";
 import { z } from "zod";
 
 import type { EventOrError } from "./event-buffer.ts";
-import {
-	MAX_BATCH_SIZE,
-	escapeUserMessageTag,
-	isErrorEvent,
-	parseEvents,
-	toJstString,
-} from "./event-buffer.ts";
+import { MAX_BATCH_SIZE, escapeUserMessageTag, isErrorEvent, parseEvents } from "./event-buffer.ts";
 
 const MAX_REPORT_CHARS = 10_000;
 
@@ -29,7 +24,7 @@ export function formatCommands(events: EventOrError[]): string {
 				return `[ERROR] ${e._error}: ${e._raw}`;
 			}
 
-			const dateStr = toJstString(e.ts);
+			const dateStr = formatTimestamp(new Date(e.ts));
 			const isUserMessage = e.authorId !== "system" && e.metadata?.isBot !== true;
 			const content = isUserMessage
 				? `<user_message>${escapeUserMessageTag(e.content)}</user_message>`

--- a/packages/memory/src/conversation-recorder.ts
+++ b/packages/memory/src/conversation-recorder.ts
@@ -20,9 +20,10 @@ import {
 } from "./namespace.ts";
 import { Segmenter } from "./segmenter.ts";
 import { MemoryStorage } from "./storage.ts";
+import type { ChatMessage } from "./types.ts";
 
 export interface GuildInstance {
-	segmenter: { addMessage(userId: string, msg: unknown): Promise<Episode[]> };
+	segmenter: { addMessage(userId: string, msg: ChatMessage): Promise<Episode[]> };
 	storage: { close(): void };
 	consolidation: { consolidate(userId: string): Promise<ConsolidationResult> };
 }

--- a/packages/scheduling/src/heartbeat-helpers.ts
+++ b/packages/scheduling/src/heartbeat-helpers.ts
@@ -1,3 +1,4 @@
+import { JST_OFFSET_MS } from "@vicissitude/shared/functions";
 import type { DueReminder, HeartbeatConfig } from "@vicissitude/shared/types";
 
 /** Heartbeat config JSON の相対パス（プロジェクトルート起点） */
@@ -38,9 +39,6 @@ export function createDefaultHeartbeatConfig(): HeartbeatConfig {
 }
 
 // ─── evaluateDueReminders ────────────────────────────────────────
-
-/** JST (UTC+9) のオフセット（ミリ秒） */
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 /**
  * 設定と現在時刻から、実行すべきリマインダーを判定する純粋関数。

--- a/packages/shared/src/functions.ts
+++ b/packages/shared/src/functions.ts
@@ -1,7 +1,7 @@
 // ─── formatTimestamp / formatTime ────────────────────────────────
 
 /** JST (UTC+9) のオフセット（ミリ秒） */
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+export const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 function pad(n: number): string {
 	return n.toString().padStart(2, "0");

--- a/spec/agent/hang-detection.spec.ts
+++ b/spec/agent/hang-detection.spec.ts
@@ -314,7 +314,10 @@ describe("AgentRunner ハング検知と自動ローテーション", () => {
 			const sessionPort = createSimpleSessionPort();
 
 			// heartbeatReader が常に現在時刻を返す（MCP wait_for_events が呼ばれている状態）
-			const heartbeatReader = { getLastSeenAt: mock(() => Date.now()) };
+			const heartbeatReader = {
+				getLastSeenAt: mock(() => Date.now()),
+				consumeRotationRequest: mock(() => null),
+			};
 
 			const runner = new TestAgent({
 				profile: createProfile(),
@@ -352,7 +355,10 @@ describe("AgentRunner ハング検知と自動ローテーション", () => {
 
 			// heartbeatReader が古い値を返す（MCP が止まっている状態）
 			const staleTime = Date.now() - 10_000;
-			const heartbeatReader = { getLastSeenAt: mock(() => staleTime) };
+			const heartbeatReader = {
+				getLastSeenAt: mock(() => staleTime),
+				consumeRotationRequest: mock(() => null),
+			};
 
 			const runner = new TestAgent({
 				profile: createProfile(),
@@ -475,16 +481,17 @@ describe("AgentRunner ハング検知と自動ローテーション", () => {
 			runner.stop();
 		});
 
-		test("consumeRotationRequest が未実装（undefined）の場合、ローテーションは発生しない", async () => {
+		test("consumeRotationRequest が常に null を返す場合、ローテーションは発生しない", async () => {
 			const rotationSpy = mock(() => Promise.resolve());
 			const sessionStore = createSessionStore("existing-session-id");
 
 			const eventBuffer = createEventBuffer(() => new Promise(() => {}));
 			const sessionPort = createSimpleSessionPort();
 
-			// consumeRotationRequest を持たない heartbeatReader
+			// consumeRotationRequest が常に null を返す heartbeatReader
 			const heartbeatReader = {
 				getLastSeenAt: mock(() => Date.now()),
+				consumeRotationRequest: mock(() => null),
 			};
 
 			const runner = new TestAgent({
@@ -507,7 +514,7 @@ describe("AgentRunner ハング検知と自動ローテーション", () => {
 
 			await Bun.sleep(250);
 
-			// heartbeat は alive、consumeRotationRequest は undefined なのでローテーションは発生しない
+			// heartbeat は alive、consumeRotationRequest は常に null なのでローテーションは発生しない
 			expect(rotationSpy).not.toHaveBeenCalled();
 
 			runner.stop();


### PR DESCRIPTION
## Summary
- JST_OFFSET_MS と toJstString の3箇所重複を `shared/functions.ts` の `formatTimestamp` に統一（関心の分離）
- `GuildInstance.segmenter.addMessage` の `msg: unknown` を `ChatMessage` 型に修正（契約による設計）
- `HeartbeatReader.consumeRotationRequest` を非オプショナルに変更し、インターフェース契約を厳密化（カプセル化・契約による設計）

## 背景
カプセル化、関心の分離、契約による設計、副作用の隔離の4原則に基づくプロジェクト全体リファクタリングの Phase 0（基盤整備）。

## Test plan
- [x] `nr validate` (fmt:check + lint + type check) 通過
- [x] `nr test:spec` 全1344テスト通過
- [x] `nr test` 全1790テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)