### PR TITLE
refactor(design): Phase 3 関心の分離 — キャッシュ抽出・マイグレーション分離・DI改善

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -7,6 +7,7 @@ import { DiscordAgent } from "@vicissitude/agent/discord/discord-agent";
 import { GuildRouter } from "@vicissitude/agent/discord/router";
 import { McBrainManager } from "@vicissitude/agent/minecraft/brain-manager";
 import { SessionStore } from "@vicissitude/agent/session-store";
+import { HeartbeatService } from "@vicissitude/application/heartbeat-service";
 import { MessageIngestionService } from "@vicissitude/application/message-ingestion-service";
 import { createGatewayServer } from "@vicissitude/gateway/server";
 import { WsConnectionManager } from "@vicissitude/gateway/ws-handler";
@@ -26,6 +27,7 @@ import { OllamaEmbeddingAdapter } from "@vicissitude/ollama";
 import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import { ConsolidationScheduler } from "@vicissitude/scheduling/consolidation-scheduler";
+import { JsonHeartbeatConfigRepository } from "@vicissitude/scheduling/heartbeat-config";
 import { HEARTBEAT_CONFIG_RELATIVE_PATH } from "@vicissitude/scheduling/heartbeat-helpers";
 import { HeartbeatScheduler } from "@vicissitude/scheduling/heartbeat-scheduler";
 import type {
@@ -441,6 +443,7 @@ export async function bootstrap(): Promise<void> {
 		ttsSynthesizer,
 		ttsStyleMapper,
 		moodReader: moodStore,
+		logger,
 	});
 	const gatewayServer = createGatewayServer(config.gatewayPort, wsManager);
 	logger.info(
@@ -531,12 +534,12 @@ export async function bootstrap(): Promise<void> {
 	const heartbeatConfigPath = resolve(root, HEARTBEAT_CONFIG_RELATIVE_PATH);
 	syncMcCheckReminder(heartbeatConfigPath, !!config.minecraft, logger);
 	removeLegacyConsolidateReminder(heartbeatConfigPath, logger);
-	const heartbeatScheduler = new HeartbeatScheduler(
-		heartbeatRouter,
+	const heartbeatScheduler = new HeartbeatScheduler({
+		configRepo: new JsonHeartbeatConfigRepository(heartbeatConfigPath),
+		heartbeatService: new HeartbeatService({ agent: heartbeatRouter, logger }),
 		logger,
-		metrics.collector,
-		root,
-	);
+		metrics: metrics.collector,
+	});
 
 	// Session gauge
 	const sessionGaugeTimer = startSessionGauge(sessionStore, metrics.collector);

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -1,5 +1,5 @@
 /* oxlint-disable max-dependencies, max-lines -- bootstrap file naturally requires many imports and lines for DI wiring */
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { resolve } from "path";
 
 import { ContextBuilder } from "@vicissitude/agent/discord/context-builder";
@@ -46,6 +46,11 @@ import { spawn, type Subprocess } from "bun";
 import { type AppConfig, loadConfig } from "./config.ts";
 import { ChannelConfigLoader, type ChannelConfigData } from "./gateway/channel-config-loader.ts";
 import { DiscordGateway } from "./gateway/discord.ts";
+import {
+	migrateMemoryDir,
+	removeLegacyConsolidateReminder,
+	syncMcCheckReminder,
+} from "./migrations.ts";
 import { createPortLayout } from "./port-allocator.ts";
 
 // ─── Store Layer ────────────────────────────────────────────────
@@ -150,45 +155,6 @@ export function createMetrics(logger: Logger) {
 	collector.registerCounter(METRIC.LLM_CACHE_READ_TOKENS, "LLM cache read tokens total");
 	collector.setGauge(METRIC.BOT_INFO, 1, { bot_name: "hua" });
 	return { collector, server: new PrometheusServer(collector, logger) };
-}
-
-// ─── mc-check Reminder Sync ─────────────────────────────────────
-
-/** config.minecraft の有無に応じて mc-check リマインダーの enabled を同期する */
-function syncMcCheckReminder(configPath: string, minecraftEnabled: boolean, logger: Logger): void {
-	if (!existsSync(configPath)) return;
-	try {
-		const raw = JSON.parse(readFileSync(configPath, "utf-8")) as {
-			reminders?: { id: string; enabled: boolean }[];
-		};
-		const mcCheck = raw.reminders?.find((r) => r.id === "mc-check");
-		if (!mcCheck || mcCheck.enabled === minecraftEnabled) return;
-		mcCheck.enabled = minecraftEnabled;
-		writeFileSync(configPath, JSON.stringify(raw, null, 2));
-		logger.info(
-			`[bootstrap] mc-check reminder ${minecraftEnabled ? "enabled" : "disabled"} (synced with config.minecraft)`,
-		);
-	} catch {
-		// パース失敗時はスキップ（HeartbeatScheduler がデフォルト設定で初期化する）
-	}
-}
-
-/** ltm-consolidate リマインダーを削除する（MCP ツール廃止に伴う移行） */
-function removeLegacyConsolidateReminder(configPath: string, logger: Logger): void {
-	if (!existsSync(configPath)) return;
-	try {
-		const raw = JSON.parse(readFileSync(configPath, "utf-8")) as {
-			reminders?: { id: string }[];
-		};
-		if (!raw.reminders) return;
-		const idx = raw.reminders.findIndex((r) => r.id === "ltm-consolidate");
-		if (idx === -1) return;
-		raw.reminders.splice(idx, 1);
-		writeFileSync(configPath, JSON.stringify(raw, null, 2));
-		logger.info("[bootstrap] Removed ltm-consolidate reminder (consolidation is now automatic)");
-	} catch {
-		// パース失敗時はスキップ
-	}
 }
 
 // ─── Channel Config ─────────────────────────────────────────────
@@ -432,12 +398,7 @@ export async function bootstrap(): Promise<void> {
 	const logger = new ConsoleLogger();
 
 	// Migrate data/ltm → data/memory
-	const oldMemoryDir = resolve(config.dataDir, "ltm");
-	const newMemoryDir = resolve(config.dataDir, "memory");
-	if (existsSync(oldMemoryDir) && !existsSync(newMemoryDir)) {
-		renameSync(oldMemoryDir, newMemoryDir);
-		logger.info("[bootstrap] Migrated data/ltm → data/memory");
-	}
+	migrateMemoryDir(config.dataDir, logger);
 
 	// Store
 	const { db, sessionStore } = createStoreLayer(config);

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -94,6 +94,8 @@ export function createGuildAgents(
 		agentIdPrefix?: string;
 		/** ポート番号のオフセット（デフォルト: 0）。basePort + portOffset + index でポートを決定 */
 		portOffset?: number;
+		appRoot: string;
+		coreMcpPort: number;
 	},
 ): Map<string, DiscordAgent> {
 	const agents = new Map<string, DiscordAgent>();
@@ -112,6 +114,8 @@ export function createGuildAgents(
 			model: { providerId: config.opencode.providerId, modelId: config.opencode.modelId },
 			summaryWriter: deps.summaryWriter,
 			agentIdPrefix: deps.agentIdPrefix,
+			appRoot: deps.appRoot,
+			coreMcpPort: deps.coreMcpPort,
 		});
 		agents.set(guildId, agent);
 	}
@@ -499,6 +503,8 @@ export async function bootstrap(): Promise<void> {
 		logger,
 		metrics: metrics.collector,
 		summaryWriter,
+		appRoot: root,
+		coreMcpPort: config.coreMcpPort,
 	});
 
 	// Memory recording
@@ -545,6 +551,8 @@ export async function bootstrap(): Promise<void> {
 		metrics: metrics.collector,
 		agentIdPrefix: "discord:heartbeat",
 		portOffset: ports.heartbeatOffset,
+		appRoot: root,
+		coreMcpPort: config.coreMcpPort,
 	});
 	const firstHeartbeatAgent = heartbeatAgents.values().next().value as AiAgent | undefined;
 	if (!firstHeartbeatAgent) {
@@ -588,6 +596,8 @@ export async function bootstrap(): Promise<void> {
 			providerId: config.mcBrain.providerId,
 			modelId: config.mcBrain.modelId,
 			sessionMaxAgeMs: config.opencode.sessionMaxAgeHours * 3_600_000,
+			mcHost: config.minecraft.host,
+			mcMcpPort: String(config.minecraft.mcpPort),
 		});
 	}
 

--- a/apps/discord/src/migrations.ts
+++ b/apps/discord/src/migrations.ts
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+import type { Logger } from "@vicissitude/shared/types";
+
+/** config.minecraft の有無に応じて mc-check リマインダーの enabled を同期する */
+export function syncMcCheckReminder(
+	configPath: string,
+	minecraftEnabled: boolean,
+	logger: Logger,
+): void {
+	if (!existsSync(configPath)) return;
+	try {
+		const raw = JSON.parse(readFileSync(configPath, "utf-8")) as {
+			reminders?: { id: string; enabled: boolean }[];
+		};
+		const mcCheck = raw.reminders?.find((r) => r.id === "mc-check");
+		if (!mcCheck || mcCheck.enabled === minecraftEnabled) return;
+		mcCheck.enabled = minecraftEnabled;
+		writeFileSync(configPath, JSON.stringify(raw, null, 2));
+		logger.info(
+			`[bootstrap] mc-check reminder ${minecraftEnabled ? "enabled" : "disabled"} (synced with config.minecraft)`,
+		);
+	} catch {
+		// パース失敗時はスキップ（HeartbeatScheduler がデフォルト設定で初期化する）
+	}
+}
+
+/** ltm-consolidate リマインダーを削除する（MCP ツール廃止に伴う移行） */
+export function removeLegacyConsolidateReminder(configPath: string, logger: Logger): void {
+	if (!existsSync(configPath)) return;
+	try {
+		const raw = JSON.parse(readFileSync(configPath, "utf-8")) as {
+			reminders?: { id: string }[];
+		};
+		if (!raw.reminders) return;
+		const idx = raw.reminders.findIndex((r) => r.id === "ltm-consolidate");
+		if (idx === -1) return;
+		raw.reminders.splice(idx, 1);
+		writeFileSync(configPath, JSON.stringify(raw, null, 2));
+		logger.info("[bootstrap] Removed ltm-consolidate reminder (consolidation is now automatic)");
+	} catch {
+		// パース失敗時はスキップ
+	}
+}
+
+/** data/ltm → data/memory のディレクトリ移行 */
+export function migrateMemoryDir(dataDir: string, logger: Logger): void {
+	const oldMemoryDir = resolve(dataDir, "ltm");
+	const newMemoryDir = resolve(dataDir, "memory");
+	if (existsSync(oldMemoryDir) && !existsSync(newMemoryDir)) {
+		renameSync(oldMemoryDir, newMemoryDir);
+		logger.info("[bootstrap] Migrated data/ltm → data/memory");
+	}
+}

--- a/packages/agent/src/discord/discord-agent.ts
+++ b/packages/agent/src/discord/discord-agent.ts
@@ -3,6 +3,7 @@ import type {
 	ContextBuilderPort,
 	Logger,
 	MetricsCollector,
+	SessionStorePort,
 	SessionSummaryWriter,
 } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
@@ -11,13 +12,12 @@ import { consumeRotationRequest, getHeartbeat } from "@vicissitude/store/queries
 
 import { mcpServerConfigs } from "../mcp-config.ts";
 import { AgentRunner } from "../runner.ts";
-import type { SessionStore } from "../session-store.ts";
 import { createConversationProfile } from "./profile.ts";
 
 export interface DiscordAgentDeps {
 	guildId: string;
 	db: StoreDb;
-	sessionStore: SessionStore;
+	sessionStore: SessionStorePort;
 	contextBuilder: ContextBuilderPort;
 	logger: Logger;
 	/** OpenCode SDK サーバーのポート番号 */

--- a/packages/agent/src/discord/discord-agent.ts
+++ b/packages/agent/src/discord/discord-agent.ts
@@ -28,6 +28,8 @@ export interface DiscordAgentDeps {
 	summaryWriter?: SessionSummaryWriter;
 	/** agentId のプレフィックス（デフォルト: "discord"）。Heartbeat 専用エージェントなどでセッション分離に使用 */
 	agentIdPrefix?: string;
+	appRoot: string;
+	coreMcpPort: number;
 }
 
 export class DiscordAgent extends AgentRunner {
@@ -35,7 +37,10 @@ export class DiscordAgent extends AgentRunner {
 		const agentId = `${deps.agentIdPrefix ?? "discord"}:${deps.guildId}`;
 		const profile = createConversationProfile({
 			...deps.model,
-			mcpServers: mcpServerConfigs(agentId),
+			mcpServers: mcpServerConfigs(agentId, {
+				appRoot: deps.appRoot,
+				coreMcpPort: deps.coreMcpPort,
+			}),
 		});
 		super({
 			profile,

--- a/packages/agent/src/mcp-config.ts
+++ b/packages/agent/src/mcp-config.ts
@@ -2,11 +2,9 @@ import { resolve } from "path";
 
 import type { McpServerConfig } from "./profile.ts";
 
-const DEFAULT_BASE_PORT = 4096;
-
-function getRoot(): string {
-	// oxlint-disable-next-line typescript/no-unsafe-return -- resolve() / process.env の戻り値は string だが oxlint が誤検知する
-	return process.env.APP_ROOT ?? resolve(import.meta.dirname, "../..");
+export interface McpConfigOptions {
+	appRoot: string;
+	coreMcpPort: number;
 }
 
 /**
@@ -14,10 +12,8 @@ function getRoot(): string {
  * core MCP は HTTP サーバーとして全 guild で共有。
  * agentId は URL クエリパラメータとしてサーバーに渡され、wait_for_events のバインドに使われる。
  */
-export function mcpServerConfigs(agentId: string) {
-	const root = getRoot();
-	const basePort = Number(process.env.OPENCODE_BASE_PORT ?? String(DEFAULT_BASE_PORT));
-	const coreMcpPort = Number(process.env.CORE_MCP_PORT ?? String(basePort - 1));
+export function mcpServerConfigs(agentId: string, opts: McpConfigOptions) {
+	const { appRoot, coreMcpPort } = opts;
 
 	const configs: Record<string, McpServerConfig> = {
 		core: {
@@ -26,35 +22,42 @@ export function mcpServerConfigs(agentId: string) {
 		},
 		"code-exec": {
 			type: "local",
-			command: ["bun", "run", resolve(root, "dist/code-exec-server.js")],
+			command: ["bun", "run", resolve(appRoot, "dist/code-exec-server.js")],
 		},
 	};
 
 	return configs;
 }
 
+export interface McpMinecraftConfigOptions {
+	appRoot: string;
+	mcHost?: string;
+	mcMcpPort?: string;
+}
+
 /**
  * Minecraft エージェント用 MCP サーバー設定を返す。
  * mc-bridge-server.ts（ブリッジ）+ minecraft MCP（MC_HOST 設定時のみ）。
  */
-export function mcpMinecraftConfigs(): Record<string, McpServerConfig> {
-	const root = getRoot();
+export function mcpMinecraftConfigs(
+	opts: McpMinecraftConfigOptions,
+): Record<string, McpServerConfig> {
+	const { appRoot, mcHost, mcMcpPort } = opts;
 
 	const configs: Record<string, McpServerConfig> = {
 		"mc-bridge": {
 			type: "local",
-			command: ["bun", "run", resolve(root, "dist/mc-bridge-server.js")],
+			command: ["bun", "run", resolve(appRoot, "dist/mc-bridge-server.js")],
 			environment: {
-				DATA_DIR: resolve(root, "data"),
+				DATA_DIR: resolve(appRoot, "data"),
 			},
 		},
 	};
 
-	if (process.env.MC_HOST) {
-		const mcMcpPort = process.env.MC_MCP_PORT ?? "3001";
+	if (mcHost) {
 		configs.minecraft = {
 			type: "remote",
-			url: `http://localhost:${mcMcpPort}/mcp`,
+			url: `http://localhost:${mcMcpPort ?? "3001"}/mcp`,
 		};
 	}
 

--- a/packages/agent/src/minecraft/brain-manager.ts
+++ b/packages/agent/src/minecraft/brain-manager.ts
@@ -1,18 +1,17 @@
 import { MINECRAFT_AGENT_ID } from "@vicissitude/minecraft/constants";
-import type { Logger } from "@vicissitude/shared/types";
+import type { Logger, SessionStorePort } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
 import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
 import { clearSessionLock, hasSessionLock } from "@vicissitude/store/mc-bridge";
 import { appendEvent } from "@vicissitude/store/queries";
 
-import type { SessionStore } from "../session-store.ts";
 import { MinecraftAgent } from "./minecraft-agent.ts";
 
 const DEFAULT_LIFECYCLE_POLL_MS = 10_000;
 
 export interface McBrainManagerDeps {
 	db: StoreDb;
-	sessionStore: SessionStore;
+	sessionStore: SessionStorePort;
 	logger: Logger;
 	root: string;
 	opencodePort: number;

--- a/packages/agent/src/minecraft/brain-manager.ts
+++ b/packages/agent/src/minecraft/brain-manager.ts
@@ -20,6 +20,8 @@ export interface McBrainManagerDeps {
 	sessionMaxAgeMs: number;
 	/** ライフサイクルポーリング間隔（ms）。デフォルト 10_000 */
 	lifecyclePollMs?: number;
+	mcHost?: string;
+	mcMcpPort?: string;
 }
 
 /**
@@ -78,8 +80,18 @@ export class McBrainManager {
 	private createAgent(): void {
 		if (this.agent || this.stopping) return;
 
-		const { db, sessionStore, logger, root, opencodePort, providerId, modelId, sessionMaxAgeMs } =
-			this.deps;
+		const {
+			db,
+			sessionStore,
+			logger,
+			root,
+			opencodePort,
+			providerId,
+			modelId,
+			sessionMaxAgeMs,
+			mcHost,
+			mcMcpPort,
+		} = this.deps;
 		this.agent = new MinecraftAgent({
 			eventBuffer: new SqliteEventBuffer(db, MINECRAFT_AGENT_ID, logger),
 			sessionStore,
@@ -88,6 +100,8 @@ export class McBrainManager {
 			opencodePort,
 			sessionMaxAgeMs,
 			model: { providerId, modelId },
+			mcHost,
+			mcMcpPort,
 		});
 		// 初期イベントを挿入してポーリングループの最初の waitForEvents を通過させる
 		const bootstrapEvent = {

--- a/packages/agent/src/minecraft/minecraft-agent.ts
+++ b/packages/agent/src/minecraft/minecraft-agent.ts
@@ -18,13 +18,19 @@ export interface MinecraftAgentDeps {
 	opencodePort: number;
 	sessionMaxAgeMs: number;
 	model: { providerId: string; modelId: string };
+	mcHost?: string;
+	mcMcpPort?: string;
 }
 
 export class MinecraftAgent extends AgentRunner {
 	constructor(deps: MinecraftAgentDeps) {
 		const profile = createMinecraftProfile({
 			...deps.model,
-			mcpServers: mcpMinecraftConfigs(),
+			mcpServers: mcpMinecraftConfigs({
+				appRoot: deps.root,
+				mcHost: deps.mcHost,
+				mcMcpPort: deps.mcMcpPort,
+			}),
 		});
 		const overlayDir: string = resolve(deps.root, "data/context/minecraft");
 		const baseDir: string = resolve(deps.root, "context/minecraft");

--- a/packages/agent/src/minecraft/minecraft-agent.ts
+++ b/packages/agent/src/minecraft/minecraft-agent.ts
@@ -2,16 +2,15 @@ import { resolve } from "path";
 
 import { MINECRAFT_AGENT_ID } from "@vicissitude/minecraft/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
-import type { EventBuffer, Logger } from "@vicissitude/shared/types";
+import type { EventBuffer, Logger, SessionStorePort } from "@vicissitude/shared/types";
 
 import { mcpMinecraftConfigs } from "../mcp-config.ts";
 import { AgentRunner } from "../runner.ts";
-import type { SessionStore } from "../session-store.ts";
 import { MinecraftContextBuilder } from "./context-builder.ts";
 import { createMinecraftProfile } from "./profile.ts";
 
 export interface MinecraftAgentDeps {
-	sessionStore: SessionStore;
+	sessionStore: SessionStorePort;
 	logger: Logger;
 	root: string;
 	eventBuffer: EventBuffer;

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -25,7 +25,7 @@ const DEFAULT_HANG_TIMEOUT_MS = 600_000;
 export interface HeartbeatReader {
 	getLastSeenAt(agentId: string): number | undefined;
 	/** MCP 側からのローテーション要求を消費する。要求があればタイムスタンプを返し、DB 側はリセットする */
-	consumeRotationRequest?(agentId: string): number | null;
+	consumeRotationRequest(agentId: string): number | null;
 }
 
 export interface RunnerDeps {
@@ -151,7 +151,7 @@ export class AgentRunner implements AiAgent {
 			}
 
 			// MCP 側からのローテーション要求をチェック（respond スキップ閾値超過時に書き込まれる）
-			const rotationTs = this.heartbeatReader?.consumeRotationRequest?.(this.agentId) ?? null;
+			const rotationTs = this.heartbeatReader?.consumeRotationRequest(this.agentId) ?? null;
 			if (rotationTs !== null) {
 				this.logger.warn(
 					`[${this.profile.name}:${this.agentId}] MCP respond-skip rotation request detected (requested at ${rotationTs}), rotating session`,

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -10,11 +10,11 @@ import type {
 	OpencodeSessionEvent,
 	OpencodeSessionPort,
 	SendOptions,
+	SessionStorePort,
 	SessionSummaryWriter,
 } from "@vicissitude/shared/types";
 
 import type { AgentProfile } from "./profile.ts";
-import type { SessionStore } from "./session-store.ts";
 
 const MAX_RECONNECT_DELAY_MS = 30_000;
 const INITIAL_RECONNECT_DELAY_MS = 2_000;
@@ -31,7 +31,7 @@ export interface HeartbeatReader {
 export interface RunnerDeps {
 	profile: AgentProfile;
 	agentId: string;
-	sessionStore: SessionStore;
+	sessionStore: SessionStorePort;
 	contextBuilder: ContextBuilderPort;
 	logger: Logger;
 	sessionPort: OpencodeSessionPort;
@@ -61,7 +61,7 @@ export class AgentRunner implements AiAgent {
 
 	private readonly profile: AgentProfile;
 	private readonly agentId: string;
-	private readonly sessionStore: SessionStore;
+	private readonly sessionStore: SessionStorePort;
 	private readonly contextBuilder: ContextBuilderPort;
 	private readonly logger: Logger;
 	private readonly sessionPort: OpencodeSessionPort;

--- a/packages/application/src/message-ingestion-service.ts
+++ b/packages/application/src/message-ingestion-service.ts
@@ -1,4 +1,5 @@
 import { discordGuildNamespace } from "@vicissitude/shared/namespace";
+import type { BufferedEventStore } from "@vicissitude/shared/ports";
 import type {
 	BufferedEvent,
 	ConversationMessage,
@@ -6,10 +7,6 @@ import type {
 	IncomingMessage,
 	Logger,
 } from "@vicissitude/shared/types";
-
-export interface BufferedEventStore {
-	append(agentId: string, event: BufferedEvent): void;
-}
 
 export interface MessageIngestionServiceDeps {
 	eventStore: BufferedEventStore;

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -8,7 +8,6 @@
 	"dependencies": {
 		"@sinclair/typebox": "^0.34.48",
 		"@vicissitude/avatar": "workspace:*",
-		"@vicissitude/observability": "workspace:*",
 		"@vicissitude/shared": "workspace:*",
 		"elysia": "^1.4.27"
 	}

--- a/packages/gateway/src/ws-handler.test.ts
+++ b/packages/gateway/src/ws-handler.test.ts
@@ -9,6 +9,8 @@ import { WsConnectionManager, type WebSocketConnection } from "./ws-handler.ts";
 
 // ─── Helpers ────────────────────────────────────────────────────
 
+const noopLogger = createMockLogger();
+
 function createMockConnection(): WebSocketConnection & { sent: string[] } {
 	const sent: string[] = [];
 	return {
@@ -40,7 +42,7 @@ const sampleServerMessage: ServerMessage = {
 describe("WsConnectionManager (unit)", () => {
 	describe("handleMessage - 存在しない connectionId", () => {
 		it("接続が見つからない場合、ハンドラは呼ばれず早期リターンする", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			let handlerCalled = false;
 			manager.onMessage(() => {
 				handlerCalled = true;
@@ -53,7 +55,7 @@ describe("WsConnectionManager (unit)", () => {
 		});
 
 		it("接続が見つからない場合、エラーメッセージも送信されない", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
 
@@ -69,7 +71,7 @@ describe("WsConnectionManager (unit)", () => {
 
 	describe("handleMessage - エラーレスポンスの内容", () => {
 		it("パース失敗時、ErrorMessage の code が INVALID_MESSAGE である", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
 
@@ -81,7 +83,7 @@ describe("WsConnectionManager (unit)", () => {
 		});
 
 		it("パース失敗時、ErrorMessage に timestamp が含まれる", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
 
@@ -100,7 +102,7 @@ describe("WsConnectionManager (unit)", () => {
 		it("接続数にかかわらず JSON.stringify が1回だけ呼ばれる", () => {
 			const stringifySpy = spyOn(JSON, "stringify");
 
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			manager.handleOpen("conn-1", createMockConnection());
 			manager.handleOpen("conn-2", createMockConnection());
 			manager.handleOpen("conn-3", createMockConnection());
@@ -116,7 +118,7 @@ describe("WsConnectionManager (unit)", () => {
 		});
 
 		it("全接続に同一の文字列インスタンスが送信される", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn1 = createMockConnection();
 			const conn2 = createMockConnection();
 			const conn3 = createMockConnection();
@@ -208,7 +210,7 @@ describe("WsConnectionManager (unit)", () => {
 		};
 
 		it("deps 省略時、既存動作が変わらない（ChatResponseMessage + EmotionUpdateMessage のみ）", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
 
@@ -226,6 +228,7 @@ describe("WsConnectionManager (unit)", () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: mockSynthesizer,
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
@@ -253,6 +256,7 @@ describe("WsConnectionManager (unit)", () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: mockSynthesizer,
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
@@ -282,6 +286,7 @@ describe("WsConnectionManager (unit)", () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: nullSynthesizer,
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
@@ -307,6 +312,7 @@ describe("WsConnectionManager (unit)", () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: failingSynthesizer,
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
@@ -333,6 +339,7 @@ describe("WsConnectionManager (unit)", () => {
 		it("ttsStyleMapper のみ設定して ttsSynthesizer がない場合、TTS は実行されない", async () => {
 			const manager = new WsConnectionManager({
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
@@ -350,6 +357,7 @@ describe("WsConnectionManager (unit)", () => {
 		it("ttsSynthesizer のみ設定して ttsStyleMapper がない場合、TTS は実行されない", async () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: mockSynthesizer,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);

--- a/packages/gateway/src/ws-handler.ts
+++ b/packages/gateway/src/ws-handler.ts
@@ -1,5 +1,4 @@
 import { createEmotionToExpressionMapper } from "@vicissitude/avatar";
-import { ConsoleLogger } from "@vicissitude/observability/logger";
 import { createEmotion } from "@vicissitude/shared/emotion";
 import type {
 	ClientMessageHandler,
@@ -34,7 +33,7 @@ export interface WsConnectionManagerDeps {
 	ttsSynthesizer?: TtsSynthesizer;
 	ttsStyleMapper?: EmotionToTtsStyleMapper;
 	moodReader?: MoodReader;
-	logger?: Logger;
+	logger: Logger;
 }
 
 export class WsConnectionManager implements GatewayPort {
@@ -46,11 +45,11 @@ export class WsConnectionManager implements GatewayPort {
 	private readonly moodReader: MoodReader | undefined;
 	private readonly logger: Logger;
 
-	constructor(deps?: WsConnectionManagerDeps) {
-		this.ttsSynthesizer = deps?.ttsSynthesizer;
-		this.ttsStyleMapper = deps?.ttsStyleMapper;
-		this.moodReader = deps?.moodReader;
-		this.logger = deps?.logger ?? new ConsoleLogger();
+	constructor(deps: WsConnectionManagerDeps) {
+		this.ttsSynthesizer = deps.ttsSynthesizer;
+		this.ttsStyleMapper = deps.ttsStyleMapper;
+		this.moodReader = deps.moodReader;
+		this.logger = deps.logger;
 	}
 
 	handleOpen(connectionId: string, connection: WebSocketConnection): void {

--- a/packages/infrastructure/src/store/sqlite-buffered-event-store.ts
+++ b/packages/infrastructure/src/store/sqlite-buffered-event-store.ts
@@ -1,4 +1,4 @@
-import type { BufferedEventStore } from "@vicissitude/application/message-ingestion-service";
+import type { BufferedEventStore } from "@vicissitude/shared/ports";
 import type { BufferedEvent } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
 import { appendEvent } from "@vicissitude/store/queries";

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -11,7 +11,6 @@ import type { MemoryLlmPort } from "@vicissitude/memory/llm-port";
 import {
 	INTERNAL_NAMESPACE,
 	type MemoryNamespace,
-	namespaceKey,
 	resolveMemoryDbDir,
 	resolveMemoryDbPath,
 	resolveNamespaceFromAgentId,
@@ -29,6 +28,7 @@ import { SqliteMoodStore } from "@vicissitude/store/mood-store";
 import { Client, GatewayIntentBits } from "discord.js";
 
 import { startHttpServer } from "./http-server.ts";
+import { MemoryInstanceCache } from "./memory-cache.ts";
 import { wrapServerWithMetrics } from "./tool-metrics.ts";
 import { registerDiscordTools } from "./tools/discord.ts";
 import { createSkipTracker, registerEventBufferTools } from "./tools/event-buffer.ts";
@@ -105,31 +105,7 @@ async function main(): Promise<void> {
 		embed: (text: string) => ollama.embed(text),
 	};
 
-	const MAX_MEMORY_INSTANCES = 50;
-
-	const memoryInstances = new Map<string, MemoryReadServices>();
-	const memoryStorages = new Map<string, MemoryStorage>();
-
-	function getOrCreateMemory(namespace: MemoryNamespace): MemoryReadServices {
-		const key = namespaceKey(namespace);
-
-		const existing = memoryInstances.get(key);
-		if (existing) {
-			// LRU: 再挿入して最新アクセスとして記録
-			memoryInstances.delete(key);
-			memoryInstances.set(key, existing);
-			return existing;
-		}
-
-		// Evict oldest entry if at capacity
-		if (memoryInstances.size >= MAX_MEMORY_INSTANCES) {
-			const oldestKey = memoryInstances.keys().next().value as string;
-			memoryInstances.delete(oldestKey);
-			const oldStorage = memoryStorages.get(oldestKey);
-			oldStorage?.close();
-			memoryStorages.delete(oldestKey);
-		}
-
+	const memoryCache = new MemoryInstanceCache(50, (namespace) => {
 		const dbDir = resolveMemoryDbDir(MEMORY_DATA_DIR, namespace);
 		mkdirSync(dbDir, { recursive: true });
 		const storage = new MemoryStorage(resolveMemoryDbPath(MEMORY_DATA_DIR, namespace));
@@ -138,9 +114,11 @@ async function main(): Promise<void> {
 			retrieval: new Retrieval(embedOnlyLlm, storage, episodic),
 			semantic: new SemanticMemory(storage),
 		};
-		memoryInstances.set(key, instance);
-		memoryStorages.set(key, storage);
-		return instance;
+		return { instance, storage };
+	});
+
+	function getOrCreateMemory(namespace: MemoryNamespace): MemoryReadServices {
+		return memoryCache.getOrCreate(namespace);
 	}
 
 	// --- Prometheus Metrics ---
@@ -237,10 +215,10 @@ async function main(): Promise<void> {
 
 			if (process.env.GENIUS_ACCESS_TOKEN) {
 				const geniusClient = new GeniusClient(process.env.GENIUS_ACCESS_TOKEN);
-				getOrCreateMemory(INTERNAL_NAMESPACE);
-				const internalStorage = memoryStorages.get(namespaceKey(INTERNAL_NAMESPACE));
+				memoryCache.getOrCreate(INTERNAL_NAMESPACE);
+				const internalStorage = memoryCache.getStorage(INTERNAL_NAMESPACE);
 				if (!internalStorage)
-					throw new Error("unreachable: getOrCreateMemory failed to populate memoryStorages");
+					throw new Error("unreachable: getOrCreate failed to populate memoryCache");
 				const listeningMemory = new ListeningMemory(internalStorage, {
 					embed: (text) => ollama.embed(text),
 				});
@@ -279,11 +257,7 @@ async function main(): Promise<void> {
 		closeAllSessions();
 		stopServer();
 		void discordClient.destroy();
-		for (const storage of memoryStorages.values()) {
-			storage.close();
-		}
-		memoryInstances.clear();
-		memoryStorages.clear();
+		memoryCache.closeAll();
 		closeDb(db);
 		process.exit(0);
 	}

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -1,4 +1,5 @@
 import { mkdirSync } from "fs";
+import { resolve } from "path";
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { EmotionEstimator } from "@vicissitude/agent/emotion/estimator";
@@ -22,6 +23,7 @@ import { ConsoleLogger } from "@vicissitude/observability/logger";
 import { METRIC, PrometheusCollector, PrometheusServer } from "@vicissitude/observability/metrics";
 import { OllamaEmbeddingAdapter } from "@vicissitude/ollama";
 import { OllamaChatAdapter } from "@vicissitude/ollama/ollama-chat-adapter";
+import { JsonHeartbeatConfigRepository } from "@vicissitude/scheduling/heartbeat-config";
 import { closeDb, createDb } from "@vicissitude/store/db";
 import { SqliteMoodStore } from "@vicissitude/store/mood-store";
 import { Client, GatewayIntentBits } from "discord.js";
@@ -37,252 +39,257 @@ import { registerMetaTools } from "./tools/meta.ts";
 import { registerScheduleTools } from "./tools/schedule.ts";
 import { registerSpotifyTools } from "./tools/spotify.ts";
 
-// --- Logger ---
+async function main(): Promise<void> {
+	// --- Logger ---
 
-const logger = new ConsoleLogger();
+	const logger = new ConsoleLogger();
 
-// --- Configuration from environment ---
+	// --- Configuration from environment ---
 
-const CORE_MCP_PORT = Number(process.env.CORE_MCP_PORT ?? "4095");
-const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://ollama:11434";
-const MEMORY_EMBEDDING_MODEL = process.env.MEMORY_EMBEDDING_MODEL ?? "embeddinggemma";
-const MEMORY_DATA_DIR = process.env.MEMORY_DATA_DIR ?? "data/memory";
-const EMOTION_CHAT_MODEL = process.env.EMOTION_CHAT_MODEL ?? "gemma3";
-const DATA_DIR = process.env.DATA_DIR ?? "data";
+	const CORE_MCP_PORT = Number(process.env.CORE_MCP_PORT ?? "4095");
+	const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://ollama:11434";
+	const MEMORY_EMBEDDING_MODEL = process.env.MEMORY_EMBEDDING_MODEL ?? "embeddinggemma";
+	const MEMORY_DATA_DIR = process.env.MEMORY_DATA_DIR ?? "data/memory";
+	const EMOTION_CHAT_MODEL = process.env.EMOTION_CHAT_MODEL ?? "gemma3";
+	const DATA_DIR = process.env.DATA_DIR ?? "data";
+	const configRepo = new JsonHeartbeatConfigRepository(resolve(DATA_DIR, "heartbeat-config.json"));
 
-if (!process.env.DISCORD_TOKEN) {
-	logger.error("[core-server] DISCORD_TOKEN environment variable is required");
-	process.exit(1);
-}
-
-// --- Discord Client ---
-
-const discordClient = new Client({
-	intents: [
-		GatewayIntentBits.Guilds,
-		GatewayIntentBits.GuildMessages,
-		GatewayIntentBits.MessageContent,
-		GatewayIntentBits.GuildMessageReactions,
-	],
-});
-
-try {
-	await discordClient.login(process.env.DISCORD_TOKEN);
-} catch (err) {
-	logger.error("[core-server] Failed to login to Discord:", err);
-	process.exit(1);
-}
-
-// --- Drizzle DB ---
-
-const db = createDb(DATA_DIR);
-const moodStore = new SqliteMoodStore(db);
-
-// --- Memory (embed-only — consolidation runs in the main process) ---
-
-const ollama = new OllamaEmbeddingAdapter(OLLAMA_BASE_URL, MEMORY_EMBEDDING_MODEL);
-const ollamaChat = new OllamaChatAdapter(OLLAMA_BASE_URL, EMOTION_CHAT_MODEL);
-const emotionEstimator = new EmotionEstimator(ollamaChat);
-
-/** MemoryLlmPort that only supports embed — chat/chatStructured throw since they are unused here */
-const embedOnlyLlm: MemoryLlmPort = {
-	chat(): Promise<never> {
-		return Promise.reject(
-			new Error("chat is not available in core-server (consolidation runs in main process)"),
-		);
-	},
-	chatStructured(): Promise<never> {
-		return Promise.reject(
-			new Error(
-				"chatStructured is not available in core-server (consolidation runs in main process)",
-			),
-		);
-	},
-	embed: (text: string) => ollama.embed(text),
-};
-
-const MAX_MEMORY_INSTANCES = 50;
-
-const memoryInstances = new Map<string, MemoryReadServices>();
-const memoryStorages = new Map<string, MemoryStorage>();
-
-function getOrCreateMemory(namespace: MemoryNamespace): MemoryReadServices {
-	const key = namespaceKey(namespace);
-
-	const existing = memoryInstances.get(key);
-	if (existing) {
-		// LRU: 再挿入して最新アクセスとして記録
-		memoryInstances.delete(key);
-		memoryInstances.set(key, existing);
-		return existing;
+	if (!process.env.DISCORD_TOKEN) {
+		logger.error("[core-server] DISCORD_TOKEN environment variable is required");
+		process.exit(1);
 	}
 
-	// Evict oldest entry if at capacity
-	if (memoryInstances.size >= MAX_MEMORY_INSTANCES) {
-		const oldestKey = memoryInstances.keys().next().value as string;
-		memoryInstances.delete(oldestKey);
-		const oldStorage = memoryStorages.get(oldestKey);
-		oldStorage?.close();
-		memoryStorages.delete(oldestKey);
-	}
+	// --- Discord Client ---
 
-	const dbDir = resolveMemoryDbDir(MEMORY_DATA_DIR, namespace);
-	mkdirSync(dbDir, { recursive: true });
-	const storage = new MemoryStorage(resolveMemoryDbPath(MEMORY_DATA_DIR, namespace));
-	const episodic = new EpisodicMemory(storage);
-	const instance: MemoryReadServices = {
-		retrieval: new Retrieval(embedOnlyLlm, storage, episodic),
-		semantic: new SemanticMemory(storage),
-	};
-	memoryInstances.set(key, instance);
-	memoryStorages.set(key, storage);
-	return instance;
-}
-
-// --- Prometheus Metrics ---
-
-const CORE_METRICS_PORT = Number(process.env.CORE_METRICS_PORT) || 9093;
-
-const metricsCollector = new PrometheusCollector();
-metricsCollector.registerCounter(METRIC.MCP_TOOL_CALLS, "Core MCP tool calls total");
-
-const metricsServer = new PrometheusServer(metricsCollector, logger, CORE_METRICS_PORT);
-metricsServer.start();
-
-// --- MCP Server Factory ---
-
-function createServer(agentId: string | null): McpServer {
-	const rawServer = new McpServer({ name: "core", version: "1.0.0" });
-	const toolDescriptions = new Map<string, string | undefined>();
-	const server = wrapServerWithMetrics(rawServer, {
-		metrics: metricsCollector,
-		logger,
-		toolDescriptions,
+	const discordClient = new Client({
+		intents: [
+			GatewayIntentBits.Guilds,
+			GatewayIntentBits.GuildMessages,
+			GatewayIntentBits.MessageContent,
+			GatewayIntentBits.GuildMessageReactions,
+		],
 	});
 
-	const boundNamespace: MemoryNamespace | undefined =
-		resolveNamespaceFromAgentId(agentId) ?? undefined;
-	if (agentId && !boundNamespace) {
-		logger.warn(
-			`[core-server] agent_id=${agentId} did not resolve to a known namespace — tools require explicit guild_id`,
-		);
+	try {
+		await discordClient.login(process.env.DISCORD_TOKEN);
+	} catch (err) {
+		logger.error("[core-server] Failed to login to Discord:", err);
+		process.exit(1);
 	}
-	const boundGuildId =
-		boundNamespace?.surface === "discord-guild" ? boundNamespace.guildId : undefined;
-	const moodKey = boundGuildId ? `discord:${boundGuildId}` : (agentId ?? undefined);
-	const skipTracker = agentId ? createSkipTracker() : undefined;
 
-	registerDiscordTools(
-		server,
-		{
-			discordClient,
-			emotionAnalyzer: emotionEstimator,
-			moodWriter: moodStore,
-			agentId: agentId ?? undefined,
-			moodKey,
-			skipTracker,
+	// --- Drizzle DB ---
+
+	const db = createDb(DATA_DIR);
+	const moodStore = new SqliteMoodStore(db);
+
+	// --- Memory (embed-only — consolidation runs in the main process) ---
+
+	const ollama = new OllamaEmbeddingAdapter(OLLAMA_BASE_URL, MEMORY_EMBEDDING_MODEL);
+	const ollamaChat = new OllamaChatAdapter(OLLAMA_BASE_URL, EMOTION_CHAT_MODEL);
+	const emotionEstimator = new EmotionEstimator(ollamaChat);
+
+	/** MemoryLlmPort that only supports embed — chat/chatStructured throw since they are unused here */
+	const embedOnlyLlm: MemoryLlmPort = {
+		chat(): Promise<never> {
+			return Promise.reject(
+				new Error("chat is not available in core-server (consolidation runs in main process)"),
+			);
 		},
-		boundGuildId,
-	);
-	registerScheduleTools(server, boundGuildId);
-	if (agentId) {
-		const recentMessagesFetcher = async (channelId: string) => {
-			const ch = await discordClient.channels.fetch(channelId);
-			if (!ch?.isTextBased() || !("messages" in ch)) return [];
-			const msgs = await ch.messages.fetch({ limit: 5 });
-			return [...msgs.values()].map((m) => ({
-				authorName: m.member?.displayName ?? m.author.displayName,
-				content: m.content,
-				timestamp: m.createdAt,
-				reactions: [...m.reactions.cache.values()].map((r) => ({
-					emoji: r.emoji.name ?? r.emoji.toString(),
-					count: r.count,
-				})),
-			}));
-		};
-		registerEventBufferTools(server, {
-			db,
-			agentId,
-			moodKey,
-			recentMessagesFetcher,
-			moodReader: moodStore,
-			logger,
-			skipTracker,
-		});
-	} else {
-		logger.warn("[core-server] session created without agent_id — wait_for_events unavailable");
-	}
-	registerMemoryTools(server, { getOrCreateMemory }, boundNamespace);
-	registerDiscordBridgeTools(server, { db }, boundGuildId);
+		chatStructured(): Promise<never> {
+			return Promise.reject(
+				new Error(
+					"chatStructured is not available in core-server (consolidation runs in main process)",
+				),
+			);
+		},
+		embed: (text: string) => ollama.embed(text),
+	};
 
-	if (
-		process.env.SPOTIFY_CLIENT_ID &&
-		process.env.SPOTIFY_CLIENT_SECRET &&
-		process.env.SPOTIFY_REFRESH_TOKEN
-	) {
-		registerSpotifyTools(
+	const MAX_MEMORY_INSTANCES = 50;
+
+	const memoryInstances = new Map<string, MemoryReadServices>();
+	const memoryStorages = new Map<string, MemoryStorage>();
+
+	function getOrCreateMemory(namespace: MemoryNamespace): MemoryReadServices {
+		const key = namespaceKey(namespace);
+
+		const existing = memoryInstances.get(key);
+		if (existing) {
+			// LRU: 再挿入して最新アクセスとして記録
+			memoryInstances.delete(key);
+			memoryInstances.set(key, existing);
+			return existing;
+		}
+
+		// Evict oldest entry if at capacity
+		if (memoryInstances.size >= MAX_MEMORY_INSTANCES) {
+			const oldestKey = memoryInstances.keys().next().value as string;
+			memoryInstances.delete(oldestKey);
+			const oldStorage = memoryStorages.get(oldestKey);
+			oldStorage?.close();
+			memoryStorages.delete(oldestKey);
+		}
+
+		const dbDir = resolveMemoryDbDir(MEMORY_DATA_DIR, namespace);
+		mkdirSync(dbDir, { recursive: true });
+		const storage = new MemoryStorage(resolveMemoryDbPath(MEMORY_DATA_DIR, namespace));
+		const episodic = new EpisodicMemory(storage);
+		const instance: MemoryReadServices = {
+			retrieval: new Retrieval(embedOnlyLlm, storage, episodic),
+			semantic: new SemanticMemory(storage),
+		};
+		memoryInstances.set(key, instance);
+		memoryStorages.set(key, storage);
+		return instance;
+	}
+
+	// --- Prometheus Metrics ---
+
+	const CORE_METRICS_PORT = Number(process.env.CORE_METRICS_PORT) || 9093;
+
+	const metricsCollector = new PrometheusCollector();
+	metricsCollector.registerCounter(METRIC.MCP_TOOL_CALLS, "Core MCP tool calls total");
+
+	const metricsServer = new PrometheusServer(metricsCollector, logger, CORE_METRICS_PORT);
+	metricsServer.start();
+
+	// --- MCP Server Factory ---
+
+	function createServer(agentId: string | null): McpServer {
+		const rawServer = new McpServer({ name: "core", version: "1.0.0" });
+		const toolDescriptions = new Map<string, string | undefined>();
+		const server = wrapServerWithMetrics(rawServer, {
+			metrics: metricsCollector,
+			logger,
+			toolDescriptions,
+		});
+
+		const boundNamespace: MemoryNamespace | undefined =
+			resolveNamespaceFromAgentId(agentId) ?? undefined;
+		if (agentId && !boundNamespace) {
+			logger.warn(
+				`[core-server] agent_id=${agentId} did not resolve to a known namespace — tools require explicit guild_id`,
+			);
+		}
+		const boundGuildId =
+			boundNamespace?.surface === "discord-guild" ? boundNamespace.guildId : undefined;
+		const moodKey = boundGuildId ? `discord:${boundGuildId}` : (agentId ?? undefined);
+		const skipTracker = agentId ? createSkipTracker() : undefined;
+
+		registerDiscordTools(
 			server,
 			{
-				clientId: process.env.SPOTIFY_CLIENT_ID,
-				clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
-				refreshToken: process.env.SPOTIFY_REFRESH_TOKEN,
-				recommendPlaylistId: process.env.SPOTIFY_RECOMMEND_PLAYLIST_ID,
+				discordClient,
+				emotionAnalyzer: emotionEstimator,
+				moodWriter: moodStore,
+				agentId: agentId ?? undefined,
+				moodKey,
+				skipTracker,
 			},
-			logger,
+			boundGuildId,
 		);
-
-		if (process.env.GENIUS_ACCESS_TOKEN) {
-			const geniusClient = new GeniusClient(process.env.GENIUS_ACCESS_TOKEN);
-			getOrCreateMemory(INTERNAL_NAMESPACE);
-			const internalStorage = memoryStorages.get(namespaceKey(INTERNAL_NAMESPACE));
-			if (!internalStorage)
-				throw new Error("unreachable: getOrCreateMemory failed to populate memoryStorages");
-			const listeningMemory = new ListeningMemory(internalStorage, {
-				embed: (text) => ollama.embed(text),
+		registerScheduleTools(server, configRepo, boundGuildId);
+		if (agentId) {
+			const recentMessagesFetcher = async (channelId: string) => {
+				const ch = await discordClient.channels.fetch(channelId);
+				if (!ch?.isTextBased() || !("messages" in ch)) return [];
+				const msgs = await ch.messages.fetch({ limit: 5 });
+				return [...msgs.values()].map((m) => ({
+					authorName: m.member?.displayName ?? m.author.displayName,
+					content: m.content,
+					timestamp: m.createdAt,
+					reactions: [...m.reactions.cache.values()].map((r) => ({
+						emoji: r.emoji.name ?? r.emoji.toString(),
+						count: r.count,
+					})),
+				}));
+			};
+			registerEventBufferTools(server, {
+				db,
+				agentId,
+				moodKey,
+				recentMessagesFetcher,
+				moodReader: moodStore,
+				logger,
+				skipTracker,
 			});
-			registerListeningTools(server, {
-				fetchLyrics: (title, artist) => geniusClient.fetchLyrics(title, artist),
-				saveListening: async (record) => {
-					await listeningMemory.saveListening({
-						track: record.track,
-						impression: record.impression,
-						listenedAt: record.listenedAt,
-					});
-				},
-			});
+		} else {
+			logger.warn("[core-server] session created without agent_id — wait_for_events unavailable");
 		}
+		registerMemoryTools(server, { getOrCreateMemory }, boundNamespace);
+		registerDiscordBridgeTools(server, { db }, boundGuildId);
+
+		if (
+			process.env.SPOTIFY_CLIENT_ID &&
+			process.env.SPOTIFY_CLIENT_SECRET &&
+			process.env.SPOTIFY_REFRESH_TOKEN
+		) {
+			registerSpotifyTools(
+				server,
+				{
+					clientId: process.env.SPOTIFY_CLIENT_ID,
+					clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
+					refreshToken: process.env.SPOTIFY_REFRESH_TOKEN,
+					recommendPlaylistId: process.env.SPOTIFY_RECOMMEND_PLAYLIST_ID,
+				},
+				logger,
+			);
+
+			if (process.env.GENIUS_ACCESS_TOKEN) {
+				const geniusClient = new GeniusClient(process.env.GENIUS_ACCESS_TOKEN);
+				getOrCreateMemory(INTERNAL_NAMESPACE);
+				const internalStorage = memoryStorages.get(namespaceKey(INTERNAL_NAMESPACE));
+				if (!internalStorage)
+					throw new Error("unreachable: getOrCreateMemory failed to populate memoryStorages");
+				const listeningMemory = new ListeningMemory(internalStorage, {
+					embed: (text) => ollama.embed(text),
+				});
+				registerListeningTools(server, {
+					fetchLyrics: (title, artist) => geniusClient.fetchLyrics(title, artist),
+					saveListening: async (record) => {
+						await listeningMemory.saveListening({
+							track: record.track,
+							impression: record.impression,
+							listenedAt: record.listenedAt,
+						});
+					},
+				});
+			}
+		}
+
+		registerMetaTools(server, toolDescriptions);
+
+		return server;
 	}
 
-	registerMetaTools(server, toolDescriptions);
+	// --- Start HTTP Server ---
 
-	return server;
-}
+	const { cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
+		createServer,
+		CORE_MCP_PORT,
+		"core",
+		logger,
+	);
 
-// --- Start HTTP Server ---
+	// --- Graceful Shutdown ---
 
-const { cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
-	createServer,
-	CORE_MCP_PORT,
-	"core",
-	logger,
-);
-
-// --- Graceful Shutdown ---
-
-function shutdown() {
-	metricsServer.stop();
-	clearInterval(cleanupTimer);
-	closeAllSessions();
-	stopServer();
-	void discordClient.destroy();
-	for (const storage of memoryStorages.values()) {
-		storage.close();
+	function shutdown() {
+		metricsServer.stop();
+		clearInterval(cleanupTimer);
+		closeAllSessions();
+		stopServer();
+		void discordClient.destroy();
+		for (const storage of memoryStorages.values()) {
+			storage.close();
+		}
+		memoryInstances.clear();
+		memoryStorages.clear();
+		closeDb(db);
+		process.exit(0);
 	}
-	memoryInstances.clear();
-	memoryStorages.clear();
-	closeDb(db);
-	process.exit(0);
+
+	process.on("SIGINT", () => shutdown());
+	process.on("SIGTERM", () => shutdown());
 }
 
-process.on("SIGINT", () => shutdown());
-process.on("SIGTERM", () => shutdown());
+void main();

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { EmotionEstimator } from "@vicissitude/agent/emotion/estimator";
 import { GeniusClient } from "@vicissitude/listening/genius-client";
 import { ListeningMemory } from "@vicissitude/listening/listening-memory";
+import type { MemoryReadServices } from "@vicissitude/memory";
 import { EpisodicMemory } from "@vicissitude/memory/episodic";
 import type { MemoryLlmPort } from "@vicissitude/memory/llm-port";
 import {
@@ -31,7 +32,7 @@ import { registerDiscordTools } from "./tools/discord.ts";
 import { createSkipTracker, registerEventBufferTools } from "./tools/event-buffer.ts";
 import { registerListeningTools } from "./tools/listening.ts";
 import { registerDiscordBridgeTools } from "./tools/mc-bridge-discord.ts";
-import { type MemoryReadServices, registerMemoryTools } from "./tools/memory.ts";
+import { registerMemoryTools } from "./tools/memory.ts";
 import { registerMetaTools } from "./tools/meta.ts";
 import { registerScheduleTools } from "./tools/schedule.ts";
 import { registerSpotifyTools } from "./tools/spotify.ts";

--- a/packages/mcp/src/memory-cache.ts
+++ b/packages/mcp/src/memory-cache.ts
@@ -1,0 +1,57 @@
+import type { MemoryReadServices } from "@vicissitude/memory";
+import type { MemoryNamespace } from "@vicissitude/memory/namespace";
+import { namespaceKey } from "@vicissitude/memory/namespace";
+import type { MemoryStorage } from "@vicissitude/memory/storage";
+
+export class MemoryInstanceCache {
+	private readonly instances = new Map<string, MemoryReadServices>();
+	private readonly storages = new Map<string, MemoryStorage>();
+
+	constructor(
+		private readonly maxSize: number,
+		private readonly factory: (namespace: MemoryNamespace) => {
+			instance: MemoryReadServices;
+			storage: MemoryStorage;
+		},
+	) {}
+
+	getOrCreate(namespace: MemoryNamespace): MemoryReadServices {
+		const key = namespaceKey(namespace);
+
+		const existing = this.instances.get(key);
+		if (existing) {
+			// LRU: 再挿入して最新アクセスとして記録
+			this.instances.delete(key);
+			this.instances.set(key, existing);
+			return existing;
+		}
+
+		// Evict oldest entry if at capacity
+		if (this.instances.size >= this.maxSize) {
+			const oldestKey = this.instances.keys().next().value as string;
+			this.instances.delete(oldestKey);
+			const oldStorage = this.storages.get(oldestKey);
+			oldStorage?.close();
+			this.storages.delete(oldestKey);
+		}
+
+		const { instance, storage } = this.factory(namespace);
+		this.instances.set(key, instance);
+		this.storages.set(key, storage);
+		return instance;
+	}
+
+	/** 特定の namespace の MemoryStorage を取得（ListeningMemory 用） */
+	getStorage(namespace: MemoryNamespace): MemoryStorage | undefined {
+		return this.storages.get(namespaceKey(namespace));
+	}
+
+	/** 全リソースを解放 */
+	closeAll(): void {
+		for (const storage of this.storages.values()) {
+			storage.close();
+		}
+		this.instances.clear();
+		this.storages.clear();
+	}
+}

--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable max-lines -- event-buffer tools + polling + formatting helpers are tightly coupled */
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { describeEmotion, isNeutralEmotion } from "@vicissitude/shared/emotion";
+import { formatTimestamp } from "@vicissitude/shared/functions";
 import type { MoodReader } from "@vicissitude/shared/ports";
 import type { Attachment, Logger } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
@@ -165,19 +166,6 @@ export function escapeUserMessageTag(content: string): string {
 
 // ─── formatEvents ────────────────────────────────────────────────
 
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
-
-export function toJstString(ts: string | Date): string {
-	const utc = ts instanceof Date ? ts.getTime() : new Date(ts).getTime();
-	const jst = new Date(utc + JST_OFFSET_MS);
-	const y = jst.getUTCFullYear();
-	const mo = String(jst.getUTCMonth() + 1).padStart(2, "0");
-	const d = String(jst.getUTCDate()).padStart(2, "0");
-	const h = String(jst.getUTCHours()).padStart(2, "0");
-	const mi = String(jst.getUTCMinutes()).padStart(2, "0");
-	return `${y}-${mo}-${d} ${h}:${mi}`;
-}
-
 /** parseEvents がパースに失敗したエラーイベントかどうかを判定する type guard */
 export function isErrorEvent(e: EventOrError): e is ErrorEvent {
 	return "_error" in e && "_raw" in e;
@@ -194,7 +182,7 @@ export function formatEvents(events: EventOrError[]): string {
 				return `[ERROR] ${e._error}: ${e._raw}`;
 			}
 
-			const dateStr = toJstString(e.ts);
+			const dateStr = formatTimestamp(new Date(e.ts));
 			const channel = e.metadata?.channelName ? ` #${e.metadata.channelName}` : "";
 			const hint = classifyActionHint(e);
 			const extras: string[] = [];
@@ -247,7 +235,7 @@ export function formatRecentMessages(channelMessages: Map<string, RecentMessage[
 		if (messages.length === 0) continue;
 		const lines: string[] = [`## #${channelName}`];
 		for (const msg of messages) {
-			const dateStr = toJstString(msg.timestamp);
+			const dateStr = formatTimestamp(msg.timestamp);
 			let line = `[${dateStr} JST] ${msg.authorName}: ${msg.content}`;
 			if (msg.reactions.length > 0) {
 				const reactionStr = msg.reactions.map((r) => `${r.emoji}×${r.count}`).join(" ");

--- a/packages/mcp/src/tools/mc-bridge-minecraft.ts
+++ b/packages/mcp/src/tools/mc-bridge-minecraft.ts
@@ -1,18 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { MINECRAFT_AGENT_ID } from "@vicissitude/minecraft/constants";
+import { formatTimestamp } from "@vicissitude/shared/functions";
 import type { StoreDb } from "@vicissitude/store/db";
 import { getSessionLockGuildId } from "@vicissitude/store/mc-bridge";
 import { appendEvent, consumeEvents } from "@vicissitude/store/queries";
 import { z } from "zod";
 
 import type { EventOrError } from "./event-buffer.ts";
-import {
-	MAX_BATCH_SIZE,
-	escapeUserMessageTag,
-	isErrorEvent,
-	parseEvents,
-	toJstString,
-} from "./event-buffer.ts";
+import { MAX_BATCH_SIZE, escapeUserMessageTag, isErrorEvent, parseEvents } from "./event-buffer.ts";
 
 const MAX_REPORT_CHARS = 10_000;
 
@@ -29,7 +24,7 @@ export function formatCommands(events: EventOrError[]): string {
 				return `[ERROR] ${e._error}: ${e._raw}`;
 			}
 
-			const dateStr = toJstString(e.ts);
+			const dateStr = formatTimestamp(new Date(e.ts));
 			const isUserMessage = e.authorId !== "system" && e.metadata?.isBot !== true;
 			const content = isUserMessage
 				? `<user_message>${escapeUserMessageTag(e.content)}</user_message>`

--- a/packages/mcp/src/tools/memory.ts
+++ b/packages/mcp/src/tools/memory.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { MemoryReadServices } from "@vicissitude/memory";
 import {
 	defaultSubject,
 	discordGuildNamespace,
@@ -6,20 +7,13 @@ import {
 	INTERNAL_NAMESPACE,
 	type MemoryNamespace,
 } from "@vicissitude/memory/namespace";
-import type { Retrieval } from "@vicissitude/memory/retrieval";
 import type { SemanticFact } from "@vicissitude/memory/semantic-fact";
-import type { SemanticMemory } from "@vicissitude/memory/semantic-memory";
 import { z } from "zod";
 
 const guildIdSchema = z.string().regex(GUILD_ID_RE).describe("Discord guild ID");
 
 const formatFacts = (fs: SemanticFact[]) =>
 	fs.map((f) => `- [${f.category}] ${f.fact} (keywords: ${f.keywords.join(", ")})`);
-
-export interface MemoryReadServices {
-	retrieval: Retrieval;
-	semantic: SemanticMemory;
-}
 
 export interface MemoryDeps {
 	getOrCreateMemory: (namespace: MemoryNamespace) => MemoryReadServices;

--- a/packages/mcp/src/tools/schedule.ts
+++ b/packages/mcp/src/tools/schedule.ts
@@ -1,18 +1,15 @@
 /* oxlint-disable max-lines -- schedule tools register 5 MCP tools in one module */
-import { existsSync, mkdirSync, readFileSync } from "fs";
-import { dirname, resolve } from "path";
-
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import {
-	HEARTBEAT_CONFIG_RELATIVE_PATH,
-	createDefaultHeartbeatConfig,
-} from "@vicissitude/scheduling/heartbeat-helpers";
-import { APP_ROOT } from "@vicissitude/shared/config";
 import { GUILD_ID_RE } from "@vicissitude/shared/namespace";
 import type { HeartbeatConfig, HeartbeatReminder } from "@vicissitude/shared/types";
 import { z } from "zod";
 
 const guildIdSchema = z.string().regex(GUILD_ID_RE).describe("Discord guild ID");
+
+export interface HeartbeatConfigPort {
+	load(): Promise<HeartbeatConfig>;
+	save(config: HeartbeatConfig): Promise<void>;
+}
 
 export function filterRemindersByGuild(
 	reminders: HeartbeatReminder[],
@@ -25,32 +22,16 @@ export function checkGuildScope(reminder: HeartbeatReminder, guildId: string): b
 	return reminder.guildId === guildId || reminder.guildId === undefined;
 }
 
-const DATA_DIR = process.env.DATA_DIR;
-const CONFIG_PATH = DATA_DIR
-	? resolve(DATA_DIR, "heartbeat-config.json")
-	: resolve(APP_ROOT, HEARTBEAT_CONFIG_RELATIVE_PATH);
-
-function loadConfig(): HeartbeatConfig {
-	if (!existsSync(CONFIG_PATH)) return createDefaultHeartbeatConfig();
-	try {
-		return JSON.parse(readFileSync(CONFIG_PATH, "utf-8")) as HeartbeatConfig;
-	} catch {
-		return createDefaultHeartbeatConfig();
-	}
-}
-
-async function saveConfig(config: HeartbeatConfig): Promise<void> {
-	const dir = dirname(CONFIG_PATH);
-	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-	await Bun.write(CONFIG_PATH, JSON.stringify(config, null, 2));
-}
-
-function registerReadTools(server: McpServer, boundGuildId?: string): void {
+function registerReadTools(
+	server: McpServer,
+	configPort: HeartbeatConfigPort,
+	boundGuildId?: string,
+): void {
 	server.registerTool(
 		"get_heartbeat_config",
 		{ description: "現在の heartbeat 設定を表示する" },
-		() => {
-			const config = loadConfig();
+		async () => {
+			const config = await configPort.load();
 			return { content: [{ type: "text", text: JSON.stringify(config, null, 2) }] };
 		},
 	);
@@ -61,12 +42,12 @@ function registerReadTools(server: McpServer, boundGuildId?: string): void {
 			description: "リマインダー一覧を表示する（現在のギルド＋グローバルのみ）",
 			inputSchema: boundGuildId ? {} : { guild_id: guildIdSchema },
 		},
-		({ guild_id }: { guild_id?: string }) => {
+		async ({ guild_id }: { guild_id?: string }) => {
 			const gid = boundGuildId ?? guild_id;
 			if (!gid) {
 				return { content: [{ type: "text" as const, text: "Error: guild_id is required" }] };
 			}
-			const config = loadConfig();
+			const config = await configPort.load();
 			const visible = filterRemindersByGuild(config.reminders, gid);
 			const lines = visible.map((r) => {
 				const schedule =
@@ -89,9 +70,9 @@ function registerReadTools(server: McpServer, boundGuildId?: string): void {
 			inputSchema: { minutes: z.number().min(1).describe("チェック間隔（分）") },
 		},
 		async ({ minutes }) => {
-			const config = loadConfig();
+			const config = await configPort.load();
 			config.baseIntervalMinutes = minutes;
-			await saveConfig(config);
+			await configPort.save(config);
 			return {
 				content: [
 					{
@@ -104,7 +85,11 @@ function registerReadTools(server: McpServer, boundGuildId?: string): void {
 	);
 }
 
-function registerAddReminder(server: McpServer, boundGuildId?: string): void {
+function registerAddReminder(
+	server: McpServer,
+	configPort: HeartbeatConfigPort,
+	boundGuildId?: string,
+): void {
 	server.registerTool(
 		"add_reminder",
 		{
@@ -148,7 +133,7 @@ function registerAddReminder(server: McpServer, boundGuildId?: string): void {
 			if (!resolvedGuildId) {
 				return { content: [{ type: "text" as const, text: "Error: guild_id is required" }] };
 			}
-			const config = loadConfig();
+			const config = await configPort.load();
 
 			if (config.reminders.some((r) => r.id === id)) {
 				return {
@@ -189,7 +174,7 @@ function registerAddReminder(server: McpServer, boundGuildId?: string): void {
 			}
 
 			config.reminders.push(reminder);
-			await saveConfig(config);
+			await configPort.save(config);
 			return {
 				content: [{ type: "text" as const, text: `リマインダー "${id}" を追加しました` }],
 			};
@@ -197,7 +182,11 @@ function registerAddReminder(server: McpServer, boundGuildId?: string): void {
 	);
 }
 
-function registerModifyReminders(server: McpServer, boundGuildId?: string): void {
+function registerModifyReminders(
+	server: McpServer,
+	configPort: HeartbeatConfigPort,
+	boundGuildId?: string,
+): void {
 	server.registerTool(
 		"update_reminder",
 		{
@@ -239,7 +228,7 @@ function registerModifyReminders(server: McpServer, boundGuildId?: string): void
 			if (!gid) {
 				return { content: [{ type: "text" as const, text: "Error: guild_id is required" }] };
 			}
-			const config = loadConfig();
+			const config = await configPort.load();
 			const reminder = config.reminders.find((r) => r.id === id);
 
 			if (!reminder) {
@@ -272,7 +261,7 @@ function registerModifyReminders(server: McpServer, boundGuildId?: string): void
 				};
 			}
 
-			await saveConfig(config);
+			await configPort.save(config);
 			return {
 				content: [{ type: "text" as const, text: `リマインダー "${id}" を更新しました` }],
 			};
@@ -293,7 +282,7 @@ function registerModifyReminders(server: McpServer, boundGuildId?: string): void
 			if (!gid) {
 				return { content: [{ type: "text" as const, text: "Error: guild_id is required" }] };
 			}
-			const config = loadConfig();
+			const config = await configPort.load();
 			const reminder = config.reminders.find((r) => r.id === id);
 
 			if (!reminder) {
@@ -314,7 +303,7 @@ function registerModifyReminders(server: McpServer, boundGuildId?: string): void
 			}
 
 			config.reminders.splice(config.reminders.indexOf(reminder), 1);
-			await saveConfig(config);
+			await configPort.save(config);
 			return {
 				content: [{ type: "text" as const, text: `リマインダー "${id}" を削除しました` }],
 			};
@@ -322,8 +311,12 @@ function registerModifyReminders(server: McpServer, boundGuildId?: string): void
 	);
 }
 
-export function registerScheduleTools(server: McpServer, boundGuildId?: string): void {
-	registerReadTools(server, boundGuildId);
-	registerAddReminder(server, boundGuildId);
-	registerModifyReminders(server, boundGuildId);
+export function registerScheduleTools(
+	server: McpServer,
+	configPort: HeartbeatConfigPort,
+	boundGuildId?: string,
+): void {
+	registerReadTools(server, configPort, boundGuildId);
+	registerAddReminder(server, configPort, boundGuildId);
+	registerModifyReminders(server, configPort, boundGuildId);
 }

--- a/packages/memory/src/conversation-recorder.ts
+++ b/packages/memory/src/conversation-recorder.ts
@@ -20,9 +20,10 @@ import {
 } from "./namespace.ts";
 import { Segmenter } from "./segmenter.ts";
 import { MemoryStorage } from "./storage.ts";
+import type { ChatMessage } from "./types.ts";
 
 export interface GuildInstance {
-	segmenter: { addMessage(userId: string, msg: unknown): Promise<Episode[]> };
+	segmenter: { addMessage(userId: string, msg: ChatMessage): Promise<Episode[]> };
 	storage: { close(): void };
 	consolidation: { consolidate(userId: string): Promise<ConsolidationResult> };
 }

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -39,6 +39,12 @@ export type { RetrievalOptions, RetrievalResult, ScoredEpisode, ScoredFact } fro
 // Re-export storage
 export { MemoryStorage } from "./storage.ts";
 
+/** Memory の読み取り専用サブセット（retrieval + semantic のみ） */
+export interface MemoryReadServices {
+	retrieval: Retrieval;
+	semantic: SemanticMemory;
+}
+
 /** Memory instance — the main entry point */
 export interface Memory {
 	segmenter: Segmenter;

--- a/packages/minecraft/src/server.ts
+++ b/packages/minecraft/src/server.ts
@@ -14,169 +14,174 @@ import { createMcMetrics } from "./mc-metrics.ts";
 import { registerMinecraftTools } from "./mcp-tools.ts";
 import { ReactiveLayer } from "./reactive-layer.ts";
 
-// ── Logger ───────────────────────────────────────────────────────────────────
-const logger = new ConsoleLogger();
+/* oxlint-disable-next-line max-lines-per-function -- server entry point; splitting would add indirection without benefit */
+function main(): void {
+	// ── Logger ───────────────────────────────────────────────────────────────────
+	const logger = new ConsoleLogger();
 
-// ── Environment ──────────────────────────────────────────────────────────────
-const viewerPortRaw = Number(process.env.MC_VIEWER_PORT ?? "3007");
-if (!Number.isInteger(viewerPortRaw) || viewerPortRaw < 1 || viewerPortRaw > 65535) {
-	logger.error("[minecraft] MC_VIEWER_PORT must be a valid port number (1-65535)");
-	process.exit(1);
-}
-const MC_VIEWER_PORT = viewerPortRaw;
-const MC_HOST = process.env.MC_HOST;
-if (!MC_HOST) {
-	logger.error("[minecraft] MC_HOST is required");
-	process.exit(1);
-}
-const portRaw = Number(process.env.MC_PORT ?? "25565");
-if (!Number.isInteger(portRaw) || portRaw < 1 || portRaw > 65535) {
-	logger.error("[minecraft] MC_PORT must be a valid port number (1-65535)");
-	process.exit(1);
-}
-const MC_PORT = portRaw;
-const MC_USERNAME = process.env.MC_USERNAME ?? "hua";
-const MC_VERSION = process.env.MC_VERSION ?? undefined;
-let MC_AUTH_MODE: ReturnType<typeof parseMcAuthMode>;
-try {
-	MC_AUTH_MODE = parseMcAuthMode(process.env.MC_AUTH_MODE ?? "offline");
-} catch (e) {
-	logger.error("[minecraft] " + (e as Error).message);
-	process.exit(1);
-}
-const MC_PROFILES_FOLDER = process.env.MC_PROFILES_FOLDER;
-if (MC_AUTH_MODE === "offline" && MC_PROFILES_FOLDER) {
-	logger.warn(
-		"[minecraft] MC_PROFILES_FOLDER is set but MC_AUTH_MODE is 'offline'; it will be ignored",
-	);
-}
-const mcpPortRaw = Number(process.env.MC_MCP_PORT ?? "3001");
-if (!Number.isInteger(mcpPortRaw) || mcpPortRaw < 1 || mcpPortRaw > 65535) {
-	logger.error("[minecraft] MC_MCP_PORT must be a valid port number (1-65535)");
-	process.exit(1);
-}
-const MC_MCP_PORT = mcpPortRaw;
-const DATA_DIR = process.env.DATA_DIR;
+	// ── Environment ──────────────────────────────────────────────────────────────
+	const viewerPortRaw = Number(process.env.MC_VIEWER_PORT ?? "3007");
+	if (!Number.isInteger(viewerPortRaw) || viewerPortRaw < 1 || viewerPortRaw > 65535) {
+		logger.error("[minecraft] MC_VIEWER_PORT must be a valid port number (1-65535)");
+		process.exit(1);
+	}
+	const MC_VIEWER_PORT = viewerPortRaw;
+	const MC_HOST = process.env.MC_HOST;
+	if (!MC_HOST) {
+		logger.error("[minecraft] MC_HOST is required");
+		process.exit(1);
+	}
+	const portRaw = Number(process.env.MC_PORT ?? "25565");
+	if (!Number.isInteger(portRaw) || portRaw < 1 || portRaw > 65535) {
+		logger.error("[minecraft] MC_PORT must be a valid port number (1-65535)");
+		process.exit(1);
+	}
+	const MC_PORT = portRaw;
+	const MC_USERNAME = process.env.MC_USERNAME ?? "hua";
+	const MC_VERSION = process.env.MC_VERSION ?? undefined;
+	let MC_AUTH_MODE: ReturnType<typeof parseMcAuthMode>;
+	try {
+		MC_AUTH_MODE = parseMcAuthMode(process.env.MC_AUTH_MODE ?? "offline");
+	} catch (e) {
+		logger.error("[minecraft] " + (e as Error).message);
+		process.exit(1);
+	}
+	const MC_PROFILES_FOLDER = process.env.MC_PROFILES_FOLDER;
+	if (MC_AUTH_MODE === "offline" && MC_PROFILES_FOLDER) {
+		logger.warn(
+			"[minecraft] MC_PROFILES_FOLDER is set but MC_AUTH_MODE is 'offline'; it will be ignored",
+		);
+	}
+	const mcpPortRaw = Number(process.env.MC_MCP_PORT ?? "3001");
+	if (!Number.isInteger(mcpPortRaw) || mcpPortRaw < 1 || mcpPortRaw > 65535) {
+		logger.error("[minecraft] MC_MCP_PORT must be a valid port number (1-65535)");
+		process.exit(1);
+	}
+	const MC_MCP_PORT = mcpPortRaw;
+	const DATA_DIR = process.env.DATA_DIR;
 
-// ── Metrics ───────────────────────────────────────────────────────────────────
-const { collector: mcCollector, server: mcMetricsServer } = createMcMetrics(logger);
-mcMetricsServer.start();
+	// ── Metrics ───────────────────────────────────────────────────────────────────
+	const { collector: mcCollector, server: mcMetricsServer } = createMcMetrics(logger);
+	mcMetricsServer.start();
 
-// ── Bridge DB (auto-notification) ─────────────────────────────────────────────
-const bridgeDb = DATA_DIR ? createDb(DATA_DIR) : undefined;
-const autoNotifier = bridgeDb
-	? createAutoNotifier(bridgeDb, { metrics: mcCollector, logger })
-	: undefined;
-if (!bridgeDb) {
-	logger.warn("[minecraft] DATA_DIR not set; Discord auto-notifications disabled");
-}
+	// ── Bridge DB (auto-notification) ─────────────────────────────────────────────
+	const bridgeDb = DATA_DIR ? createDb(DATA_DIR) : undefined;
+	const autoNotifier = bridgeDb
+		? createAutoNotifier(bridgeDb, { metrics: mcCollector, logger })
+		: undefined;
+	if (!bridgeDb) {
+		logger.warn("[minecraft] DATA_DIR not set; Discord auto-notifications disabled");
+	}
 
-// ── Bootstrap ────────────────────────────────────────────────────────────────
-const ctx = createBotContext({
-	metrics: mcCollector,
-	urgentEventNotifier: (kind, description, importance) => {
-		autoNotifier?.(kind, description, importance);
-	},
-});
-const connection = createBotConnection(
-	{
-		host: MC_HOST,
-		port: MC_PORT,
-		username: MC_USERNAME,
-		version: MC_VERSION,
-		authMode: MC_AUTH_MODE,
-		profilesFolder: MC_PROFILES_FOLDER,
-		viewerPort: MC_VIEWER_PORT,
-	},
-	ctx,
-	logger,
-);
-
-const jobManager = new JobManager(
-	ctx.pushEvent.bind(ctx),
-	ctx.setActionState.bind(ctx),
-	mcCollector,
-);
-
-const reactiveLayer = new ReactiveLayer(ctx, {
-	onCancelJob: () => jobManager.cancelCurrentJob(),
-});
-
-function createServer(): McpServer {
-	const server = new McpServer({ name: "minecraft", version: "0.1.0" });
-	registerMinecraftTools({
-		server,
-		ctx,
-		jobManager,
-		viewerPort: MC_VIEWER_PORT,
-		options: {
-			metrics: mcCollector,
-			logger,
-			stuckRecovery: {
-				reconnect: () => connection.triggerReconnect(),
-				onRecoverySuccess: () => {
-					jobManager.resetStuckNotification();
-				},
-				cooldownMs: 300_000,
-			},
+	// ── Bootstrap ────────────────────────────────────────────────────────────────
+	const ctx = createBotContext({
+		metrics: mcCollector,
+		urgentEventNotifier: (kind, description, importance) => {
+			autoNotifier?.(kind, description, importance);
 		},
 	});
-	return server;
-}
+	const connection = createBotConnection(
+		{
+			host: MC_HOST,
+			port: MC_PORT,
+			username: MC_USERNAME,
+			version: MC_VERSION,
+			authMode: MC_AUTH_MODE,
+			profilesFolder: MC_PROFILES_FOLDER,
+			viewerPort: MC_VIEWER_PORT,
+		},
+		ctx,
+		logger,
+	);
 
-const { cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
-	createServer,
-	MC_MCP_PORT,
-	"minecraft",
-	logger,
-);
+	const jobManager = new JobManager(
+		ctx.pushEvent.bind(ctx),
+		ctx.setActionState.bind(ctx),
+		mcCollector,
+	);
 
-// ── Session Lock Polling ──────────────────────────────────────────────────────
-const SESSION_LOCK_POLL_MS = 10_000;
-let sessionLockTimer: ReturnType<typeof setInterval> | null = null;
+	const reactiveLayer = new ReactiveLayer(ctx, {
+		onCancelJob: () => jobManager.cancelCurrentJob(),
+	});
 
-if (bridgeDb) {
-	// bridgeDb がある場合: セッションロックに連動して bot を接続/切断する
-	let botConnected = false;
-	sessionLockTimer = setInterval(() => {
-		try {
-			const locked = hasSessionLock(bridgeDb);
-			if (locked && !botConnected) {
-				logger.info("[minecraft] Session lock detected — starting bot connection");
-				connection.start();
-				reactiveLayer.attach();
-				botConnected = true;
-			} else if (!locked && botConnected) {
-				logger.info("[minecraft] Session lock released — shutting down bot connection");
-				reactiveLayer.detach();
-				connection.shutdown();
-				botConnected = false;
+	function createServer(): McpServer {
+		const server = new McpServer({ name: "minecraft", version: "0.1.0" });
+		registerMinecraftTools({
+			server,
+			ctx,
+			jobManager,
+			viewerPort: MC_VIEWER_PORT,
+			options: {
+				metrics: mcCollector,
+				logger,
+				stuckRecovery: {
+					reconnect: () => connection.triggerReconnect(),
+					onRecoverySuccess: () => {
+						jobManager.resetStuckNotification();
+					},
+					cooldownMs: 300_000,
+				},
+			},
+		});
+		return server;
+	}
+
+	const { cleanupTimer, closeAllSessions, stopServer } = startHttpServer(
+		createServer,
+		MC_MCP_PORT,
+		"minecraft",
+		logger,
+	);
+
+	// ── Session Lock Polling ──────────────────────────────────────────────────────
+	const SESSION_LOCK_POLL_MS = 10_000;
+	let sessionLockTimer: ReturnType<typeof setInterval> | null = null;
+
+	if (bridgeDb) {
+		// bridgeDb がある場合: セッションロックに連動して bot を接続/切断する
+		let botConnected = false;
+		sessionLockTimer = setInterval(() => {
+			try {
+				const locked = hasSessionLock(bridgeDb);
+				if (locked && !botConnected) {
+					logger.info("[minecraft] Session lock detected — starting bot connection");
+					connection.start();
+					reactiveLayer.attach();
+					botConnected = true;
+				} else if (!locked && botConnected) {
+					logger.info("[minecraft] Session lock released — shutting down bot connection");
+					reactiveLayer.detach();
+					connection.shutdown();
+					botConnected = false;
+				}
+			} catch (err) {
+				logger.error("[minecraft] Session lock polling error:", err);
 			}
-		} catch (err) {
-			logger.error("[minecraft] Session lock polling error:", err);
-		}
-	}, SESSION_LOCK_POLL_MS);
-} else {
-	// bridgeDb なし（開発環境）: 従来通り即座に接続
-	connection.start();
-	reactiveLayer.attach();
+		}, SESSION_LOCK_POLL_MS);
+	} else {
+		// bridgeDb なし（開発環境）: 従来通り即座に接続
+		connection.start();
+		reactiveLayer.attach();
+	}
+
+	// ── Shutdown ─────────────────────────────────────────────────────────────────
+	const shutdown = (): void => {
+		if (sessionLockTimer) clearInterval(sessionLockTimer);
+		clearInterval(cleanupTimer);
+		closeAllSessions();
+		stopServer();
+		mcMetricsServer.stop();
+		reactiveLayer.detach();
+		connection.shutdown();
+		if (bridgeDb) closeDb(bridgeDb);
+		process.exit(0);
+	};
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
+	process.on("uncaughtException", (err) =>
+		logger.error("[minecraft] uncaughtException:", err.message),
+	);
+	process.on("unhandledRejection", (err) => logger.error("[minecraft] unhandledRejection:", err));
 }
 
-// ── Shutdown ─────────────────────────────────────────────────────────────────
-const shutdown = (): void => {
-	if (sessionLockTimer) clearInterval(sessionLockTimer);
-	clearInterval(cleanupTimer);
-	closeAllSessions();
-	stopServer();
-	mcMetricsServer.stop();
-	reactiveLayer.detach();
-	connection.shutdown();
-	if (bridgeDb) closeDb(bridgeDb);
-	process.exit(0);
-};
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-process.on("uncaughtException", (err) =>
-	logger.error("[minecraft] uncaughtException:", err.message),
-);
-process.on("unhandledRejection", (err) => logger.error("[minecraft] unhandledRejection:", err));
+main();

--- a/packages/scheduling/src/heartbeat-helpers.ts
+++ b/packages/scheduling/src/heartbeat-helpers.ts
@@ -1,3 +1,4 @@
+import { JST_OFFSET_MS } from "@vicissitude/shared/functions";
 import type { DueReminder, HeartbeatConfig } from "@vicissitude/shared/types";
 
 /** Heartbeat config JSON の相対パス（プロジェクトルート起点） */
@@ -38,9 +39,6 @@ export function createDefaultHeartbeatConfig(): HeartbeatConfig {
 }
 
 // ─── evaluateDueReminders ────────────────────────────────────────
-
-/** JST (UTC+9) のオフセット（ミリ秒） */
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 /**
  * 設定と現在時刻から、実行すべきリマインダーを判定する純粋関数。

--- a/packages/scheduling/src/heartbeat-scheduler.test.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.test.ts
@@ -1,46 +1,35 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
-import { existsSync, mkdirSync, rmSync } from "fs";
-import { join } from "path";
+import { describe, expect, mock, test } from "bun:test";
 
 import { createMockLogger, createMockMetrics } from "@vicissitude/shared/test-helpers";
-import type { AiAgent, HeartbeatConfig } from "@vicissitude/shared/types";
+import type { HeartbeatConfig } from "@vicissitude/shared/types";
 
 import { HeartbeatScheduler } from "./heartbeat-scheduler.ts";
 
-const TEMP_ROOT = `/tmp/vicissitude-heartbeat-scheduler-${process.pid}`;
-
-function createMockAgent(): AiAgent {
+function createMockConfigRepo(config: HeartbeatConfig) {
 	return {
-		send: mock(() => Promise.resolve({ text: "", sessionId: "session-1" })),
-		stop: mock(() => {}),
+		load: mock(() => Promise.resolve(config)),
+		save: mock(() => Promise.resolve()),
 	};
 }
 
-async function writeHeartbeatConfig(config: HeartbeatConfig): Promise<void> {
-	const dir = join(TEMP_ROOT, "data");
-	mkdirSync(dir, { recursive: true });
-	await Bun.write(join(dir, "heartbeat-config.json"), JSON.stringify(config, null, 2));
+function createMockHeartbeatService() {
+	return {
+		execute: mock(() => Promise.resolve(new Set<string>())),
+	};
 }
-
-afterEach(() => {
-	if (existsSync(TEMP_ROOT)) {
-		rmSync(TEMP_ROOT, { recursive: true, force: true });
-	}
-});
 
 describe("HeartbeatScheduler", () => {
 	test("due reminder がないときは HEARTBEAT_REMINDERS_EXECUTED を増やさない", async () => {
-		await writeHeartbeatConfig({
-			baseIntervalMinutes: 30,
-			reminders: [],
-		});
 		const metrics = createMockMetrics();
-		const scheduler = new HeartbeatScheduler(
-			createMockAgent(),
-			createMockLogger(),
+		const scheduler = new HeartbeatScheduler({
+			configRepo: createMockConfigRepo({
+				baseIntervalMinutes: 30,
+				reminders: [],
+			}),
+			heartbeatService: createMockHeartbeatService(),
+			logger: createMockLogger(),
 			metrics,
-			TEMP_ROOT,
-		);
+		});
 
 		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
 
@@ -48,25 +37,24 @@ describe("HeartbeatScheduler", () => {
 	});
 
 	test("due reminder があるときだけ HEARTBEAT_REMINDERS_EXECUTED を増やす", async () => {
-		await writeHeartbeatConfig({
-			baseIntervalMinutes: 30,
-			reminders: [
-				{
-					id: "due-1",
-					description: "check home",
-					schedule: { type: "interval", minutes: 1 },
-					lastExecutedAt: null,
-					enabled: true,
-				},
-			],
-		});
 		const metrics = createMockMetrics();
-		const scheduler = new HeartbeatScheduler(
-			createMockAgent(),
-			createMockLogger(),
+		const scheduler = new HeartbeatScheduler({
+			configRepo: createMockConfigRepo({
+				baseIntervalMinutes: 30,
+				reminders: [
+					{
+						id: "due-1",
+						description: "check home",
+						schedule: { type: "interval", minutes: 1 },
+						lastExecutedAt: null,
+						enabled: true,
+					},
+				],
+			}),
+			heartbeatService: createMockHeartbeatService(),
+			logger: createMockLogger(),
 			metrics,
-			TEMP_ROOT,
-		);
+		});
 
 		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
 

--- a/packages/scheduling/src/heartbeat-scheduler.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.ts
@@ -1,38 +1,38 @@
-import { resolve } from "path";
-
-import { HeartbeatService } from "@vicissitude/application/heartbeat-service";
 import { METRIC } from "@vicissitude/observability/metrics";
 import { delayResolve, withTimeout } from "@vicissitude/shared/functions";
-import type { AiAgent, HeartbeatConfig, Logger, MetricsCollector } from "@vicissitude/shared/types";
+import type {
+	DueReminder,
+	HeartbeatConfig,
+	Logger,
+	MetricsCollector,
+} from "@vicissitude/shared/types";
 
-import { JsonHeartbeatConfigRepository } from "./heartbeat-config.ts";
-import { HEARTBEAT_CONFIG_RELATIVE_PATH, evaluateDueReminders } from "./heartbeat-helpers.ts";
+import { evaluateDueReminders } from "./heartbeat-helpers.ts";
 
 // ─── HeartbeatScheduler ─────────────────────────────────────────
 
 const HEARTBEAT_TICK_INTERVAL_MS = 60_000;
 const HEARTBEAT_TICK_TIMEOUT_MS = 180_000;
 
+export interface HeartbeatSchedulerDeps {
+	configRepo: {
+		load(): HeartbeatConfig | Promise<HeartbeatConfig>;
+		save(config: HeartbeatConfig): Promise<void>;
+	};
+	heartbeatService: { execute(dueReminders: DueReminder[]): Promise<Set<string>> };
+	logger: Logger;
+	metrics?: MetricsCollector;
+}
+
 export class HeartbeatScheduler {
 	private timer: ReturnType<typeof setInterval> | null = null;
 	private running = false;
-	private readonly configRepo: JsonHeartbeatConfigRepository;
-	private readonly heartbeatService: HeartbeatService;
 
-	constructor(
-		agent: AiAgent,
-		private readonly logger: Logger,
-		private readonly metrics: MetricsCollector | undefined,
-		root: string,
-	) {
-		const configPath: string = resolve(root, HEARTBEAT_CONFIG_RELATIVE_PATH);
-		this.configRepo = new JsonHeartbeatConfigRepository(configPath);
-		this.heartbeatService = new HeartbeatService({ agent, logger });
-	}
+	constructor(private readonly deps: HeartbeatSchedulerDeps) {}
 
 	start(): void {
 		if (this.timer) return;
-		this.logger.info("[heartbeat] scheduler started (1min interval)");
+		this.deps.logger.info("[heartbeat] scheduler started (1min interval)");
 		void this.tick();
 		this.timer = setInterval(() => void this.tick(), HEARTBEAT_TICK_INTERVAL_MS);
 	}
@@ -42,12 +42,12 @@ export class HeartbeatScheduler {
 			clearInterval(this.timer);
 			this.timer = null;
 		}
-		this.logger.info("[heartbeat] scheduler stopped");
+		this.deps.logger.info("[heartbeat] scheduler stopped");
 	}
 
 	private async tick(): Promise<void> {
 		if (this.running) {
-			this.logger.info("[heartbeat] previous tick still running, skipping");
+			this.deps.logger.info("[heartbeat] previous tick still running, skipping");
 			return;
 		}
 
@@ -56,13 +56,13 @@ export class HeartbeatScheduler {
 		const execution = this.executeTick();
 		try {
 			await withTimeout(execution, HEARTBEAT_TICK_TIMEOUT_MS, "heartbeat tick timed out");
-			this.metrics?.incrementCounter(METRIC.HEARTBEAT_TICKS, { outcome: "success" });
+			this.deps.metrics?.incrementCounter(METRIC.HEARTBEAT_TICKS, { outcome: "success" });
 		} catch (error) {
-			this.metrics?.incrementCounter(METRIC.HEARTBEAT_TICKS, { outcome: "error" });
-			this.logger.error("[heartbeat] tick error:", error);
+			this.deps.metrics?.incrementCounter(METRIC.HEARTBEAT_TICKS, { outcome: "error" });
+			this.deps.logger.error("[heartbeat] tick error:", error);
 		} finally {
 			const duration = (performance.now() - start) / 1000;
-			this.metrics?.observeHistogram(METRIC.HEARTBEAT_TICK_DURATION, duration);
+			this.deps.metrics?.observeHistogram(METRIC.HEARTBEAT_TICK_DURATION, duration);
 		}
 
 		// Wait for execution to complete, but cap at double the timeout to prevent deadlock
@@ -71,7 +71,7 @@ export class HeartbeatScheduler {
 			delayResolve(HEARTBEAT_TICK_TIMEOUT_MS, false as const),
 		]);
 		if (!settled) {
-			this.logger.error(
+			this.deps.logger.error(
 				"[heartbeat] execution did not settle after force timeout, resetting running flag",
 			);
 		}
@@ -79,23 +79,23 @@ export class HeartbeatScheduler {
 	}
 
 	private async executeTick(): Promise<void> {
-		const config = await this.configRepo.load();
+		const config = await this.deps.configRepo.load();
 		const executed = await this.executeHeartbeat(config);
 		if (executed) {
-			this.metrics?.incrementCounter(METRIC.HEARTBEAT_REMINDERS_EXECUTED);
+			this.deps.metrics?.incrementCounter(METRIC.HEARTBEAT_REMINDERS_EXECUTED);
 		}
 	}
 
 	private async executeHeartbeat(config: HeartbeatConfig): Promise<boolean> {
 		const dueReminders = evaluateDueReminders(config, new Date());
 		if (dueReminders.length === 0) return false;
-		this.logger.info(
+		this.deps.logger.info(
 			`[heartbeat] ${String(dueReminders.length)} due reminder(s): ${dueReminders.map((d) => d.reminder.id).join(", ")}`,
 		);
 
-		const succeededIds = await this.heartbeatService.execute(dueReminders);
+		const succeededIds = await this.deps.heartbeatService.execute(dueReminders);
 		if (succeededIds.size === 0) {
-			this.logger.info("[heartbeat] no guilds succeeded, skipping config update");
+			this.deps.logger.info("[heartbeat] no guilds succeeded, skipping config update");
 			return true;
 		}
 
@@ -105,8 +105,8 @@ export class HeartbeatScheduler {
 				reminder.lastExecutedAt = executedAt;
 			}
 		}
-		await this.configRepo.save(config);
-		this.logger.info("[heartbeat] done");
+		await this.deps.configRepo.save(config);
+		this.deps.logger.info("[heartbeat] done");
 		return true;
 	}
 }

--- a/packages/shared/src/functions.ts
+++ b/packages/shared/src/functions.ts
@@ -1,7 +1,7 @@
 // ─── formatTimestamp / formatTime ────────────────────────────────
 
 /** JST (UTC+9) のオフセット（ミリ秒） */
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+export const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 function pad(n: number): string {
 	return n.toString().padStart(2, "0");

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -1,5 +1,6 @@
 import type { Emotion, VrmExpressionWeight } from "./emotion";
 import type { TtsResult, TtsStyleParams } from "./tts";
+import type { BufferedEvent } from "./types";
 import type { BodyAnimationPreset, ClientMessage, ServerMessage } from "./ws-protocol";
 
 // ─── LlmPromptPort ──────────────────────────────────────────────
@@ -122,4 +123,11 @@ export interface GatewayPort {
 	broadcast(message: ServerMessage): void;
 	onMessage(handler: ClientMessageHandler): void;
 	getConnectionCount(): number;
+}
+
+// ─── BufferedEventStore ─────────────────────────────────────────
+
+/** イベントバッファへの追記ポート */
+export interface BufferedEventStore {
+	append(agentId: string, event: BufferedEvent): void;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -195,6 +195,18 @@ export interface AiAgent {
 	stop(): void;
 }
 
+// ─── Session Store Port ─────────────────────────────────────────
+
+export interface SessionStorePort {
+	get(agentName: string, sessionKey: string): string | undefined;
+	getRow(
+		agentName: string,
+		sessionKey: string,
+	): { sessionId: string; createdAt: number } | undefined;
+	save(agentName: string, sessionKey: string, sessionId: string): void;
+	delete(agentName: string, sessionKey: string): void;
+}
+
 // ─── Context Builder Port ────────────────────────────────────────
 
 export interface ContextBuilderPort {

--- a/spec/agent/hang-detection.spec.ts
+++ b/spec/agent/hang-detection.spec.ts
@@ -314,7 +314,10 @@ describe("AgentRunner ハング検知と自動ローテーション", () => {
 			const sessionPort = createSimpleSessionPort();
 
 			// heartbeatReader が常に現在時刻を返す（MCP wait_for_events が呼ばれている状態）
-			const heartbeatReader = { getLastSeenAt: mock(() => Date.now()) };
+			const heartbeatReader = {
+				getLastSeenAt: mock(() => Date.now()),
+				consumeRotationRequest: mock(() => null),
+			};
 
 			const runner = new TestAgent({
 				profile: createProfile(),
@@ -352,7 +355,10 @@ describe("AgentRunner ハング検知と自動ローテーション", () => {
 
 			// heartbeatReader が古い値を返す（MCP が止まっている状態）
 			const staleTime = Date.now() - 10_000;
-			const heartbeatReader = { getLastSeenAt: mock(() => staleTime) };
+			const heartbeatReader = {
+				getLastSeenAt: mock(() => staleTime),
+				consumeRotationRequest: mock(() => null),
+			};
 
 			const runner = new TestAgent({
 				profile: createProfile(),
@@ -475,16 +481,17 @@ describe("AgentRunner ハング検知と自動ローテーション", () => {
 			runner.stop();
 		});
 
-		test("consumeRotationRequest が未実装（undefined）の場合、ローテーションは発生しない", async () => {
+		test("consumeRotationRequest が常に null を返す場合、ローテーションは発生しない", async () => {
 			const rotationSpy = mock(() => Promise.resolve());
 			const sessionStore = createSessionStore("existing-session-id");
 
 			const eventBuffer = createEventBuffer(() => new Promise(() => {}));
 			const sessionPort = createSimpleSessionPort();
 
-			// consumeRotationRequest を持たない heartbeatReader
+			// consumeRotationRequest が常に null を返す heartbeatReader
 			const heartbeatReader = {
 				getLastSeenAt: mock(() => Date.now()),
+				consumeRotationRequest: mock(() => null),
 			};
 
 			const runner = new TestAgent({
@@ -507,7 +514,7 @@ describe("AgentRunner ハング検知と自動ローテーション", () => {
 
 			await Bun.sleep(250);
 
-			// heartbeat は alive、consumeRotationRequest は undefined なのでローテーションは発生しない
+			// heartbeat は alive、consumeRotationRequest は常に null なのでローテーションは発生しない
 			expect(rotationSpy).not.toHaveBeenCalled();
 
 			runner.stop();

--- a/spec/agent/mcp-config.spec.ts
+++ b/spec/agent/mcp-config.spec.ts
@@ -1,28 +1,24 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import { mcpMinecraftConfigs, mcpServerConfigs } from "@vicissitude/agent/mcp-config";
 
 // ─── mcpServerConfigs ────────────────────────────────────────────
 
 describe("mcpServerConfigs", () => {
-	const originalEnv = { ...process.env };
-
-	afterEach(() => {
-		process.env = { ...originalEnv };
-	});
+	const defaultOpts = { appRoot: "/test/root", coreMcpPort: 4095 };
 
 	it("core と code-exec のみ返す", () => {
-		const configs = mcpServerConfigs("discord:123");
+		const configs = mcpServerConfigs("discord:123", defaultOpts);
 		expect(Object.keys(configs).toSorted()).toEqual(["code-exec", "core"]);
 	});
 
 	it("core は remote 型", () => {
-		const configs = mcpServerConfigs("discord:123");
+		const configs = mcpServerConfigs("discord:123", defaultOpts);
 		expect(configs.core?.type).toBe("remote");
 	});
 
 	it("core の URL に agent_id クエリパラメータが含まれる", () => {
-		const configs = mcpServerConfigs("discord:123");
+		const configs = mcpServerConfigs("discord:123", defaultOpts);
 		const core = configs.core;
 		expect(core?.type).toBe("remote");
 		if (core?.type === "remote") {
@@ -30,33 +26,20 @@ describe("mcpServerConfigs", () => {
 			expect(url.searchParams.get("agent_id")).toBe("discord:123");
 		}
 	});
-
-	it("MC_HOST が設定されていても minecraft を含まない", () => {
-		process.env.MC_HOST = "localhost";
-		process.env.MC_MCP_PORT = "3001";
-		const configs = mcpServerConfigs("discord:456");
-		expect(configs).not.toHaveProperty("minecraft");
-	});
 });
 
 // ─── mcpMinecraftConfigs ─────────────────────────────────────
 
 describe("mcpMinecraftConfigs", () => {
-	const originalEnv = { ...process.env };
+	const defaultOpts = { appRoot: "/test/root" };
 
-	afterEach(() => {
-		process.env = { ...originalEnv };
-	});
-
-	it("MC_HOST 未設定時は mc-bridge のみ返す", () => {
-		delete process.env.MC_HOST;
-		const configs = mcpMinecraftConfigs();
+	it("mcHost 未設定時は mc-bridge のみ返す", () => {
+		const configs = mcpMinecraftConfigs(defaultOpts);
 		expect(Object.keys(configs)).toEqual(["mc-bridge"]);
 	});
 
-	it("MC_HOST 設定時は mc-bridge と minecraft を返す", () => {
-		process.env.MC_HOST = "localhost";
-		const configs = mcpMinecraftConfigs();
+	it("mcHost 設定時は mc-bridge と minecraft を返す", () => {
+		const configs = mcpMinecraftConfigs({ ...defaultOpts, mcHost: "localhost" });
 		expect(Object.keys(configs).toSorted()).toEqual(["mc-bridge", "minecraft"]);
 	});
 });

--- a/spec/application/message-ingestion-service.spec.ts
+++ b/spec/application/message-ingestion-service.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 
-import type { BufferedEventStore } from "@vicissitude/application/message-ingestion-service";
 import { MessageIngestionService } from "@vicissitude/application/message-ingestion-service";
 import { discordGuildNamespace } from "@vicissitude/memory/namespace";
+import type { BufferedEventStore } from "@vicissitude/shared/ports";
 import type {
 	BufferedEvent,
 	ConversationRecorder,

--- a/spec/gateway/ws-handler.spec.ts
+++ b/spec/gateway/ws-handler.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 
 import { WsConnectionManager } from "@vicissitude/gateway/ws-handler";
 import type { EmotionToTtsStyleMapper, TtsSynthesizer } from "@vicissitude/shared/ports";
+import { createMockLogger } from "@vicissitude/shared/test-helpers";
 import { createTtsStyleParams, type TtsResult } from "@vicissitude/shared/tts";
 import type {
 	AudioDataMessage,
@@ -11,6 +12,8 @@ import type {
 	ErrorMessage,
 	ServerMessage,
 } from "@vicissitude/shared/ws-protocol";
+
+const noopLogger = createMockLogger();
 
 // ─── WebSocketConnection Mock ───────────────────────────────────
 //
@@ -61,7 +64,7 @@ const sampleEmotionUpdate: ServerMessage = {
 describe("WsConnectionManager", () => {
 	describe("接続管理", () => {
 		it("handleOpen で接続を追加すると getConnectionCount が増える", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn = createMockConnection();
 
 			manager.handleOpen("conn-1", conn);
@@ -70,7 +73,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("複数の接続を追加すると getConnectionCount がその数を返す", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			manager.handleOpen("conn-1", createMockConnection());
 			manager.handleOpen("conn-2", createMockConnection());
 			manager.handleOpen("conn-3", createMockConnection());
@@ -79,7 +82,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("handleClose で接続を削除すると getConnectionCount が減る", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			manager.handleOpen("conn-1", createMockConnection());
 			manager.handleOpen("conn-2", createMockConnection());
 
@@ -89,12 +92,12 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("接続がない状態で getConnectionCount は 0 を返す", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			expect(manager.getConnectionCount()).toBe(0);
 		});
 
 		it("存在しない connectionId の handleClose はエラーにならない", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			expect(() => manager.handleClose("nonexistent")).not.toThrow();
 		});
 	});
@@ -103,7 +106,7 @@ describe("WsConnectionManager", () => {
 
 	describe("send", () => {
 		it("指定 connectionId の接続にメッセージが JSON 文字列として送られる", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
 
@@ -114,7 +117,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("他の接続には送信されない", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn1 = createMockConnection();
 			const conn2 = createMockConnection();
 			manager.handleOpen("conn-1", conn1);
@@ -127,7 +130,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("存在しない connectionId への send はエラーにならない（静かに無視）", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			expect(() => manager.send("nonexistent", sampleServerMessage)).not.toThrow();
 		});
 	});
@@ -136,7 +139,7 @@ describe("WsConnectionManager", () => {
 
 	describe("broadcast", () => {
 		it("全接続にメッセージが JSON 文字列として送られる", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn1 = createMockConnection();
 			const conn2 = createMockConnection();
 			const conn3 = createMockConnection();
@@ -153,7 +156,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("接続がない状態で broadcast してもエラーにならない", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			expect(() => manager.broadcast(sampleServerMessage)).not.toThrow();
 		});
 	});
@@ -162,7 +165,7 @@ describe("WsConnectionManager", () => {
 
 	describe("onMessage", () => {
 		it("登録したハンドラが parseClientMessage 通過後のメッセージで呼ばれる", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const received: { connectionId: string; message: unknown }[] = [];
 			manager.onMessage((connectionId, message) => {
 				received.push({ connectionId, message });
@@ -179,7 +182,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("複数のハンドラを登録した場合、全てが呼ばれる", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			let count1 = 0;
 			let count2 = 0;
 			manager.onMessage(() => {
@@ -202,7 +205,7 @@ describe("WsConnectionManager", () => {
 
 	describe("不正メッセージ処理", () => {
 		it("不正な JSON を受信すると送信元に ErrorMessage が返される", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
 
@@ -214,7 +217,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("JSON は有効だがスキーマ違反の場合、送信元に ErrorMessage が返される", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
 
@@ -226,7 +229,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("パースエラー時の ErrorMessage の code は INVALID_MESSAGE である", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
 
@@ -239,7 +242,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("不正メッセージ時にハンドラは呼ばれない", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			let handlerCalled = false;
 			manager.onMessage(() => {
 				handlerCalled = true;
@@ -253,7 +256,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("不正メッセージでも他の接続には影響しない", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn1 = createMockConnection();
 			const conn2 = createMockConnection();
 			manager.handleOpen("conn-1", conn1);
@@ -272,7 +275,7 @@ describe("WsConnectionManager", () => {
 
 	describe("ハンドラ例外の隔離", () => {
 		it("ハンドラが例外を投げても INVALID_MESSAGE ErrorMessage は送信されない", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			manager.onMessage(() => {
 				throw new Error("handler crashed");
 			});
@@ -288,7 +291,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("先行ハンドラが例外を投げても後続ハンドラは呼ばれる", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			let secondHandlerCalled = false;
 
 			manager.onMessage(() => {
@@ -306,7 +309,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("ハンドラが例外を投げてもパース自体は成功しているのでメッセージは有効である", () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const received: unknown[] = [];
 
 			manager.onMessage(() => {
@@ -349,6 +352,7 @@ describe("WsConnectionManager", () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: createMockSynthesizer(),
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
@@ -374,6 +378,7 @@ describe("WsConnectionManager", () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: createMockSynthesizer(),
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
@@ -400,6 +405,7 @@ describe("WsConnectionManager", () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: createMockSynthesizer(),
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
@@ -421,7 +427,7 @@ describe("WsConnectionManager", () => {
 		});
 
 		it("TTS synthesizer 未設定時はテキスト応答のみ（AudioDataMessage なし）", async () => {
-			const manager = new WsConnectionManager();
+			const manager = new WsConnectionManager({ logger: noopLogger });
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
 
@@ -441,6 +447,7 @@ describe("WsConnectionManager", () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: createMockSynthesizer(null),
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
@@ -479,6 +486,7 @@ describe("WsConnectionManager", () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: signalAwareSynthesizer,
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);
@@ -507,6 +515,7 @@ describe("WsConnectionManager", () => {
 			const manager = new WsConnectionManager({
 				ttsSynthesizer: failingSynthesizer,
 				ttsStyleMapper: mockStyleMapper,
+				logger: noopLogger,
 			});
 			const conn = createMockConnection();
 			manager.handleOpen("conn-1", conn);

--- a/spec/mcp/tools/memory-cross-ns.spec.ts
+++ b/spec/mcp/tools/memory-cross-ns.spec.ts
@@ -2,7 +2,8 @@
 /* oxlint-disable require-await -- モック関数は同期値を返すが、インターフェースが async を要求する */
 import { describe, expect, test } from "bun:test";
 
-import type { MemoryDeps, MemoryReadServices } from "@vicissitude/mcp/tools/memory";
+import type { MemoryDeps } from "@vicissitude/mcp/tools/memory";
+import type { MemoryReadServices } from "@vicissitude/memory";
 import type { Episode } from "@vicissitude/memory/episode";
 import {
 	discordGuildNamespace,


### PR DESCRIPTION
## Summary

Phase 0–2 に続く設計品質改善の Phase 3。関心の分離を徹底し、各モジュールの責務を明確にする。

- **P3-3**: `bootstrap.ts` のマイグレーションロジック (`syncMcCheckReminder`, `removeLegacyConsolidateReminder`, `migrateMemoryDir`) を `apps/discord/src/migrations.ts` に分離
- **P3-1**: `core-server.ts` の LRU Memory キャッシュを `MemoryInstanceCache` クラスに抽出 (`packages/mcp/src/memory-cache.ts`)
- **P3-4a**: `HeartbeatScheduler` のコンストラクタ内 `new` を DI に変更 (`HeartbeatSchedulerDeps` インターフェース導入)
- **P3-4b**: `WsConnectionManager` の `logger` を必須化し、`ConsoleLogger` フォールバック生成を削除

## Test plan

- [x] `nr validate` — fmt:check + lint + type check 全 pass
- [x] `nr test` — 1789 tests, 0 fail
- [x] `nr test:spec` — 1343 tests, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)