### PR TITLE
fix(lint): CI の lint エラー 4 件を修正

### DIFF
--- a/packages/mcp/src/http-server.ts
+++ b/packages/mcp/src/http-server.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { Logger } from "@vicissitude/shared/types";
 import type { Server as BunServer } from "bun";
+type HttpServer = BunServer<undefined>;
 
 interface SessionEntry {
 	server: McpServer;
@@ -21,7 +22,7 @@ function createFetchHandler(
 	sessions: Map<string, SessionEntry>,
 	label: string,
 	logger: Logger,
-): (req: Request, server: BunServer) => Response | Promise<Response> {
+): (req: Request, server: HttpServer) => Response | Promise<Response> {
 	return async (req, bunServer) => {
 		const url = new URL(req.url);
 		const pathname = url.pathname;

--- a/packages/mcp/src/http-server.ts
+++ b/packages/mcp/src/http-server.ts
@@ -106,7 +106,7 @@ export function startHttpServer(
 	};
 
 	const stopServer = (): void => {
-		httpServer.stop(true);
+		void httpServer.stop(true);
 	};
 
 	const cleanupTimer = setInterval(() => {

--- a/packages/minecraft/src/bot-queries.test.ts
+++ b/packages/minecraft/src/bot-queries.test.ts
@@ -87,7 +87,7 @@ describe("canPerceiveEntity", () => {
 			height: 1.95,
 		};
 
-		await expect(canPerceiveEntity(bot, entity as never)).resolves.toBe(true);
+		expect(await canPerceiveEntity(bot, entity as never)).toBe(true);
 		expect(raycast).not.toHaveBeenCalled();
 	});
 
@@ -103,7 +103,7 @@ describe("canPerceiveEntity", () => {
 			height: 1.95,
 		};
 
-		await expect(canPerceiveEntity(bot, entity as never)).resolves.toBe(false);
+		expect(await canPerceiveEntity(bot, entity as never)).toBe(false);
 	});
 });
 

--- a/packages/minecraft/src/mc-metrics.ts
+++ b/packages/minecraft/src/mc-metrics.ts
@@ -95,7 +95,7 @@ export function createMcMetrics(
 		},
 		stop() {
 			if (bunServer) {
-				bunServer.stop();
+				void bunServer.stop();
 				bunServer = null;
 				logger.info("[mc-metrics] Prometheus server stopped");
 			}


### PR DESCRIPTION
## Summary
- `bot-queries.test.ts`: `await expect(...).resolves` → `expect(await ...)` で `await-thenable` 解消
- `mc-metrics.ts`: `bunServer.stop()` に `void` 演算子を付与して `no-floating-promises` 解消
- `http-server.ts`: `httpServer.stop(true)` に `void` 演算子を付与して `no-floating-promises` 解消

## Test plan
- [x] CI の lint が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)