### PR TITLE
refactor(agent): profile を外部注入し二重生成を解消 (#597)

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -140,11 +140,9 @@ export function createGuildAgents(
 			eventBuffer,
 			sessionMaxAgeMs: config.opencode.sessionMaxAgeHours * 3_600_000,
 			metrics: deps.metrics,
-			model: { providerId: config.opencode.providerId, modelId: config.opencode.modelId },
+			profile,
 			summaryWriter: deps.summaryWriter,
 			agentIdPrefix: deps.agentIdPrefix,
-			appRoot: deps.appRoot,
-			coreMcpPort: deps.coreMcpPort,
 		});
 		agents.set(guildId, agent);
 	}

--- a/packages/agent/src/discord/discord-agent.ts
+++ b/packages/agent/src/discord/discord-agent.ts
@@ -10,9 +10,8 @@ import type {
 import type { StoreDb } from "@vicissitude/store/db";
 import { consumeRotationRequest, getHeartbeat } from "@vicissitude/store/queries";
 
-import { mcpServerConfigs } from "../mcp-config.ts";
+import type { AgentProfile } from "../profile.ts";
 import { AgentRunner } from "../runner.ts";
-import { createConversationProfile } from "./profile.ts";
 
 export interface DiscordAgentDeps {
 	guildId: string;
@@ -24,26 +23,17 @@ export interface DiscordAgentDeps {
 	eventBuffer: EventBuffer;
 	sessionMaxAgeMs: number;
 	metrics?: MetricsCollector;
-	model: { providerId: string; modelId: string };
+	profile: AgentProfile;
 	summaryWriter?: SessionSummaryWriter;
 	/** agentId のプレフィックス（デフォルト: "discord"）。Heartbeat 専用エージェントなどでセッション分離に使用 */
 	agentIdPrefix?: string;
-	appRoot: string;
-	coreMcpPort: number;
 }
 
 export class DiscordAgent extends AgentRunner {
 	constructor(deps: DiscordAgentDeps) {
 		const agentId = `${deps.agentIdPrefix ?? "discord"}:${deps.guildId}`;
-		const profile = createConversationProfile({
-			...deps.model,
-			mcpServers: mcpServerConfigs(agentId, {
-				appRoot: deps.appRoot,
-				coreMcpPort: deps.coreMcpPort,
-			}),
-		});
 		super({
-			profile,
+			profile: deps.profile,
 			agentId,
 			sessionStore: deps.sessionStore,
 			contextBuilder: deps.contextBuilder,

--- a/packages/agent/src/minecraft/brain-manager.ts
+++ b/packages/agent/src/minecraft/brain-manager.ts
@@ -119,11 +119,8 @@ export class McBrainManager {
 			contextBuilder,
 			sessionStore: deps.sessionStore,
 			logger: deps.logger,
-			root: deps.root,
 			sessionMaxAgeMs: deps.sessionMaxAgeMs,
-			model: { providerId: deps.providerId, modelId: deps.modelId },
-			mcHost: deps.mcHost,
-			mcMcpPort: deps.mcMcpPort,
+			profile,
 		});
 		// 初期イベントを挿入してポーリングループの最初の waitForEvents を通過させる
 		const bootstrapEvent = {

--- a/packages/agent/src/minecraft/minecraft-agent.ts
+++ b/packages/agent/src/minecraft/minecraft-agent.ts
@@ -7,35 +7,23 @@ import type {
 	SessionStorePort,
 } from "@vicissitude/shared/types";
 
-import { mcpMinecraftConfigs } from "../mcp-config.ts";
+import type { AgentProfile } from "../profile.ts";
 import { AgentRunner } from "../runner.ts";
-import { createMinecraftProfile } from "./profile.ts";
 
 export interface MinecraftAgentDeps {
 	sessionStore: SessionStorePort;
 	logger: Logger;
-	root: string;
 	eventBuffer: EventBuffer;
 	sessionPort: OpencodeSessionPort;
 	contextBuilder: ContextBuilderPort;
 	sessionMaxAgeMs: number;
-	model: { providerId: string; modelId: string };
-	mcHost?: string;
-	mcMcpPort?: string;
+	profile: AgentProfile;
 }
 
 export class MinecraftAgent extends AgentRunner {
 	constructor(deps: MinecraftAgentDeps) {
-		const profile = createMinecraftProfile({
-			...deps.model,
-			mcpServers: mcpMinecraftConfigs({
-				appRoot: deps.root,
-				mcHost: deps.mcHost,
-				mcMcpPort: deps.mcMcpPort,
-			}),
-		});
 		super({
-			profile,
+			profile: deps.profile,
 			agentId: MINECRAFT_AGENT_ID,
 			sessionStore: deps.sessionStore,
 			contextBuilder: deps.contextBuilder,


### PR DESCRIPTION
## Summary

- `DiscordAgent` / `MinecraftAgent` のコンストラクタ内で profile を再生成していた処理を除去
- 呼び出し元（`bootstrap.ts` / `brain-manager.ts`）で生成済みの `AgentProfile` を DI で渡す形に統一
- `DiscordAgentDeps` から `appRoot` / `coreMcpPort` / `model` を除去、`MinecraftAgentDeps` から `root` / `mcHost` / `mcMcpPort` / `model` を除去

Closes #597

## Test plan

- [x] `nr validate` — fmt:check PASS, lint エラー0件, check エラーは既存の `apps/web` のみ
- [x] `nr test:spec` — 1343 tests PASS
- [x] `nr test:unit` — 446 tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)