### PR TITLE
refactor: raceAbort を @vicissitude/shared/functions に集約 (#654)

### DIFF
--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable max-lines, max-lines-per-function -- AgentRunner のポーリングループ・セッション管理が密結合のため分割困難 */
 import { METRIC, recordTokenMetrics } from "@vicissitude/observability/metrics";
+import { raceAbort } from "@vicissitude/shared/functions";
 import type {
 	AgentResponse,
 	AiAgent,
@@ -21,38 +22,6 @@ const INITIAL_RECONNECT_DELAY_MS = 2_000;
 const IDLE_COOLDOWN_MS = 2_000;
 const DEFAULT_HANG_TIMEOUT_MS = 600_000;
 const DEFAULT_SUMMARY_TIMEOUT_MS = 30_000;
-
-/**
- * AbortSignal の abort reason を Error に正規化する。
- * `AbortSignal.timeout` → `TimeoutError` (DOMException)、
- * `AbortController.abort()` → 任意の reason (未設定なら DOMException "AbortError")。
- */
-function abortReasonToError(signal: AbortSignal): Error {
-	const reason = signal.reason;
-	if (reason instanceof Error) return reason;
-	return new DOMException("Aborted", "AbortError");
-}
-
-/**
- * Promise と AbortSignal を競合させ、signal が先に abort されたら reject する。
- * signal 側の打ち切りで即座にリジェクトさせるため、promise 実装が signal を
- * 尊重しない（= 永久 pending のまま）場合でも呼び出し元を解放できる。
- */
-async function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
-	if (signal.aborted) {
-		throw abortReasonToError(signal);
-	}
-	let onAbort: (() => void) | undefined;
-	const abortPromise = new Promise<never>((_resolve, reject) => {
-		onAbort = () => reject(abortReasonToError(signal));
-		signal.addEventListener("abort", onAbort, { once: true });
-	});
-	try {
-		return await Promise.race([promise, abortPromise]);
-	} finally {
-		if (onAbort) signal.removeEventListener("abort", onAbort);
-	}
-}
 
 /** MCP プロセスが書き込むハートビートを読み取るポート */
 export interface HeartbeatReader {

--- a/packages/shared/src/functions.ts
+++ b/packages/shared/src/functions.ts
@@ -33,7 +33,14 @@ export function delayResolve<T>(ms: number, value: T): Promise<T> {
 	});
 }
 
-// ─── withTimeout ─────────────────────────────────────────────────
+// ─── withTimeout / raceAbort ─────────────────────────────────────
+//
+// タイムアウト系ヘルパーの使い分けポリシー:
+// - `withTimeout`: setTimeout ベース。呼び出し先に AbortSignal を伝播する必要がない
+//   ケース（内部処理のみで完結する操作）に使う。
+// - `raceAbort`:   AbortSignal ベース。呼び出し先（SDK / fetch 等）に signal を
+//   伝播してキャンセルさせたい、または外部から既存の signal で打ち切りたい
+//   ケースに使う。`AbortSignal.timeout(ms)` と組み合わせれば時間打ち切りも可能。
 
 export async function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
@@ -45,5 +52,39 @@ export async function withTimeout<T>(promise: Promise<T>, ms: number, message: s
 		return await Promise.race([promise, timeout]);
 	} finally {
 		if (timer) clearTimeout(timer);
+	}
+}
+
+/**
+ * AbortSignal.reason を Error に正規化する。
+ * `AbortSignal.timeout` 由来は `TimeoutError` (DOMException)、
+ * `AbortController.abort()` は reason 自体（Error でなければ `AbortError` に正規化）。
+ */
+function abortReasonToError(signal: AbortSignal): Error {
+	const reason = signal.reason;
+	if (reason instanceof Error) return reason;
+	return new DOMException("Aborted", "AbortError");
+}
+
+/**
+ * Promise と AbortSignal を競合させ、signal が先に abort されたら reject する。
+ * signal 側の打ち切りで即座にリジェクトさせるため、promise 実装が signal を
+ * 尊重しない（= 永久 pending のまま）場合でも呼び出し元を解放できる。
+ *
+ * reject 値は `abortReasonToError` で正規化された Error。
+ */
+export async function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted) {
+		throw abortReasonToError(signal);
+	}
+	let onAbort: (() => void) | undefined;
+	const abortPromise = new Promise<never>((_resolve, reject) => {
+		onAbort = () => reject(abortReasonToError(signal));
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+	try {
+		return await Promise.race([promise, abortPromise]);
+	} finally {
+		if (onAbort) signal.removeEventListener("abort", onAbort);
 	}
 }


### PR DESCRIPTION
## Summary

Issue #654 の対応。PR #651 のレビュー指摘 (design-reviewer) フォローアップ。

- `raceAbort` を `packages/agent/src/runner.ts` から `packages/shared/src/functions.ts` に移動し、他パッケージから再利用可能にする
- `abortReasonToError` は `raceAbort` 内部専用ヘルパーとして shared 内に閉じる（module private、export しない）
- `withTimeout` と `raceAbort` の使い分けポリシーを functions.ts のコメントに明記

## Policy（functions.ts コメントに明記）

- `withTimeout`: setTimeout ベース。呼び出し先に AbortSignal を伝播する必要がない内部処理に使う。
- `raceAbort`: AbortSignal ベース。呼び出し先（SDK / fetch 等）に signal を伝播してキャンセルさせたい、または外部 signal で打ち切りたいケースに使う。

`withTimeout` は AbortSignal を扱えないため、signal 伝播を要する用途との統合はせず併存とする。

## Test plan

- [x] `nr validate`: 0 errors, 2 warnings（既存のみ）
- [x] `nr test`: 1886 pass / 0 fail
- [x] spec テスト (`spec/agent/*`) は内部関数名に依存していないため影響なし
- [x] unit テスト (`packages/agent/src/runner.test.ts`) はふるまい観察のため関数移動の影響なし

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)