### PR TITLE
feat: retryable:false は即ローテーション、retryable:true は cap 10s backoff 後ローテーション (#641)

### DIFF
--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -422,6 +422,41 @@ describe("AgentRunner", () => {
 		sessionDone.resolve({ type: "cancelled" });
 	});
 
+	test("requestSessionRotation: force=true の場合 minRotationIntervalMs 以内でも実行される", async () => {
+		const firstEvent = deferred<void>();
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		const sessionPort = createSessionPort(() => sessionDone.promise);
+		const sessionStore = createSessionStore();
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: sessionStore as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		activeRunners.add(runner);
+
+		sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+
+		// 1回目（force=false / デフォルト）
+		await runner.requestSessionRotation();
+		expect(sessionPort.deleteSession).toHaveBeenCalledTimes(1);
+
+		// 再度セッションを保存
+		sessionStore.save("conversation", "__polling__:guild-1", "session-def");
+
+		// minRotationIntervalMs 以内だが force=true → スキップしない
+		await runner.requestSessionRotation(true);
+		expect(sessionPort.deleteSession).toHaveBeenCalledTimes(2);
+
+		runner.stop();
+		sessionDone.resolve({ type: "cancelled" });
+	});
+
 	test("requestSessionRotation: minRotationIntervalMs 以内の連続呼び出しは無視される", async () => {
 		const firstEvent = deferred<void>();
 		const sessionDone = deferred<OpencodeSessionEvent>();
@@ -709,6 +744,226 @@ describe("AgentRunner", () => {
 
 		runner.stop();
 		sessionDone.resolve({ type: "cancelled" });
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// バックオフ・ローテーション戦略の内部ロジック（ホワイトボックス）
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AgentRunner バックオフ・ローテーション戦略（内部ロジック）", () => {
+	test("error イベント（retryable:true）で sleep 数列が 2s→4s→8s→10s になる", async () => {
+		const firstEvent = deferred<void>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		let sessionWatchCount = 0;
+		const lastSession = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			// 4 回エラー → cap 到達後に 5 回目エラー → rotation → lastSession
+			if (sessionWatchCount <= 4) {
+				return Promise.resolve({ type: "error", message: "err", retryable: true as const });
+			}
+			if (sessionWatchCount === 5) {
+				return Promise.resolve({ type: "error", message: "err", retryable: true as const });
+			}
+			return lastSession.promise;
+		});
+
+		const sleepCalls: number[] = [];
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms) => {
+			sleepCalls.push(ms);
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		// 5 回のエラー + ローテーション分の非同期ステップを消化
+		for (let i = 0; i < 30; i++) {
+			// eslint-disable-next-line no-await-in-loop
+			await Bun.sleep(0);
+		}
+
+		// バックオフ数列: 2000 → 4000 → 8000 → 10000
+		expect(sleepCalls[0]).toBe(2000);
+		expect(sleepCalls[1]).toBe(4000);
+		expect(sleepCalls[2]).toBe(8000);
+		expect(sleepCalls[3]).toBe(10000);
+
+		runner.stop();
+		lastSession.resolve({ type: "cancelled" });
+	});
+
+	test("例外（throw）時も retryable:true 扱いでバックオフ delay が増加する", async () => {
+		const firstEvent = deferred<void>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		let sessionWatchCount = 0;
+		const thirdSession = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			if (sessionWatchCount === 1) return Promise.reject(new Error("thrown error 1"));
+			if (sessionWatchCount === 2) return Promise.reject(new Error("thrown error 2"));
+			return thirdSession.promise;
+		});
+
+		const sleepCalls: number[] = [];
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms) => {
+			sleepCalls.push(ms);
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		for (let i = 0; i < 10; i++) {
+			// eslint-disable-next-line no-await-in-loop
+			await Bun.sleep(0);
+		}
+
+		// 例外時も指数バックオフ: 2000 → 4000
+		expect(sleepCalls[0]).toBe(2000);
+		expect(sleepCalls[1]).toBe(4000);
+
+		runner.stop();
+		thirdSession.resolve({ type: "cancelled" });
+	});
+
+	test("retryable:false エラー後は delay が 2s にリセットされる（後続エラーでバックオフが 2s から始まる）", async () => {
+		const firstEvent = deferred<void>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		let sessionWatchCount = 0;
+		const lastSession = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			if (sessionWatchCount === 1) {
+				return Promise.resolve({
+					type: "error",
+					message: "non-retryable",
+					retryable: false as const,
+				});
+			}
+			if (sessionWatchCount === 2) {
+				return Promise.resolve({ type: "error", message: "retryable", retryable: true as const });
+			}
+			return lastSession.promise;
+		});
+
+		const sleepCalls: number[] = [];
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms) => {
+			sleepCalls.push(ms);
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		for (let i = 0; i < 20; i++) {
+			// eslint-disable-next-line no-await-in-loop
+			await Bun.sleep(0);
+		}
+
+		// retryable:false は sleep なし（sleepCalls に 2000 以上のものは入らないはず）
+		// 続くretryable:true エラーでは delay が 2s からリスタート
+		const longSleeps = sleepCalls.filter((ms) => ms >= 2000);
+		// retryable:false のローテーション後の最初のバックオフが 2000 であること
+		if (longSleeps.length > 0) {
+			expect(longSleeps[0]).toBe(2000);
+		}
+
+		runner.stop();
+		lastSession.resolve({ type: "cancelled" });
+	});
+
+	test("prevSleepWasCapped リセット: idle 後の次のエラーで prevSleepWasCapped が false に戻る", async () => {
+		// idle が来た後は prevSleepWasCapped がリセットされ、
+		// cap 到達からのローテーションが再び必要な回数 error を重ねないと発動しないことを確認
+		const firstEvent = deferred<void>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		let sessionWatchCount = 0;
+		const lastSession = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			// 1〜4 回目: error (cap 到達) → 5 回目: cap 後エラー → rotation発動
+			// 6 回目: idle (delay/prevSleepWasCapped リセット)
+			// 7 回目: error (2s から再開)
+			if (sessionWatchCount <= 4) {
+				return Promise.resolve({ type: "error", message: "err", retryable: true as const });
+			}
+			if (sessionWatchCount === 5) {
+				// cap 後エラー → rotation → delay リセット
+				return Promise.resolve({ type: "error", message: "err", retryable: true as const });
+			}
+			if (sessionWatchCount === 6) {
+				return Promise.resolve({ type: "idle" });
+			}
+			if (sessionWatchCount === 7) {
+				return Promise.resolve({ type: "error", message: "err", retryable: true as const });
+			}
+			return lastSession.promise;
+		});
+
+		const sleepCalls: number[] = [];
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms) => {
+			sleepCalls.push(ms);
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		for (let i = 0; i < 50; i++) {
+			// eslint-disable-next-line no-await-in-loop
+			await Bun.sleep(0);
+		}
+
+		// idle 後に再エラーが来たとき、sleepCalls の末尾付近が 2000 であること
+		// （cap のまま 10000 が来ていないことを確認）
+		const lastSleep = sleepCalls.at(-1);
+		// idle 後の最初のバックオフは 2s（cap に達していない）
+		expect(lastSleep).toBe(2000);
+
+		runner.stop();
+		lastSession.resolve({ type: "cancelled" });
 	});
 });
 

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -1,4 +1,4 @@
-/* oxlint-disable max-lines -- AgentRunner のポーリングループ・セッション管理が密結合のため分割困難 */
+/* oxlint-disable max-lines, max-lines-per-function -- AgentRunner のポーリングループ・セッション管理が密結合のため分割困難 */
 import { METRIC, recordTokenMetrics } from "@vicissitude/observability/metrics";
 import type {
 	AgentResponse,
@@ -16,7 +16,7 @@ import type {
 
 import type { AgentProfile } from "./profile.ts";
 
-const MAX_RECONNECT_DELAY_MS = 30_000;
+const MAX_RECONNECT_DELAY_MS = 10_000;
 const INITIAL_RECONNECT_DELAY_MS = 2_000;
 const IDLE_COOLDOWN_MS = 2_000;
 const DEFAULT_HANG_TIMEOUT_MS = 600_000;
@@ -144,7 +144,7 @@ export class AgentRunner implements AiAgent {
 				// ローテーション後に再度すぐ検知されないよう、タイムスタンプをリセット
 				this.lastWaitForEventsAt = Date.now();
 				this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, { reason: "hang_detected" });
-				this.requestSessionRotation().catch((err) => {
+				this.requestSessionRotation(true).catch((err) => {
 					this.logger.error(
 						`[${this.profile.name}:${this.agentId}] hang recovery rotation failed`,
 						err,
@@ -162,6 +162,9 @@ export class AgentRunner implements AiAgent {
 		const signal = this.abortController.signal;
 
 		let delay = INITIAL_RECONNECT_DELAY_MS;
+		// 直前のループで cap に到達した sleep を行ったかどうかを追跡する。
+		// cap 到達後も error が継続した場合にローテーションへエスカレーションするために使用。
+		let prevSleepWasCapped = false;
 
 		while (this.running && !signal.aborted) {
 			try {
@@ -198,6 +201,7 @@ export class AgentRunner implements AiAgent {
 				if (event.type === "compacted" || event.type === "streamDisconnected") {
 					this.rewatchSession(signal);
 					delay = INITIAL_RECONNECT_DELAY_MS;
+					prevSleepWasCapped = false;
 					continue;
 				}
 
@@ -206,10 +210,39 @@ export class AgentRunner implements AiAgent {
 
 				if (event.type !== "error") {
 					delay = INITIAL_RECONNECT_DELAY_MS;
+					prevSleepWasCapped = false;
 					// eslint-disable-next-line no-await-in-loop -- cooldown after idle to prevent busy loop
 					await this.sleep(IDLE_COOLDOWN_MS);
 					continue;
 				}
+
+				// --- error イベントのエラー戦略 ---
+				if (event.retryable === false) {
+					// retryable:false: 即時ローテーション（バックオフなし）
+					this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, {
+						reason: "error_non_retryable_rotation",
+					});
+					// eslint-disable-next-line no-await-in-loop -- rotation after non-retryable error
+					await this.requestSessionRotation(true);
+					delay = INITIAL_RECONNECT_DELAY_MS;
+					prevSleepWasCapped = false;
+					continue;
+				}
+
+				// retryable:true / undefined: exp backoff。直前 sleep が cap かつ今回も error ならローテーション
+				if (prevSleepWasCapped) {
+					this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, {
+						reason: "error_retryable_rotation",
+					});
+					// eslint-disable-next-line no-await-in-loop -- rotation after cap escalation
+					await this.requestSessionRotation(true);
+					delay = INITIAL_RECONNECT_DELAY_MS;
+					prevSleepWasCapped = false;
+					continue;
+				}
+				this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, {
+					reason: "error_retryable_backoff",
+				});
 			} catch (err) {
 				if (signal.aborted) return;
 				this.logger.error(
@@ -217,7 +250,10 @@ export class AgentRunner implements AiAgent {
 					err,
 				);
 				this.sessionWatch = null;
-				this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, { reason: "error" });
+				// 例外時は retryable 不明のため retryable:true 扱いのバックオフ
+				this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, {
+					reason: "error_retryable_backoff",
+				});
 			}
 
 			if (signal.aborted) return;
@@ -225,13 +261,18 @@ export class AgentRunner implements AiAgent {
 			this.logger.info(`[${this.profile.name}:${this.agentId}] restarting in ${delay}ms...`);
 			// eslint-disable-next-line no-await-in-loop -- backoff delay between restarts
 			await this.sleep(delay);
-			delay = Math.min(delay * 2, MAX_RECONNECT_DELAY_MS);
+			const nextDelay = Math.min(delay * 2, MAX_RECONNECT_DELAY_MS);
+			prevSleepWasCapped = delay >= MAX_RECONNECT_DELAY_MS;
+			delay = nextDelay;
+
+			if (signal.aborted) return;
 		}
 	}
 
-	async requestSessionRotation(): Promise<void> {
+	async requestSessionRotation(force = false): Promise<void> {
 		const now = Date.now();
 		if (
+			!force &&
 			this.lastRotationRequestAt &&
 			now - this.lastRotationRequestAt < this.minRotationIntervalMs
 		) {
@@ -384,7 +425,6 @@ export class AgentRunner implements AiAgent {
 			retryable: typeof event.retryable === "boolean" ? String(event.retryable) : "unknown",
 			error_class: event.errorClass ?? "unknown",
 		});
-		this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, { reason: "error" });
 	}
 
 	private async resolveSessionId(): Promise<string> {

--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -323,9 +323,7 @@ describe("retryable:true のバックオフ戦略", () => {
 		// sleep が呼ばれた（即時ローテーションではなくバックオフ）
 		expect(sleepValues.length).toBeGreaterThanOrEqual(1);
 		// 即時ローテーションではないので deleteSession は呼ばれない
-		expect(
-			(sessionPort.deleteSession as ReturnType<typeof mock>).mock.calls.length,
-		).toBe(0);
+		expect((sessionPort.deleteSession as ReturnType<typeof mock>).mock.calls.length).toBe(0);
 
 		runner.stop();
 		session2.resolve({ type: "cancelled" });
@@ -424,7 +422,8 @@ describe("retryable:false の即時ローテーション戦略", () => {
 		await Bun.sleep(0);
 		await Bun.sleep(0);
 
-		const deleteCallCount1 = (sessionPort.deleteSession as ReturnType<typeof mock>).mock.calls.length;
+		const deleteCallCount1 = (sessionPort.deleteSession as ReturnType<typeof mock>).mock.calls
+			.length;
 		expect(deleteCallCount1).toBeGreaterThanOrEqual(1);
 
 		// 2回目: 再度 retryable:false → 再ローテーション（ランナー停止していない）
@@ -434,7 +433,8 @@ describe("retryable:false の即時ローテーション戦略", () => {
 		await Bun.sleep(0);
 		await Bun.sleep(0);
 
-		const deleteCallCount2 = (sessionPort.deleteSession as ReturnType<typeof mock>).mock.calls.length;
+		const deleteCallCount2 = (sessionPort.deleteSession as ReturnType<typeof mock>).mock.calls
+			.length;
 		expect(deleteCallCount2).toBeGreaterThan(deleteCallCount1);
 
 		runner.stop();
@@ -744,8 +744,7 @@ describe("SESSION_RESTARTS reason ラベルの分類", () => {
 		);
 		const nonRetryableRotations = restartCalls.filter(
 			(call: unknown[]) =>
-				(call[1] as Record<string, string> | undefined)?.reason ===
-				"error_non_retryable_rotation",
+				(call[1] as Record<string, string> | undefined)?.reason === "error_non_retryable_rotation",
 		);
 		expect(nonRetryableRotations.length).toBeGreaterThanOrEqual(1);
 

--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -512,12 +512,14 @@ describe("rotation 後のリセット", () => {
 describe("正常復帰後の delay リセット（既存契約維持）", () => {
 	test("idle 後のエラーでは delay が 2s にリセットされている", async () => {
 		const firstEvent = deferred<void>();
+		// [0] error → sleep 2s, [1] error → sleep 4s, [2] idle → delay reset,
+		// [3] error → sleep 2s (reset確認), [4] pending (runner.stop() 後のガード)
 		const sessions = [
-			deferred<OpencodeSessionEvent>(), // [0] error → sleep 2s
-			deferred<OpencodeSessionEvent>(), // [1] error → sleep 4s
-			deferred<OpencodeSessionEvent>(), // [2] idle → delay reset
-			deferred<OpencodeSessionEvent>(), // [3] error → sleep 2s (reset確認)
-			deferred<OpencodeSessionEvent>(), // [4] pending (runner.stop() 後のガード)
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
 		];
 		let waitCallCount = 0;
 		const eventBuffer = createEventBuffer(() => {

--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -1,0 +1,751 @@
+/**
+ * runner.ts の session error 戦略仕様テスト
+ *
+ * ## エラー戦略概要
+ *
+ * - `retryable:true` (または undefined/unknown → デフォルトで true 扱い):
+ *   exponential backoff (2s → 4s → 8s → 10s, cap=10s) でリトライ。
+ *   cap (10s) 到達後もエラーが継続した場合、opencode session rotation にエスカレーション。
+ *
+ * - `retryable:false`:
+ *   backoff せず即座に session rotation。
+ *
+ * - rotation 後も同じロジックを再度回す（ランナー停止はしない）。
+ * - 正常復帰 (idle) 後は delay をリセット。
+ *
+ * ## SESSION_RESTARTS reason ラベル
+ *
+ * | reason                      | 意味                                              |
+ * | --------------------------- | ------------------------------------------------- |
+ * | error_retryable_backoff     | retryable:true でバックオフ中の再起動             |
+ * | error_retryable_rotation    | retryable:true で cap 到達後のローテーション      |
+ * | error_non_retryable_rotation| retryable:false の即時ローテーション              |
+ * | hang_detected               | (既存) ハング検知によるローテーション             |
+ */
+/* oxlint-disable max-lines, max-lines-per-function -- テストファイルはケース数に応じて長くなるため許容 */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { AgentRunner, type RunnerDeps } from "@vicissitude/agent/runner";
+import { METRIC } from "@vicissitude/observability/metrics";
+import type {
+	ContextBuilderPort,
+	EventBuffer,
+	OpencodeSessionEvent,
+	OpencodeSessionPort,
+} from "@vicissitude/shared/types";
+
+import type { AgentProfile } from "../../packages/agent/src/profile.ts";
+import { createMockLogger, createMockMetrics } from "../test-helpers.ts";
+
+// ─── テスト用サブクラス ───────────────────────────────────────────
+
+class TestAgent extends AgentRunner {
+	sleepSpy: ((ms: number) => Promise<void>) | null = null;
+
+	// oxlint-disable-next-line no-useless-constructor -- protected → public に昇格させるために必要
+	constructor(deps: RunnerDeps) {
+		super(deps);
+	}
+
+	protected override sleep(ms: number): Promise<void> {
+		if (this.sleepSpy) return this.sleepSpy(ms);
+		return super.sleep(ms);
+	}
+}
+
+// ─── ヘルパー ─────────────────────────────────────────────────────
+
+function deferred<T>() {
+	let resolveDeferred!: (value: T) => void;
+	let rejectDeferred!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolve, reject) => {
+		resolveDeferred = resolve;
+		rejectDeferred = reject;
+	});
+	return { promise, resolve: resolveDeferred, reject: rejectDeferred };
+}
+
+function createProfile(overrides: Partial<AgentProfile> = {}): AgentProfile {
+	return {
+		name: "conversation",
+		mcpServers: {},
+		builtinTools: {},
+		pollingPrompt: "loop forever",
+		restartPolicy: "wait_for_events",
+		model: { providerId: "test-provider", modelId: "test-model" },
+		...overrides,
+	};
+}
+
+function createContextBuilder(): ContextBuilderPort {
+	return { build: mock(() => Promise.resolve("system prompt")) };
+}
+
+function createSessionStore() {
+	let sessionId: string | undefined;
+	return {
+		get: mock(() => sessionId),
+		getRow: mock(() => (sessionId ? { key: "k", sessionId, createdAt: Date.now() } : undefined)),
+		save: mock((_profile: string, _key: string, nextSessionId: string) => {
+			sessionId = nextSessionId;
+		}),
+		delete: mock(() => {
+			sessionId = undefined;
+		}),
+	};
+}
+
+function neverResolve(_signal: AbortSignal): Promise<void> {
+	return new Promise(() => {});
+}
+
+function createEventBuffer(waitImpl?: (signal: AbortSignal) => Promise<void>): EventBuffer {
+	return {
+		append: mock(() => {}),
+		waitForEvents: mock(waitImpl ?? neverResolve),
+	};
+}
+
+/**
+ * promptAsyncAndWatchSession が毎回 sessions 配列から順番に Promise を返す sessionPort を作成する。
+ * sessions 配列を使い切ったら最後の要素を返し続ける。
+ */
+function createSessionPortWithSessions(
+	sessions: Array<Promise<OpencodeSessionEvent>>,
+): OpencodeSessionPort & {
+	deleteSession: ReturnType<typeof mock>;
+	close: ReturnType<typeof mock>;
+} {
+	let callCount = 0;
+	return {
+		createSession: mock(() => Promise.resolve("session-1")),
+		sessionExists: mock(() => Promise.resolve(false)),
+		prompt: mock(() => Promise.resolve({ text: "summary", tokens: undefined })),
+		promptAsync: mock(() => Promise.resolve()),
+		promptAsyncAndWatchSession: mock(() => {
+			const idx = Math.min(callCount, sessions.length - 1);
+			callCount += 1;
+			return sessions[idx];
+		}),
+		waitForSessionIdle: mock(() => {
+			const idx = Math.min(callCount, sessions.length - 1);
+			callCount += 1;
+			return sessions[idx];
+		}),
+		deleteSession: mock(() => Promise.resolve()),
+		close: mock(() => {}),
+	} as unknown as OpencodeSessionPort & {
+		deleteSession: ReturnType<typeof mock>;
+		close: ReturnType<typeof mock>;
+	};
+}
+
+const activeRunners = new Set<AgentRunner>();
+
+afterEach(() => {
+	for (const runner of activeRunners) {
+		runner.stop();
+	}
+	activeRunners.clear();
+});
+
+// ─── テスト ───────────────────────────────────────────────────────
+
+describe("retryable:true のバックオフ戦略", () => {
+	test("retryable:true のエラーで 2s → 4s → 8s → 10s の sleep 列になる", async () => {
+		const firstEvent = deferred<void>();
+		const sessions = [
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+		];
+		let waitCallCount = 0;
+		const eventBuffer = createEventBuffer(() => {
+			waitCallCount += 1;
+			if (waitCallCount === 1) return firstEvent.promise;
+			return Promise.resolve();
+		});
+		const sessionPort = createSessionPortWithSessions(sessions.map((d) => d.promise));
+		const sleepValues: number[] = [];
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms: number) => {
+			sleepValues.push(ms);
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 1回目のエラー → sleep 2s
+		sessions[0]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 2回目のエラー → sleep 4s
+		sessions[1]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 3回目のエラー → sleep 8s
+		sessions[2]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 4回目のエラー → sleep 10s (cap)
+		sessions[3]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// バックオフ数列が 2s → 4s → 8s → 10s になっている
+		expect(sleepValues.slice(0, 4)).toEqual([2000, 4000, 8000, 10000]);
+
+		runner.stop();
+		sessions[4]?.resolve({ type: "cancelled" });
+	});
+
+	test("retryable:true で cap(10s) 到達後もエラーが継続するとローテーションにエスカレーション", async () => {
+		const firstEvent = deferred<void>();
+		// cap 到達（4回）+ cap 後エラー（1回）= 計5セッション
+		const sessions = [
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+		];
+		let waitCallCount = 0;
+		const eventBuffer = createEventBuffer(() => {
+			waitCallCount += 1;
+			if (waitCallCount === 1) return firstEvent.promise;
+			return Promise.resolve();
+		});
+		const sessionPort = createSessionPortWithSessions(sessions.map((d) => d.promise));
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 1〜4回目のエラー: バックオフ (2s→4s→8s→10s=cap)
+		for (let i = 0; i < 4; i++) {
+			sessions[i]?.resolve({ type: "error", message: "err", retryable: true });
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+		}
+
+		// 5回目のエラー: cap 到達済みなのでローテーション発動
+		sessions[4]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// deleteSession が呼ばれた（ローテーション発動）
+		expect(sessionPort.deleteSession).toHaveBeenCalled();
+
+		runner.stop();
+		sessions[5]?.resolve({ type: "cancelled" });
+	});
+
+	test("retryable undefined のエラーは retryable:true として扱われバックオフする", async () => {
+		const firstEvent = deferred<void>();
+		const session1 = deferred<OpencodeSessionEvent>();
+		const session2 = deferred<OpencodeSessionEvent>();
+		let waitCallCount = 0;
+		const eventBuffer = createEventBuffer(() => {
+			waitCallCount += 1;
+			if (waitCallCount === 1) return firstEvent.promise;
+			return Promise.resolve();
+		});
+		const sessionPort = createSessionPortWithSessions([session1.promise, session2.promise]);
+
+		const sleepValues: number[] = [];
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms: number) => {
+			sleepValues.push(ms);
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// retryable フィールドなし → retryable:true 扱いでバックオフ
+		session1.resolve({ type: "error", message: "unknown error" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// sleep が呼ばれた（即時ローテーションではなくバックオフ）
+		expect(sleepValues.length).toBeGreaterThanOrEqual(1);
+		// 即時ローテーションではないので deleteSession は呼ばれない
+		expect(
+			(sessionPort.deleteSession as ReturnType<typeof mock>).mock.calls.length,
+		).toBe(0);
+
+		runner.stop();
+		session2.resolve({ type: "cancelled" });
+	});
+});
+
+describe("retryable:false の即時ローテーション戦略", () => {
+	test("retryable:false のエラーで sleep なく即座に rotation が発動する", async () => {
+		const firstEvent = deferred<void>();
+		const session1 = deferred<OpencodeSessionEvent>();
+		const session2 = deferred<OpencodeSessionEvent>();
+		let waitCallCount = 0;
+		const eventBuffer = createEventBuffer(() => {
+			waitCallCount += 1;
+			if (waitCallCount === 1) return firstEvent.promise;
+			return Promise.resolve();
+		});
+		const sessionPort = createSessionPortWithSessions([session1.promise, session2.promise]);
+
+		const sleepValues: number[] = [];
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms: number) => {
+			sleepValues.push(ms);
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// retryable:false → 即時ローテーション
+		session1.resolve({ type: "error", message: "Bad Request", status: 400, retryable: false });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// deleteSession が呼ばれた
+		expect(sessionPort.deleteSession).toHaveBeenCalled();
+		// 2s 以上の sleep は発生していない
+		const longSleeps = sleepValues.filter((ms) => ms >= 2000);
+		expect(longSleeps.length).toBe(0);
+
+		runner.stop();
+		session2.resolve({ type: "cancelled" });
+	});
+
+	test("retryable:false のローテーション後も再エラーで同じロジックが回る（ランナー停止しない）", async () => {
+		const firstEvent = deferred<void>();
+		const sessions = [
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+		];
+		let waitCallCount = 0;
+		const eventBuffer = createEventBuffer(() => {
+			waitCallCount += 1;
+			if (waitCallCount === 1) return firstEvent.promise;
+			return Promise.resolve();
+		});
+		const sessionPort = createSessionPortWithSessions(sessions.map((d) => d.promise));
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 1回目: retryable:false → 即時ローテーション
+		sessions[0]?.resolve({ type: "error", message: "err", retryable: false });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const deleteCallCount1 = (sessionPort.deleteSession as ReturnType<typeof mock>).mock.calls.length;
+		expect(deleteCallCount1).toBeGreaterThanOrEqual(1);
+
+		// 2回目: 再度 retryable:false → 再ローテーション（ランナー停止していない）
+		sessions[1]?.resolve({ type: "error", message: "err", retryable: false });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const deleteCallCount2 = (sessionPort.deleteSession as ReturnType<typeof mock>).mock.calls.length;
+		expect(deleteCallCount2).toBeGreaterThan(deleteCallCount1);
+
+		runner.stop();
+		sessions[2]?.resolve({ type: "cancelled" });
+	});
+});
+
+describe("rotation 後のリセット", () => {
+	test("rotation 後は delay が 2s にリセットされる", async () => {
+		const firstEvent = deferred<void>();
+		// cap 到達（4回）+ cap 後エラー（ローテーション）+ rotation 後の新エラー
+		const sessions = Array.from({ length: 8 }, () => deferred<OpencodeSessionEvent>());
+		let waitCallCount = 0;
+		const eventBuffer = createEventBuffer(() => {
+			waitCallCount += 1;
+			if (waitCallCount === 1) return firstEvent.promise;
+			return Promise.resolve();
+		});
+		const sessionPort = createSessionPortWithSessions(sessions.map((d) => d.promise));
+
+		const sleepValues: number[] = [];
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms: number) => {
+			sleepValues.push(ms);
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 1〜4回目のエラー: バックオフで cap 到達
+		for (let i = 0; i < 4; i++) {
+			sessions[i]?.resolve({ type: "error", message: "err", retryable: true });
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+		}
+
+		// 5回目: cap 到達済みなのでローテーション発動、delay はリセットされる
+		sessions[4]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const sleepsBefore = sleepValues.length;
+
+		// rotation 後の新エラー → delay は 2s からリスタート
+		sessions[5]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const newSleep = sleepValues[sleepsBefore];
+		// rotation 後の初回エラーは 2s から再開（10s ではない）
+		expect(newSleep).toBe(2000);
+
+		runner.stop();
+		sessions[6]?.resolve({ type: "cancelled" });
+	});
+});
+
+describe("正常復帰後の delay リセット（既存契約維持）", () => {
+	test("idle 後のエラーでは delay が 2s にリセットされている", async () => {
+		const firstEvent = deferred<void>();
+		const sessions = [
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(),
+		];
+		let waitCallCount = 0;
+		const eventBuffer = createEventBuffer(() => {
+			waitCallCount += 1;
+			if (waitCallCount === 1) return firstEvent.promise;
+			return Promise.resolve();
+		});
+		const sessionPort = createSessionPortWithSessions(sessions.map((d) => d.promise));
+
+		const sleepValues: number[] = [];
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms: number) => {
+			sleepValues.push(ms);
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// エラー発生 → sleep 2s
+		sessions[0]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// エラー → sleep 4s
+		sessions[1]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 正常復帰 (idle) → delay リセット
+		sessions[2]?.resolve({ type: "idle" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const idleSleepCount = sleepValues.length;
+
+		// 再エラー → delay は 2s からリスタート
+		sessions[3]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// idle 後の sleep は IDLE_COOLDOWN_MS (2000) なので、
+		// 次のエラー sleep は 2000 から始まる
+		const sleepAfterIdle = sleepValues[idleSleepCount];
+		expect(sleepAfterIdle).toBe(2000);
+
+		runner.stop();
+	});
+});
+
+describe("SESSION_RESTARTS reason ラベルの分類", () => {
+	test("retryable:true でバックオフ中の再起動は reason=error_retryable_backoff", async () => {
+		const firstEvent = deferred<void>();
+		const session1 = deferred<OpencodeSessionEvent>();
+		const session2 = deferred<OpencodeSessionEvent>();
+		let waitCallCount = 0;
+		const eventBuffer = createEventBuffer(() => {
+			waitCallCount += 1;
+			if (waitCallCount === 1) return firstEvent.promise;
+			return Promise.resolve();
+		});
+		const sessionPort = createSessionPortWithSessions([session1.promise, session2.promise]);
+		const metrics = createMockMetrics();
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+			metrics,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		session1.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const incrementCalls = (metrics.incrementCounter as ReturnType<typeof mock>).mock.calls;
+		const restartCalls = incrementCalls.filter(
+			(call: unknown[]) => call[0] === METRIC.SESSION_RESTARTS,
+		);
+		const backoffRestarts = restartCalls.filter(
+			(call: unknown[]) =>
+				(call[1] as Record<string, string> | undefined)?.reason === "error_retryable_backoff",
+		);
+		expect(backoffRestarts.length).toBeGreaterThanOrEqual(1);
+
+		runner.stop();
+		session2.resolve({ type: "cancelled" });
+	});
+
+	test("retryable:true で cap 到達後の rotation は reason=error_retryable_rotation", async () => {
+		const firstEvent = deferred<void>();
+		const sessions = Array.from({ length: 7 }, () => deferred<OpencodeSessionEvent>());
+		let waitCallCount = 0;
+		const eventBuffer = createEventBuffer(() => {
+			waitCallCount += 1;
+			if (waitCallCount === 1) return firstEvent.promise;
+			return Promise.resolve();
+		});
+		const sessionPort = createSessionPortWithSessions(sessions.map((d) => d.promise));
+		const metrics = createMockMetrics();
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+			metrics,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 1〜4回目のエラー (cap到達まで)
+		for (let i = 0; i < 4; i++) {
+			sessions[i]?.resolve({ type: "error", message: "err", retryable: true });
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+		}
+
+		// 5回目: ローテーション発動
+		sessions[4]?.resolve({ type: "error", message: "err", retryable: true });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const incrementCalls = (metrics.incrementCounter as ReturnType<typeof mock>).mock.calls;
+		const restartCalls = incrementCalls.filter(
+			(call: unknown[]) => call[0] === METRIC.SESSION_RESTARTS,
+		);
+		const rotationRestarts = restartCalls.filter(
+			(call: unknown[]) =>
+				(call[1] as Record<string, string> | undefined)?.reason === "error_retryable_rotation",
+		);
+		expect(rotationRestarts.length).toBeGreaterThanOrEqual(1);
+
+		runner.stop();
+		sessions[5]?.resolve({ type: "cancelled" });
+	});
+
+	test("retryable:false の即時 rotation は reason=error_non_retryable_rotation", async () => {
+		const firstEvent = deferred<void>();
+		const session1 = deferred<OpencodeSessionEvent>();
+		const session2 = deferred<OpencodeSessionEvent>();
+		let waitCallCount = 0;
+		const eventBuffer = createEventBuffer(() => {
+			waitCallCount += 1;
+			if (waitCallCount === 1) return firstEvent.promise;
+			return Promise.resolve();
+		});
+		const sessionPort = createSessionPortWithSessions([session1.promise, session2.promise]);
+		const metrics = createMockMetrics();
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+			metrics,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		session1.resolve({ type: "error", message: "err", retryable: false });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const incrementCalls = (metrics.incrementCounter as ReturnType<typeof mock>).mock.calls;
+		const restartCalls = incrementCalls.filter(
+			(call: unknown[]) => call[0] === METRIC.SESSION_RESTARTS,
+		);
+		const nonRetryableRotations = restartCalls.filter(
+			(call: unknown[]) =>
+				(call[1] as Record<string, string> | undefined)?.reason ===
+				"error_non_retryable_rotation",
+		);
+		expect(nonRetryableRotations.length).toBeGreaterThanOrEqual(1);
+
+		runner.stop();
+		session2.resolve({ type: "cancelled" });
+	});
+});

--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -22,7 +22,7 @@
  * | error_non_retryable_rotation| retryable:false の即時ローテーション              |
  * | hang_detected               | (既存) ハング検知によるローテーション             |
  */
-/* oxlint-disable max-lines, max-lines-per-function -- テストファイルはケース数に応じて長くなるため許容 */
+/* oxlint-disable max-lines, max-lines-per-function, no-await-in-loop -- テストファイルはケース数に応じて長くなるため許容 */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { AgentRunner, type RunnerDeps } from "@vicissitude/agent/runner";
@@ -513,10 +513,11 @@ describe("正常復帰後の delay リセット（既存契約維持）", () => 
 	test("idle 後のエラーでは delay が 2s にリセットされている", async () => {
 		const firstEvent = deferred<void>();
 		const sessions = [
-			deferred<OpencodeSessionEvent>(),
-			deferred<OpencodeSessionEvent>(),
-			deferred<OpencodeSessionEvent>(),
-			deferred<OpencodeSessionEvent>(),
+			deferred<OpencodeSessionEvent>(), // [0] error → sleep 2s
+			deferred<OpencodeSessionEvent>(), // [1] error → sleep 4s
+			deferred<OpencodeSessionEvent>(), // [2] idle → delay reset
+			deferred<OpencodeSessionEvent>(), // [3] error → sleep 2s (reset確認)
+			deferred<OpencodeSessionEvent>(), // [4] pending (runner.stop() 後のガード)
 		];
 		let waitCallCount = 0;
 		const eventBuffer = createEventBuffer(() => {
@@ -581,6 +582,7 @@ describe("正常復帰後の delay リセット（既存契約維持）", () => 
 		expect(sleepAfterIdle).toBe(2000);
 
 		runner.stop();
+		sessions[4]?.resolve({ type: "cancelled" });
 	});
 });
 

--- a/spec/agent/session-error-metrics.spec.ts
+++ b/spec/agent/session-error-metrics.spec.ts
@@ -362,10 +362,15 @@ describe("Runner: session restart メトリクス記録", () => {
 			(call: unknown[]) => call[0] === METRIC.SESSION_RESTARTS,
 		);
 		expect(restartCalls.length).toBeGreaterThanOrEqual(1);
-		// reason ラベルに "error" が含まれる
-		const errorRestarts = restartCalls.filter(
-			(call: unknown[]) => (call[1] as Record<string, string> | undefined)?.reason === "error",
-		);
+		// reason ラベルにエラー系の値が含まれる（retryable:undefined は retryable:true 扱いでバックオフ）
+		const errorRestarts = restartCalls.filter((call: unknown[]) => {
+			const reason = (call[1] as Record<string, string> | undefined)?.reason;
+			return (
+				reason === "error_retryable_backoff" ||
+				reason === "error_retryable_rotation" ||
+				reason === "error_non_retryable_rotation"
+			);
+		});
 		expect(errorRestarts.length).toBeGreaterThanOrEqual(1);
 
 		runner.stop();


### PR DESCRIPTION
Closes #641

## Summary

`session.error` の backoff 戦略を retryable フラグで分岐。busy loop を防止する。

- **`retryable:false`**: backoff なしで即 opencode session rotation
- **`retryable:true` / undefined**: exp backoff cap 10s (2s → 4s → 8s → 10s)、cap 到達後は rotation にエスカレーション
- rotation 後は delay を 2s にリセットし同じロジックを再度回す（ランナー停止はしない）

## 変更点

- `MAX_RECONNECT_DELAY_MS` を `30_000` → `10_000` に変更
- `requestSessionRotation(force?: boolean)` オプション引数を追加。`force=true` でスロットル (`minRotationIntervalMs`) をバイパス。ハング検知タイマーも `force=true` で呼び出すよう変更（既存の外部呼び出しは後方互換）
- `SESSION_RESTARTS` の `reason` ラベルを 3 種類に細分化:
  - `error_retryable_backoff` — バックオフ中の再起動
  - `error_retryable_rotation` — cap 到達後のローテーション
  - `error_non_retryable_rotation` — retryable:false の即時ローテーション
  - `hang_detected` は維持

## Test plan

- [x] `spec/agent/runner-error-strategy.spec.ts` を新規追加 (10 test, 全 pass)
- [x] `spec/agent/session-error-metrics.spec.ts` を新 reason ラベル体系に更新
- [x] `packages/agent/src/runner.test.ts` にホワイトボックス unit test 5件追加
- [x] `nr test`: 1866 pass, 0 fail
- [x] `nr validate`: PASS (fmt:check + lint + check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)