### PR TITLE
chore(mcp): wait_for_events のタイムアウト出力を英語に統一 (#617)

### DIFF
--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -469,7 +469,7 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 			});
 			if (result === null) {
 				logger?.debug(`[event-buffer] タイムアウト (${timeout_seconds}s)`);
-				return { content: [{ type: "text" as const, text: "イベントなし（タイムアウト）" }] };
+				return { content: [{ type: "text" as const, text: "No events (timeout)" }] };
 			}
 			const hints = result.map((e) => (isErrorEvent(e) ? "error" : classifyActionHint(e)));
 			logger?.info(


### PR DESCRIPTION
## Summary

- `wait_for_events` のタイムアウト時ツール出力 `"イベントなし（タイムアウト）"` を `"No events (timeout)"` に変更
- commit db48d1e で統一したツール出力の英語化の漏れを修正

Closes #617

## Test plan

- [x] event-buffer 関連テスト 105 pass（`bun test --filter "event-buffer"`）
- [x] 全テスト 1854 pass（既存の `vec3` パッケージ依存エラー 1 件は今回の変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)