### PR TITLE
refactor: highestPriorityHint と HINT_PRIORITY の未使用コードを削除 (#631)

### DIFF
--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -282,26 +282,6 @@ async function fetchRecentMessagesContext(
 	return { type: "text", text: context };
 }
 
-const HINT_PRIORITY: Record<ActionHint, number> = {
-	respond: 3,
-	optional: 2,
-	read_only: 1,
-	internal: 0,
-};
-
-/** EventOrError 配列から最も優先度の高い ActionHint を返す */
-export function highestPriorityHint(events: EventOrError[]): ActionHint {
-	let best: ActionHint = "internal";
-	for (const e of events) {
-		if (isErrorEvent(e)) continue;
-		const hint = classifyActionHint(e);
-		if (HINT_PRIORITY[hint] > HINT_PRIORITY[best]) {
-			best = hint;
-		}
-	}
-	return best;
-}
-
 /** 文字列配列の各値の出現回数を返す */
 function countValues(values: string[]): Record<string, number> {
 	const counts: Record<string, number> = {};

--- a/spec/mcp/tools/event-buffer.spec.ts
+++ b/spec/mcp/tools/event-buffer.spec.ts
@@ -9,7 +9,6 @@ import {
 	formatEventMetadata,
 	formatEvents,
 	formatRecentMessages,
-	highestPriorityHint,
 	isErrorEvent,
 	parseEvents,
 	pollEvents,
@@ -203,47 +202,6 @@ describe("classifyActionHint", () => {
 			metadata: { isMentioned: true },
 		};
 		expect(classifyActionHint(event)).toBe("internal");
-	});
-});
-
-describe("highestPriorityHint", () => {
-	test("respond が1つでもあれば respond を返す", () => {
-		const events = [
-			{ ts: "t", content: "a", authorId: "u1", authorName: "A", messageId: "m1" },
-			{
-				ts: "t",
-				content: "b",
-				authorId: "u2",
-				authorName: "B",
-				messageId: "m2",
-				metadata: { isMentioned: true },
-			},
-		];
-		expect(highestPriorityHint(events)).toBe("respond");
-	});
-
-	test("respond がなく optional があれば optional を返す", () => {
-		const events = [{ ts: "t", content: "a", authorId: "u1", authorName: "A", messageId: "m1" }];
-		expect(highestPriorityHint(events)).toBe("optional");
-	});
-
-	test("internal のみなら internal を返す", () => {
-		const events = [
-			{ ts: "t", content: "sys", authorId: "system", authorName: "system", messageId: "s1" },
-		];
-		expect(highestPriorityHint(events)).toBe("internal");
-	});
-
-	test("空配列なら internal を返す", () => {
-		expect(highestPriorityHint([])).toBe("internal");
-	});
-
-	test("エラーイベントは無視して残りから判定する", () => {
-		const events = [
-			{ _raw: "broken", _error: "invalid JSON" },
-			{ ts: "t", content: "a", authorId: "u1", authorName: "A", messageId: "m1" },
-		];
-		expect(highestPriorityHint(events)).toBe("optional");
 	});
 });
 


### PR DESCRIPTION
## Summary

- Issue #631 対応。SkipTracker 削除 (#625) 後にデッドコードとなった `highestPriorityHint` 関数と `HINT_PRIORITY` 定数を削除
- 全リポジトリで参照ゼロを Grep で確認済み（プロダクションコード・unit test・他 spec から参照なし）
- 対応する spec テストブロック (`describe("highestPriorityHint", ...)`) も同時に削除

## 変更ファイル

- `packages/mcp/src/tools/event-buffer.ts` (-20 行)
- `spec/mcp/tools/event-buffer.spec.ts` (-42 行)

合計 62 行削除のみ。新規追加・既存ロジック変更なし。

## Test plan

- [x] `nr test:spec` で全 spec PASS（1393 pass / 0 fail）
- [x] `nr lint` / `nr check` で新規エラーなし（既存違反のみ）
- [x] `correctness-reviewer` / `design-reviewer` / `spec-compliance-reviewer` 全て「問題なし」と報告

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)