### PR TITLE
test(spec): consecutivePollErrors と pollEvents エラーハンドリングの仕様テスト追加 (#605)

### DIFF
--- a/spec/mcp/tools/event-buffer.spec.ts
+++ b/spec/mcp/tools/event-buffer.spec.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable no-non-null-assertion -- test assertions after length/null checks */
 /* oxlint-disable max-lines -- spec file covering all event-buffer public APIs */
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 import {
 	classifyActionHint,
@@ -14,6 +14,7 @@ import {
 	pollEvents,
 } from "@vicissitude/mcp/tools/event-buffer";
 import type { ErrorEvent, ParsedEvent, RecentMessage } from "@vicissitude/mcp/tools/event-buffer";
+import { CREATE_TABLES_SQL } from "@vicissitude/store/db";
 import { appendEvent } from "@vicissitude/store/queries";
 import { createTestDb } from "@vicissitude/store/test-helpers";
 
@@ -921,5 +922,62 @@ describe("pollEvents", () => {
 
 		expect(result).not.toBeNull();
 		expect((result![0]! as ParsedEvent).content).toBe("delayed");
+	});
+
+	test("DBエラーが発生してもポーリングが継続し、タイムアウトで null を返す", async () => {
+		const db = createTestDb();
+		// テーブルを DROP して DB クエリをエラーにする
+		db.$client.exec("DROP TABLE event_buffer");
+
+		const deadline = Date.now() + 200;
+		const result = await pollEvents(db, "guild-1", deadline, { pollIntervalMs: 20 });
+
+		expect(result).toBeNull();
+	});
+
+	test("DBエラー発生時に logger.error が呼ばれる", async () => {
+		const db = createTestDb();
+		db.$client.exec("DROP TABLE event_buffer");
+
+		const errorFn = mock(() => {});
+		const logger = {
+			debug: mock(() => {}),
+			info: mock(() => {}),
+			warn: mock(() => {}),
+			error: errorFn,
+		};
+
+		const deadline = Date.now() + 200;
+		await pollEvents(db, "guild-1", deadline, { pollIntervalMs: 20, logger });
+
+		expect(errorFn).toHaveBeenCalled();
+	});
+
+	test("一時的なDBエラーの後、正常復帰してイベントを返す", async () => {
+		const db = createTestDb();
+		// テーブルを DROP して一時的にエラー状態にする
+		db.$client.exec("DROP TABLE event_buffer");
+
+		// 80ms 後にテーブルを再作成してイベントを挿入
+		setTimeout(() => {
+			db.$client.exec(CREATE_TABLES_SQL);
+			appendEvent(
+				db,
+				"guild-1",
+				JSON.stringify({
+					ts: "2026-03-27T00:00:00.000Z",
+					content: "recovered",
+					authorId: "u1",
+					authorName: "A",
+					messageId: "m1",
+				}),
+			);
+		}, 80);
+
+		const deadline = Date.now() + 500;
+		const result = await pollEvents(db, "guild-1", deadline, { pollIntervalMs: 20 });
+
+		expect(result).not.toBeNull();
+		expect((result![0]! as ParsedEvent).content).toBe("recovered");
 	});
 });

--- a/spec/store/event-buffer.spec.ts
+++ b/spec/store/event-buffer.spec.ts
@@ -1,6 +1,6 @@
-import type { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 
+import { CREATE_TABLES_SQL } from "@vicissitude/store/db";
 import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
 import { appendEvent } from "@vicissitude/store/queries";
 import { createTestDb } from "@vicissitude/store/test-helpers";
@@ -28,23 +28,12 @@ function createMockLogger() {
 
 /** テスト用: DB の event_buffer テーブルを DROP してポーリングエラーを発生させる */
 function breakEventBufferTable(db: ReturnType<typeof createTestDb>): void {
-	// drizzle の $client プロパティから内部の sqlite Database にアクセスする
-	const sqlite = (db as unknown as { $client: Database }).$client;
-	sqlite.exec("DROP TABLE event_buffer");
+	db.$client.exec("DROP TABLE event_buffer");
 }
 
 /** テスト用: DB の event_buffer テーブルを再作成してエラーを解消する */
 function restoreEventBufferTable(db: ReturnType<typeof createTestDb>): void {
-	const sqlite = (db as unknown as { $client: Database }).$client;
-	sqlite.exec(`
-		CREATE TABLE IF NOT EXISTS event_buffer (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			agent_id TEXT NOT NULL,
-			payload TEXT NOT NULL,
-			created_at INTEGER NOT NULL
-		)
-	`);
-	sqlite.exec("CREATE INDEX IF NOT EXISTS idx_event_buffer_agent ON event_buffer(agent_id)");
+	db.$client.exec(CREATE_TABLES_SQL);
 }
 
 describe("SqliteEventBuffer", () => {

--- a/spec/store/event-buffer.spec.ts
+++ b/spec/store/event-buffer.spec.ts
@@ -1,8 +1,51 @@
+import type { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 
 import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
 import { appendEvent } from "@vicissitude/store/queries";
 import { createTestDb } from "@vicissitude/store/test-helpers";
+
+function createMockLogger() {
+	const calls = { debug: 0, info: 0, warn: 0, error: 0 };
+	return {
+		calls,
+		logger: {
+			debug: (..._args: unknown[]) => {
+				calls.debug++;
+			},
+			info: (..._args: unknown[]) => {
+				calls.info++;
+			},
+			warn: (..._args: unknown[]) => {
+				calls.warn++;
+			},
+			error: (..._args: unknown[]) => {
+				calls.error++;
+			},
+		},
+	};
+}
+
+/** テスト用: DB の event_buffer テーブルを DROP してポーリングエラーを発生させる */
+function breakEventBufferTable(db: ReturnType<typeof createTestDb>): void {
+	// drizzle の $client プロパティから内部の sqlite Database にアクセスする
+	const sqlite = (db as unknown as { $client: Database }).$client;
+	sqlite.exec("DROP TABLE event_buffer");
+}
+
+/** テスト用: DB の event_buffer テーブルを再作成してエラーを解消する */
+function restoreEventBufferTable(db: ReturnType<typeof createTestDb>): void {
+	const sqlite = (db as unknown as { $client: Database }).$client;
+	sqlite.exec(`
+		CREATE TABLE IF NOT EXISTS event_buffer (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			agent_id TEXT NOT NULL,
+			payload TEXT NOT NULL,
+			created_at INTEGER NOT NULL
+		)
+	`);
+	sqlite.exec("CREATE INDEX IF NOT EXISTS idx_event_buffer_agent ON event_buffer(agent_id)");
+}
 
 describe("SqliteEventBuffer", () => {
 	test("event_buffer にイベントがあれば waitForEvents が解決する", async () => {
@@ -60,4 +103,89 @@ describe("SqliteEventBuffer", () => {
 
 		expect(Date.now() - start).toBeLessThan(50);
 	});
+
+	test("DBエラーが発生してもポーリングは継続しクラッシュしない", async () => {
+		const db = createTestDb();
+		const { logger } = createMockLogger();
+		const buffer = new SqliteEventBuffer(db, "agent-1", logger);
+		const controller = new AbortController();
+
+		// テーブルを DROP してエラーを発生させる
+		breakEventBufferTable(db);
+
+		// 1.5秒後に abort — ポーリングがクラッシュせず継続していることを確認
+		setTimeout(() => controller.abort(), 1500);
+
+		// waitForEvents が reject せず正常に resolve すること
+		await buffer.waitForEvents(controller.signal);
+	}, 5_000);
+
+	test("連続エラーが10回未満の場合は logger.warn でログ出力する", async () => {
+		const db = createTestDb();
+		const { calls, logger } = createMockLogger();
+		const buffer = new SqliteEventBuffer(db, "agent-1", logger);
+		const controller = new AbortController();
+
+		breakEventBufferTable(db);
+
+		// ポーリング間隔 500ms start なので、2秒で数回のポーリングが走る
+		// 最初の数回は warn で出力されるはず
+		setTimeout(() => controller.abort(), 2000);
+
+		await buffer.waitForEvents(controller.signal);
+
+		expect(calls.warn).toBeGreaterThan(0);
+	}, 5_000);
+
+	test("連続エラーが10回以上になると logger.error に昇格する", async () => {
+		const db = createTestDb();
+		const { calls, logger } = createMockLogger();
+		const buffer = new SqliteEventBuffer(db, "agent-1", logger);
+		const controller = new AbortController();
+
+		breakEventBufferTable(db);
+
+		// 10回以上のポーリングエラーが必要
+		// 間隔: 500, 750, 1125, 1687, 2531, 3796, 5000, 5000, 5000, 5000 = 約30秒
+		// 10回目に到達するまで待つ
+		setTimeout(() => controller.abort(), 32_000);
+
+		await buffer.waitForEvents(controller.signal);
+
+		// 最初の9回は warn、10回目以降は error
+		expect(calls.warn).toBe(9);
+		expect(calls.error).toBeGreaterThanOrEqual(1);
+	}, 40_000);
+
+	test("エラーが解消されたら連続エラーカウントがリセットされる", async () => {
+		const db = createTestDb();
+		const { calls, logger } = createMockLogger();
+		const buffer = new SqliteEventBuffer(db, "agent-1", logger);
+
+		// Phase 1: テーブルを壊してエラーを数回発生させる
+		breakEventBufferTable(db);
+		const controller1 = new AbortController();
+		setTimeout(() => controller1.abort(), 2000);
+		await buffer.waitForEvents(controller1.signal);
+
+		const warnCountAfterPhase1 = calls.warn;
+		expect(warnCountAfterPhase1).toBeGreaterThan(0);
+
+		// Phase 2: テーブルを復元し、イベントを挿入して正常に解決させる（カウントリセット）
+		restoreEventBufferTable(db);
+		appendEvent(db, "agent-1", '{"kind":"discord"}');
+		await buffer.waitForEvents(new AbortController().signal);
+
+		// Phase 3: 再度テーブルを壊す — カウントがリセットされているので再び warn から始まる
+		breakEventBufferTable(db);
+		calls.warn = 0;
+		calls.error = 0;
+		const controller3 = new AbortController();
+		setTimeout(() => controller3.abort(), 2000);
+		await buffer.waitForEvents(controller3.signal);
+
+		// カウントリセットされているので、再び warn が出る（error ではない）
+		expect(calls.warn).toBeGreaterThan(0);
+		expect(calls.error).toBe(0);
+	}, 10_000);
 });


### PR DESCRIPTION
## Summary
- `spec/store/event-buffer.spec.ts` に `SqliteEventBuffer.waitForEvents` の連続エラーカウント仕様テスト4件を追加
- `spec/mcp/tools/event-buffer.spec.ts` に `pollEvents` のエラーハンドリング仕様テスト3件を追加

closes #605

## Test plan
- [x] `nr test:spec` — 全1390テスト通過
- [x] 変更対象2ファイル 74テスト / 160 expect() 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)