### PR TITLE
fix(agent): generateSessionSummary を timeout 付き best-effort 化してセッションローテーション停止を解消

### DIFF
--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -1178,3 +1178,580 @@ describe("AgentRunner ハング検知タイマー（内部ロジック）", () =
 		waitDeferred.resolve();
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// セッション要約生成の内部ロジック（ホワイトボックス）
+// raceAbort / abortReasonToError / generateSessionSummary / summaryTimeoutMs DI
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** summaryPrompt 付きプロファイル（内部ロジック検証用） */
+function createProfileWithSummary(): AgentProfile {
+	return {
+		...createProfile(),
+		summaryPrompt: "要約してください",
+	};
+}
+
+/** rotation を単発で呼ぶためのシンプルな sessionPort（ポーリングループは起動しない） */
+function createSimpleSessionPort(
+	promptImpl: (signal?: AbortSignal) => Promise<{ text: string; tokens: undefined }>,
+): OpencodeSessionPort & {
+	prompt: ReturnType<typeof mock>;
+	deleteSession: ReturnType<typeof mock>;
+} {
+	return {
+		createSession: mock(() => Promise.resolve("session-1")),
+		sessionExists: mock(() => Promise.resolve(false)),
+		prompt: mock((_params: unknown, signal?: AbortSignal) => promptImpl(signal)),
+		promptAsync: mock(() => Promise.resolve()),
+		promptAsyncAndWatchSession: mock(() => Promise.resolve({ type: "idle" as const })),
+		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
+		deleteSession: mock(() => Promise.resolve()),
+		close: mock(() => {}),
+	} as unknown as OpencodeSessionPort & {
+		prompt: ReturnType<typeof mock>;
+		deleteSession: ReturnType<typeof mock>;
+	};
+}
+
+describe("AgentRunner セッション要約生成の内部ロジック（ホワイトボックス）", () => {
+	describe("raceAbort ヘルパー（generateSessionSummary 経由で観察）", () => {
+		test("promise が先に resolve したら resolve 値を使って summaryWriter.write が呼ばれる", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort(() =>
+				Promise.resolve({ text: "summarized", tokens: undefined }),
+			);
+			const summaryWriter = { write: mock(() => Promise.resolve()) };
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfileWithSummary(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "g1",
+				summaryWriter,
+				summaryTimeoutMs: 5_000,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			await runner.requestSessionRotation(true);
+
+			expect(summaryWriter.write).toHaveBeenCalledWith("g1", "summarized");
+		});
+
+		test("signal が先に abort したら abort reason で reject される（logger.warn が呼ばれる）", async () => {
+			// prompt は永久に pending のまま → timeout 側の signal が先に abort する
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort(() => new Promise(() => {}));
+			const summaryWriter = { write: mock(() => Promise.resolve()) };
+			const sessionStore = createSessionStore();
+			const logger = createMockLogger();
+
+			const runner = new TestAgent({
+				profile: createProfileWithSummary(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger,
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "g1",
+				summaryWriter,
+				// 短いタイムアウトで raceAbort の signal 先行を誘発
+				summaryTimeoutMs: 20,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			await runner.requestSessionRotation(true);
+
+			// summaryWriter.write は呼ばれず、logger.warn でハンドリング
+			expect(summaryWriter.write).toHaveBeenCalledTimes(0);
+			expect(logger.warn).toHaveBeenCalled();
+			// logger.error ではないこと（AbortError/TimeoutError は warn 扱い）
+			expect(logger.error).toHaveBeenCalledTimes(0);
+		});
+
+		test("abortController.signal が事前に aborted なら prompt は呼ばれず早期 return する", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort(() =>
+				Promise.resolve({ text: "ok", tokens: undefined }),
+			);
+			const summaryWriter = { write: mock(() => Promise.resolve()) };
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfileWithSummary(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "g1",
+				summaryWriter,
+				summaryTimeoutMs: 5_000,
+			});
+			activeRunners.add(runner);
+
+			// abortController を生成させる（ensurePolling 経由）
+			runner.ensurePolling();
+			await Bun.sleep(0);
+
+			// abortController.signal を abort 済みにする（stop() は使わず、null 化しないことで
+			// generateSessionSummary の `if (this.abortController?.signal.aborted) return;` を発火させる）
+			// @ts-expect-error -- private フィールド。ホワイトボックステストのため許容
+			const ac = runner.abortController as AbortController;
+			ac.abort();
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			await runner.requestSessionRotation(true);
+
+			// generateSessionSummary 冒頭の早期 return により prompt は呼ばれない
+			expect(sessionPort.prompt).toHaveBeenCalledTimes(0);
+			expect(summaryWriter.write).toHaveBeenCalledTimes(0);
+			// ただし rotation 本体は完遂（deleteSession / sessionStore.delete は呼ばれる）
+			expect(sessionPort.deleteSession).toHaveBeenCalledWith("session-abc");
+		});
+
+		test("raceAbort の finally で abort listener が removeEventListener される（メモリリークしない）", async () => {
+			// AbortSignal.timeout をモンキーパッチして、返された signal の
+			// addEventListener / removeEventListener をスパイでラップする。
+			// 成功パスでは raceAbort の addEventListener と finally の removeEventListener が
+			// ペアで呼ばれるはず（listener が外れないとリーク）。
+			//
+			// abortController が null の状態（ensurePolling 未呼び出し）では
+			// combinedSignal = timeoutSignal となり、raceAbort は timeoutSignal に直接
+			// addEventListener("abort", ...) を呼ぶ。
+			const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+			const addAbortCount = { n: 0 };
+			const removeAbortCount = { n: 0 };
+			AbortSignal.timeout = ((ms: number) => {
+				const s = origTimeout(ms);
+				const origAdd = s.addEventListener.bind(s);
+				const origRemove = s.removeEventListener.bind(s);
+				s.addEventListener = ((type: string, ...rest: unknown[]) => {
+					if (type === "abort") addAbortCount.n += 1;
+					return (origAdd as unknown as (...args: unknown[]) => void)(type, ...rest);
+				}) as typeof s.addEventListener;
+				s.removeEventListener = ((type: string, ...rest: unknown[]) => {
+					if (type === "abort") removeAbortCount.n += 1;
+					return (origRemove as unknown as (...args: unknown[]) => void)(type, ...rest);
+				}) as typeof s.removeEventListener;
+				return s;
+			}) as typeof AbortSignal.timeout;
+
+			try {
+				const eventBuffer = createEventBuffer(() => Promise.resolve());
+				const sessionPort = createSimpleSessionPort(() =>
+					Promise.resolve({ text: "ok", tokens: undefined }),
+				);
+				const summaryWriter = { write: mock(() => Promise.resolve()) };
+				const sessionStore = createSessionStore();
+
+				const runner = new TestAgent({
+					profile: createProfileWithSummary(),
+					agentId: "guild-1",
+					sessionStore: sessionStore as never,
+					contextBuilder: createContextBuilder(),
+					logger: createMockLogger(),
+					sessionPort: sessionPort as unknown as OpencodeSessionPort,
+					eventBuffer,
+					sessionMaxAgeMs: 3_600_000,
+					contextGuildId: "g1",
+					summaryWriter,
+					summaryTimeoutMs: 5_000,
+				});
+				activeRunners.add(runner);
+
+				// ensurePolling は呼ばない → abortController は null → combinedSignal = timeoutSignal
+				sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+				await runner.requestSessionRotation(true);
+
+				// 成功パスでは:
+				// 1. raceAbort が addEventListener("abort", ...) を 1 回呼ぶ
+				// 2. 成功して finally で removeEventListener を 1 回呼ぶ
+				expect(addAbortCount.n).toBeGreaterThanOrEqual(1);
+				expect(removeAbortCount.n).toBe(addAbortCount.n);
+				expect(summaryWriter.write).toHaveBeenCalledTimes(1);
+			} finally {
+				AbortSignal.timeout = origTimeout;
+			}
+		});
+	});
+
+	describe("abortReasonToError の正規化（logger メッセージから観察）", () => {
+		test("AbortSignal.timeout 由来の TimeoutError が保たれ、logger.warn に TimeoutError が含まれる", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			// prompt を永久 pending にして timeout 側から打ち切らせる
+			const sessionPort = createSimpleSessionPort(() => new Promise(() => {}));
+			const summaryWriter = { write: mock(() => Promise.resolve()) };
+			const sessionStore = createSessionStore();
+			const logger = createMockLogger();
+
+			const runner = new TestAgent({
+				profile: createProfileWithSummary(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger,
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "g1",
+				summaryWriter,
+				summaryTimeoutMs: 20,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			await runner.requestSessionRotation(true);
+
+			// logger.warn の第1引数（メッセージ文字列）に TimeoutError が含まれるはず
+			const warnMessages = (logger.warn as ReturnType<typeof mock>).mock.calls
+				.map((args) => String(args[0]))
+				.join("\n");
+			expect(warnMessages).toContain("TimeoutError");
+			expect(logger.error).toHaveBeenCalledTimes(0);
+		});
+
+		test("AbortController.abort() (reason 未設定) では AbortError に正規化され logger.warn が呼ばれる", async () => {
+			// prompt を pending のままにして、runner 側の abortController を手動 abort させる。
+			// AbortController.abort() は reason 未指定のため DOMException("AbortError") になる。
+			const promptDeferred = deferred<{ text: string; tokens: undefined }>();
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort(() => promptDeferred.promise);
+			const summaryWriter = { write: mock(() => Promise.resolve()) };
+			const sessionStore = createSessionStore();
+			const logger = createMockLogger();
+
+			const runner = new TestAgent({
+				profile: createProfileWithSummary(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger,
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "g1",
+				summaryWriter,
+				// timeout より先に abort が走るよう十分長く
+				summaryTimeoutMs: 60_000,
+			});
+			activeRunners.add(runner);
+
+			// abortController を生成させるために ensurePolling → 即 stop
+			runner.ensurePolling();
+			await Bun.sleep(0);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			const rotationPromise = runner.requestSessionRotation(true);
+			// prompt 呼び出しが走るのを待つ
+			await Bun.sleep(0);
+
+			// runner.stop() → abortController.abort() により signal が abort される
+			runner.stop();
+			await rotationPromise;
+
+			const warnMessages = (logger.warn as ReturnType<typeof mock>).mock.calls
+				.map((args) => String(args[0]))
+				.join("\n");
+			expect(warnMessages).toContain("AbortError");
+			expect(logger.error).toHaveBeenCalledTimes(0);
+		});
+	});
+
+	describe("generateSessionSummary の内部分岐", () => {
+		test("早期 return: summaryWriter 未設定なら prompt は呼ばれない", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort(() =>
+				Promise.resolve({ text: "ok", tokens: undefined }),
+			);
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfileWithSummary(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "g1",
+				// summaryWriter は未設定
+				summaryTimeoutMs: 5_000,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			await runner.requestSessionRotation(true);
+
+			expect(sessionPort.prompt).toHaveBeenCalledTimes(0);
+			// rotation 本体は完遂する
+			expect(sessionPort.deleteSession).toHaveBeenCalledWith("session-abc");
+		});
+
+		test("早期 return: contextGuildId 未設定なら prompt は呼ばれない", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort(() =>
+				Promise.resolve({ text: "ok", tokens: undefined }),
+			);
+			const summaryWriter = { write: mock(() => Promise.resolve()) };
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfileWithSummary(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				// contextGuildId 未設定
+				summaryWriter,
+				summaryTimeoutMs: 5_000,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			await runner.requestSessionRotation(true);
+
+			expect(sessionPort.prompt).toHaveBeenCalledTimes(0);
+			expect(summaryWriter.write).toHaveBeenCalledTimes(0);
+		});
+
+		test("早期 return: profile.summaryPrompt 未設定なら prompt は呼ばれない", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort(() =>
+				Promise.resolve({ text: "ok", tokens: undefined }),
+			);
+			const summaryWriter = { write: mock(() => Promise.resolve()) };
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				// summaryPrompt 無しの通常プロファイル
+				profile: createProfile(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "g1",
+				summaryWriter,
+				summaryTimeoutMs: 5_000,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			await runner.requestSessionRotation(true);
+
+			expect(sessionPort.prompt).toHaveBeenCalledTimes(0);
+			expect(summaryWriter.write).toHaveBeenCalledTimes(0);
+		});
+
+		test("text が空白のみなら summaryWriter.write は呼ばれない", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort(() =>
+				Promise.resolve({ text: "   \n  ", tokens: undefined }),
+			);
+			const summaryWriter = { write: mock(() => Promise.resolve()) };
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfileWithSummary(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "g1",
+				summaryWriter,
+				summaryTimeoutMs: 5_000,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			await runner.requestSessionRotation(true);
+
+			expect(sessionPort.prompt).toHaveBeenCalledTimes(1);
+			expect(summaryWriter.write).toHaveBeenCalledTimes(0);
+		});
+
+		test("非 Abort/Timeout の例外は logger.error で記録される（既存契約維持）", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort(() =>
+				Promise.reject(new Error("some runtime error")),
+			);
+			const summaryWriter = { write: mock(() => Promise.resolve()) };
+			const sessionStore = createSessionStore();
+			const logger = createMockLogger();
+
+			const runner = new TestAgent({
+				profile: createProfileWithSummary(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger,
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "g1",
+				summaryWriter,
+				summaryTimeoutMs: 5_000,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			await runner.requestSessionRotation(true);
+
+			expect(logger.error).toHaveBeenCalled();
+			// warn ではなく error 側
+			const warnTimeoutCalls = (logger.warn as ReturnType<typeof mock>).mock.calls.filter((args) =>
+				String(args[0]).includes("session summary aborted"),
+			);
+			expect(warnTimeoutCalls.length).toBe(0);
+		});
+
+		test("AbortSignal.any 合成: abortController 側が先に abort しても logger.warn で AbortError 扱いになる", async () => {
+			// summaryTimeoutMs を十分長くし、runner.stop() を先に走らせて
+			// abortController 側が先に打ち切ることを確認する（timeoutSignal と合成した signal の動作検証）。
+			const promptDeferred = deferred<{ text: string; tokens: undefined }>();
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort(() => promptDeferred.promise);
+			const summaryWriter = { write: mock(() => Promise.resolve()) };
+			const sessionStore = createSessionStore();
+			const logger = createMockLogger();
+
+			const runner = new TestAgent({
+				profile: createProfileWithSummary(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger,
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "g1",
+				summaryWriter,
+				summaryTimeoutMs: 60_000,
+			});
+			activeRunners.add(runner);
+
+			runner.ensurePolling();
+			await Bun.sleep(0);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+			const rotationPromise = runner.requestSessionRotation(true);
+			await Bun.sleep(0);
+
+			runner.stop();
+			await rotationPromise;
+
+			// AbortError 側での warn が記録されている
+			const warnMessages = (logger.warn as ReturnType<typeof mock>).mock.calls
+				.map((args) => String(args[0]))
+				.join("\n");
+			expect(warnMessages).toContain("session summary aborted");
+			expect(warnMessages).toContain("AbortError");
+		});
+	});
+
+	describe("summaryTimeoutMs の DI", () => {
+		test("未指定時は DEFAULT_SUMMARY_TIMEOUT_MS (30_000) が AbortSignal.timeout に渡される", async () => {
+			// AbortSignal.timeout をモンキーパッチして呼び出し時の ms を記録する
+			const timeoutCalls: number[] = [];
+			const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+			AbortSignal.timeout = ((ms: number) => {
+				timeoutCalls.push(ms);
+				return origTimeout(ms);
+			}) as typeof AbortSignal.timeout;
+
+			try {
+				const eventBuffer = createEventBuffer(() => Promise.resolve());
+				const sessionPort = createSimpleSessionPort(() =>
+					Promise.resolve({ text: "ok", tokens: undefined }),
+				);
+				const summaryWriter = { write: mock(() => Promise.resolve()) };
+				const sessionStore = createSessionStore();
+
+				const runner = new TestAgent({
+					profile: createProfileWithSummary(),
+					agentId: "guild-1",
+					sessionStore: sessionStore as never,
+					contextBuilder: createContextBuilder(),
+					logger: createMockLogger(),
+					sessionPort: sessionPort as unknown as OpencodeSessionPort,
+					eventBuffer,
+					sessionMaxAgeMs: 3_600_000,
+					contextGuildId: "g1",
+					summaryWriter,
+					// summaryTimeoutMs 未指定
+				});
+				activeRunners.add(runner);
+
+				sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+				await runner.requestSessionRotation(true);
+
+				expect(timeoutCalls).toContain(30_000);
+			} finally {
+				AbortSignal.timeout = origTimeout;
+			}
+		});
+
+		test("指定時は渡された値が AbortSignal.timeout に使われる", async () => {
+			const timeoutCalls: number[] = [];
+			const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+			AbortSignal.timeout = ((ms: number) => {
+				timeoutCalls.push(ms);
+				return origTimeout(ms);
+			}) as typeof AbortSignal.timeout;
+
+			try {
+				const eventBuffer = createEventBuffer(() => Promise.resolve());
+				const sessionPort = createSimpleSessionPort(() =>
+					Promise.resolve({ text: "ok", tokens: undefined }),
+				);
+				const summaryWriter = { write: mock(() => Promise.resolve()) };
+				const sessionStore = createSessionStore();
+
+				const runner = new TestAgent({
+					profile: createProfileWithSummary(),
+					agentId: "guild-1",
+					sessionStore: sessionStore as never,
+					contextBuilder: createContextBuilder(),
+					logger: createMockLogger(),
+					sessionPort: sessionPort as unknown as OpencodeSessionPort,
+					eventBuffer,
+					sessionMaxAgeMs: 3_600_000,
+					contextGuildId: "g1",
+					summaryWriter,
+					summaryTimeoutMs: 12_345,
+				});
+				activeRunners.add(runner);
+
+				sessionStore.save("conversation", "__polling__:guild-1", "session-abc");
+				await runner.requestSessionRotation(true);
+
+				expect(timeoutCalls).toContain(12_345);
+				expect(timeoutCalls).not.toContain(30_000);
+			} finally {
+				AbortSignal.timeout = origTimeout;
+			}
+		});
+	});
+});

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -522,9 +522,10 @@ export class AgentRunner implements AiAgent {
 	 * いかなる失敗（同期 throw・reject・timeout・abort）が起きても関数全体は resolve する。
 	 * これにより呼び出し元の rotation (deleteSession / sessionStore.delete) が必ず完遂する。
 	 *
-	 * 実装メモ: `sessionPort.prompt` が signal に反応しない実装（SDK 側の不具合や
-	 * モック）でも rotation を止めないため、runner 側でも `Promise.race` により
-	 * 独立して打ち切る。SDK に signal を伝播する強化はアダプタ層で別途行う。
+	 * 実装メモ: `combinedSignal` を `sessionPort.prompt` に渡して SDK 側で HTTP
+	 * リクエストをキャンセルさせる。加えて、SDK 側が signal を尊重しない実装
+	 * （モック・SDK 不具合）でも rotation を止めないため、runner 側でも
+	 * `raceAbort` により独立して打ち切る（二重防衛）。
 	 */
 	private async generateSessionSummary(sessionId: string): Promise<void> {
 		if (this.abortController?.signal.aborted) return;
@@ -534,12 +535,15 @@ export class AgentRunner implements AiAgent {
 			? AbortSignal.any([timeoutSignal, this.abortController.signal])
 			: timeoutSignal;
 		try {
-			const promptPromise = this.sessionPort.prompt({
-				sessionId,
-				text: this.profile.summaryPrompt,
-				model: this.profile.model,
-				tools: {},
-			});
+			const promptPromise = this.sessionPort.prompt(
+				{
+					sessionId,
+					text: this.profile.summaryPrompt,
+					model: this.profile.model,
+					tools: {},
+				},
+				combinedSignal,
+			);
 			const { text } = await raceAbort(promptPromise, combinedSignal);
 			if (!text.trim()) return;
 			await this.summaryWriter.write(this.contextGuildId, text);
@@ -550,12 +554,13 @@ export class AgentRunner implements AiAgent {
 			const name = err instanceof Error ? err.name : "";
 			if (name === "AbortError" || name === "TimeoutError") {
 				this.logger.warn(
-					`[${this.profile.name}:${this.agentId}] session summary aborted (${name}, timeout=${this.summaryTimeoutMs}ms); continuing rotation without summary`,
+					`[${this.profile.name}:${this.agentId}] session summary aborted (sessionId=${sessionId}, ${name}, timeout=${this.summaryTimeoutMs}ms); continuing rotation without summary`,
+					err,
 				);
 				return;
 			}
 			this.logger.error(
-				`[${this.profile.name}:${this.agentId}] failed to generate session summary`,
+				`[${this.profile.name}:${this.agentId}] failed to generate session summary (sessionId=${sessionId})`,
 				err,
 			);
 		}

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -20,6 +20,39 @@ const MAX_RECONNECT_DELAY_MS = 10_000;
 const INITIAL_RECONNECT_DELAY_MS = 2_000;
 const IDLE_COOLDOWN_MS = 2_000;
 const DEFAULT_HANG_TIMEOUT_MS = 600_000;
+const DEFAULT_SUMMARY_TIMEOUT_MS = 30_000;
+
+/**
+ * AbortSignal の abort reason を Error に正規化する。
+ * `AbortSignal.timeout` → `TimeoutError` (DOMException)、
+ * `AbortController.abort()` → 任意の reason (未設定なら DOMException "AbortError")。
+ */
+function abortReasonToError(signal: AbortSignal): Error {
+	const reason = signal.reason;
+	if (reason instanceof Error) return reason;
+	return new DOMException("Aborted", "AbortError");
+}
+
+/**
+ * Promise と AbortSignal を競合させ、signal が先に abort されたら reject する。
+ * signal 側の打ち切りで即座にリジェクトさせるため、promise 実装が signal を
+ * 尊重しない（= 永久 pending のまま）場合でも呼び出し元を解放できる。
+ */
+async function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted) {
+		throw abortReasonToError(signal);
+	}
+	let onAbort: (() => void) | undefined;
+	const abortPromise = new Promise<never>((_resolve, reject) => {
+		onAbort = () => reject(abortReasonToError(signal));
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+	try {
+		return await Promise.race([promise, abortPromise]);
+	} finally {
+		if (onAbort) signal.removeEventListener("abort", onAbort);
+	}
+}
 
 /** MCP プロセスが書き込むハートビートを読み取るポート */
 export interface HeartbeatReader {
@@ -44,6 +77,8 @@ export interface RunnerDeps {
 	hangTimeoutMs?: number;
 	/** MCP wait_for_events のハートビートリーダー。設定時は SQLite のハートビートも考慮してハング判定する */
 	heartbeatReader?: HeartbeatReader;
+	/** セッション要約生成 (`sessionPort.prompt`) のタイムアウト（ms）。壊れたセッションで summary が永久に返らないときに rotation を止めないため必須。デフォルト: 30_000 */
+	summaryTimeoutMs?: number;
 }
 
 export class AgentRunner implements AiAgent {
@@ -70,6 +105,7 @@ export class AgentRunner implements AiAgent {
 	private readonly summaryWriter?: SessionSummaryWriter;
 	private readonly hangTimeoutMs: number;
 	private readonly heartbeatReader?: HeartbeatReader;
+	private readonly summaryTimeoutMs: number;
 
 	private get sessionKey(): string {
 		return `__polling__:${this.agentId}`;
@@ -89,6 +125,7 @@ export class AgentRunner implements AiAgent {
 		this.summaryWriter = deps.summaryWriter;
 		this.hangTimeoutMs = deps.hangTimeoutMs ?? DEFAULT_HANG_TIMEOUT_MS;
 		this.heartbeatReader = deps.heartbeatReader;
+		this.summaryTimeoutMs = deps.summaryTimeoutMs ?? DEFAULT_SUMMARY_TIMEOUT_MS;
 	}
 
 	send(options: SendOptions): Promise<AgentResponse> {
@@ -477,22 +514,46 @@ export class AgentRunner implements AiAgent {
 		this.logger.info(`[${this.profile.name}:${this.agentId}] session rotated after ${hours}h`);
 	}
 
+	/**
+	 * セッション要約を best-effort で生成する。
+	 *
+	 * 壊れたセッションでは `sessionPort.prompt` が永久に返らないケースがある。
+	 * この関数は timeout + runner abort を合成した AbortSignal で prompt を打ち切り、
+	 * いかなる失敗（同期 throw・reject・timeout・abort）が起きても関数全体は resolve する。
+	 * これにより呼び出し元の rotation (deleteSession / sessionStore.delete) が必ず完遂する。
+	 *
+	 * 実装メモ: `sessionPort.prompt` が signal に反応しない実装（SDK 側の不具合や
+	 * モック）でも rotation を止めないため、runner 側でも `Promise.race` により
+	 * 独立して打ち切る。SDK に signal を伝播する強化はアダプタ層で別途行う。
+	 */
 	private async generateSessionSummary(sessionId: string): Promise<void> {
 		if (this.abortController?.signal.aborted) return;
 		if (!this.contextGuildId || !this.summaryWriter || !this.profile.summaryPrompt) return;
+		const timeoutSignal = AbortSignal.timeout(this.summaryTimeoutMs);
+		const combinedSignal = this.abortController
+			? AbortSignal.any([timeoutSignal, this.abortController.signal])
+			: timeoutSignal;
 		try {
-			const { text } = await this.sessionPort.prompt({
+			const promptPromise = this.sessionPort.prompt({
 				sessionId,
 				text: this.profile.summaryPrompt,
 				model: this.profile.model,
 				tools: {},
 			});
+			const { text } = await raceAbort(promptPromise, combinedSignal);
 			if (!text.trim()) return;
 			await this.summaryWriter.write(this.contextGuildId, text);
 			this.logger.info(
 				`[${this.profile.name}:${this.agentId}] session summary saved for guild ${this.contextGuildId}`,
 			);
 		} catch (err) {
+			const name = err instanceof Error ? err.name : "";
+			if (name === "AbortError" || name === "TimeoutError") {
+				this.logger.warn(
+					`[${this.profile.name}:${this.agentId}] session summary aborted (${name}, timeout=${this.summaryTimeoutMs}ms); continuing rotation without summary`,
+				);
+				return;
+			}
 			this.logger.error(
 				`[${this.profile.name}:${this.agentId}] failed to generate session summary`,
 				err,

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -69,15 +69,18 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		return !result.error && !!result.data;
 	}
 
-	async prompt(params: OpencodePromptParams): Promise<PromptResult> {
+	async prompt(params: OpencodePromptParams, signal?: AbortSignal): Promise<PromptResult> {
 		const oc = await this.getClient();
-		const result = await oc.session.prompt({
-			sessionID: params.sessionId,
-			parts: [{ type: "text", text: params.text }],
-			model: { providerID: params.model.providerId, modelID: params.model.modelId },
-			system: params.system,
-			tools: params.tools ?? {},
-		});
+		const result = await oc.session.prompt(
+			{
+				sessionID: params.sessionId,
+				parts: [{ type: "text", text: params.text }],
+				model: { providerID: params.model.providerId, modelID: params.model.modelId },
+				system: params.system,
+				tools: params.tools ?? {},
+			},
+			{ signal },
+		);
 		if (result.error || !result.data) {
 			throw new Error(`Prompt failed: ${JSON.stringify(result.error)}`);
 		}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -254,7 +254,7 @@ export type OpencodeSessionEvent =
 export interface OpencodeSessionPort {
 	createSession(title: string): Promise<string>;
 	sessionExists(sessionId: string): Promise<boolean>;
-	prompt(params: OpencodePromptParams): Promise<PromptResult>;
+	prompt(params: OpencodePromptParams, signal?: AbortSignal): Promise<PromptResult>;
 	promptAsync(params: OpencodePromptParams): Promise<void>;
 	promptAsyncAndWatchSession(
 		params: OpencodePromptParams,

--- a/spec/agent/session-rotation-summary-isolation.spec.ts
+++ b/spec/agent/session-rotation-summary-isolation.spec.ts
@@ -1,0 +1,433 @@
+/**
+ * セッション要約生成がハング/失敗してもローテーションが完遂することを検証する仕様テスト。
+ *
+ * ## 背景
+ *
+ * 実運用で判明した問題: 壊れたセッションに summary prompt (`sessionPort.prompt(...)`)
+ * を投げても OpenCode 側が応答を返さず、rotation の後段 (`deleteSession`, `sessionStore.delete`)
+ * に到達しなくなる。これは以下 3 経路すべてで発生する:
+ *
+ *   1. hang detection 経路 (`startHangDetectionTimer`)
+ *   2. session error (retryable:false) 経路 (`startPollingLoop` 内)
+ *   3. age 超過経路 (`rotateSessionIfExpired`)
+ *
+ * ## 契約
+ *
+ * - summary 生成 (`sessionPort.prompt`) が **永久に pending のまま** でも、
+ *   rotation は `sessionPort.deleteSession` → `sessionStore.delete` まで完遂する。
+ * - summary 生成が **throw** しても、rotation は完遂する（既存契約の再確認）。
+ * - summary 生成が **正常 resolve** する場合は `summaryWriter.write` が呼ばれる（回帰防止）。
+ *
+ * ## RunnerDeps の前提
+ *
+ * - 実装側で `summaryTimeoutMs` オプションを新設する前提で、本 spec では短い値
+ *   (例: 100ms) を指定して現実時間内にテストが完了するよう構成する。
+ */
+/* oxlint-disable max-lines, max-lines-per-function -- テストファイルはケース数に応じて長くなるため許容 */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { AgentRunner, type RunnerDeps } from "@vicissitude/agent/runner";
+import type {
+	ContextBuilderPort,
+	EventBuffer,
+	OpencodeSessionEvent,
+	OpencodeSessionPort,
+	PromptResult,
+	SessionSummaryWriter,
+} from "@vicissitude/shared/types";
+
+import type { AgentProfile } from "../../packages/agent/src/profile.ts";
+import { createMockLogger } from "../test-helpers.ts";
+
+// ─── テスト用サブクラス ───────────────────────────────────────────
+
+class TestAgent extends AgentRunner {
+	sleepSpy: ((ms: number) => Promise<void>) | null = null;
+
+	// oxlint-disable-next-line no-useless-constructor -- protected → public に昇格させるために必要
+	constructor(deps: RunnerDeps) {
+		super(deps);
+	}
+
+	protected override sleep(ms: number): Promise<void> {
+		if (this.sleepSpy) return this.sleepSpy(ms);
+		return super.sleep(ms);
+	}
+}
+
+// ─── ヘルパー ─────────────────────────────────────────────────────
+
+const TEST_SUMMARY_PROMPT = "要約してください";
+/** summary prompt がハングしても現実時間内にテストが終わるよう十分短い値 */
+const SHORT_SUMMARY_TIMEOUT_MS = 100;
+
+function deferred<T>() {
+	let resolveDeferred!: (value: T) => void;
+	let rejectDeferred!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolve, reject) => {
+		resolveDeferred = resolve;
+		rejectDeferred = reject;
+	});
+	return { promise, resolve: resolveDeferred, reject: rejectDeferred };
+}
+
+function createProfile(overrides: Partial<AgentProfile> = {}): AgentProfile {
+	return {
+		name: "conversation",
+		mcpServers: {},
+		builtinTools: {},
+		pollingPrompt: "loop forever",
+		restartPolicy: "wait_for_events",
+		model: { providerId: "test-provider", modelId: "test-model" },
+		summaryPrompt: TEST_SUMMARY_PROMPT,
+		...overrides,
+	};
+}
+
+function createContextBuilder(): ContextBuilderPort {
+	return { build: mock(() => Promise.resolve("system prompt")) };
+}
+
+function createSessionStore(existingSessionId?: string) {
+	let sessionId: string | undefined = existingSessionId;
+	// age 超過経路では createdAt を過去に寄せる。ここでは未指定時 undefined のまま。
+	let createdAt: number | undefined = existingSessionId ? Date.now() - 7_200_000 : undefined;
+	return {
+		get: mock(() => sessionId),
+		getRow: mock(() => (sessionId && createdAt ? { key: "k", sessionId, createdAt } : undefined)),
+		save: mock((_profile: string, _key: string, nextSessionId: string) => {
+			sessionId = nextSessionId;
+			createdAt = Date.now();
+		}),
+		delete: mock(() => {
+			sessionId = undefined;
+			createdAt = undefined;
+		}),
+	};
+}
+
+function neverResolve(_signal: AbortSignal): Promise<void> {
+	return new Promise(() => {});
+}
+
+function createEventBuffer(waitImpl?: (signal: AbortSignal) => Promise<void>): EventBuffer {
+	return {
+		append: mock(() => {}),
+		waitForEvents: mock(waitImpl ?? neverResolve),
+	};
+}
+
+function createSummaryWriter(): SessionSummaryWriter & { write: ReturnType<typeof mock> } {
+	return {
+		write: mock(() => Promise.resolve()),
+	};
+}
+
+/**
+ * 単発 rotation 用（ポーリングループを使わず、`requestSessionRotation()` を直接呼ぶ）。
+ */
+function createSimpleSessionPort(): OpencodeSessionPort & {
+	prompt: ReturnType<typeof mock>;
+	deleteSession: ReturnType<typeof mock>;
+} {
+	return {
+		createSession: mock(() => Promise.resolve("session-1")),
+		sessionExists: mock(() => Promise.resolve(false)),
+		prompt: mock(() => Promise.resolve({ text: "要約テキスト", tokens: undefined })),
+		promptAsync: mock(() => Promise.resolve()),
+		promptAsyncAndWatchSession: mock(() => Promise.resolve({ type: "idle" as const })),
+		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
+		deleteSession: mock(() => Promise.resolve()),
+		close: mock(() => {}),
+	} as unknown as OpencodeSessionPort & {
+		prompt: ReturnType<typeof mock>;
+		deleteSession: ReturnType<typeof mock>;
+	};
+}
+
+/**
+ * エラー経路（retryable:false）のポーリングループ用。
+ * `promptAsyncAndWatchSession` は 1 回目 `firstDone`、2 回目以降 `secondDone` を返す。
+ */
+function createSessionPortForPollingLoop(
+	firstDone: Promise<OpencodeSessionEvent>,
+	secondDone: Promise<OpencodeSessionEvent>,
+): OpencodeSessionPort & {
+	prompt: ReturnType<typeof mock>;
+	deleteSession: ReturnType<typeof mock>;
+} {
+	let callCount = 0;
+	return {
+		createSession: mock(() => Promise.resolve("session-1")),
+		sessionExists: mock(() => Promise.resolve(false)),
+		prompt: mock(() => Promise.resolve({ text: "要約テキスト", tokens: undefined })),
+		promptAsync: mock(() => Promise.resolve()),
+		promptAsyncAndWatchSession: mock(() => {
+			callCount += 1;
+			return callCount === 1 ? firstDone : secondDone;
+		}),
+		waitForSessionIdle: mock(() => (callCount === 1 ? firstDone : secondDone)),
+		deleteSession: mock(() => Promise.resolve()),
+		close: mock(() => {}),
+	} as unknown as OpencodeSessionPort & {
+		prompt: ReturnType<typeof mock>;
+		deleteSession: ReturnType<typeof mock>;
+	};
+}
+
+const activeRunners = new Set<AgentRunner>();
+
+afterEach(() => {
+	for (const runner of activeRunners) {
+		runner.stop();
+	}
+	activeRunners.clear();
+});
+
+// ─── テスト ───────────────────────────────────────────────────────
+
+describe("セッション要約生成のハング隔離", () => {
+	describe("summary prompt が永久に pending のまま（hang）でも rotation は完遂する", () => {
+		test("age 超過経路: summary prompt が hang しても deleteSession / sessionStore.delete は呼ばれる", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort();
+			// summary 用 prompt が永久に resolve しない状態
+			sessionPort.prompt = mock(() => new Promise<PromptResult>(() => {}));
+
+			const summaryWriter = createSummaryWriter();
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "123456789",
+				summaryWriter,
+				summaryTimeoutMs: SHORT_SUMMARY_TIMEOUT_MS,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-hang");
+
+			// requestSessionRotation は age 超過経路でも使われる公開 API。
+			// summary が hang しても現実時間内に resolve することを期待。
+			await runner.requestSessionRotation(true);
+
+			expect(sessionPort.prompt).toHaveBeenCalledTimes(1);
+			expect(summaryWriter.write).toHaveBeenCalledTimes(0);
+			expect(sessionPort.deleteSession).toHaveBeenCalledWith("session-hang");
+			expect(sessionStore.delete).toHaveBeenCalledTimes(1);
+		});
+
+		test("hang detection 経路: summary prompt が hang しても deleteSession / sessionStore.delete は呼ばれる", async () => {
+			// waitForEvents が永遠に待機（hang 状態）
+			const eventBuffer = createEventBuffer(() => new Promise(() => {}));
+			const sessionPort = createSimpleSessionPort();
+			sessionPort.prompt = mock(() => new Promise<PromptResult>(() => {}));
+
+			const summaryWriter = createSummaryWriter();
+			const sessionStore = createSessionStore("existing-session-id");
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "123456789",
+				summaryWriter,
+				hangTimeoutMs: 50,
+				summaryTimeoutMs: SHORT_SUMMARY_TIMEOUT_MS,
+			});
+			runner.sleepSpy = () => Promise.resolve();
+			activeRunners.add(runner);
+
+			runner.ensurePolling();
+
+			// hangTimeoutMs (50ms) 経過で rotation が発動し、
+			// summary prompt hang (永久 pending) でも summaryTimeoutMs (100ms) 後に
+			// rotation が続行される。マージンを取って 400ms 待機。
+			await Bun.sleep(400);
+
+			expect(sessionPort.deleteSession).toHaveBeenCalledWith("existing-session-id");
+			expect(sessionStore.delete).toHaveBeenCalled();
+
+			runner.stop();
+		});
+
+		test("retryable:false エラー経路: summary prompt が hang しても deleteSession / sessionStore.delete は呼ばれる", async () => {
+			const firstEvent = deferred<void>();
+			const firstSessionDone = deferred<OpencodeSessionEvent>();
+			const secondSessionDone = deferred<OpencodeSessionEvent>();
+			const eventBuffer = createEventBuffer(() => firstEvent.promise);
+			const sessionPort = createSessionPortForPollingLoop(
+				firstSessionDone.promise,
+				secondSessionDone.promise,
+			);
+			// summary 用 prompt が永久に resolve しない
+			sessionPort.prompt = mock(() => new Promise<PromptResult>(() => {}));
+
+			const summaryWriter = createSummaryWriter();
+			const sessionStore = createSessionStore("existing-session-id");
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "123456789",
+				summaryWriter,
+				summaryTimeoutMs: SHORT_SUMMARY_TIMEOUT_MS,
+			});
+			runner.sleepSpy = () => Promise.resolve();
+			activeRunners.add(runner);
+
+			runner.ensurePolling();
+			firstEvent.resolve();
+			await Bun.sleep(0);
+
+			// retryable:false の session error → 即時ローテーション経路
+			firstSessionDone.resolve({
+				type: "error",
+				message: "Bad Request",
+				status: 400,
+				retryable: false,
+			});
+
+			// summary prompt の timeout (100ms) 経過後に rotation が完遂することを確認。
+			// マージンを取って 400ms 待機。
+			await Bun.sleep(400);
+
+			expect(sessionPort.deleteSession).toHaveBeenCalled();
+			expect(sessionStore.delete).toHaveBeenCalled();
+
+			runner.stop();
+			secondSessionDone.resolve({ type: "cancelled" });
+		});
+	});
+
+	describe("summary prompt が throw しても rotation は完遂する（既存契約の再確認）", () => {
+		test("age 超過経路: prompt が reject しても deleteSession / sessionStore.delete は呼ばれる", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort();
+			sessionPort.prompt = mock(() => Promise.reject(new Error("prompt failed")));
+
+			const summaryWriter = createSummaryWriter();
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "123456789",
+				summaryWriter,
+				summaryTimeoutMs: SHORT_SUMMARY_TIMEOUT_MS,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-throw");
+
+			await runner.requestSessionRotation(true);
+
+			expect(sessionPort.prompt).toHaveBeenCalledTimes(1);
+			expect(summaryWriter.write).toHaveBeenCalledTimes(0);
+			expect(sessionPort.deleteSession).toHaveBeenCalledWith("session-throw");
+			expect(sessionStore.delete).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("summary prompt が正常 resolve する場合は summaryWriter.write が呼ばれる（回帰防止）", () => {
+		test("age 超過経路: prompt 正常時は write が呼ばれ、rotation も完遂する", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort();
+			sessionPort.prompt = mock(() =>
+				Promise.resolve({ text: "これは会話の要約", tokens: undefined }),
+			);
+
+			const summaryWriter = createSummaryWriter();
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "123456789",
+				summaryWriter,
+				summaryTimeoutMs: SHORT_SUMMARY_TIMEOUT_MS,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-ok");
+
+			await runner.requestSessionRotation(true);
+
+			expect(sessionPort.prompt).toHaveBeenCalledTimes(1);
+			expect(summaryWriter.write).toHaveBeenCalledTimes(1);
+			expect(summaryWriter.write).toHaveBeenCalledWith("123456789", "これは会話の要約");
+			expect(sessionPort.deleteSession).toHaveBeenCalledWith("session-ok");
+			expect(sessionStore.delete).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("summary timeout のタイミング契約", () => {
+		test("summary prompt が hang しても rotation 全体は summaryTimeoutMs + α 以内に完了する", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort();
+			sessionPort.prompt = mock(() => new Promise<PromptResult>(() => {}));
+
+			const summaryWriter = createSummaryWriter();
+			const sessionStore = createSessionStore();
+
+			const summaryTimeoutMs = SHORT_SUMMARY_TIMEOUT_MS;
+			// タイムアウト判定のマージン: 現実の setTimeout 誤差 + 後続処理時間を吸収
+			const marginMs = 500;
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "123456789",
+				summaryWriter,
+				summaryTimeoutMs,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-hang");
+
+			const start = Date.now();
+			await runner.requestSessionRotation(true);
+			const elapsed = Date.now() - start;
+
+			expect(elapsed).toBeLessThan(summaryTimeoutMs + marginMs);
+			expect(sessionPort.deleteSession).toHaveBeenCalled();
+			expect(sessionStore.delete).toHaveBeenCalled();
+		});
+	});
+});

--- a/spec/agent/session-summary.spec.ts
+++ b/spec/agent/session-summary.spec.ts
@@ -694,7 +694,7 @@ describe("AgentRunner セッション要約引き継ぎ", () => {
 	});
 
 	describe("prompt(要約) の呼び出しパラメータ", () => {
-		test("prompt は sessionId・summaryPrompt・model で呼ばれる", async () => {
+		test("prompt は sessionId・summaryPrompt・model・AbortSignal で呼ばれる", async () => {
 			const eventBuffer = createEventBuffer(() => Promise.resolve());
 			const sessionPort = createSimpleSessionPort();
 
@@ -719,12 +719,15 @@ describe("AgentRunner セッション要約引き継ぎ", () => {
 
 			await runner.requestSessionRotation();
 
-			expect(sessionPort.prompt).toHaveBeenCalledWith({
-				sessionId: "session-xyz",
-				text: TEST_SUMMARY_PROMPT,
-				model: { providerId: "test-provider", modelId: "test-model" },
-				tools: {},
-			});
+			expect(sessionPort.prompt).toHaveBeenCalledWith(
+				{
+					sessionId: "session-xyz",
+					text: TEST_SUMMARY_PROMPT,
+					model: { providerId: "test-provider", modelId: "test-model" },
+					tools: {},
+				},
+				expect.any(AbortSignal),
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- 壊れたセッションで \`sessionPort.prompt\` が永久 pending となり、\`requestSessionRotation\` / \`rotateSessionIfExpired\` が \`deleteSession\` / \`sessionStore.delete\` に到達せずローテーションが完遂しない不具合を修正。
- \`generateSessionSummary\` を **AbortSignal + timeout 付き best-effort** 化。summary が hang・timeout・throw のいずれでも rotation は必ず完遂する。
- 実ログで \`requesting session rotation\` は 10 分おきに連発する一方、\`session force-rotated (stuck recovery)\` / \`created new session\` が **0 件**だったことから根本原因を特定。

## 真因

\`requestSessionRotation\` は以下の順序で処理する:

\`\`\`ts
await this.generateSessionSummary(sessionId);      // ← ここで詰まる
await this.sessionPort.deleteSession(sessionId);   // 到達しない
this.sessionStore.delete(...);                     // 到達しない
this.logger.info("session force-rotated");         // 到達しない
\`\`\`

\`generateSessionSummary\` は \`sessionPort.prompt\` で同じ壊れた session に summary プロンプトを投げるが、ContextOverflowError 状態等では OpenCode 側の応答が返らず **永久 await**。既存の \`try/catch\` は同期 throw しか拾えないので、pending promise は救えない。

## 修正内容

| ファイル | 変更内容 |
|---|---|
| \`packages/shared/src/types.ts\` | \`OpencodeSessionPort.prompt\` に \`signal?: AbortSignal\` 第 2 引数追加（optional） |
| \`packages/opencode/src/session-adapter.ts\` | 受け取った signal を \`oc.session.prompt(..., { signal })\` で SDK に伝播 |
| \`packages/agent/src/runner.ts\` | \`DEFAULT_SUMMARY_TIMEOUT_MS=30_000\` 定数 + \`RunnerDeps.summaryTimeoutMs?: number\` DI。\`generateSessionSummary\` で \`AbortSignal.any([AbortSignal.timeout(...), abortController.signal])\` 合成 + \`raceAbort\` による二重防御。\`AbortError\`/\`TimeoutError\` は warn ログで継続、他例外は従来どおり error |
| \`packages/agent/src/runner.test.ts\` | \`raceAbort\` / \`abortReasonToError\` / 内部分岐 / DI の unit test 追加（+577 行、39 test all pass） |
| \`spec/agent/session-rotation-summary-isolation.spec.ts\`（新規） | 公開契約: summary hang / reject / timeout / runner stop 中断でも rotation が完遂（6 test all pass） |

## 設計判断

- **二重防御**: SDK に signal を伝播するだけでなく、runner 側でも \`Promise.race\` で独立に打ち切る。SDK バージョンアップ / mock の signal 未対応に備える。将来 SDK の signal サポートが十分信頼できるようになれば simplify 可能（別 Issue 予定）
- **\`summaryTimeoutMs\` は \`RunnerDeps\` で DI**: テスト可能性のため。\`hangTimeoutMs\` と同じ取り扱い。デフォルト 30_000 ms は summary プロンプトが tools 無し 500 文字以内という軽量処理である事から妥当と判断

## Test plan

- [x] \`nr test:spec\`: **1419 pass / 0 fail**
- [x] \`nr test:unit\`: **467 pass / 0 fail**
- [x] \`nr validate\`: PASS (fmt:check + lint 0 errors + tsgo --noEmit)
- [x] 新規 spec 単独: \`spec/agent/session-rotation-summary-isolation.spec.ts\` 6 test 全 pass
- [ ] デプロイ後、ログで \`session force-rotated (stuck recovery)\` / \`created new session\` が出現すること、\`hang detected\` の連発が止まることを確認

## 後続 Issue 候補（別途起票予定）

- \`raceAbort\` / \`abortReasonToError\` の将来的削除検討（SDK signal 信頼度次第で simplify）
- README にセッションローテーション + summary 生成仕様の追記（先行課題、本 PR スコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)