### PR TITLE
refactor(mcp): ツール出力・description の言語を英語に統一 (#450)

### DIFF
--- a/packages/application/src/heartbeat-service.ts
+++ b/packages/application/src/heartbeat-service.ts
@@ -11,9 +11,9 @@ export function buildHeartbeatPrompt(dueReminders: DueReminder[]): string {
 			const schedule = due.reminder.schedule;
 			const scheduleLabel =
 				schedule.type === "interval"
-					? `${String(schedule.minutes)}分ごと`
-					: `毎日 ${String(schedule.hour)}:${String(schedule.minute).padStart(2, "0")}`;
-			const lastLabel = due.reminder.lastExecutedAt ?? "なし";
+					? `every ${String(schedule.minutes)}min`
+					: `daily ${String(schedule.hour)}:${String(schedule.minute).padStart(2, "0")}`;
+			const lastLabel = due.reminder.lastExecutedAt ?? "never";
 			return `- [${scheduleLabel}] ${due.reminder.description}（最後: ${lastLabel}）`;
 		})
 		.join("\n");

--- a/packages/mcp/src/tools/mc-bridge-discord.ts
+++ b/packages/mcp/src/tools/mc-bridge-discord.ts
@@ -26,9 +26,13 @@ export function registerDiscordBridgeTools(
 	server.registerTool(
 		"minecraft_delegate",
 		{
-			description: "マイクラの自分に指示を出す。次のポーリングで反映される。",
+			description: "Delegate a command to the Minecraft agent. Reflected on next poll.",
 			inputSchema: {
-				command: z.string().min(1).max(MAX_COMMAND_CHARS).describe("マイクラでやること"),
+				command: z
+					.string()
+					.min(1)
+					.max(MAX_COMMAND_CHARS)
+					.describe("Command for the Minecraft agent"),
 			},
 		},
 		({ command }) => {
@@ -47,23 +51,27 @@ export function registerDiscordBridgeTools(
 		},
 	);
 
-	server.registerTool("minecraft_status", { description: "マイクラの最新状況を確認する。" }, () => {
-		const status = getMcConnectionStatus(db);
-		const label = status.connected ? "接続中" : "未接続";
-		const text = `接続状態: ${label}${status.since ? ` (${status.since})` : ""}`;
+	server.registerTool(
+		"minecraft_status",
+		{ description: "Check the latest Minecraft connection status." },
+		() => {
+			const status = getMcConnectionStatus(db);
+			const label = status.connected ? "connected" : "disconnected";
+			const text = `Connection status: ${label}${status.since ? ` (${status.since})` : ""}`;
 
-		return {
-			content: [{ type: "text" as const, text }],
-		};
-	});
+			return {
+				content: [{ type: "text" as const, text }],
+			};
+		},
+	);
 
 	server.registerTool(
 		"minecraft_start_session",
 		{
-			description: "マイクラのセッションを開始する。マイクラが停止中のときに使う。",
+			description: "Start a Minecraft session. Use when Minecraft is stopped.",
 			inputSchema: boundGuildId
 				? {}
-				: { guild_id: z.string().min(1).describe("呼び出し元の guild ID") },
+				: { guild_id: z.string().min(1).describe("Caller's guild ID") },
 		},
 		({ guild_id }: { guild_id?: string }) => {
 			const gid = boundGuildId ?? guild_id;
@@ -95,10 +103,10 @@ export function registerDiscordBridgeTools(
 	server.registerTool(
 		"minecraft_stop_session",
 		{
-			description: "マイクラのセッションを停止する。",
+			description: "Stop the Minecraft session.",
 			inputSchema: boundGuildId
 				? {}
-				: { guild_id: z.string().min(1).describe("呼び出し元の guild ID") },
+				: { guild_id: z.string().min(1).describe("Caller's guild ID") },
 		},
 		({ guild_id }: { guild_id?: string }) => {
 			const gid = boundGuildId ?? guild_id;

--- a/packages/mcp/src/tools/memory.ts
+++ b/packages/mcp/src/tools/memory.ts
@@ -35,11 +35,11 @@ export function registerMemoryTools(
 		"memory_retrieve",
 		{
 			description:
-				"クエリに関連する長期記憶をハイブリッド検索（テキスト＋ベクトル＋FSRS リランキング）で取得する",
+				"Retrieve long-term memories related to the query via hybrid search (text + vector + FSRS re-ranking)",
 			inputSchema: {
 				...(boundNamespace ? {} : { guild_id: guildIdSchema }),
-				query: z.string().min(1).describe("検索クエリ"),
-				limit: z.number().min(1).max(50).optional().describe("最大取得件数（デフォルト: 10）"),
+				query: z.string().min(1).describe("Search query"),
+				limit: z.number().min(1).max(50).optional().describe("Max results (default: 10)"),
 			},
 		},
 		async ({ guild_id, query, limit }: { guild_id?: string; query: string; limit?: number }) => {
@@ -71,7 +71,7 @@ export function registerMemoryTools(
 				const parts: string[] = [];
 
 				if (result.episodes.length > 0) {
-					parts.push("## エピソード記憶");
+					parts.push("## Episodic Memory");
 					for (const ep of result.episodes) {
 						parts.push(`### ${ep.episode.title} (score: ${ep.score.toFixed(3)})`);
 						parts.push(ep.episode.summary);
@@ -80,7 +80,7 @@ export function registerMemoryTools(
 				}
 
 				if (result.facts.length > 0) {
-					parts.push("## 意味記憶（ファクト）");
+					parts.push("## Semantic Memory (Facts)");
 					for (const f of result.facts) {
 						parts.push(`- [${f.fact.category}] ${f.fact.fact} (score: ${f.score.toFixed(3)})`);
 					}
@@ -88,7 +88,7 @@ export function registerMemoryTools(
 
 				if (internalResult) {
 					if (internalResult.episodes.length > 0) {
-						parts.push("## ふあ自身の記憶（エピソード）");
+						parts.push("## Hua's Own Memory (Episodes)");
 						for (const ep of internalResult.episodes) {
 							parts.push(`### ${ep.episode.title} (score: ${ep.score.toFixed(3)})`);
 							parts.push(ep.episode.summary);
@@ -97,7 +97,7 @@ export function registerMemoryTools(
 					}
 
 					if (internalResult.facts.length > 0) {
-						parts.push("## ふあ自身の記憶（ファクト）");
+						parts.push("## Hua's Own Memory (Facts)");
 						for (const f of internalResult.facts) {
 							parts.push(`- [${f.fact.category}] ${f.fact.fact} (score: ${f.score.toFixed(3)})`);
 						}
@@ -105,7 +105,7 @@ export function registerMemoryTools(
 				}
 
 				if (parts.length === 0) {
-					parts.push("関連する記憶は見つかりませんでした。");
+					parts.push("No relevant memories found.");
 				}
 
 				return { content: [{ type: "text", text: parts.join("\n") }] };
@@ -126,7 +126,7 @@ export function registerMemoryTools(
 	server.registerTool(
 		"memory_get_facts",
 		{
-			description: "蓄積されたファクト（意味記憶）一覧を取得する",
+			description: "List accumulated facts (semantic memory)",
 			inputSchema: {
 				...(boundNamespace ? {} : { guild_id: guildIdSchema }),
 				category: z
@@ -141,7 +141,7 @@ export function registerMemoryTools(
 						"guideline",
 					])
 					.optional()
-					.describe("カテゴリでフィルタ（省略で全件）"),
+					.describe("Filter by category (omit for all)"),
 			},
 		},
 		async ({
@@ -185,17 +185,17 @@ export function registerMemoryTools(
 
 				if (facts.length === 0 && (!internalFacts || internalFacts.length === 0)) {
 					return {
-						content: [{ type: "text", text: "ファクトはまだありません。" }],
+						content: [{ type: "text", text: "No facts yet." }],
 					};
 				}
 
 				const parts: string[] = [];
 				if (facts.length > 0) {
-					parts.push(`${facts.length} 件のファクト:`);
+					parts.push(`${facts.length} facts:`);
 					parts.push(...formatFacts(facts));
 				}
 				if (internalFacts && internalFacts.length > 0) {
-					parts.push(`\nふあ自身の記憶（${internalFacts.length} 件）:`);
+					parts.push(`\nHua's own memory (${internalFacts.length} facts):`);
 					parts.push(...formatFacts(internalFacts));
 				}
 

--- a/packages/mcp/src/tools/schedule.ts
+++ b/packages/mcp/src/tools/schedule.ts
@@ -25,7 +25,7 @@ function registerReadTools(
 ): void {
 	server.registerTool(
 		"get_heartbeat_config",
-		{ description: "現在の heartbeat 設定を表示する" },
+		{ description: "Show current heartbeat configuration" },
 		async () => {
 			const config = await configPort.load();
 			return { content: [{ type: "text", text: JSON.stringify(config, null, 2) }] };
@@ -35,7 +35,7 @@ function registerReadTools(
 	server.registerTool(
 		"list_reminders",
 		{
-			description: "リマインダー一覧を表示する（現在のギルド＋グローバルのみ）",
+			description: "List reminders (current guild + global only)",
 			inputSchema: boundGuildId ? {} : { guild_id: guildIdSchema },
 		},
 		async ({ guild_id }: { guild_id?: string }) => {
@@ -48,22 +48,22 @@ function registerReadTools(
 			const lines = visible.map((r) => {
 				const schedule =
 					r.schedule.type === "interval"
-						? `${String(r.schedule.minutes)}分ごと`
-						: `毎日 ${String(r.schedule.hour)}:${String(r.schedule.minute).padStart(2, "0")}`;
-				const status = r.enabled ? "有効" : "無効";
-				const last = r.lastExecutedAt ?? "未実行";
+						? `every ${String(r.schedule.minutes)}min`
+						: `daily ${String(r.schedule.hour)}:${String(r.schedule.minute).padStart(2, "0")}`;
+				const status = r.enabled ? "enabled" : "disabled";
+				const last = r.lastExecutedAt ?? "never";
 				const scope = r.guildId ? `guild:${r.guildId}` : "global";
-				return `- [${r.id}] ${r.description} (${schedule}, ${status}, ${scope}, 最後: ${last})`;
+				return `- [${r.id}] ${r.description} (${schedule}, ${status}, ${scope}, last: ${last})`;
 			});
-			return { content: [{ type: "text" as const, text: lines.join("\n") || "リマインダーなし" }] };
+			return { content: [{ type: "text" as const, text: lines.join("\n") || "No reminders" }] };
 		},
 	);
 
 	server.registerTool(
 		"set_base_interval",
 		{
-			description: "ベースチェック間隔を変更する（分）",
-			inputSchema: { minutes: z.number().min(1).describe("チェック間隔（分）") },
+			description: "Set base check interval (minutes)",
+			inputSchema: { minutes: z.number().min(1).describe("Check interval in minutes") },
 		},
 		async ({ minutes }) => {
 			const config = await configPort.load();
@@ -73,7 +73,7 @@ function registerReadTools(
 				content: [
 					{
 						type: "text",
-						text: `ベース間隔を ${String(minutes)} 分に変更しました`,
+						text: `Base interval set to ${String(minutes)} minutes`,
 					},
 				],
 			};
@@ -89,21 +89,23 @@ function registerAddReminder(
 	server.registerTool(
 		"add_reminder",
 		{
-			description: "新しいリマインダーを追加する（デフォルトで現在のギルドに紐づく）",
+			description: "Add a new reminder (defaults to current guild)",
 			inputSchema: {
 				...(boundGuildId ? {} : { guild_id: guildIdSchema }),
-				id: z.string().describe("一意の識別子"),
-				description: z.string().describe("リマインダーの説明"),
-				schedule_type: z.enum(["interval", "daily"]).describe("スケジュールタイプ"),
-				interval_minutes: z.number().min(1).optional().describe("interval の場合の分数（1以上）"),
-				daily_hour: z.number().min(0).max(23).optional().describe("daily の場合の時"),
-				daily_minute: z.number().min(0).max(59).optional().describe("daily の場合の分"),
+				id: z.string().describe("Unique identifier"),
+				description: z.string().describe("Reminder description"),
+				schedule_type: z.enum(["interval", "daily"]).describe("Schedule type"),
+				interval_minutes: z
+					.number()
+					.min(1)
+					.optional()
+					.describe("Minutes for interval type (min 1)"),
+				daily_hour: z.number().min(0).max(23).optional().describe("Hour for daily type"),
+				daily_minute: z.number().min(0).max(59).optional().describe("Minute for daily type"),
 				global: z
 					.boolean()
 					.optional()
-					.describe(
-						"true にするとギルドに紐づかないグローバルリマインダーになる（デフォルト: false）",
-					),
+					.describe("Set true for a global reminder not bound to any guild (default: false)"),
 			},
 		},
 		async ({
@@ -172,7 +174,7 @@ function registerAddReminder(
 			config.reminders.push(reminder);
 			await configPort.save(config);
 			return {
-				content: [{ type: "text" as const, text: `リマインダー "${id}" を追加しました` }],
+				content: [{ type: "text" as const, text: `Reminder "${id}" added` }],
 			};
 		},
 	);
@@ -186,19 +188,20 @@ function registerModifyReminders(
 	server.registerTool(
 		"update_reminder",
 		{
-			description: "リマインダーを更新する（自ギルドまたはグローバルのみ）",
+			description: "Update a reminder (own guild or global only)",
 			inputSchema: {
 				...(boundGuildId ? {} : { guild_id: guildIdSchema }),
-				id: z.string().describe("更新するリマインダーの ID"),
-				description: z.string().optional().describe("新しい説明"),
-				enabled: z.boolean().optional().describe("有効/無効"),
-				schedule_type: z
-					.enum(["interval", "daily"])
+				id: z.string().describe("ID of the reminder to update"),
+				description: z.string().optional().describe("New description"),
+				enabled: z.boolean().optional().describe("Enable/disable"),
+				schedule_type: z.enum(["interval", "daily"]).optional().describe("New schedule type"),
+				interval_minutes: z
+					.number()
+					.min(1)
 					.optional()
-					.describe("新しいスケジュールタイプ"),
-				interval_minutes: z.number().min(1).optional().describe("interval の場合の分数（1以上）"),
-				daily_hour: z.number().min(0).max(23).optional().describe("daily の場合の時"),
-				daily_minute: z.number().min(0).max(59).optional().describe("daily の場合の分"),
+					.describe("Minutes for interval type (min 1)"),
+				daily_hour: z.number().min(0).max(23).optional().describe("Hour for daily type"),
+				daily_minute: z.number().min(0).max(59).optional().describe("Minute for daily type"),
 			},
 		},
 		async ({
@@ -259,7 +262,7 @@ function registerModifyReminders(
 
 			await configPort.save(config);
 			return {
-				content: [{ type: "text" as const, text: `リマインダー "${id}" を更新しました` }],
+				content: [{ type: "text" as const, text: `Reminder "${id}" updated` }],
 			};
 		},
 	);
@@ -267,10 +270,10 @@ function registerModifyReminders(
 	server.registerTool(
 		"remove_reminder",
 		{
-			description: "リマインダーを削除する（自ギルドまたはグローバルのみ）",
+			description: "Remove a reminder (own guild or global only)",
 			inputSchema: {
 				...(boundGuildId ? {} : { guild_id: guildIdSchema }),
-				id: z.string().describe("削除するリマインダーの ID"),
+				id: z.string().describe("ID of the reminder to remove"),
 			},
 		},
 		async ({ guild_id, id }: { guild_id?: string; id: string }) => {
@@ -301,7 +304,7 @@ function registerModifyReminders(
 			config.reminders.splice(config.reminders.indexOf(reminder), 1);
 			await configPort.save(config);
 			return {
-				content: [{ type: "text" as const, text: `リマインダー "${id}" を削除しました` }],
+				content: [{ type: "text" as const, text: `Reminder "${id}" removed` }],
 			};
 		},
 	);

--- a/spec/application/heartbeat-service.spec.ts
+++ b/spec/application/heartbeat-service.spec.ts
@@ -25,7 +25,7 @@ describe("buildHeartbeatPrompt", () => {
 		]);
 
 		expect(prompt).toContain("水やり");
-		expect(prompt).toContain("30分ごと");
+		expect(prompt).toContain("every 30min");
 	});
 });
 

--- a/spec/gateway/scheduler.spec.ts
+++ b/spec/gateway/scheduler.spec.ts
@@ -21,7 +21,7 @@ describe("buildHeartbeatPrompt", () => {
 		];
 		const result = buildHeartbeatPrompt(reminders);
 		expect(result).toContain("[heartbeat]");
-		expect(result).toContain("30分ごと");
+		expect(result).toContain("every 30min");
 		expect(result).toContain("ホームチャンネルの様子を見る");
 		expect(result).toContain("2026-03-01T00:00:00Z");
 	});
@@ -40,9 +40,9 @@ describe("buildHeartbeatPrompt", () => {
 			},
 		];
 		const result = buildHeartbeatPrompt(reminders);
-		expect(result).toContain("毎日 9:00");
+		expect(result).toContain("daily 9:00");
 		expect(result).toContain("朝の挨拶");
-		expect(result).toContain("なし");
+		expect(result).toContain("never");
 	});
 
 	it("複数のリマインダーがすべてプロンプトに含まれる", () => {
@@ -71,8 +71,8 @@ describe("buildHeartbeatPrompt", () => {
 		const result = buildHeartbeatPrompt(reminders);
 		expect(result).toContain("タスクA");
 		expect(result).toContain("タスクB");
-		expect(result).toContain("10分ごと");
-		expect(result).toContain("毎日 21:30");
+		expect(result).toContain("every 10min");
+		expect(result).toContain("daily 21:30");
 	});
 });
 

--- a/spec/mcp/tools/mc-bridge-http.spec.ts
+++ b/spec/mcp/tools/mc-bridge-http.spec.ts
@@ -111,6 +111,6 @@ describe("MCP HTTP + mc-bridge ツール結合テスト", () => {
 
 		expect(result.result).toBeDefined();
 		const text = result.result?.content.at(0)?.text ?? "";
-		expect(text).toContain("接続中");
+		expect(text).toContain("connected");
 	});
 });

--- a/spec/mcp/tools/memory-cross-ns.spec.ts
+++ b/spec/mcp/tools/memory-cross-ns.spec.ts
@@ -201,7 +201,7 @@ describe("memory_retrieve", () => {
 		const result: ToolResult = await handler({ query: "nothing" });
 
 		expect(result.isError).toBeUndefined();
-		expect(result.content[0]!.text).toContain("関連する記憶は見つかりませんでした");
+		expect(result.content[0]!.text).toContain("No relevant memories found.");
 	});
 
 	test("boundNamespace が undefined で guild_id 指定時に internal も並行検索される", async () => {
@@ -251,9 +251,9 @@ describe("memory_retrieve: cross-namespace 検索", () => {
 		expect(text).toContain("音楽聴取ログ");
 
 		// セクションヘッダーが含まれる
-		expect(text).toContain("## エピソード記憶");
-		expect(text).toContain("## ふあ自身の記憶（エピソード）");
-		expect(text).toContain("## ふあ自身の記憶（ファクト）");
+		expect(text).toContain("## Episodic Memory");
+		expect(text).toContain("## Hua's Own Memory (Episodes)");
+		expect(text).toContain("## Hua's Own Memory (Facts)");
 	});
 
 	test("boundNamespace が internal の場合、結果が重複しない（二重検索しない）", async () => {
@@ -363,7 +363,7 @@ describe("memory_get_facts", () => {
 		const result: ToolResult = await handler({});
 
 		expect(result.isError).toBeUndefined();
-		expect(result.content[0]!.text).toContain("ファクトはまだありません");
+		expect(result.content[0]!.text).toContain("No facts yet.");
 	});
 
 	test("boundNamespace が undefined で guild_id 指定時に internal もマージされる", async () => {


### PR DESCRIPTION
## Summary

- mc-bridge-discord.ts, schedule.ts, memory.ts の tool description とツール出力メッセージを英語に統一
- heartbeat-service.ts の共有フォーマット（`分ごと` → `every Xmin`、`毎日` → `daily`）も連動変更
- mc-bridge-discord.ts のキャラクターボイス（「マイクラ起動するね。ちょっと待って。」等）は日本語のまま維持
- 関連する spec テスト（4ファイル）のアサーション文字列を更新

## Test plan

- [x] `nr test:spec` — 1396 pass / 0 fail
- [x] `nr test:unit` — 453 pass / 0 fail
- [x] `nr validate` — fmt:check, lint, check 全パス

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)