### PR TITLE
refactor: ConsoleLogger コンストラクタの string ユニオン型を削除 (#627)

### DIFF
--- a/packages/observability/src/logger.test.ts
+++ b/packages/observability/src/logger.test.ts
@@ -68,7 +68,7 @@ describe("ConsoleLogger", () => {
 
 	test("debug() → level=20（debug レベル有効時のみ出力）", () => {
 		setup();
-		const logger = new ConsoleLogger("debug");
+		const logger = new ConsoleLogger({ level: "debug" });
 		logger.debug("trace info");
 
 		expect(stdoutCapture.calls).toHaveLength(1);
@@ -79,7 +79,7 @@ describe("ConsoleLogger", () => {
 
 	test("debug() → info レベルでは出力されない", () => {
 		setup();
-		const logger = new ConsoleLogger("info");
+		const logger = new ConsoleLogger({ level: "info" });
 		logger.debug("should not appear");
 
 		expect(stdoutCapture.calls).toHaveLength(0);

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -5,12 +5,11 @@ export class ConsoleLogger implements Logger {
 	private readonly pino: pino.Logger;
 
 	/**
-	 * @param options — ログレベルまたは設定オブジェクト。
-	 *   文字列を渡すとログレベルとして扱う（後方互換）。
+	 * @param options — 設定オブジェクト。
 	 *   stdio MCP サーバーでは stdout が MCP 通信に使われるため `{ destination: "stderr" }` を指定する。
 	 */
-	constructor(options?: string | { level?: string; destination?: "stdout" | "stderr" }) {
-		const opts = typeof options === "string" ? { level: options } : (options ?? {});
+	constructor(options?: { level?: string; destination?: "stderr" }) {
+		const opts = options ?? {};
 		const level = opts.level ?? process.env.LOG_LEVEL ?? "info";
 		this.pino = pino({ level }, opts.destination === "stderr" ? pino.destination(2) : undefined);
 	}

--- a/spec/observability/logger.spec.ts
+++ b/spec/observability/logger.spec.ts
@@ -39,35 +39,35 @@ describe("ConsoleLogger", () => {
 
 	describe("ログレベルフィルタリング", () => {
 		it("info レベルで debug() は出力されない", () => {
-			const logger = new ConsoleLogger("info");
+			const logger = new ConsoleLogger({ level: "info" });
 			logger.debug("should not appear");
 
 			expect(output()).toBe("");
 		});
 
 		it("debug レベルで debug() が出力される", () => {
-			const logger = new ConsoleLogger("debug");
+			const logger = new ConsoleLogger({ level: "debug" });
 			logger.debug("visible");
 
 			expect(output()).toContain("visible");
 		});
 
 		it("info レベルで info() が出力される", () => {
-			const logger = new ConsoleLogger("info");
+			const logger = new ConsoleLogger({ level: "info" });
 			logger.info("info message");
 
 			expect(output()).toContain("info message");
 		});
 
 		it("info レベルで warn() が出力される", () => {
-			const logger = new ConsoleLogger("info");
+			const logger = new ConsoleLogger({ level: "info" });
 			logger.warn("warn message");
 
 			expect(output()).toContain("warn message");
 		});
 
 		it("info レベルで error() が出力される", () => {
-			const logger = new ConsoleLogger("info");
+			const logger = new ConsoleLogger({ level: "info" });
 			logger.error("error message");
 
 			expect(output()).toContain("error message");


### PR DESCRIPTION
## Summary
- `ConsoleLogger` コンストラクタの `string | { level?, destination? }` ユニオン型を `{ level?: string; destination?: "stderr" }` に統一
- `typeof options === "string"` 分岐と `"stdout"` リテラル型を削除
- 全呼び出し元（spec/unit テスト）をオブジェクト形式に更新

Closes #627

## Test plan
- [x] `spec/observability/logger.spec.ts` — 10 pass / 0 fail
- [x] `packages/observability/src/logger.test.ts` — 全 pass
- [x] `nr check` / `nr lint` — logger 関連のエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)