### PR TITLE
fix(opencode): classifyEvent で sessionID 未設定の session.error を終端エラー扱い (#657)

### DIFF
--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -128,7 +128,10 @@ export function classifyEvent(
 	}
 	if (typed.type === "session.error") {
 		const err = typed;
-		if (err.properties.sessionID === sessionId) {
+		// SDK v2 では sessionID は optional。未設定の場合は OpenCode がサーバ全体の
+		// エラーとして発火しているため、現在監視中のセッションにも終端エラーとして伝播させる。
+		const eventSessionId = err.properties.sessionID;
+		if (eventSessionId === sessionId || eventSessionId === undefined) {
 			return {
 				type: "error",
 				message: JSON.stringify(err.properties),

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -347,6 +347,53 @@ describe("classifyEvent", () => {
 
 		expect(result).toBeNull();
 	});
+
+	test("session.error で sessionID が undefined の場合もエラーとして扱う", () => {
+		// SDK v2 では EventSessionError.properties.sessionID は optional。
+		// OpenCode がサーバ全体のエラーとして sessionID 無しで session.error を
+		// 発火した場合、現在監視中のセッションに対しても終端エラーとして扱う必要がある。
+		const event = {
+			type: "session.error",
+			properties: {
+				error: {
+					name: "APIError",
+					data: {
+						message: "Server-wide failure",
+						statusCode: 500,
+						isRetryable: false,
+					},
+				},
+			},
+		} as unknown as Event;
+
+		const result = classifyEvent(event, sessionId, new Map());
+
+		expect(result).not.toBeNull();
+		expect(result?.type).toBe("error");
+		if (result?.type !== "error") throw new Error("unreachable");
+		expect(result.errorClass).toBe("APIError");
+	});
+
+	test("session.error で別セッション ID の場合は null を返す（sessionID 未設定ケースと区別）", () => {
+		const event = {
+			type: "session.error",
+			properties: {
+				sessionID: "other-session",
+				error: {
+					name: "APIError",
+					data: {
+						message: "Other session failure",
+						statusCode: 500,
+						isRetryable: false,
+					},
+				},
+			},
+		} as unknown as Event;
+
+		const result = classifyEvent(event, sessionId, new Map());
+
+		expect(result).toBeNull();
+	});
 });
 
 // ─── extractText ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `classifyEvent` の `session.error` 分岐で、SDK v2 の `EventSessionError.properties.sessionID` が optional である仕様に追従
- `sessionID` が `undefined` の場合は OpenCode がサーバ全体のエラーとして発火しているとみなし、現在監視中のセッションに対しても終端エラーとして伝播させる
- spec テストに再現・回帰ケースを追加

Closes #657

## Test plan

- [x] `nr test:spec -- spec/opencode/stream-helpers.spec.ts` — 新規追加含め classifyEvent 関連テスト全 pass
- [x] `nr test` — 1894 pass / 0 fail（回帰なし）
- [x] `nr lint` — 変更箇所の警告・エラーなし（既存の warning 2 件のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)