### PR TITLE
test(opencode): logPartActivity の spec テストを追加

### DIFF
--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -402,7 +402,7 @@ describe("logPartActivity", () => {
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
 		// 200 文字 + "…" で切り詰められる
-		expect(logger.infoMessages[0].length).toBeLessThan(longText.length + 50);
+		expect(logger.infoMessages[0]?.length).toBeLessThan(longText.length + 50);
 	});
 
 	test("tool パート（running）のログ出力", () => {

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -348,11 +348,19 @@ describe("logPartActivity", () => {
 	const sessionId = "test-session";
 
 	function makeLogger() {
+		const infoMessages: string[] = [];
+		const errorMessages: string[] = [];
 		return {
-			info: mock(() => {}),
-			error: mock(() => {}),
+			info: mock((msg: string) => {
+				infoMessages.push(msg);
+			}),
+			error: mock((msg: string) => {
+				errorMessages.push(msg);
+			}),
 			warn: mock(() => {}),
 			debug: mock(() => {}),
+			infoMessages,
+			errorMessages,
 		};
 	}
 
@@ -372,9 +380,8 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
-		const msg = logger.info.mock.calls[0][0] as string;
-		expect(msg).toContain("[opencode:activity] text:");
-		expect(msg).toContain("Hello world");
+		expect(logger.infoMessages[0]).toContain("[opencode:activity] text:");
+		expect(logger.infoMessages[0]).toContain("Hello world");
 	});
 
 	test("text パートが空白のみの場合はログを出力しない", () => {
@@ -394,9 +401,8 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
-		const msg = logger.info.mock.calls[0][0] as string;
 		// 200 文字 + "…" で切り詰められる
-		expect(msg.length).toBeLessThan(longText.length + 50);
+		expect(logger.infoMessages[0].length).toBeLessThan(longText.length + 50);
 	});
 
 	test("tool パート（running）のログ出力", () => {
@@ -410,9 +416,8 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
-		const msg = logger.info.mock.calls[0][0] as string;
-		expect(msg).toContain("[opencode:activity] tool-start:");
-		expect(msg).toContain("search_code");
+		expect(logger.infoMessages[0]).toContain("[opencode:activity] tool-start:");
+		expect(logger.infoMessages[0]).toContain("search_code");
 	});
 
 	test("tool パート（completed）のログ出力", () => {
@@ -426,10 +431,9 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
-		const msg = logger.info.mock.calls[0][0] as string;
-		expect(msg).toContain("[opencode:activity] tool-done:");
-		expect(msg).toContain("read_file");
-		expect(msg).toContain("500ms");
+		expect(logger.infoMessages[0]).toContain("[opencode:activity] tool-done:");
+		expect(logger.infoMessages[0]).toContain("read_file");
+		expect(logger.infoMessages[0]).toContain("500ms");
 	});
 
 	test("tool パート（error）のログ出力", () => {
@@ -443,10 +447,9 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.error).toHaveBeenCalledTimes(1);
-		const msg = logger.error.mock.calls[0][0] as string;
-		expect(msg).toContain("[opencode:activity] tool-error:");
-		expect(msg).toContain("write_file");
-		expect(msg).toContain("permission denied");
+		expect(logger.errorMessages[0]).toContain("[opencode:activity] tool-error:");
+		expect(logger.errorMessages[0]).toContain("write_file");
+		expect(logger.errorMessages[0]).toContain("permission denied");
 	});
 
 	test("step-finish パートのログ出力", () => {
@@ -461,13 +464,12 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
-		const msg = logger.info.mock.calls[0][0] as string;
-		expect(msg).toContain("[opencode:activity] step-finish:");
-		expect(msg).toContain("reason=end_turn");
-		expect(msg).toContain("in=1000");
-		expect(msg).toContain("out=500");
-		expect(msg).toContain("reasoning=200");
-		expect(msg).toContain("cost=0.05");
+		expect(logger.infoMessages[0]).toContain("[opencode:activity] step-finish:");
+		expect(logger.infoMessages[0]).toContain("reason=end_turn");
+		expect(logger.infoMessages[0]).toContain("in=1000");
+		expect(logger.infoMessages[0]).toContain("out=500");
+		expect(logger.infoMessages[0]).toContain("reasoning=200");
+		expect(logger.infoMessages[0]).toContain("cost=0.05");
 	});
 
 	test("sessionId が異なる場合にログが出ない", () => {

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -9,6 +9,7 @@
  * - extractTokens: トークン情報の変換
  * - sumTokens: トークン合算
  * - abortSession: ベストエフォート停止
+ * - logPartActivity: セッション内アクティビティのログ出力
  */
 import { describe, expect, mock, test } from "bun:test";
 
@@ -19,6 +20,7 @@ import {
 	classifyEvent,
 	extractText,
 	extractTokens,
+	logPartActivity,
 	nextStreamEvent,
 	returnStreamOnce,
 	sumTokens,
@@ -337,5 +339,164 @@ describe("abortSession", () => {
 		// エラーがスローされないことを確認
 		const result = await abortSession(client, "session-1");
 		expect(result).toBeUndefined();
+	});
+});
+
+// ─── logPartActivity ──────────────────────────────────────────────
+
+describe("logPartActivity", () => {
+	const sessionId = "test-session";
+
+	function makeLogger() {
+		return {
+			info: mock(() => {}),
+			error: mock(() => {}),
+			warn: mock(() => {}),
+			debug: mock(() => {}),
+		};
+	}
+
+	function makePartEvent(partProps: Record<string, unknown>, sid: string = sessionId): Event {
+		return {
+			type: "message.part.updated",
+			properties: {
+				part: { sessionID: sid, ...partProps },
+			},
+		} as unknown as Event;
+	}
+
+	test("text パートのログ出力", () => {
+		const logger = makeLogger();
+		const event = makePartEvent({ type: "text", text: "Hello world" });
+
+		logPartActivity(event, sessionId, logger);
+
+		expect(logger.info).toHaveBeenCalledTimes(1);
+		const msg = logger.info.mock.calls[0]![0] as string;
+		expect(msg).toContain("[opencode:activity] text:");
+		expect(msg).toContain("Hello world");
+	});
+
+	test("text パートが空白のみの場合はログを出力しない", () => {
+		const logger = makeLogger();
+		const event = makePartEvent({ type: "text", text: "   \n  " });
+
+		logPartActivity(event, sessionId, logger);
+
+		expect(logger.info).not.toHaveBeenCalled();
+	});
+
+	test("text パートが長い場合は切り詰める", () => {
+		const logger = makeLogger();
+		const longText = "a".repeat(300);
+		const event = makePartEvent({ type: "text", text: longText });
+
+		logPartActivity(event, sessionId, logger);
+
+		expect(logger.info).toHaveBeenCalledTimes(1);
+		const msg = logger.info.mock.calls[0]![0] as string;
+		// 200 文字 + "…" で切り詰められる
+		expect(msg.length).toBeLessThan(longText.length + 50);
+	});
+
+	test("tool パート（running）のログ出力", () => {
+		const logger = makeLogger();
+		const event = makePartEvent({
+			type: "tool",
+			tool: "search_code",
+			state: { status: "running" },
+		});
+
+		logPartActivity(event, sessionId, logger);
+
+		expect(logger.info).toHaveBeenCalledTimes(1);
+		const msg = logger.info.mock.calls[0]![0] as string;
+		expect(msg).toContain("[opencode:activity] tool-start:");
+		expect(msg).toContain("search_code");
+	});
+
+	test("tool パート（completed）のログ出力", () => {
+		const logger = makeLogger();
+		const event = makePartEvent({
+			type: "tool",
+			tool: "read_file",
+			state: { status: "completed", time: { start: 1000, end: 1500 } },
+		});
+
+		logPartActivity(event, sessionId, logger);
+
+		expect(logger.info).toHaveBeenCalledTimes(1);
+		const msg = logger.info.mock.calls[0]![0] as string;
+		expect(msg).toContain("[opencode:activity] tool-done:");
+		expect(msg).toContain("read_file");
+		expect(msg).toContain("500ms");
+	});
+
+	test("tool パート（error）のログ出力", () => {
+		const logger = makeLogger();
+		const event = makePartEvent({
+			type: "tool",
+			tool: "write_file",
+			state: { status: "error", error: "permission denied" },
+		});
+
+		logPartActivity(event, sessionId, logger);
+
+		expect(logger.error).toHaveBeenCalledTimes(1);
+		const msg = logger.error.mock.calls[0]![0] as string;
+		expect(msg).toContain("[opencode:activity] tool-error:");
+		expect(msg).toContain("write_file");
+		expect(msg).toContain("permission denied");
+	});
+
+	test("step-finish パートのログ出力", () => {
+		const logger = makeLogger();
+		const event = makePartEvent({
+			type: "step-finish",
+			reason: "end_turn",
+			tokens: { input: 1000, output: 500, reasoning: 200 },
+			cost: 0.05,
+		});
+
+		logPartActivity(event, sessionId, logger);
+
+		expect(logger.info).toHaveBeenCalledTimes(1);
+		const msg = logger.info.mock.calls[0]![0] as string;
+		expect(msg).toContain("[opencode:activity] step-finish:");
+		expect(msg).toContain("reason=end_turn");
+		expect(msg).toContain("in=1000");
+		expect(msg).toContain("out=500");
+		expect(msg).toContain("reasoning=200");
+		expect(msg).toContain("cost=0.05");
+	});
+
+	test("sessionId が異なる場合にログが出ない", () => {
+		const logger = makeLogger();
+		const event = makePartEvent({ type: "text", text: "Hello" }, "other-session");
+
+		logPartActivity(event, sessionId, logger);
+
+		expect(logger.info).not.toHaveBeenCalled();
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	test("logger が undefined の場合にエラーにならない", () => {
+		const event = makePartEvent({ type: "text", text: "Hello" });
+
+		// エラーなく完了すること
+		expect(() => logPartActivity(event, sessionId, undefined)).not.toThrow();
+	});
+
+	test("message.part.updated 以外のイベントは無視する", () => {
+		const logger = makeLogger();
+		const event = {
+			type: "session.idle",
+			properties: { sessionID: sessionId },
+		} as unknown as Event;
+
+		logPartActivity(event, sessionId, logger);
+
+		expect(logger.info).not.toHaveBeenCalled();
+		expect(logger.error).not.toHaveBeenCalled();
 	});
 });

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -372,7 +372,7 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
-		const msg = logger.info.mock.calls[0]![0] as string;
+		const msg = logger.info.mock.calls[0][0] as string;
 		expect(msg).toContain("[opencode:activity] text:");
 		expect(msg).toContain("Hello world");
 	});
@@ -394,7 +394,7 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
-		const msg = logger.info.mock.calls[0]![0] as string;
+		const msg = logger.info.mock.calls[0][0] as string;
 		// 200 文字 + "…" で切り詰められる
 		expect(msg.length).toBeLessThan(longText.length + 50);
 	});
@@ -410,7 +410,7 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
-		const msg = logger.info.mock.calls[0]![0] as string;
+		const msg = logger.info.mock.calls[0][0] as string;
 		expect(msg).toContain("[opencode:activity] tool-start:");
 		expect(msg).toContain("search_code");
 	});
@@ -426,7 +426,7 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
-		const msg = logger.info.mock.calls[0]![0] as string;
+		const msg = logger.info.mock.calls[0][0] as string;
 		expect(msg).toContain("[opencode:activity] tool-done:");
 		expect(msg).toContain("read_file");
 		expect(msg).toContain("500ms");
@@ -443,7 +443,7 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.error).toHaveBeenCalledTimes(1);
-		const msg = logger.error.mock.calls[0]![0] as string;
+		const msg = logger.error.mock.calls[0][0] as string;
 		expect(msg).toContain("[opencode:activity] tool-error:");
 		expect(msg).toContain("write_file");
 		expect(msg).toContain("permission denied");
@@ -461,7 +461,7 @@ describe("logPartActivity", () => {
 		logPartActivity(event, sessionId, logger);
 
 		expect(logger.info).toHaveBeenCalledTimes(1);
-		const msg = logger.info.mock.calls[0]![0] as string;
+		const msg = logger.info.mock.calls[0][0] as string;
 		expect(msg).toContain("[opencode:activity] step-finish:");
 		expect(msg).toContain("reason=end_turn");
 		expect(msg).toContain("in=1000");
@@ -484,7 +484,8 @@ describe("logPartActivity", () => {
 		const event = makePartEvent({ type: "text", text: "Hello" });
 
 		// エラーなく完了すること
-		expect(() => logPartActivity(event, sessionId, undefined)).not.toThrow();
+		const noLogger: undefined = void 0;
+		expect(() => logPartActivity(event, sessionId, noLogger)).not.toThrow();
 	});
 
 	test("message.part.updated 以外のイベントは無視する", () => {


### PR DESCRIPTION
## Summary
- `logPartActivity` 関数の仕様テスト 9 件を `spec/opencode/stream-helpers.spec.ts` に追加
- text パート（通常・空白・長文切り詰め）、tool パート（running/completed/error）、step-finish パート、セッション ID フィルタ、logger undefined 安全性、イベント型フィルタをカバー

Closes #610

## Test plan
- [x] `bun test spec/opencode/stream-helpers.spec.ts` — 31 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)