### PR TITLE
test(spec): send_message/reply のスレッド・フォーラム送信を spec で検証 (#638)

### DIFF
--- a/spec/mcp/tools/discord-test-helpers.ts
+++ b/spec/mcp/tools/discord-test-helpers.ts
@@ -168,6 +168,76 @@ export function createClientStubWithImageAttachments(): DiscordDeps["discordClie
 	} as unknown as DiscordDeps["discordClient"];
 }
 
+/**
+ * 通常スレッド（テキストチャンネル配下のスレッド）相当の channel を返すスタブ。
+ * `getTextChannel` が通過できる最低条件（`isTextBased() === true` と `send` プロパティ）を満たしつつ、
+ * スレッド性の意図を明示するため `isThread: () => true` と `parent` を持たせている。
+ */
+export function createThreadChannelClientStub(): DiscordDeps["discordClient"] {
+	const sentMessage = {
+		id: "thread-sent-msg-1",
+		reply: () => Promise.resolve({ id: "thread-reply-msg-1" }),
+		react: () => Promise.resolve(),
+	};
+
+	return {
+		channels: {
+			fetch: () =>
+				Promise.resolve({
+					isTextBased: () => true,
+					isThread: () => true,
+					// 通常テキストチャンネル配下のスレッドを模倣
+					parent: { type: 0, isTextBased: () => true },
+					send: () => Promise.resolve(sentMessage),
+					sendTyping: () => Promise.resolve(),
+					messages: {
+						fetch: (idOrOptions: unknown) => {
+							if (typeof idOrOptions === "object" && idOrOptions !== null) {
+								return Promise.resolve([]);
+							}
+							return Promise.resolve(sentMessage);
+						},
+					},
+				}),
+		},
+	} as unknown as DiscordDeps["discordClient"];
+}
+
+/**
+ * フォーラムチャンネル配下のスレッド（フォーラムポスト）相当の channel を返すスタブ。
+ * 通常スレッドと同様に `getTextChannel` を通過する条件を満たし、
+ * `parent.type` をフォーラム相当 (15 = GuildForum) に設定することで意図を明示する。
+ */
+export function createForumThreadClientStub(): DiscordDeps["discordClient"] {
+	const sentMessage = {
+		id: "forum-sent-msg-1",
+		reply: () => Promise.resolve({ id: "forum-reply-msg-1" }),
+		react: () => Promise.resolve(),
+	};
+
+	return {
+		channels: {
+			fetch: () =>
+				Promise.resolve({
+					isTextBased: () => true,
+					isThread: () => true,
+					// GuildForum (ChannelType.GuildForum = 15) 配下のスレッド
+					parent: { type: 15, isTextBased: () => false },
+					send: () => Promise.resolve(sentMessage),
+					sendTyping: () => Promise.resolve(),
+					messages: {
+						fetch: (idOrOptions: unknown) => {
+							if (typeof idOrOptions === "object" && idOrOptions !== null) {
+								return Promise.resolve([]);
+							}
+							return Promise.resolve(sentMessage);
+						},
+					},
+				}),
+		},
+	} as unknown as DiscordDeps["discordClient"];
+}
+
 /** 複数画像添付ありのメッセージを返すスタブ */
 export function createClientStubWithMultipleImageAttachments(): DiscordDeps["discordClient"] {
 	return {

--- a/spec/mcp/tools/discord.spec.ts
+++ b/spec/mcp/tools/discord.spec.ts
@@ -7,6 +7,8 @@ import {
 	createClientStubWithMultipleImageAttachments,
 	createClientStubWithReactError,
 	createDiscordClientStub,
+	createForumThreadClientStub,
+	createThreadChannelClientStub,
 	type ToolResult,
 } from "./discord-test-helpers";
 
@@ -118,6 +120,60 @@ describe("reply", () => {
 			threw = true;
 		}
 		expect(threw).toBe(true);
+	});
+});
+
+describe("send_message (thread/forum)", () => {
+	test("通常スレッド相当のチャンネルでも送信が成功する", async () => {
+		const { tools } = captureTools({ discordClient: createThreadChannelClientStub() });
+		const sendMessage = tools.get("send_message")!;
+
+		const result = (await sendMessage({
+			channel_id: "thread-1",
+			content: "スレッドへ送信",
+		})) as ToolResult;
+
+		expect(result.content[0]!.text).toBe("Sent message thread-sent-msg-1");
+	});
+
+	test("フォーラム配下スレッド相当のチャンネルでも送信が成功する", async () => {
+		const { tools } = captureTools({ discordClient: createForumThreadClientStub() });
+		const sendMessage = tools.get("send_message")!;
+
+		const result = (await sendMessage({
+			channel_id: "forum-thread-1",
+			content: "フォーラムポストへ送信",
+		})) as ToolResult;
+
+		expect(result.content[0]!.text).toBe("Sent message forum-sent-msg-1");
+	});
+});
+
+describe("reply (thread/forum)", () => {
+	test("通常スレッド相当のチャンネルでもリプライが成功する", async () => {
+		const { tools } = captureTools({ discordClient: createThreadChannelClientStub() });
+		const reply = tools.get("reply")!;
+
+		const result = (await reply({
+			channel_id: "thread-1",
+			message_id: "thread-sent-msg-1",
+			content: "スレッドでリプライ",
+		})) as ToolResult;
+
+		expect(result.content[0]!.text).toBe("Replied with message thread-reply-msg-1");
+	});
+
+	test("フォーラム配下スレッド相当のチャンネルでもリプライが成功する", async () => {
+		const { tools } = captureTools({ discordClient: createForumThreadClientStub() });
+		const reply = tools.get("reply")!;
+
+		const result = (await reply({
+			channel_id: "forum-thread-1",
+			message_id: "forum-sent-msg-1",
+			content: "フォーラムポストでリプライ",
+		})) as ToolResult;
+
+		expect(result.content[0]!.text).toBe("Replied with message forum-reply-msg-1");
 	});
 });
 


### PR DESCRIPTION
## Summary

Issue #638 対応。`send_message` / `reply` ツールが通常スレッド・フォーラム配下スレッドでも動作することを spec で保証する。

- `spec/mcp/tools/discord-test-helpers.ts` に `createThreadChannelClientStub` / `createForumThreadClientStub` factory を追加
- `spec/mcp/tools/discord.spec.ts` に `describe(\"send_message (thread/forum)\")` と `describe(\"reply (thread/forum)\")` の計 4 ケースを追加
- 実装 (`packages/mcp/src/tools/discord.ts`) は変更なし（既に `isTextBased() && \"send\" in channel` のみで判定しており、スレッドでも動作する）

## Test plan

- [x] `bun run test:spec` — 1397 pass / 0 fail（新規 4 ケース含む）
- [x] `bun test spec/mcp/tools/discord.spec.ts` — 20 pass / 0 fail
- [x] `spec/mcp/tools/` 配下 lint エラーなし
- [x] 既存 spec を破壊していない

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)