### PR TITLE
docs(context): send_message 説明を簡潔化しスレッド対応を明記

### DIFF
--- a/context/TOOLS-CORE.md
+++ b/context/TOOLS-CORE.md
@@ -2,7 +2,7 @@
 
 ### discord サーバー
 
-- `send_message(channel_id, content, file_path?)` - チャンネルにメッセージ送信（オプションでファイル添付）。送信前にタイピングインジケーターと文字数に応じた遅延を自動挿入
+- `send_message(channel_id, content, file_path?)` - チャンネルにメッセージ送信（オプションでファイル添付）。スレッド・フォーラムスレッドにも送信可能
 - `reply(channel_id, message_id, content, file_path?)` - メッセージに返信（オプションでファイル添付）
 - `add_reaction(channel_id, message_id, emoji)` - リアクション追加
 - `read_messages(channel_id, limit?)` - チャンネルの最近のメッセージを読む

--- a/context/TOOLS-CORE.md
+++ b/context/TOOLS-CORE.md
@@ -2,7 +2,9 @@
 
 ### discord サーバー
 
-- `send_message(channel_id, content, file_path?)` - チャンネルにメッセージ送信（オプションでファイル添付）。スレッド・フォーラムスレッドにも送信可能
+> `channel_id` にはテキストチャンネルだけでなくスレッド・フォーラムスレッドの ID も指定可能。
+
+- `send_message(channel_id, content, file_path?)` - チャンネルにメッセージ送信（オプションでファイル添付）
 - `reply(channel_id, message_id, content, file_path?)` - メッセージに返信（オプションでファイル添付）
 - `add_reaction(channel_id, message_id, emoji)` - リアクション追加
 - `read_messages(channel_id, limit?)` - チャンネルの最近のメッセージを読む

--- a/packages/mcp/src/tools/discord.ts
+++ b/packages/mcp/src/tools/discord.ts
@@ -73,7 +73,7 @@ export function registerDiscordTools(
 		"send_message",
 		{
 			description:
-				"Send a message to a Discord channel (optionally with a file attachment). Automatically shows typing indicator before sending.",
+				"Send a message to a Discord channel (optionally with a file attachment). channel_id accepts text channels, threads, and forum threads.",
 			inputSchema: {
 				channel_id: z.string(),
 				content: z.string(),


### PR DESCRIPTION
## Summary
- ログ上、エージェントが `isThread: true` のメタデータを見て「フォーラムスレッドだから送信できない」と誤認してメッセージ送信をスキップするケースが観測された（実際には `send_message` は問題なく動作する）
- `TOOLS-CORE.md` の `send_message` 説明に「スレッド・フォーラムスレッドにも送信可能」と明記
- あわせて LLM の注意を散らすだけのタイピング挙動の説明を削除

## Test plan
- [ ] 本番で実フォーラムスレッドに対して送信されるか観察