### PR TITLE
test(spec): #618 timeout_seconds デフォルト値・idle タイムアウト・TTL クリーンアップの spec 追加

### DIFF
--- a/packages/mcp/src/http-server.ts
+++ b/packages/mcp/src/http-server.ts
@@ -83,6 +83,10 @@ export interface HttpServerHandle {
 	cleanupTimer: ReturnType<typeof setInterval>;
 	closeAllSessions: () => void;
 	stopServer: () => void;
+	/** 現在のアクティブセッション数を返す */
+	sessionCount: () => number;
+	/** TTL クリーンアップを手動実行する。ttlOverrideMs でセッション TTL を上書き可能 */
+	runCleanup: (ttlOverrideMs?: number) => void;
 }
 
 export function startHttpServer(
@@ -110,19 +114,29 @@ export function startHttpServer(
 		void httpServer.stop(true);
 	};
 
-	const cleanupTimer = setInterval(() => {
+	const runCleanup = (ttlOverrideMs?: number): void => {
+		const ttl = ttlOverrideMs ?? SESSION_TTL_MS;
 		const now = Date.now();
 		for (const [id, entry] of sessions) {
 			if (entry.activeRequests > 0) continue;
-			if (now - entry.lastAccess > SESSION_TTL_MS) {
+			if (now - entry.lastAccess > ttl) {
 				entry.server.close().catch(() => {});
 				entry.transport.close().catch(() => {});
 				sessions.delete(id);
 			}
 		}
-	}, SESSION_CLEANUP_INTERVAL_MS);
+	};
+
+	const cleanupTimer = setInterval(() => runCleanup(), SESSION_CLEANUP_INTERVAL_MS);
 
 	logger.info(`[${label}] MCP server listening on port ${httpServer.port}`);
 
-	return { port: httpServer.port ?? port, cleanupTimer, closeAllSessions, stopServer };
+	return {
+		port: httpServer.port ?? port,
+		cleanupTimer,
+		closeAllSessions,
+		stopServer,
+		sessionCount: () => sessions.size,
+		runCleanup,
+	};
 }

--- a/spec/mcp/minecraft/http-server.spec.ts
+++ b/spec/mcp/minecraft/http-server.spec.ts
@@ -118,7 +118,9 @@ describe("idle タイムアウト無効化", () => {
 	function createSlowServer(): McpServer {
 		const server = new McpServer({ name: "slow-test", version: "0.1.0" });
 		server.registerTool("slow_tool", { description: "slow tool" }, async () => {
-			await new Promise((resolve) => setTimeout(resolve, 2000));
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 2000);
+			});
 			return { content: [{ type: "text" as const, text: "done" }] };
 		});
 		return server;
@@ -176,7 +178,9 @@ describe("セッション TTL クリーンアップ", () => {
 		expect(handle.sessionCount()).toBe(1);
 
 		// lastAccess が確実に過去になるよう 1 tick 待つ
-		await new Promise((resolve) => setTimeout(resolve, 5));
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 5);
+		});
 		handle.runCleanup(0);
 		expect(handle.sessionCount()).toBe(0);
 	});
@@ -195,7 +199,9 @@ describe("セッション TTL クリーンアップ", () => {
 		expect(handle.sessionCount()).toBe(1);
 
 		// 後片付け
-		await new Promise((resolve) => setTimeout(resolve, 5));
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 5);
+		});
 		handle.runCleanup(0);
 	});
 });

--- a/spec/mcp/minecraft/http-server.spec.ts
+++ b/spec/mcp/minecraft/http-server.spec.ts
@@ -114,6 +114,92 @@ describe("MCP HTTP Server ライフサイクル", () => {
 	});
 });
 
+describe("idle タイムアウト無効化", () => {
+	function createSlowServer(): McpServer {
+		const server = new McpServer({ name: "slow-test", version: "0.1.0" });
+		server.registerTool("slow_tool", { description: "slow tool" }, async () => {
+			await new Promise((resolve) => setTimeout(resolve, 2000));
+			return { content: [{ type: "text" as const, text: "done" }] };
+		});
+		return server;
+	}
+
+	const handle = startHttpServer(createSlowServer, 0, "slow-test", stubLogger);
+	const baseUrl = `http://localhost:${handle.port}`;
+
+	afterAll(() => {
+		clearInterval(handle.cleanupTimer);
+		handle.closeAllSessions();
+		handle.stopServer();
+	});
+
+	test("MCP ツール実行が長時間かかっても idle タイムアウトで切断されない", async () => {
+		const initRes = await fetch(`${baseUrl}/mcp`, {
+			method: "POST",
+			headers: MCP_HEADERS,
+			body: MCP_INIT_BODY,
+		});
+		const sessionId = initRes.headers.get("mcp-session-id");
+		expect(sessionId).toBeTruthy();
+
+		const res = await fetch(`${baseUrl}/mcp`, {
+			method: "POST",
+			headers: { ...MCP_HEADERS, "mcp-session-id": sessionId ?? "" },
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/call",
+				params: { name: "slow_tool" },
+			}),
+		});
+		expect(res.status).toBe(200);
+	});
+});
+
+describe("セッション TTL クリーンアップ", () => {
+	const handle = startHttpServer(createTestServer, 0, "ttl-test", stubLogger);
+	const baseUrl = `http://localhost:${handle.port}`;
+
+	afterAll(() => {
+		clearInterval(handle.cleanupTimer);
+		handle.closeAllSessions();
+		handle.stopServer();
+	});
+
+	test("アイドル状態のセッションは TTL 超過で削除される", async () => {
+		const initRes = await fetch(`${baseUrl}/mcp`, {
+			method: "POST",
+			headers: MCP_HEADERS,
+			body: MCP_INIT_BODY,
+		});
+		expect(initRes.headers.get("mcp-session-id")).toBeTruthy();
+		expect(handle.sessionCount()).toBe(1);
+
+		// lastAccess が確実に過去になるよう 1 tick 待つ
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		handle.runCleanup(0);
+		expect(handle.sessionCount()).toBe(0);
+	});
+
+	test("TTL 以内のセッションはクリーンアップで削除されない", async () => {
+		const initRes = await fetch(`${baseUrl}/mcp`, {
+			method: "POST",
+			headers: MCP_HEADERS,
+			body: MCP_INIT_BODY,
+		});
+		expect(initRes.headers.get("mcp-session-id")).toBeTruthy();
+		expect(handle.sessionCount()).toBe(1);
+
+		// 十分大きな TTL でクリーンアップ → lastAccess が新しいので削除されない
+		handle.runCleanup(60 * 60 * 1000);
+		expect(handle.sessionCount()).toBe(1);
+
+		// 後片付け
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		handle.runCleanup(0);
+	});
+});
+
 function createFailingServer(): McpServer {
 	throw new Error("factory error");
 }

--- a/spec/mcp/tools/event-buffer.spec.ts
+++ b/spec/mcp/tools/event-buffer.spec.ts
@@ -2,6 +2,7 @@
 /* oxlint-disable max-lines -- spec file covering all event-buffer public APIs */
 import { describe, expect, mock, test } from "bun:test";
 
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
 	MAX_POLL_TIMEOUT_SECONDS,
 	classifyActionHint,
@@ -13,6 +14,7 @@ import {
 	isErrorEvent,
 	parseEvents,
 	pollEvents,
+	registerEventBufferTools,
 } from "@vicissitude/mcp/tools/event-buffer";
 import type { ErrorEvent, ParsedEvent, RecentMessage } from "@vicissitude/mcp/tools/event-buffer";
 import { CREATE_TABLES_SQL } from "@vicissitude/store/db";
@@ -1051,5 +1053,28 @@ describe("timeout constraints", () => {
 
 	test("MAX_POLL_TIMEOUT_SECONDS が Bun idleTimeout (255s) 未満である", () => {
 		expect(MAX_POLL_TIMEOUT_SECONDS).toBeLessThan(BUN_IDLE_TIMEOUT_MAX);
+	});
+
+	test("timeout_seconds のデフォルト値は MAX_POLL_TIMEOUT_SECONDS である", () => {
+		let capturedInputSchema: Record<string, unknown> | undefined;
+
+		const fakeServer = {
+			registerTool(
+				_name: string,
+				metadata: { inputSchema: Record<string, unknown> },
+				_handler: unknown,
+			) {
+				capturedInputSchema = metadata.inputSchema;
+			},
+		} as unknown as McpServer;
+
+		registerEventBufferTools(fakeServer, {
+			db: createTestDb(),
+			agentId: "test-agent",
+		});
+
+		expect(capturedInputSchema).toBeDefined();
+		const timeoutSchema = capturedInputSchema!.timeout_seconds as { parse(v: unknown): number };
+		expect(timeoutSchema.parse(undefined)).toBe(MAX_POLL_TIMEOUT_SECONDS);
 	});
 });

--- a/spec/mcp/tools/event-buffer.spec.ts
+++ b/spec/mcp/tools/event-buffer.spec.ts
@@ -1075,6 +1075,7 @@ describe("timeout constraints", () => {
 
 		expect(capturedInputSchema).toBeDefined();
 		const timeoutSchema = capturedInputSchema!.timeout_seconds as { parse(v: unknown): number };
+		// oxlint-disable-next-line no-useless-undefined -- undefined を渡してデフォルト値の適用を検証する
 		expect(timeoutSchema.parse(undefined)).toBe(MAX_POLL_TIMEOUT_SECONDS);
 	});
 });


### PR DESCRIPTION
## Summary

- `spec/mcp/tools/event-buffer.spec.ts`: `timeout_seconds` のデフォルト値が `MAX_POLL_TIMEOUT_SECONDS` であることを検証する spec を追加
- `spec/mcp/minecraft/http-server.spec.ts`: MCP ツール実行が idle タイムアウトで切断されないことを検証する spec を追加
- `spec/mcp/minecraft/http-server.spec.ts`: セッション TTL クリーンアップの動作（アイドルセッション削除・TTL 以内のセッション生存）を検証する spec を追加
- `packages/mcp/src/http-server.ts`: テスタビリティのため `sessionCount()` と `runCleanup()` を `HttpServerHandle` に追加

### 未対応: `activeRequests > 0` のブラックボックステスト

Issue #618 の項目3「リクエスト処理中のセッションが TTL クリーンアップされないこと」について、MCP SDK の `handleRequest` が SSE/JSON 共にレスポンスを即座に返すため、`activeRequests > 0` の状態をブラックボックステストで捕捉することが困難でした。代わりに TTL クリーンアップの基本動作（削除・生存）を検証する spec を追加しています。

Closes #618

## Test plan

- [x] `nr test:spec` — 全 spec テスト通過（1864 tests, 0 fail）
- [x] `nr validate` — lint エラー 0（warning 2 は既存）
- [x] `nr test` — 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)