### PR TITLE
refactor(shared): HeartbeatConfigPort を shared/ports.ts に統合

### DIFF
--- a/packages/mcp/src/tools/schedule.ts
+++ b/packages/mcp/src/tools/schedule.ts
@@ -1,15 +1,11 @@
 /* oxlint-disable max-lines -- schedule tools register 5 MCP tools in one module */
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { GUILD_ID_RE } from "@vicissitude/shared/namespace";
-import type { HeartbeatConfig, HeartbeatReminder } from "@vicissitude/shared/types";
+import type { HeartbeatConfigPort } from "@vicissitude/shared/ports";
+import type { HeartbeatReminder } from "@vicissitude/shared/types";
 import { z } from "zod";
 
 const guildIdSchema = z.string().regex(GUILD_ID_RE).describe("Discord guild ID");
-
-export interface HeartbeatConfigPort {
-	load(): Promise<HeartbeatConfig>;
-	save(config: HeartbeatConfig): Promise<void>;
-}
 
 export function filterRemindersByGuild(
 	reminders: HeartbeatReminder[],

--- a/packages/scheduling/src/heartbeat-scheduler.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.ts
@@ -1,5 +1,6 @@
 import { METRIC } from "@vicissitude/observability/metrics";
 import { delayResolve, withTimeout } from "@vicissitude/shared/functions";
+import type { HeartbeatConfigPort } from "@vicissitude/shared/ports";
 import type {
 	DueReminder,
 	HeartbeatConfig,
@@ -15,10 +16,7 @@ const HEARTBEAT_TICK_INTERVAL_MS = 60_000;
 const HEARTBEAT_TICK_TIMEOUT_MS = 180_000;
 
 export interface HeartbeatSchedulerDeps {
-	configRepo: {
-		load(): HeartbeatConfig | Promise<HeartbeatConfig>;
-		save(config: HeartbeatConfig): Promise<void>;
-	};
+	configRepo: HeartbeatConfigPort;
 	heartbeatService: { execute(dueReminders: DueReminder[]): Promise<Set<string>> };
 	logger: Logger;
 	metrics?: MetricsCollector;

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -1,6 +1,6 @@
 import type { Emotion, VrmExpressionWeight } from "./emotion";
 import type { TtsResult, TtsStyleParams } from "./tts";
-import type { BufferedEvent } from "./types";
+import type { BufferedEvent, HeartbeatConfig } from "./types";
 import type { BodyAnimationPreset, ClientMessage, ServerMessage } from "./ws-protocol";
 
 // ─── LlmPromptPort ──────────────────────────────────────────────
@@ -130,4 +130,12 @@ export interface GatewayPort {
 /** イベントバッファへの追記ポート */
 export interface BufferedEventStore {
 	append(agentId: string, event: BufferedEvent): void;
+}
+
+// ─── HeartbeatConfigPort ────────────────────────────────────────
+
+/** Heartbeat 設定の読み書きポート */
+export interface HeartbeatConfigPort {
+	load(): HeartbeatConfig | Promise<HeartbeatConfig>;
+	save(config: HeartbeatConfig): Promise<void>;
 }

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -136,6 +136,6 @@ export interface BufferedEventStore {
 
 /** Heartbeat 設定の読み書きポート */
 export interface HeartbeatConfigPort {
-	load(): HeartbeatConfig | Promise<HeartbeatConfig>;
+	load(): Promise<HeartbeatConfig>;
 	save(config: HeartbeatConfig): Promise<void>;
 }


### PR DESCRIPTION
## Summary
- `HeartbeatConfigPort` を `packages/shared/src/ports.ts` に統合し、散在していた型定義を一本化
- `packages/mcp/src/tools/schedule.ts` のローカル定義を削除し shared からの import に置換
- `packages/scheduling/src/heartbeat-scheduler.ts` のインライン型を `HeartbeatConfigPort` に置換
- `load()` の戻り値型は `Promise<HeartbeatConfig>` に統一（全実装・全呼び出し元が async）

## Test plan
- [x] `nr validate` — lint 0 errors, TS エラーなし（web 既存問題除く）
- [x] `nr test` — 1789 pass / 0 fail

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)