### PR TITLE
fix: classifyEvent で session.deleted を terminal event として扱う (#656)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,6 @@
       "dependencies": {
         "@sinclair/typebox": "^0.34.48",
         "@vicissitude/avatar": "workspace:*",
-        "@vicissitude/observability": "workspace:*",
         "@vicissitude/shared": "workspace:*",
         "elysia": "^1.4.27",
       },

--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -761,13 +761,10 @@ describe("AgentRunner", () => {
 		await Bun.sleep(0);
 		await Bun.sleep(0);
 
-		// session_deleted_rotation ラベルで incrementCounter が呼ばれている
-		const deletedRotationCalls = metrics.incrementCounter.mock.calls.filter(
-			(args) => (args[1] as { reason?: string } | undefined)?.reason === "session_deleted_rotation",
-		);
-		expect(deletedRotationCalls.length).toBe(1);
-		// メトリクス名は session_restarts_total
-		expect(deletedRotationCalls[0]?.[0]).toBe("session_restarts_total");
+		// session_restarts_total メトリクスが reason=session_deleted_rotation で呼ばれている
+		expect(metrics.incrementCounter).toHaveBeenCalledWith("session_restarts_total", {
+			reason: "session_deleted_rotation",
+		});
 
 		runner.stop();
 		secondSessionDone.resolve({ type: "cancelled" });

--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -717,6 +717,216 @@ describe("AgentRunner", () => {
 		secondSessionDone.resolve({ type: "cancelled" });
 	});
 
+	test("deleted イベント受信時に SESSION_RESTARTS が reason=session_deleted_rotation でインクリメントされる", async () => {
+		const firstEvent = deferred<void>();
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		let sessionWatchCount = 0;
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			return sessionWatchCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+		});
+		const sessionStore = createSessionStore();
+		const metrics = {
+			incrementCounter: mock(() => {}),
+			addCounter: mock(() => {}),
+			setGauge: mock(() => {}),
+			incrementGauge: mock(() => {}),
+			decrementGauge: mock(() => {}),
+			observeHistogram: mock(() => {}),
+		};
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: sessionStore as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+			metrics,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+
+		// deleted イベント発火
+		firstSessionDone.resolve({ type: "deleted" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// session_deleted_rotation ラベルで incrementCounter が呼ばれている
+		const deletedRotationCalls = metrics.incrementCounter.mock.calls.filter(
+			(args) => (args[1] as { reason?: string } | undefined)?.reason === "session_deleted_rotation",
+		);
+		expect(deletedRotationCalls.length).toBe(1);
+		// メトリクス名は session_restarts_total
+		expect(deletedRotationCalls[0]?.[0]).toBe("session_restarts_total");
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("deleted イベント受信時に requestSessionRotation(force=true) が呼ばれる（throttle 回避）", async () => {
+		const firstEvent = deferred<void>();
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		let sessionWatchCount = 0;
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			return sessionWatchCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+		});
+		const sessionStore = createSessionStore();
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: sessionStore as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		const rotationSpy = mock(() => Promise.resolve());
+		runner.requestSessionRotation = rotationSpy;
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+
+		firstSessionDone.resolve({ type: "deleted" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// requestSessionRotation が呼ばれ、かつ force=true が渡されている
+		expect(rotationSpy).toHaveBeenCalledTimes(1);
+		expect(rotationSpy).toHaveBeenCalledWith(true);
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("handleSessionEnd: deleted イベントで warn ログが出力される", async () => {
+		const firstEvent = deferred<void>();
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		let sessionWatchCount = 0;
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			return sessionWatchCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+		});
+		const logger = createMockLogger();
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger,
+			sessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		// requestSessionRotation をモックして副作用を止める（warn ログ検証のノイズを減らす）
+		runner.requestSessionRotation = mock(() => Promise.resolve());
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		await Bun.sleep(0);
+
+		firstSessionDone.resolve({ type: "deleted" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// "deleted externally" を含む warn ログが出ている
+		const warnMessages = (logger.warn as ReturnType<typeof mock>).mock.calls
+			.map((args) => String(args[0]))
+			.join("\n");
+		expect(warnMessages).toContain("deleted externally");
+		// error ログは出ていない
+		expect(logger.error).toHaveBeenCalledTimes(0);
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("deleted 後に delay が INITIAL_RECONNECT_DELAY_MS にリセットされる", async () => {
+		// deleted → rotation → 次の error で backoff が 2s から始まることを確認
+		const firstEvent = deferred<void>();
+		const eventBuffer = createEventBuffer(() => firstEvent.promise);
+		let sessionWatchCount = 0;
+		const lastSession = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			if (sessionWatchCount === 1) {
+				// まず error を何度か経験させて delay を膨らませる
+				return Promise.resolve({ type: "error", message: "err", retryable: true as const });
+			}
+			if (sessionWatchCount === 2) {
+				return Promise.resolve({ type: "error", message: "err", retryable: true as const });
+			}
+			if (sessionWatchCount === 3) {
+				// deleted で delay リセット
+				return Promise.resolve({ type: "deleted" as const });
+			}
+			if (sessionWatchCount === 4) {
+				// リセット確認用の error
+				return Promise.resolve({ type: "error", message: "err", retryable: true as const });
+			}
+			return lastSession.promise;
+		});
+
+		const sleepCalls: number[] = [];
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms) => {
+			sleepCalls.push(ms);
+			return Promise.resolve();
+		};
+		// requestSessionRotation はスタブ化（実際の delete 等の副作用を止める）
+		runner.requestSessionRotation = mock(() => Promise.resolve());
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		firstEvent.resolve();
+		for (let i = 0; i < 30; i++) {
+			// eslint-disable-next-line no-await-in-loop
+			await Bun.sleep(0);
+		}
+
+		// error×2 で sleep が 2000, 4000 と進み、deleted 後の error では 2000 に戻る
+		expect(sleepCalls[0]).toBe(2000);
+		expect(sleepCalls[1]).toBe(4000);
+		// deleted 後の最初の error 時の sleep は INITIAL に戻っている
+		expect(sleepCalls[2]).toBe(2000);
+
+		runner.stop();
+		lastSession.resolve({ type: "cancelled" });
+	});
+
 	test("send() はポーリングループが未起動なら自動起動する", async () => {
 		const firstEvent = deferred<void>();
 		const sessionDone = deferred<OpencodeSessionEvent>();

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -201,6 +201,17 @@ export class AgentRunner implements AiAgent {
 				this.handleSessionEnd(event);
 				if (event.type === "cancelled") return;
 
+				if (event.type === "deleted") {
+					this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, {
+						reason: "session_deleted_rotation",
+					});
+					// eslint-disable-next-line no-await-in-loop -- rotation after external deletion
+					await this.requestSessionRotation(true);
+					delay = INITIAL_RECONNECT_DELAY_MS;
+					prevSleepWasCapped = false;
+					continue;
+				}
+
 				// compacted / streamDisconnected: セッションはまだ生きており LLM がポーリングを続けているため、
 				// waitForEvents を挟まず即座にセッション監視を再開する。
 				// rotateSessionIfExpired もスキップする（セッション削除すると rewatch が空振りする）。
@@ -421,6 +432,12 @@ export class AgentRunner implements AiAgent {
 					trigger: "polling",
 				});
 			}
+			return;
+		}
+		if (event.type === "deleted") {
+			this.logger.warn(
+				`[${this.profile.name}:${this.agentId}] session deleted externally, will rotate`,
+			);
 			return;
 		}
 		this.logger.error(`[${this.profile.name}:${this.agentId}] session error event`, event.message);

--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -122,6 +122,10 @@ export function classifyEvent(
 		const compacted = typed;
 		if (compacted.properties.sessionID === sessionId) return { type: "compacted" };
 	}
+	if (typed.type === "session.deleted") {
+		const deleted = typed;
+		if (deleted.properties.info.id === sessionId) return { type: "deleted" };
+	}
 	if (typed.type === "session.error") {
 		const err = typed;
 		if (err.properties.sessionID === sessionId) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -240,6 +240,7 @@ export type OpencodeSessionEvent =
 	| { type: "compacted" }
 	| { type: "streamDisconnected"; tokens?: TokenUsage }
 	| { type: "cancelled" }
+	| { type: "deleted" }
 	| {
 			type: "error";
 			message: string;

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -287,6 +287,30 @@ describe("classifyEvent", () => {
 		expect(result).toEqual({ type: "compacted" });
 	});
 
+	test("session.deleted イベントで { type: 'deleted' } を返す", () => {
+		// SDK v2 の EventSessionDeleted は properties.info: Session を持ち、
+		// セッション ID は info.id で識別する
+		const event = {
+			type: "session.deleted",
+			properties: { info: { id: sessionId } },
+		} as unknown as Event;
+
+		const result = classifyEvent(event, sessionId, new Map());
+
+		expect(result).toEqual({ type: "deleted" });
+	});
+
+	test("別セッション ID の session.deleted は null を返す", () => {
+		const event = {
+			type: "session.deleted",
+			properties: { info: { id: "other-session" } },
+		} as unknown as Event;
+
+		const result = classifyEvent(event, sessionId, new Map());
+
+		expect(result).toBeNull();
+	});
+
 	test("message.updated イベントはトークンを蓄積し null を返す", () => {
 		const tokensByMessage = new Map<string, TokenUsage>();
 		const event = {


### PR DESCRIPTION
## Summary

- `classifyEvent` に `session.deleted` 分岐を追加し、自セッション ID 一致時に `{ type: "deleted" }` を返す
- runner で `deleted` を受けた際に強制セッションローテーション (`requestSessionRotation(true)`) で復旧する
- `OpencodeSessionEvent` 型に `{ type: "deleted" }` バリアントを追加

## 設計判断

`session.deleted` を cancelled に寄せず独立バリアントとした。cancelled は signal abort による自己取消で runner ループを終了するのに対し、deleted は外部要因によるセッション消滅でセッションローテーションによる復旧が必要で、意味が異なるため。

## 実装メモ

- SDK v2 の `EventSessionDeleted` は `properties.sessionID` ではなく `properties.info.id` でセッション ID を保持するため、他 session.* イベントとは判定キーが異なる
- `SESSION_RESTARTS` メトリクスに新 reason ラベル `session_deleted_rotation` を追加

## Test plan

- [x] `nr test:spec` — 1421 pass / 0 fail
- [x] `nr test:unit` — 471 pass / 0 fail
- [x] `nr lint` — 0 errors
- [x] `nr check` — 変更範囲 0 errors（apps/web の `routeTree.gen` 関連 2 件は既存 / 無関係）

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)