### PR TITLE
docs(spec): summary abort/timeout 時の callOrder を明文化 (#655)

### DIFF
--- a/spec/agent/session-rotation-summary-isolation.spec.ts
+++ b/spec/agent/session-rotation-summary-isolation.spec.ts
@@ -391,6 +391,134 @@ describe("セッション要約生成のハング隔離", () => {
 		});
 	});
 
+	describe("summary abort/timeout 時の callOrder 契約", () => {
+		test("summary prompt が hang (timeout) した場合: callOrder は ['prompt', 'deleteSession'] で write はスキップ", async () => {
+			const callOrder: string[] = [];
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort();
+			sessionPort.prompt = mock(() => {
+				callOrder.push("prompt");
+				return new Promise<PromptResult>(() => {});
+			});
+			sessionPort.deleteSession = mock(() => {
+				callOrder.push("deleteSession");
+				return Promise.resolve();
+			});
+
+			const summaryWriter = createSummaryWriter();
+			summaryWriter.write = mock(() => {
+				callOrder.push("write");
+				return Promise.resolve();
+			});
+
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "123456789",
+				summaryWriter,
+				summaryTimeoutMs: SHORT_SUMMARY_TIMEOUT_MS,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-hang");
+
+			await runner.requestSessionRotation(true);
+
+			expect(callOrder).toEqual(["prompt", "deleteSession"]);
+			expect(summaryWriter.write).toHaveBeenCalledTimes(0);
+		});
+
+		test("summary prompt が throw (reject) した場合: callOrder は ['prompt', 'deleteSession'] で write はスキップ", async () => {
+			const callOrder: string[] = [];
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort();
+			sessionPort.prompt = mock(() => {
+				callOrder.push("prompt");
+				return Promise.reject(new Error("prompt failed"));
+			});
+			sessionPort.deleteSession = mock(() => {
+				callOrder.push("deleteSession");
+				return Promise.resolve();
+			});
+
+			const summaryWriter = createSummaryWriter();
+			summaryWriter.write = mock(() => {
+				callOrder.push("write");
+				return Promise.resolve();
+			});
+
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "123456789",
+				summaryWriter,
+				summaryTimeoutMs: SHORT_SUMMARY_TIMEOUT_MS,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-throw");
+
+			await runner.requestSessionRotation(true);
+
+			expect(callOrder).toEqual(["prompt", "deleteSession"]);
+			expect(summaryWriter.write).toHaveBeenCalledTimes(0);
+		});
+	});
+
+	describe("summary signal 伝播契約", () => {
+		test("sessionPort.prompt には AbortSignal が渡され、summary timeout 経過後は aborted となる", async () => {
+			const eventBuffer = createEventBuffer(() => Promise.resolve());
+			const sessionPort = createSimpleSessionPort();
+
+			let capturedSignal: AbortSignal | undefined;
+			sessionPort.prompt = mock((_params: unknown, signal?: AbortSignal) => {
+				capturedSignal = signal;
+				return new Promise<PromptResult>(() => {});
+			});
+
+			const summaryWriter = createSummaryWriter();
+			const sessionStore = createSessionStore();
+
+			const runner = new TestAgent({
+				profile: createProfile(),
+				agentId: "guild-1",
+				sessionStore: sessionStore as never,
+				contextBuilder: createContextBuilder(),
+				logger: createMockLogger(),
+				sessionPort: sessionPort as unknown as OpencodeSessionPort,
+				eventBuffer,
+				sessionMaxAgeMs: 3_600_000,
+				contextGuildId: "123456789",
+				summaryWriter,
+				summaryTimeoutMs: SHORT_SUMMARY_TIMEOUT_MS,
+			});
+			activeRunners.add(runner);
+
+			sessionStore.save("conversation", "__polling__:guild-1", "session-hang");
+
+			await runner.requestSessionRotation(true);
+
+			expect(capturedSignal).toBeInstanceOf(AbortSignal);
+			expect(capturedSignal?.aborted).toBe(true);
+		});
+	});
+
 	describe("summary timeout のタイミング契約", () => {
 		test("summary prompt が hang しても rotation 全体は summaryTimeoutMs + α 以内に完了する", async () => {
 			const eventBuffer = createEventBuffer(() => Promise.resolve());

--- a/spec/agent/session-summary.spec.ts
+++ b/spec/agent/session-summary.spec.ts
@@ -141,8 +141,15 @@ afterEach(() => {
 // ─── テスト ───────────────────────────────────────────────────────
 
 describe("AgentRunner セッション要約引き継ぎ", () => {
+	/**
+	 * 本 describe の callOrder 契約は **summary 成功時のみ** を記述する。
+	 *
+	 * summary がタイムアウト / アボート / reject した場合は、
+	 * `write` はスキップされて callOrder が `["prompt", "deleteSession"]` となる。
+	 * その隔離契約は `spec/agent/session-rotation-summary-isolation.spec.ts` を参照。
+	 */
 	describe("rotateSessionIfExpired での要約生成", () => {
-		test("セッションローテーション時に prompt → summaryWriter.write の順で呼ばれる", async () => {
+		test("セッションローテーション時に prompt → summaryWriter.write の順で呼ばれる（summary 成功時のみ）", async () => {
 			const callOrder: string[] = [];
 
 			const firstEvent = deferred<void>();
@@ -199,7 +206,7 @@ describe("AgentRunner セッション要約引き継ぎ", () => {
 			secondSessionDone.resolve({ type: "cancelled" });
 		});
 
-		test("summaryWriter.write は sessionPort.deleteSession より前に呼ばれる", async () => {
+		test("summaryWriter.write は sessionPort.deleteSession より前に呼ばれる（summary 成功時のみ）", async () => {
 			const callOrder: string[] = [];
 
 			const firstEvent = deferred<void>();


### PR DESCRIPTION
## Summary

Issue #655 対応。`generateSessionSummary` が timeout / abort / reject した場合の callOrder 契約を spec で明文化する。

## Changes

- `spec/agent/session-summary.spec.ts`
  - 既存の callOrder 契約テスト (`["prompt", "write"]` および `["prompt", "write", "deleteSession"]`) のタイトルに「（summary 成功時のみ）」を追記
  - describe ブロック冒頭にコメントを追加し、abort/timeout 時の隔離契約は `session-rotation-summary-isolation.spec.ts` を参照するよう導線を引く
- `spec/agent/session-rotation-summary-isolation.spec.ts`
  - summary prompt が hang (timeout) / throw (reject) した場合に callOrder が `["prompt", "deleteSession"]` となり `summaryWriter.write` がスキップされる契約を追加
  - `sessionPort.prompt` に渡された AbortSignal が summary timeout 経過後に `aborted = true` となる signal 伝播契約を追加

## Test plan

- [x] `nr test:spec` が全 pass (1426 tests)
- [x] `nr validate` で fmt:check / lint / check が全て通る (0 errors)
- [x] 追加した spec テストが AgentRunner の実装 (PR #654) に対して pass する

## Issue

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)