### PR TITLE
fix: MCP子プロセスでDiscord Gateway接続を廃止しREST-onlyに変更

### DIFF
--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -25,7 +25,7 @@ import { OllamaChatAdapter } from "@vicissitude/ollama/ollama-chat-adapter";
 import { JsonHeartbeatConfigRepository } from "@vicissitude/scheduling/heartbeat-config";
 import { closeDb, createDb } from "@vicissitude/store/db";
 import { SqliteMoodStore } from "@vicissitude/store/mood-store";
-import { Client, GatewayIntentBits } from "discord.js";
+import { Client } from "discord.js";
 
 import { MemoryInstanceCache } from "./memory-cache.ts";
 import { registerDiscordTools } from "./tools/discord.ts";
@@ -69,23 +69,12 @@ async function main(): Promise<void> {
 		process.exit(1);
 	}
 
-	// --- Discord Client ---
+	// --- Discord Client (REST-only, no Gateway connection) ---
+	// MCP ツールは REST API のみ使用し、Gateway イベントは不要。
+	// login() を呼ばないことで Gateway セッションの生成を回避する。
 
-	const discordClient = new Client({
-		intents: [
-			GatewayIntentBits.Guilds,
-			GatewayIntentBits.GuildMessages,
-			GatewayIntentBits.MessageContent,
-			GatewayIntentBits.GuildMessageReactions,
-		],
-	});
-
-	try {
-		await discordClient.login(process.env.DISCORD_TOKEN);
-	} catch (err) {
-		logger.error("[core-server] Failed to login to Discord:", err);
-		process.exit(1);
-	}
+	const discordClient = new Client({ intents: [] });
+	discordClient.token = process.env.DISCORD_TOKEN;
 
 	// --- Drizzle DB ---
 

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -75,6 +75,7 @@ async function main(): Promise<void> {
 
 	const discordClient = new Client({ intents: [] });
 	discordClient.token = process.env.DISCORD_TOKEN;
+	discordClient.rest.setToken(process.env.DISCORD_TOKEN);
 
 	// --- Drizzle DB ---
 


### PR DESCRIPTION
## Summary

- MCP 子プロセス（core-server）で `discordClient.login()` を廃止し、`discordClient.token` のセットのみに変更
- `intents` を空配列にし、Gateway 接続を行わない REST-only クライアントに変更
- ギルド N 個の場合、2N 個の Gateway セッション → 0 個に削減

## 変更内容

`packages/mcp/src/core-server.ts` のみ（6 insertions, 17 deletions）:
- `GatewayIntentBits` の import を削除
- `new Client({ intents: [...] })` → `new Client({ intents: [] })`
- `await discordClient.login()` + try-catch → `discordClient.token = ...`（同期的なトークンセット）

## Test plan

- [x] `nr validate` 通過（fmt:check + lint + type check）
- [x] `nr test` 全 1865 テスト通過

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)