### PR TITLE
feat(observability): OpenCode セッション内アクティビティログ

### DIFF
--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -19,6 +19,7 @@ import {
 	classifyEvent,
 	extractText,
 	extractTokens,
+	logPartActivity,
 	nextStreamEvent,
 	returnStreamOnce,
 	sumTokens,
@@ -164,6 +165,8 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 					}
 				}
 
+				logPartActivity(typed, params.sessionId, this.logger);
+
 				const classified = classifyEvent(typed, params.sessionId, tokensByMessage);
 				if (classified) {
 					if (classified.type === "error") {
@@ -220,6 +223,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 				if (rawType === "session.status" || rawType === "session.updated") {
 					this.logger?.info(`[opencode] waitIdle: type=${rawType} props=${JSON.stringify(props)}`);
 				}
+				logPartActivity(typed, sessionId, this.logger);
 				const result = classifyEvent(typed, sessionId, tokensByMessage);
 				if (result) {
 					if (result.type === "error") {

--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -173,10 +173,9 @@ export function sumTokens(tokensByMessage: Map<string, TokenUsage>): TokenUsage 
 	return { input, output, cacheRead };
 }
 
-const TEXT_LOG_MAX = 200;
-
 /** message.part.updated イベントからセッション内のアクティビティをログに出す */
 export function logPartActivity(event: Event, sessionId: string, logger: Logger | undefined): void {
+	const TEXT_LOG_MAX = 200;
 	if (!logger || event.type !== "message.part.updated") return;
 	const { part } = event.properties;
 	if (part.sessionID !== sessionId) return;
@@ -191,10 +190,7 @@ export function logPartActivity(event: Event, sessionId: string, logger: Logger 
 		if (status === "running") {
 			logger.info(`[opencode:activity] tool-start: ${part.tool}`);
 		} else if (status === "completed") {
-			const elapsed =
-				"time" in part.state && part.state.time
-					? `${part.state.time.end - part.state.time.start}ms`
-					: "?";
+			const elapsed = part.state.time ? `${part.state.time.end - part.state.time.start}ms` : "?";
 			logger.info(`[opencode:activity] tool-done: ${part.tool} (${elapsed})`);
 		} else if (status === "error") {
 			const errMsg = "error" in part.state ? part.state.error : "unknown";

--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -1,6 +1,6 @@
 import type { Event, EventMessageUpdated, OpencodeClient, Part } from "@opencode-ai/sdk/v2";
 import { withTimeout } from "@vicissitude/shared/functions";
-import type { OpencodeSessionEvent, TokenUsage } from "@vicissitude/shared/types";
+import type { Logger, OpencodeSessionEvent, TokenUsage } from "@vicissitude/shared/types";
 
 export type AbortableAsyncStream<T> = AsyncIterator<T> & {
 	return?: (value?: unknown) => Promise<IteratorResult<T>>;
@@ -171,4 +171,39 @@ export function sumTokens(tokensByMessage: Map<string, TokenUsage>): TokenUsage 
 		cacheRead += t.cacheRead;
 	}
 	return { input, output, cacheRead };
+}
+
+const TEXT_LOG_MAX = 200;
+
+/** message.part.updated イベントからセッション内のアクティビティをログに出す */
+export function logPartActivity(event: Event, sessionId: string, logger: Logger | undefined): void {
+	if (!logger || event.type !== "message.part.updated") return;
+	const { part } = event.properties;
+	if (part.sessionID !== sessionId) return;
+
+	if (part.type === "text") {
+		const text = part.text.trim();
+		if (!text) return;
+		const preview = text.length > TEXT_LOG_MAX ? `${text.slice(0, TEXT_LOG_MAX)}…` : text;
+		logger.info(`[opencode:activity] text: ${preview}`);
+	} else if (part.type === "tool") {
+		const status = part.state.status;
+		if (status === "running") {
+			logger.info(`[opencode:activity] tool-start: ${part.tool}`);
+		} else if (status === "completed") {
+			const elapsed =
+				"time" in part.state && part.state.time
+					? `${part.state.time.end - part.state.time.start}ms`
+					: "?";
+			logger.info(`[opencode:activity] tool-done: ${part.tool} (${elapsed})`);
+		} else if (status === "error") {
+			const errMsg = "error" in part.state ? part.state.error : "unknown";
+			logger.error(`[opencode:activity] tool-error: ${part.tool}: ${errMsg}`);
+		}
+	} else if (part.type === "step-finish") {
+		const { input: i, output: o, reasoning: r } = part.tokens;
+		logger.info(
+			`[opencode:activity] step-finish: reason=${part.reason} tokens(in=${i} out=${o} reasoning=${r}) cost=${part.cost}`,
+		);
+	}
 }


### PR DESCRIPTION
## Summary
- LLM のテキスト出力・ツール呼び出し(開始/完了/エラー)・ステップ完了(トークン数/コスト)を `[opencode:activity]` タグでログ出力
- `message.part.updated` イベントから `text`, `tool`, `step-finish` パートを抽出
- `promptAsyncAndWatchSession` と `waitForSessionIdle` の両方に適用

## 背景
Discord agent の応答が遅延する問題の調査で、セッション内で LLM が何をしているかがログから見えないことが判明。
セッションの SQLite DB を直接クエリして分析した結果、ターン数の増加に伴い LLM の思考時間が劇的に増大していることを確認（初回 2-3秒 → 6ターン目 1分27秒）。

## ログ出力例
```
[opencode:activity] text: おかずがデプロイ関連で困ってるっぽい…
[opencode:activity] tool-start: core_wait_for_events
[opencode:activity] tool-done: core_wait_for_events (5851ms)
[opencode:activity] tool-start: core_send_message
[opencode:activity] tool-done: core_send_message (4012ms)
[opencode:activity] step-finish: reason=end_turn tokens(in=15623 out=412 reasoning=0) cost=0.05
```

## Test plan
- [x] `nr validate` 通過（lint + fmt + type check）
- [x] `nr test` 全テスト通過（1849 pass, 0 fail）

🤖 Generated with [Claude Code](https://claude.com/claude-code)