### PR TITLE
fix(monitoring): Loki クエリで pino 数値 level を文字列にマッピング

### DIFF
--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1371,7 +1371,7 @@
 			},
 			"targets": [
 				{
-					"expr": "sum by (level) (count_over_time({job=\"vicissitude\"} | json [1m]))",
+					"expr": "sum by (level) (count_over_time({job=\"vicissitude\"} | json | label_format level=`{{if eq .level \"60\"}}fatal{{else if eq .level \"50\"}}error{{else if eq .level \"40\"}}warn{{else if eq .level \"30\"}}info{{else if eq .level \"20\"}}debug{{else if eq .level \"10\"}}trace{{else}}{{.level}}{{end}}` [1m]))",
 					"legendFormat": "{{level}}"
 				}
 			],
@@ -1455,7 +1455,7 @@
 			},
 			"targets": [
 				{
-					"expr": "{job=\"vicissitude\"} | json | level=~\"error|warn\"",
+					"expr": "{job=\"vicissitude\"} | json | label_format level=`{{if eq .level \"60\"}}fatal{{else if eq .level \"50\"}}error{{else if eq .level \"40\"}}warn{{else if eq .level \"30\"}}info{{else if eq .level \"20\"}}debug{{else if eq .level \"10\"}}trace{{else}}{{.level}}{{end}}` | level=~\"error|warn|fatal\"",
 					"legendFormat": ""
 				}
 			],


### PR DESCRIPTION
## Summary

- pino は `level` を数値 (`50=error, 40=warn, ...`) で JSON 出力するため、Grafana ダッシュボード側の `level=~"error|warn"` や `byName:"error"` 系のフィルタ・override が全く一致せず、`Errors & Warnings` パネルが常に空になっていた。
- `label_format` テンプレートで数値→文字列 (`60→fatal / 50→error / 40→warn / 30→info / 20→debug / 10→trace`) に変換してから後段のフィルタを走らせるよう修正。
- `Errors & Warnings` の対象に `fatal` も含めた（より重大なレベルを除外するのは不自然なため）。

## 影響範囲

- `Log Volume by Level` パネル: 凡例が数値から文字列に変わり、既存の `byName:"error"/"warn"/"info"` 色分け override が効くようになる。
- `Errors & Warnings` パネル: 実際に warn/error/fatal のログが表示されるようになる。
- 過去ログにも遡及（`label_format` はクエリ時変換のため）。

## Test plan

- [ ] Grafana にダッシュボードを再インポートして `Log Volume by Level` に `error`/`warn`/`info` が表示されることを確認
- [ ] `Errors & Warnings` パネルに実際の warn/error ログが流れることを確認
- [ ] `error` 凡例が赤、`warn` がオレンジ、`info` が緑で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)