### PR TITLE
chore(deps): @opencode-ai/sdk 1.4.3 → 1.4.6 追従

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "vicissitude",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@opencode-ai/sdk": "^1.4.3",
+        "@opencode-ai/sdk": "^1.4.6",
         "canvas": "^3.2.1",
         "discord.js": "^14.25.1",
         "drizzle-orm": "^0.45.1",
@@ -137,7 +137,7 @@
     "packages/opencode": {
       "name": "@vicissitude/opencode",
       "dependencies": {
-        "@opencode-ai/sdk": "^1.4.3",
+        "@opencode-ai/sdk": "^1.4.6",
       },
     },
     "packages/scheduling": {
@@ -303,7 +303,7 @@
 
     "@monogrid/gainmap-js": ["@monogrid/gainmap-js@3.4.0", "", { "dependencies": { "promise-worker-transferable": "^1.0.4" }, "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.4.3", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.4.6", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-sQaVfEfQW3m3DeCVlurSTUjgIYdIk+gIfOys51MVFYzJHw+FyjjuAt7EKKA+LeZU5AiWGlpkIRa1rJo5KWMXCw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.1",
-		"@opencode-ai/sdk": "^1.4.3",
+		"@opencode-ai/sdk": "^1.4.6",
 		"canvas": "^3.2.1",
 		"discord.js": "^14.25.1",
 		"drizzle-orm": "^0.45.1",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -8,6 +8,6 @@
 		"./stream-helpers": "./src/stream-helpers.ts"
 	},
 	"dependencies": {
-		"@opencode-ai/sdk": "^1.4.3"
+		"@opencode-ai/sdk": "^1.4.6"
 	}
 }

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -160,13 +160,11 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 
 				const props = "properties" in typed ? (typed.properties as Record<string, unknown>) : {};
 				const eventSessionId = props?.sessionID as string | undefined;
-				if (rawType !== "server.heartbeat") {
-					const msg = `[opencode] stream event: type=${rawType} eventSession=${eventSessionId ?? "?"} targetSession=${params.sessionId}`;
-					if (rawType === "session.status" || rawType === "session.updated") {
-						this.logger?.info(`${msg} props=${JSON.stringify(props)}`);
-					} else {
-						this.logger?.debug(msg);
-					}
+				const msg = `[opencode] stream event: type=${rawType} eventSession=${eventSessionId ?? "?"} targetSession=${params.sessionId}`;
+				if (rawType === "session.status" || rawType === "session.updated") {
+					this.logger?.info(`${msg} props=${JSON.stringify(props)}`);
+				} else {
+					this.logger?.debug(msg);
 				}
 
 				logPartActivity(typed, params.sessionId, this.logger);
@@ -219,11 +217,9 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 				const rawType = (event.value as { type: string }).type;
 				const props = "properties" in typed ? (typed.properties as Record<string, unknown>) : {};
 				const eventSessionId = props?.sessionID as string | undefined;
-				if (rawType !== "server.heartbeat") {
-					this.logger?.debug(
-						`[opencode] waitIdle stream event: type=${rawType} eventSession=${eventSessionId ?? "?"} targetSession=${sessionId}`,
-					);
-				}
+				this.logger?.debug(
+					`[opencode] waitIdle stream event: type=${rawType} eventSession=${eventSessionId ?? "?"} targetSession=${sessionId}`,
+				);
 				if (rawType === "session.status" || rawType === "session.updated") {
 					this.logger?.info(`[opencode] waitIdle: type=${rawType} props=${JSON.stringify(props)}`);
 				}


### PR DESCRIPTION
## Summary

- `@opencode-ai/sdk` を `^1.4.3` → `^1.4.6` に更新
- 1.4.3 と 1.4.6 の `Event` union 差分を比較:
  - 新規: `EventWorkspaceStatus` (`workspace.status`)
  - 削除・リネーム: なし
  - session 系 terminal event (`idle` / `compacted` / `deleted` / `error`) の shape は変更なし → `classifyEvent` は修正不要
- `session-adapter.ts` の `rawType !== "server.heartbeat"` フィルタはデッドコード（1.4.3/1.4.6 どちらの SDK 型定義にも `server.heartbeat` は存在しない）だったため除去
- `EventWorkspaceStatus` を terminal として扱うかは設計判断が必要なため別 Issue (#663) として起票

## 検証結果

- `nr validate` — fmt:check 通過 / lint 警告 0 新規増 / check エラー 0 新規増（既存の apps/web の `routeTree.gen` エラーのみ、本 PR 無関係）
- `nr test` — 1897 pass / 0 fail (140 files, 130.41s)

## Test plan

- [x] `nr validate` 通過
- [x] `nr test` 全件通過
- [x] Event union 差分確認
- [x] `server.heartbeat` がデッドコードであることを両バージョン両方で確認

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)