### PR TITLE
refactor(design): Phase 4 カプセル化・DI改善 — process.env除去・Agent DI化・APP_ROOT解消

### DIFF
--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -46,7 +46,7 @@ describe("createStoreLayer", () => {
 describe("createMetrics", () => {
 	test("collector と server を返す", () => {
 		const logger = createMockLogger();
-		const { collector, server } = createMetrics(logger);
+		const { collector, server } = createMetrics(logger, 0);
 
 		expect(collector).toBeDefined();
 		expect(server).toBeDefined();

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -36,6 +36,7 @@ import type {
 	Logger,
 	MemoryFactReader,
 	MetricsCollector,
+	SessionStorePort,
 	SessionSummaryWriter,
 } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
@@ -92,7 +93,7 @@ export function createGuildAgents(
 	guildIds: string[],
 	deps: {
 		db: StoreDb;
-		sessionStore: SessionStore;
+		sessionStore: SessionStorePort;
 		contextBuilder: ContextBuilderPort;
 		logger: Logger;
 		metrics?: MetricsCollector;

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -4,7 +4,9 @@ import { resolve } from "path";
 
 import { ContextBuilder } from "@vicissitude/agent/discord/context-builder";
 import { DiscordAgent } from "@vicissitude/agent/discord/discord-agent";
+import { createConversationProfile } from "@vicissitude/agent/discord/profile";
 import { GuildRouter } from "@vicissitude/agent/discord/router";
+import { mcpServerConfigs } from "@vicissitude/agent/mcp-config";
 import { McBrainManager } from "@vicissitude/agent/minecraft/brain-manager";
 import { SessionStore } from "@vicissitude/agent/session-store";
 import { HeartbeatService } from "@vicissitude/application/heartbeat-service";
@@ -41,6 +43,7 @@ import type {
 } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
 import { createDb, closeDb } from "@vicissitude/store/db";
+import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
 import { SqliteMoodStore } from "@vicissitude/store/mood-store";
 import { incrementEmoji } from "@vicissitude/store/queries";
 import { AivisSpeechSynthesizer, createEmotionToTtsStyleMapper } from "@vicissitude/tts";
@@ -110,13 +113,31 @@ export function createGuildAgents(
 	const portOffset = deps.portOffset ?? 0;
 
 	for (const [index, guildId] of guildIds.entries()) {
+		const agentIdPrefix = deps.agentIdPrefix ?? "discord";
+		const agentId = `${agentIdPrefix}:${guildId}`;
+		const profile = createConversationProfile({
+			...config.opencode,
+			mcpServers: mcpServerConfigs(agentId, {
+				appRoot: deps.appRoot,
+				coreMcpPort: deps.coreMcpPort,
+			}),
+		});
+		const sessionPort = new OpencodeSessionAdapter({
+			port: config.opencode.basePort + portOffset + index,
+			mcpServers: profile.mcpServers,
+			builtinTools: profile.builtinTools,
+			temperature: 0.7,
+			logger: deps.logger,
+		});
+		const eventBuffer = new SqliteEventBuffer(deps.db, agentId, deps.logger);
 		const agent = new DiscordAgent({
 			guildId,
 			db: deps.db,
 			sessionStore: deps.sessionStore,
 			contextBuilder: deps.contextBuilder,
 			logger: deps.logger,
-			opencodePort: config.opencode.basePort + portOffset + index,
+			sessionPort,
+			eventBuffer,
 			sessionMaxAgeMs: config.opencode.sessionMaxAgeHours * 3_600_000,
 			metrics: deps.metrics,
 			model: { providerId: config.opencode.providerId, modelId: config.opencode.modelId },

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -133,7 +133,7 @@ export function createGuildAgents(
 
 // ─── Metrics ────────────────────────────────────────────────────
 
-export function createMetrics(logger: Logger) {
+export function createMetrics(logger: Logger, port: number) {
 	const collector = new PrometheusCollector();
 	collector.registerCounter(METRIC.DISCORD_MESSAGES_RECEIVED, "Discord messages received");
 	collector.registerCounter(METRIC.AI_REQUESTS, "AI agent requests");
@@ -157,7 +157,7 @@ export function createMetrics(logger: Logger) {
 	collector.registerCounter(METRIC.LLM_OUTPUT_TOKENS, "LLM output tokens total");
 	collector.registerCounter(METRIC.LLM_CACHE_READ_TOKENS, "LLM cache read tokens total");
 	collector.setGauge(METRIC.BOT_INFO, 1, { bot_name: "hua" });
-	return { collector, server: new PrometheusServer(collector, logger) };
+	return { collector, server: new PrometheusServer(collector, logger, port) };
 }
 
 // ─── Channel Config ─────────────────────────────────────────────
@@ -420,7 +420,8 @@ export async function bootstrap(): Promise<void> {
 	const { contextBuilder } = createContextLayer(config, root, factReader);
 
 	// Metrics
-	const metrics = createMetrics(logger);
+	const metricsPort = Number(process.env.METRICS_PORT) || 9091;
+	const metrics = createMetrics(logger, metricsPort);
 	metrics.server.start();
 
 	// Channel config

--- a/packages/agent/src/discord/discord-agent.ts
+++ b/packages/agent/src/discord/discord-agent.ts
@@ -1,13 +1,13 @@
-import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import type {
 	ContextBuilderPort,
+	EventBuffer,
 	Logger,
 	MetricsCollector,
+	OpencodeSessionPort,
 	SessionStorePort,
 	SessionSummaryWriter,
 } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
-import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
 import { consumeRotationRequest, getHeartbeat } from "@vicissitude/store/queries";
 
 import { mcpServerConfigs } from "../mcp-config.ts";
@@ -20,8 +20,8 @@ export interface DiscordAgentDeps {
 	sessionStore: SessionStorePort;
 	contextBuilder: ContextBuilderPort;
 	logger: Logger;
-	/** OpenCode SDK サーバーのポート番号 */
-	opencodePort: number;
+	sessionPort: OpencodeSessionPort;
+	eventBuffer: EventBuffer;
 	sessionMaxAgeMs: number;
 	metrics?: MetricsCollector;
 	model: { providerId: string; modelId: string };
@@ -48,14 +48,8 @@ export class DiscordAgent extends AgentRunner {
 			sessionStore: deps.sessionStore,
 			contextBuilder: deps.contextBuilder,
 			logger: deps.logger,
-			sessionPort: new OpencodeSessionAdapter({
-				port: deps.opencodePort,
-				mcpServers: profile.mcpServers,
-				builtinTools: profile.builtinTools,
-				temperature: 0.7,
-				logger: deps.logger,
-			}),
-			eventBuffer: new SqliteEventBuffer(deps.db, agentId, deps.logger),
+			sessionPort: deps.sessionPort,
+			eventBuffer: deps.eventBuffer,
 			sessionMaxAgeMs: deps.sessionMaxAgeMs,
 			metrics: deps.metrics,
 			contextGuildId: deps.guildId,

--- a/packages/agent/src/minecraft/brain-manager.ts
+++ b/packages/agent/src/minecraft/brain-manager.ts
@@ -1,11 +1,18 @@
+/* oxlint-disable max-dependencies -- brain-manager creates MinecraftAgent with all DI dependencies */
+import { resolve } from "path";
+
 import { MINECRAFT_AGENT_ID } from "@vicissitude/minecraft/constants";
-import type { Logger, SessionStorePort } from "@vicissitude/shared/types";
+import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
+import type { EventBuffer, Logger, SessionStorePort } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
 import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
 import { clearSessionLock, hasSessionLock } from "@vicissitude/store/mc-bridge";
 import { appendEvent } from "@vicissitude/store/queries";
 
+import { mcpMinecraftConfigs } from "../mcp-config.ts";
+import { MinecraftContextBuilder } from "./context-builder.ts";
 import { MinecraftAgent } from "./minecraft-agent.ts";
+import { createMinecraftProfile } from "./profile.ts";
 
 const DEFAULT_LIFECYCLE_POLL_MS = 10_000;
 
@@ -18,6 +25,8 @@ export interface McBrainManagerDeps {
 	providerId: string;
 	modelId: string;
 	sessionMaxAgeMs: number;
+	/** EventBuffer ファクトリ。省略時は SqliteEventBuffer を生成 */
+	eventBufferFactory?: (agentId: string) => EventBuffer;
 	/** ライフサイクルポーリング間隔（ms）。デフォルト 10_000 */
 	lifecyclePollMs?: number;
 	mcHost?: string;
@@ -80,28 +89,41 @@ export class McBrainManager {
 	private createAgent(): void {
 		if (this.agent || this.stopping) return;
 
-		const {
-			db,
-			sessionStore,
-			logger,
-			root,
-			opencodePort,
-			providerId,
-			modelId,
-			sessionMaxAgeMs,
-			mcHost,
-			mcMcpPort,
-		} = this.deps;
+		const { deps } = this;
+		const profile = createMinecraftProfile({
+			providerId: deps.providerId,
+			modelId: deps.modelId,
+			mcpServers: mcpMinecraftConfigs({
+				appRoot: deps.root,
+				mcHost: deps.mcHost,
+				mcMcpPort: deps.mcMcpPort,
+			}),
+		});
+		const sessionPort = new OpencodeSessionAdapter({
+			port: deps.opencodePort,
+			mcpServers: profile.mcpServers,
+			builtinTools: profile.builtinTools,
+			temperature: 0.7,
+			logger: deps.logger,
+		});
+		const overlayDir: string = resolve(deps.root, "data/context/minecraft");
+		const baseDir: string = resolve(deps.root, "context/minecraft");
+		const contextBuilder = new MinecraftContextBuilder(overlayDir, baseDir);
+		const eventBuffer = deps.eventBufferFactory
+			? deps.eventBufferFactory(MINECRAFT_AGENT_ID)
+			: new SqliteEventBuffer(deps.db, MINECRAFT_AGENT_ID, deps.logger);
+
 		this.agent = new MinecraftAgent({
-			eventBuffer: new SqliteEventBuffer(db, MINECRAFT_AGENT_ID, logger),
-			sessionStore,
-			logger,
-			root,
-			opencodePort,
-			sessionMaxAgeMs,
-			model: { providerId, modelId },
-			mcHost,
-			mcMcpPort,
+			eventBuffer,
+			sessionPort,
+			contextBuilder,
+			sessionStore: deps.sessionStore,
+			logger: deps.logger,
+			root: deps.root,
+			sessionMaxAgeMs: deps.sessionMaxAgeMs,
+			model: { providerId: deps.providerId, modelId: deps.modelId },
+			mcHost: deps.mcHost,
+			mcMcpPort: deps.mcMcpPort,
 		});
 		// 初期イベントを挿入してポーリングループの最初の waitForEvents を通過させる
 		const bootstrapEvent = {
@@ -111,9 +133,9 @@ export class McBrainManager {
 			authorName: "system",
 			messageId: `mc-bootstrap-${Date.now()}`,
 		};
-		appendEvent(db, MINECRAFT_AGENT_ID, JSON.stringify(bootstrapEvent));
+		appendEvent(deps.db, MINECRAFT_AGENT_ID, JSON.stringify(bootstrapEvent));
 		this.agent.ensurePolling();
-		logger.info("[mc-brain-manager] minecraft brain started");
+		deps.logger.info("[mc-brain-manager] minecraft brain started");
 	}
 
 	private stopAgent(): void {

--- a/packages/agent/src/minecraft/minecraft-agent.ts
+++ b/packages/agent/src/minecraft/minecraft-agent.ts
@@ -1,12 +1,14 @@
-import { resolve } from "path";
-
 import { MINECRAFT_AGENT_ID } from "@vicissitude/minecraft/constants";
-import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
-import type { EventBuffer, Logger, SessionStorePort } from "@vicissitude/shared/types";
+import type {
+	ContextBuilderPort,
+	EventBuffer,
+	Logger,
+	OpencodeSessionPort,
+	SessionStorePort,
+} from "@vicissitude/shared/types";
 
 import { mcpMinecraftConfigs } from "../mcp-config.ts";
 import { AgentRunner } from "../runner.ts";
-import { MinecraftContextBuilder } from "./context-builder.ts";
 import { createMinecraftProfile } from "./profile.ts";
 
 export interface MinecraftAgentDeps {
@@ -14,8 +16,8 @@ export interface MinecraftAgentDeps {
 	logger: Logger;
 	root: string;
 	eventBuffer: EventBuffer;
-	/** OpenCode SDK サーバーのポート番号 */
-	opencodePort: number;
+	sessionPort: OpencodeSessionPort;
+	contextBuilder: ContextBuilderPort;
 	sessionMaxAgeMs: number;
 	model: { providerId: string; modelId: string };
 	mcHost?: string;
@@ -32,21 +34,13 @@ export class MinecraftAgent extends AgentRunner {
 				mcMcpPort: deps.mcMcpPort,
 			}),
 		});
-		const overlayDir: string = resolve(deps.root, "data/context/minecraft");
-		const baseDir: string = resolve(deps.root, "context/minecraft");
 		super({
 			profile,
 			agentId: MINECRAFT_AGENT_ID,
 			sessionStore: deps.sessionStore,
-			contextBuilder: new MinecraftContextBuilder(overlayDir, baseDir),
+			contextBuilder: deps.contextBuilder,
 			logger: deps.logger,
-			sessionPort: new OpencodeSessionAdapter({
-				port: deps.opencodePort,
-				mcpServers: profile.mcpServers,
-				builtinTools: profile.builtinTools,
-				temperature: 0.7,
-				logger: deps.logger,
-			}),
+			sessionPort: deps.sessionPort,
 			eventBuffer: deps.eventBuffer,
 			sessionMaxAgeMs: deps.sessionMaxAgeMs,
 		});

--- a/packages/mcp/src/memory-cache.ts
+++ b/packages/mcp/src/memory-cache.ts
@@ -28,11 +28,13 @@ export class MemoryInstanceCache {
 
 		// Evict oldest entry if at capacity
 		if (this.instances.size >= this.maxSize) {
-			const oldestKey = this.instances.keys().next().value as string;
-			this.instances.delete(oldestKey);
-			const oldStorage = this.storages.get(oldestKey);
-			oldStorage?.close();
-			this.storages.delete(oldestKey);
+			const oldestKey = this.instances.keys().next().value;
+			if (oldestKey !== undefined) {
+				this.instances.delete(oldestKey);
+				const oldStorage = this.storages.get(oldestKey);
+				oldStorage?.close();
+				this.storages.delete(oldestKey);
+			}
 		}
 
 		const { instance, storage } = this.factory(namespace);

--- a/packages/mcp/src/memory-helpers.ts
+++ b/packages/mcp/src/memory-helpers.ts
@@ -1,12 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import path, { resolve } from "path";
 
-import { APP_ROOT } from "@vicissitude/shared/config";
-
-const root = APP_ROOT;
-export const BASE_CONTEXT_DIR = resolve(root, "context");
-export const OVERLAY_CONTEXT_DIR = resolve(root, "data/context");
-
 export function ensureDir(dir: string): void {
 	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 }

--- a/packages/mcp/src/tools/mc-memory.ts
+++ b/packages/mcp/src/tools/mc-memory.ts
@@ -4,12 +4,7 @@ import { resolve } from "path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import {
-	BASE_CONTEXT_DIR,
-	createBackup,
-	ensureDir,
-	readWithFallbackFrom,
-} from "../memory-helpers.ts";
+import { createBackup, ensureDir, readWithFallbackFrom } from "../memory-helpers.ts";
 
 const MAX_GOALS_CHARS = 20_000;
 const MAX_PROGRESS_CHARS = 20_000;
@@ -21,11 +16,13 @@ const SKILLS_FILENAME = "MINECRAFT-SKILLS.md";
 
 export interface McMemoryDeps {
 	dataDir: string;
+	/** base コンテキストディレクトリ（context/minecraft のフォールバック元） */
+	baseContextDir: string;
 }
 
 /** @internal テスト用にもエクスポート */
-export function baseMinecraftDir(): string {
-	return resolve(BASE_CONTEXT_DIR, "minecraft");
+export function baseMinecraftDir(baseContextDir: string): string {
+	return resolve(baseContextDir, "minecraft");
 }
 
 /**
@@ -33,9 +30,9 @@ export function baseMinecraftDir(): string {
  * dataDir 内のファイルを優先し、なければ base（context/minecraft/）から読む。
  * @internal テスト用にもエクスポート
  */
-export function readOverlay(dataDir: string, filename: string): string {
+export function readOverlay(dataDir: string, filename: string, baseContextDir: string): string {
 	const overlayPath = resolve(dataDir, filename);
-	return readWithFallbackFrom(overlayPath, dataDir, baseMinecraftDir());
+	return readWithFallbackFrom(overlayPath, dataDir, baseMinecraftDir(baseContextDir));
 }
 
 /** @internal テスト用にもエクスポート */
@@ -64,7 +61,7 @@ export function sanitizeSingleLine(text: string): string {
 }
 
 export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): void {
-	const { dataDir } = deps;
+	const { dataDir, baseContextDir } = deps;
 
 	// --- Goals ---
 
@@ -72,7 +69,7 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 		"mc_read_goals",
 		{ description: "Minecraft 目標ファイルを読む（現在の目標のみ）" },
 		() => {
-			const content = readOverlay(dataDir, GOALS_FILENAME);
+			const content = readOverlay(dataDir, GOALS_FILENAME, baseContextDir);
 			return {
 				content: [{ type: "text" as const, text: content || "(目標ファイルは空です)" }],
 			};
@@ -114,7 +111,7 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 				"Minecraft ワールド進捗を読む（装備段階、拠点、探索範囲、主要資源、達成済み目標、プレイヤーメモ）",
 		},
 		() => {
-			const content = readOverlay(dataDir, PROGRESS_FILENAME);
+			const content = readOverlay(dataDir, PROGRESS_FILENAME, baseContextDir);
 			return {
 				content: [{ type: "text" as const, text: content || "(進捗ファイルは空です)" }],
 			};
@@ -150,7 +147,7 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 	// --- Skills ---
 
 	server.registerTool("mc_read_skills", { description: "Minecraft スキルライブラリを読む" }, () => {
-		const content = readOverlay(dataDir, SKILLS_FILENAME);
+		const content = readOverlay(dataDir, SKILLS_FILENAME, baseContextDir);
 		return {
 			content: [{ type: "text" as const, text: content || "(スキルライブラリは空です)" }],
 		};
@@ -177,7 +174,7 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 			},
 		},
 		({ name, description, preconditions, failure_patterns }) => {
-			const existing = readOverlay(dataDir, SKILLS_FILENAME);
+			const existing = readOverlay(dataDir, SKILLS_FILENAME, baseContextDir);
 			const safeName = sanitizeSkillName(name);
 			const safeDescription = sanitizeSkillDescription(description);
 

--- a/packages/minecraft/src/mc-bridge-server.ts
+++ b/packages/minecraft/src/mc-bridge-server.ts
@@ -4,36 +4,40 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerMinecraftBridgeTools } from "@vicissitude/mcp/tools/mc-bridge-minecraft";
 import { registerMcMemoryTools } from "@vicissitude/mcp/tools/mc-memory";
-import { APP_ROOT } from "@vicissitude/shared/config";
 import { closeDb, createDb } from "@vicissitude/store/db";
 
-// --- Configuration from environment ---
+async function main(): Promise<void> {
+	// --- Configuration from environment ---
 
-const DATA_DIR = process.env.DATA_DIR ?? resolve(APP_ROOT, "data");
+	const APP_ROOT = process.env.APP_ROOT ?? resolve(process.cwd());
+	const DATA_DIR = process.env.DATA_DIR ?? resolve(APP_ROOT, "data");
 
-// --- Drizzle DB ---
+	// --- Drizzle DB ---
 
-const db = createDb(DATA_DIR);
+	const db = createDb(DATA_DIR);
 
-// --- MCP Server ---
+	// --- MCP Server ---
 
-const server = new McpServer({ name: "mc-bridge", version: "1.0.0" });
+	const server = new McpServer({ name: "mc-bridge", version: "1.0.0" });
 
-registerMinecraftBridgeTools(server, { db });
-registerMcMemoryTools(server, { dataDir: resolve(DATA_DIR, "context/minecraft") });
+	registerMinecraftBridgeTools(server, { db });
+	registerMcMemoryTools(server, { dataDir: resolve(DATA_DIR, "context/minecraft") });
 
-// --- Graceful Shutdown ---
+	// --- Graceful Shutdown ---
 
-async function shutdown() {
-	await server.close();
-	closeDb(db);
-	process.exit(0);
+	async function shutdown() {
+		await server.close();
+		closeDb(db);
+		process.exit(0);
+	}
+
+	process.on("SIGINT", () => void shutdown());
+	process.on("SIGTERM", () => void shutdown());
+
+	// --- Start server ---
+
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
 }
 
-process.on("SIGINT", () => void shutdown());
-process.on("SIGTERM", () => void shutdown());
-
-// --- Start server ---
-
-const transport = new StdioServerTransport();
-await server.connect(transport);
+void main();

--- a/packages/minecraft/src/mc-bridge-server.ts
+++ b/packages/minecraft/src/mc-bridge-server.ts
@@ -21,7 +21,10 @@ async function main(): Promise<void> {
 	const server = new McpServer({ name: "mc-bridge", version: "1.0.0" });
 
 	registerMinecraftBridgeTools(server, { db });
-	registerMcMemoryTools(server, { dataDir: resolve(DATA_DIR, "context/minecraft") });
+	registerMcMemoryTools(server, {
+		dataDir: resolve(DATA_DIR, "context/minecraft"),
+		baseContextDir: resolve(APP_ROOT, "context"),
+	});
 
 	// --- Graceful Shutdown ---
 

--- a/packages/minecraft/src/mc-metrics.ts
+++ b/packages/minecraft/src/mc-metrics.ts
@@ -52,11 +52,14 @@ export interface McMetricsServer {
 	stop(): void;
 }
 
-export function createMcMetrics(logger: Logger): {
+export function createMcMetrics(
+	logger: Logger,
+	port: number,
+	hostname: string = "0.0.0.0",
+): {
 	collector: McMetricsCollector;
 	server: McMetricsServer;
 } {
-	const port = Number(process.env.MC_METRICS_PORT) || 9092;
 	const collector = new McMetricsCollector();
 	collector.registerCounter(METRIC.MC_JOBS, "Minecraft jobs total");
 	collector.registerCounter(METRIC.MC_BOT_EVENTS, "Minecraft bot events total");
@@ -74,7 +77,6 @@ export function createMcMetrics(logger: Logger): {
 
 	const server: McMetricsServer = {
 		start() {
-			const hostname = process.env.MC_METRICS_HOST ?? "0.0.0.0";
 			bunServer = Bun.serve({
 				port,
 				hostname,

--- a/packages/minecraft/src/server.ts
+++ b/packages/minecraft/src/server.ts
@@ -61,7 +61,13 @@ function main(): void {
 	const DATA_DIR = process.env.DATA_DIR;
 
 	// ── Metrics ───────────────────────────────────────────────────────────────────
-	const { collector: mcCollector, server: mcMetricsServer } = createMcMetrics(logger);
+	const mcMetricsPort = Number(process.env.MC_METRICS_PORT) || 9092;
+	const mcMetricsHost = process.env.MC_METRICS_HOST ?? "0.0.0.0";
+	const { collector: mcCollector, server: mcMetricsServer } = createMcMetrics(
+		logger,
+		mcMetricsPort,
+		mcMetricsHost,
+	);
 	mcMetricsServer.start();
 
 	// ── Bridge DB (auto-notification) ─────────────────────────────────────────────

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -4,7 +4,7 @@ import pino from "pino";
 export class ConsoleLogger implements Logger {
 	private readonly pino: pino.Logger;
 
-	constructor(level: string = "info") {
+	constructor(level: string = process.env.LOG_LEVEL ?? "info") {
 		this.pino = pino({ level });
 	}
 

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -4,7 +4,7 @@ import pino from "pino";
 export class ConsoleLogger implements Logger {
 	private readonly pino: pino.Logger;
 
-	constructor(level: string = process.env.LOG_LEVEL ?? "info") {
+	constructor(level: string = "info") {
 		this.pino = pino({ level });
 	}
 

--- a/packages/observability/src/metrics.ts
+++ b/packages/observability/src/metrics.ts
@@ -240,29 +240,24 @@ export class PrometheusCollector implements MetricsCollector {
 
 // ─── Prometheus Server ──────────────────────────────────────────
 
-const DEFAULT_METRICS_PORT = 9091;
-
 export class PrometheusServer {
 	// oxlint-disable-next-line typescript/no-redundant-type-constituents -- Bun.serve の戻り値型が any を含むため
 	private server: ReturnType<typeof Bun.serve> | null = null;
-	private readonly port: number;
 
 	constructor(
 		private readonly collector: PrometheusCollector,
 		private readonly logger: Logger,
-		port?: number,
-	) {
-		this.port = port ?? (Number(process.env.METRICS_PORT) || DEFAULT_METRICS_PORT);
-	}
+		private readonly port: number,
+		private readonly hostname: string = "0.0.0.0",
+	) {}
 
 	start(): void {
-		const hostname = process.env.METRICS_HOST ?? "0.0.0.0";
 		this.server = Bun.serve({
 			port: this.port,
-			hostname,
+			hostname: this.hostname,
 			fetch: (req: Request) => this.handleRequest(req),
 		});
-		this.logger.info(`[metrics] Prometheus server listening on ${hostname}:${String(this.port)}`);
+		this.logger.info(`[metrics] Prometheus server listening on ${this.hostname}:${String(this.port)}`);
 	}
 
 	stop(): void {

--- a/packages/observability/src/metrics.ts
+++ b/packages/observability/src/metrics.ts
@@ -257,7 +257,9 @@ export class PrometheusServer {
 			hostname: this.hostname,
 			fetch: (req: Request) => this.handleRequest(req),
 		});
-		this.logger.info(`[metrics] Prometheus server listening on ${this.hostname}:${String(this.port)}`);
+		this.logger.info(
+			`[metrics] Prometheus server listening on ${this.hostname}:${String(this.port)}`,
+		);
 	}
 
 	stop(): void {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,6 @@
 	"exports": {
 		"./types": "./src/types.ts",
 		"./namespace": "./src/namespace.ts",
-		"./config": "./src/config.ts",
 		"./functions": "./src/functions.ts",
 		"./emotion": "./src/emotion.ts",
 		"./ws-protocol": "./src/ws-protocol.ts",

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -1,4 +1,0 @@
-import { resolve } from "path";
-
-/** プロジェクトルートパス（環境変数 or cwd） */
-export const APP_ROOT = process.env.APP_ROOT ?? resolve(process.cwd());

--- a/spec/mcp/tools/mc-memory.spec.ts
+++ b/spec/mcp/tools/mc-memory.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
 import os from "os";
-import { join } from "path";
+import { join, resolve } from "path";
 
 import {
 	readOverlay,
@@ -10,6 +10,8 @@ import {
 	sanitizeSkillName,
 	writeOverlay,
 } from "@vicissitude/mcp/tools/mc-memory";
+
+const BASE_CONTEXT_DIR = resolve(import.meta.dirname, "../../../context");
 
 function createTmpDir(): string {
 	return mkdtempSync(join(os.tmpdir(), "mc-mem-"));
@@ -20,20 +22,20 @@ describe("readOverlay", () => {
 		const dataDir = createTmpDir();
 		writeFileSync(join(dataDir, "TEST.md"), "overlay content");
 
-		const result = readOverlay(dataDir, "TEST.md");
+		const result = readOverlay(dataDir, "TEST.md", BASE_CONTEXT_DIR);
 		expect(result).toBe("overlay content");
 	});
 
 	it("overlay にファイルがなければ base（context/minecraft/）にフォールバックする", () => {
 		const dataDir = createTmpDir();
 		// base の context/minecraft/ には MINECRAFT-GOALS.md テンプレートが存在する
-		const result = readOverlay(dataDir, "MINECRAFT-GOALS.md");
+		const result = readOverlay(dataDir, "MINECRAFT-GOALS.md", BASE_CONTEXT_DIR);
 		expect(result).toContain("Minecraft 目標管理");
 	});
 
 	it("どちらにもなければ空文字列を返す", () => {
 		const dataDir = createTmpDir();
-		const result = readOverlay(dataDir, "NONEXISTENT.md");
+		const result = readOverlay(dataDir, "NONEXISTENT.md", BASE_CONTEXT_DIR);
 		expect(result).toBe("");
 	});
 });
@@ -117,7 +119,7 @@ describe("sanitizeSingleLine", () => {
 describe("progress の読み書き", () => {
 	it("base テンプレートからフォールバック読み込みできる", () => {
 		const dataDir = createTmpDir();
-		const result = readOverlay(dataDir, "MINECRAFT-PROGRESS.md");
+		const result = readOverlay(dataDir, "MINECRAFT-PROGRESS.md", BASE_CONTEXT_DIR);
 		expect(result).toContain("Minecraft ワールド進捗");
 		expect(result).toContain("装備段階");
 	});
@@ -127,7 +129,7 @@ describe("progress の読み書き", () => {
 		const progressContent = "# Minecraft ワールド進捗\n\n## 装備段階\n\n- 現在: 石\n";
 		writeOverlay(dataDir, "MINECRAFT-PROGRESS.md", progressContent);
 
-		const result = readOverlay(dataDir, "MINECRAFT-PROGRESS.md");
+		const result = readOverlay(dataDir, "MINECRAFT-PROGRESS.md", BASE_CONTEXT_DIR);
 		expect(result).toContain("現在: 石");
 	});
 });
@@ -138,7 +140,7 @@ describe("mc_record_skill の追記ロジック", () => {
 		writeFileSync(join(dataDir, "MINECRAFT-SKILLS.md"), "# Minecraft スキルライブラリ\n");
 
 		// mc_record_skill のロジックを再現
-		const existing = readOverlay(dataDir, "MINECRAFT-SKILLS.md");
+		const existing = readOverlay(dataDir, "MINECRAFT-SKILLS.md", BASE_CONTEXT_DIR);
 		const entry = `\n## テストスキル\n\nテスト説明\n`;
 		const updated = existing ? existing + entry : `# Minecraft スキルライブラリ\n${entry}`;
 		writeOverlay(dataDir, "MINECRAFT-SKILLS.md", updated);
@@ -152,7 +154,7 @@ describe("mc_record_skill の追記ロジック", () => {
 	it("スキルファイルが空の場合はヘッダー付きで新規作成される", () => {
 		const dataDir = createTmpDir();
 
-		const existing = readOverlay(dataDir, "MINECRAFT-SKILLS.md");
+		const existing = readOverlay(dataDir, "MINECRAFT-SKILLS.md", BASE_CONTEXT_DIR);
 		const entry = `\n## 初回スキル\n\n説明文\n`;
 		// existing が空文字列の場合は falsy
 		const updated = existing ? existing + entry : `# Minecraft スキルライブラリ\n${entry}`;
@@ -170,13 +172,13 @@ describe("mc_record_skill の追記ロジック", () => {
 		mkdirSync(dataDir, { recursive: true });
 
 		// 1つ目
-		const existing1 = readOverlay(dataDir, "MINECRAFT-SKILLS.md");
+		const existing1 = readOverlay(dataDir, "MINECRAFT-SKILLS.md", BASE_CONTEXT_DIR);
 		const entry1 = `\n## スキルA\n\n説明A\n`;
 		const updated1 = existing1 ? existing1 + entry1 : `# Minecraft スキルライブラリ\n${entry1}`;
 		writeOverlay(dataDir, "MINECRAFT-SKILLS.md", updated1);
 
 		// 2つ目
-		const existing2 = readOverlay(dataDir, "MINECRAFT-SKILLS.md");
+		const existing2 = readOverlay(dataDir, "MINECRAFT-SKILLS.md", BASE_CONTEXT_DIR);
 		const entry2 = `\n## スキルB\n\n説明B\n`;
 		const updated2 = existing2 + entry2;
 		writeOverlay(dataDir, "MINECRAFT-SKILLS.md", updated2);
@@ -190,7 +192,7 @@ describe("mc_record_skill の追記ロジック", () => {
 		const dataDir = createTmpDir();
 		writeFileSync(join(dataDir, "MINECRAFT-SKILLS.md"), "# Minecraft スキルライブラリ\n");
 
-		const existing = readOverlay(dataDir, "MINECRAFT-SKILLS.md");
+		const existing = readOverlay(dataDir, "MINECRAFT-SKILLS.md", BASE_CONTEXT_DIR);
 		const safeName = sanitizeSkillName("鉄鉱石採掘");
 		const safeDescription = sanitizeSkillDescription("Y=-64〜16 で鉄鉱石を採掘する");
 		const preconditions = sanitizeSingleLine("石のピッケル以上が必要");
@@ -215,7 +217,7 @@ describe("mc_record_skill の追記ロジック", () => {
 		const dataDir = createTmpDir();
 		writeFileSync(join(dataDir, "MINECRAFT-SKILLS.md"), "# Minecraft スキルライブラリ\n");
 
-		const existing = readOverlay(dataDir, "MINECRAFT-SKILLS.md");
+		const existing = readOverlay(dataDir, "MINECRAFT-SKILLS.md", BASE_CONTEXT_DIR);
 		const safeName = sanitizeSkillName("テストスキル");
 		const safeDescription = sanitizeSkillDescription("説明文");
 		const preconditions = sanitizeSingleLine("条件1\n条件2\r\n条件3");


### PR DESCRIPTION
## Summary

Phase 0–3 に続く設計品質改善の Phase 4。カプセル化と副作用の隔離を徹底し、テスタビリティを向上。

- **Step 1**: `mc-bridge-server.ts` のモジュールスコープコードを `main()` でラップ
- **Step 2**: `DiscordAgent` / `MinecraftAgent` のコンストラクタ内 `new` を除去し、`sessionPort` / `eventBuffer` / `contextBuilder` を DI 化
- **Step 3**: `ConsoleLogger` / `PrometheusServer` / `createMcMetrics` から `process.env` 参照を除去し、エントリポイントで注入
- **Step 4**: `APP_ROOT` のモジュールスコープ即時評価を解消、`memory-helpers.ts` を純粋関数化、`shared/config.ts` を削除
- **Step 5**: `createGuildAgents` の `sessionStore` 型を `SessionStore` → `SessionStorePort` に変更

## Test plan

- [x] `nr validate` — fmt:check + lint + type check 全 pass
- [x] `nr test` — 1789 tests, 0 fail
- [x] `nr test:spec` — 1343 tests, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)