### PR TITLE
feat: session_errors_total に http_status/retryable/error_class ラベル追加 (#640)

### DIFF
--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1493,6 +1493,174 @@
 			],
 			"title": "All Logs",
 			"type": "logs"
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 100
+			},
+			"id": 900,
+			"title": "Session Errors",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "${DS_PROMETHEUS}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"drawStyle": "line",
+						"fillOpacity": 30,
+						"lineWidth": 1,
+						"pointSize": 5,
+						"showPoints": "never",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "normal"
+						}
+					},
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 8,
+				"x": 0,
+				"y": 101
+			},
+			"id": 30,
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom"
+				},
+				"tooltip": {
+					"mode": "multi"
+				}
+			},
+			"targets": [
+				{
+					"expr": "sum by (http_status) (increase(session_errors_total{error_type=\"session_error\"}[1h]))",
+					"legendFormat": "{{http_status}}"
+				}
+			],
+			"title": "Session Errors by http_status (1h)",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "${DS_PROMETHEUS}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"drawStyle": "line",
+						"fillOpacity": 30,
+						"lineWidth": 1,
+						"pointSize": 5,
+						"showPoints": "never",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "normal"
+						}
+					},
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 8,
+				"x": 8,
+				"y": 101
+			},
+			"id": 31,
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom"
+				},
+				"tooltip": {
+					"mode": "multi"
+				}
+			},
+			"targets": [
+				{
+					"expr": "sum by (retryable) (increase(session_errors_total{error_type=\"session_error\"}[1h]))",
+					"legendFormat": "retryable={{retryable}}"
+				}
+			],
+			"title": "Session Errors by retryable (1h)",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "${DS_PROMETHEUS}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"drawStyle": "line",
+						"fillOpacity": 30,
+						"lineWidth": 1,
+						"pointSize": 5,
+						"showPoints": "never",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "normal"
+						}
+					},
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 8,
+				"x": 16,
+				"y": 101
+			},
+			"id": 32,
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom"
+				},
+				"tooltip": {
+					"mode": "multi"
+				}
+			},
+			"targets": [
+				{
+					"expr": "sum by (error_class) (increase(session_errors_total{error_type=\"session_error\"}[1h]))",
+					"legendFormat": "{{error_class}}"
+				}
+			],
+			"title": "Session Errors by error_class (1h)",
+			"type": "timeseries"
 		}
 	],
 	"schemaVersion": 39,

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -377,6 +377,9 @@ export class AgentRunner implements AiAgent {
 		this.metrics?.incrementCounter(METRIC.SESSION_ERRORS, {
 			source: "session_event",
 			error_type: "session_error",
+			http_status: typeof event.status === "number" ? String(event.status) : "unknown",
+			retryable: typeof event.retryable === "boolean" ? String(event.retryable) : "unknown",
+			error_class: event.errorClass ?? "unknown",
 		});
 		this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, { reason: "error" });
 	}

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -364,6 +364,9 @@ export class AgentRunner implements AiAgent {
 			this.metrics?.incrementCounter(METRIC.SESSION_ERRORS, {
 				source: "session_event",
 				error_type: "stream_disconnected",
+				http_status: "unknown",
+				retryable: "unknown",
+				error_class: "unknown",
 			});
 			if (event.tokens && this.metrics) {
 				recordTokenMetrics(this.metrics, event.tokens, {

--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -135,9 +135,11 @@ export function classifyEvent(
 	return null;
 }
 
-function extractErrorFields(
-	error: unknown,
-): { errorClass?: string; status?: number; retryable?: boolean } {
+function extractErrorFields(error: unknown): {
+	errorClass?: string;
+	status?: number;
+	retryable?: boolean;
+} {
 	if (!error || typeof error !== "object") return {};
 	const e = error as { name?: unknown; data?: unknown };
 	const errorClass = typeof e.name === "string" ? e.name : undefined;

--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -125,10 +125,29 @@ export function classifyEvent(
 	if (typed.type === "session.error") {
 		const err = typed;
 		if (err.properties.sessionID === sessionId) {
-			return { type: "error", message: JSON.stringify(err.properties) };
+			return {
+				type: "error",
+				message: JSON.stringify(err.properties),
+				...extractErrorFields(err.properties.error),
+			};
 		}
 	}
 	return null;
+}
+
+function extractErrorFields(
+	error: unknown,
+): { errorClass?: string; status?: number; retryable?: boolean } {
+	if (!error || typeof error !== "object") return {};
+	const e = error as { name?: unknown; data?: unknown };
+	const errorClass = typeof e.name === "string" ? e.name : undefined;
+	if (errorClass !== "APIError") {
+		return { errorClass };
+	}
+	const data = e.data && typeof e.data === "object" ? (e.data as Record<string, unknown>) : {};
+	const status = typeof data.statusCode === "number" ? data.statusCode : undefined;
+	const retryable = typeof data.isRetryable === "boolean" ? data.isRetryable : undefined;
+	return { errorClass, status, retryable };
 }
 function accumulateTokens(
 	typed: EventMessageUpdated,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -240,7 +240,16 @@ export type OpencodeSessionEvent =
 	| { type: "compacted" }
 	| { type: "streamDisconnected"; tokens?: TokenUsage }
 	| { type: "cancelled" }
-	| { type: "error"; message: string };
+	| {
+			type: "error";
+			message: string;
+			/** HTTP ステータスコード（ApiError の場合のみ） */
+			status?: number;
+			/** リトライ可能か（ApiError の場合のみ） */
+			retryable?: boolean;
+			/** エラーの分類名（例: "APIError", "ProviderAuthError", "UnknownError"） */
+			errorClass?: string;
+	  };
 
 export interface OpencodeSessionPort {
 	createSession(title: string): Promise<string>;

--- a/spec/agent/session-error-metrics.spec.ts
+++ b/spec/agent/session-error-metrics.spec.ts
@@ -208,6 +208,11 @@ describe("Runner: session error メトリクス記録", () => {
 			(call: unknown[]) => call[0] === METRIC.SESSION_ERRORS,
 		);
 		expect(sessionErrorCalls.length).toBeGreaterThanOrEqual(1);
+		// ラベルセットが session_error と揃っていること（Prometheus 系列一貫性のため）
+		const labels = sessionErrorCalls[0]?.[1] as Record<string, string> | undefined;
+		expect(labels?.http_status).toBe("unknown");
+		expect(labels?.retryable).toBe("unknown");
+		expect(labels?.error_class).toBe("unknown");
 
 		runner.stop();
 		secondSessionDone.resolve({ type: "cancelled" });

--- a/spec/agent/session-error-metrics.spec.ts
+++ b/spec/agent/session-error-metrics.spec.ts
@@ -212,6 +212,108 @@ describe("Runner: session error メトリクス記録", () => {
 		runner.stop();
 		secondSessionDone.resolve({ type: "cancelled" });
 	});
+
+	test("error イベントに status/retryable/errorClass が含まれる場合、ラベルとして記録される", async () => {
+		const firstEvent = deferred<void>();
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		const sessionPort = createSessionPortWithControlledResult(
+			firstSessionDone.promise,
+			secondSessionDone.promise,
+		);
+		const metrics = createMockMetrics();
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+			metrics,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		firstSessionDone.resolve({
+			type: "error",
+			message: "Bad Request",
+			status: 400,
+			retryable: false,
+			errorClass: "APIError",
+		});
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const incrementCalls = (metrics.incrementCounter as ReturnType<typeof mock>).mock.calls;
+		const sessionErrorCalls = incrementCalls.filter(
+			(call: unknown[]) => call[0] === METRIC.SESSION_ERRORS,
+		);
+		expect(sessionErrorCalls.length).toBeGreaterThanOrEqual(1);
+		const sessionErrorLabels = sessionErrorCalls[0]?.[1] as Record<string, string> | undefined;
+		expect(sessionErrorLabels?.http_status).toBe("400");
+		expect(sessionErrorLabels?.retryable).toBe("false");
+		expect(sessionErrorLabels?.error_class).toBe("APIError");
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("error イベントに構造化フィールドが無い場合、ラベルは unknown", async () => {
+		const firstEvent = deferred<void>();
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		const sessionPort = createSessionPortWithControlledResult(
+			firstSessionDone.promise,
+			secondSessionDone.promise,
+		);
+		const metrics = createMockMetrics();
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+			metrics,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		firstSessionDone.resolve({ type: "error", message: "unknown failure" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const incrementCalls = (metrics.incrementCounter as ReturnType<typeof mock>).mock.calls;
+		const sessionErrorCalls = incrementCalls.filter(
+			(call: unknown[]) => call[0] === METRIC.SESSION_ERRORS,
+		);
+		expect(sessionErrorCalls.length).toBeGreaterThanOrEqual(1);
+		const labels = sessionErrorCalls[0]?.[1] as Record<string, string> | undefined;
+		expect(labels?.http_status).toBe("unknown");
+		expect(labels?.retryable).toBe("unknown");
+		expect(labels?.error_class).toBe("unknown");
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
 });
 
 describe("Runner: session restart メトリクス記録", () => {

--- a/spec/observability/session-error-metrics.spec.ts
+++ b/spec/observability/session-error-metrics.spec.ts
@@ -28,31 +28,40 @@ describe("METRIC 定数: セッションエラー関連", () => {
 // ─── カウンタ動作の検証 ──────────────────────────────────────────
 
 describe("SESSION_ERRORS カウンタ", () => {
-	it("source, error_type ラベル付きでインクリメントできる", () => {
+	it("source, error_type, http_status, retryable, error_class ラベル付きでインクリメントできる", () => {
 		const c = new PrometheusCollector();
 		c.registerCounter(METRIC.SESSION_ERRORS, "session errors");
 		c.incrementCounter(METRIC.SESSION_ERRORS, {
-			source: "promptAsyncAndWatchSession",
+			source: "session_event",
 			error_type: "session_error",
+			http_status: "400",
+			retryable: "false",
+			error_class: "APIError",
 		});
 		c.incrementCounter(METRIC.SESSION_ERRORS, {
-			source: "waitForSessionIdle",
+			source: "session_event",
 			error_type: "session_error",
+			http_status: "502",
+			retryable: "true",
+			error_class: "APIError",
 		});
 		c.incrementCounter(METRIC.SESSION_ERRORS, {
-			source: "promptAsyncAndWatchSession",
+			source: "session_event",
 			error_type: "stream_disconnected",
+			http_status: "unknown",
+			retryable: "unknown",
+			error_class: "unknown",
 		});
 
 		const output = c.serialize();
 		expect(output).toContain(
-			'session_errors_total{error_type="session_error",source="promptAsyncAndWatchSession"} 1',
+			'session_errors_total{error_class="APIError",error_type="session_error",http_status="400",retryable="false",source="session_event"} 1',
 		);
 		expect(output).toContain(
-			'session_errors_total{error_type="session_error",source="waitForSessionIdle"} 1',
+			'session_errors_total{error_class="APIError",error_type="session_error",http_status="502",retryable="true",source="session_event"} 1',
 		);
 		expect(output).toContain(
-			'session_errors_total{error_type="stream_disconnected",source="promptAsyncAndWatchSession"} 1',
+			'session_errors_total{error_class="unknown",error_type="stream_disconnected",http_status="unknown",retryable="unknown",source="session_event"} 1',
 		);
 	});
 });

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -244,7 +244,7 @@ describe("classifyEvent", () => {
 		expect(result.errorClass).toBe("APIError");
 	});
 
-	test("session.error で ApiError 以外のエラー種別では status/retryable が undefined", () => {
+	test("session.error で APIError 以外のエラー種別では status/retryable が undefined", () => {
 		const event = {
 			type: "session.error",
 			properties: {

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -200,7 +200,7 @@ describe("classifyEvent", () => {
 		const event = {
 			type: "session.error",
 			properties: {
-				sessionID,
+				sessionID: sessionId,
 				error: {
 					name: "APIError",
 					data: {
@@ -225,7 +225,7 @@ describe("classifyEvent", () => {
 		const event = {
 			type: "session.error",
 			properties: {
-				sessionID,
+				sessionID: sessionId,
 				error: {
 					name: "APIError",
 					data: {
@@ -248,7 +248,7 @@ describe("classifyEvent", () => {
 		const event = {
 			type: "session.error",
 			properties: {
-				sessionID,
+				sessionID: sessionId,
 				error: {
 					name: "UnknownError",
 					data: { message: "oops" },
@@ -266,7 +266,7 @@ describe("classifyEvent", () => {
 	test("session.error で error プロパティ自体がない場合、全て undefined", () => {
 		const event = {
 			type: "session.error",
-			properties: { sessionID },
+			properties: { sessionID: sessionId },
 		} as unknown as Event;
 
 		const result = classifyEvent(event, sessionId, new Map());

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -196,6 +196,86 @@ describe("classifyEvent", () => {
 		expect(result.message.length).toBeGreaterThan(0);
 	});
 
+	test("session.error で APIError ペイロードの場合、structured フィールドを含む", () => {
+		const event = {
+			type: "session.error",
+			properties: {
+				sessionID,
+				error: {
+					name: "APIError",
+					data: {
+						message: "Bad Request",
+						statusCode: 400,
+						isRetryable: false,
+					},
+				},
+			},
+		} as unknown as Event;
+
+		const result = classifyEvent(event, sessionId, new Map());
+
+		expect(result).not.toBeNull();
+		if (result?.type !== "error") throw new Error("unreachable");
+		expect(result.status).toBe(400);
+		expect(result.retryable).toBe(false);
+		expect(result.errorClass).toBe("APIError");
+	});
+
+	test("session.error で 5xx かつ isRetryable=true のペイロード", () => {
+		const event = {
+			type: "session.error",
+			properties: {
+				sessionID,
+				error: {
+					name: "APIError",
+					data: {
+						message: "Upstream timeout",
+						statusCode: 502,
+						isRetryable: true,
+					},
+				},
+			},
+		} as unknown as Event;
+
+		const result = classifyEvent(event, sessionId, new Map());
+		if (result?.type !== "error") throw new Error("unreachable");
+		expect(result.status).toBe(502);
+		expect(result.retryable).toBe(true);
+		expect(result.errorClass).toBe("APIError");
+	});
+
+	test("session.error で ApiError 以外のエラー種別では status/retryable が undefined", () => {
+		const event = {
+			type: "session.error",
+			properties: {
+				sessionID,
+				error: {
+					name: "UnknownError",
+					data: { message: "oops" },
+				},
+			},
+		} as unknown as Event;
+
+		const result = classifyEvent(event, sessionId, new Map());
+		if (result?.type !== "error") throw new Error("unreachable");
+		expect(result.status).toBeUndefined();
+		expect(result.retryable).toBeUndefined();
+		expect(result.errorClass).toBe("UnknownError");
+	});
+
+	test("session.error で error プロパティ自体がない場合、全て undefined", () => {
+		const event = {
+			type: "session.error",
+			properties: { sessionID },
+		} as unknown as Event;
+
+		const result = classifyEvent(event, sessionId, new Map());
+		if (result?.type !== "error") throw new Error("unreachable");
+		expect(result.status).toBeUndefined();
+		expect(result.retryable).toBeUndefined();
+		expect(result.errorClass).toBeUndefined();
+	});
+
 	test("session.compacted イベントで { type: 'compacted' } を返す", () => {
 		const event = {
 			type: "session.compacted",


### PR DESCRIPTION
## Summary

Closes #640

- `classifyEvent` で `session.error` ペイロードから `ApiError` の `statusCode` / `isRetryable` と `error.name` を抽出し、`OpencodeSessionEvent` の error バリアントに `status` / `retryable` / `errorClass` として載せる
- `Runner.handleSessionEnd` で `session_errors_total` に `http_status` / `retryable` / `error_class` ラベルを付与（`session_error` と `stream_disconnected` で同じラベルセットに揃えて Prometheus 系列の一貫性を確保）
- Grafana ダッシュボードに `http_status` / `retryable` / `error_class` ブレークダウンの時系列パネル 3 つを "Session Errors" 行として追加

## Test plan

- [x] `nr validate` PASS（oxfmt / oxlint / tsgo）
- [x] `nr test` PASS（1847 pass / 0 fail）
- [x] 新規 spec: classifyEvent の 4 ケース（APIError 4xx, APIError 5xx retryable=true, 非APIError, error プロパティなし）
- [x] 新規 spec: Runner の SESSION_ERRORS ラベル記録（session_error + stream_disconnected）
- [x] Prometheus serialize spec: 新ラベル 5 組合せの形式検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)