### PR TITLE
chore: レビューサブエージェントのモデルを sonnet → opus に変更

### DIFF
--- a/.claude/agents/agent-architecture-reviewer.md
+++ b/.claude/agents/agent-architecture-reviewer.md
@@ -2,7 +2,7 @@
 name: agent-architecture-reviewer
 description: AIキャラクター「ふあ」のエージェント設計品質をレビューする。プロンプト設計、ツール使用方法、マルチエージェント構成、キャラクター一貫性を検証する。
 tools: Glob, Grep, Read, Bash(git diff:*), Bash(git log:*)
-model: sonnet
+model: opus
 ---
 
 あなたはAIエージェントアーキテクチャのレビュアーです。Discord bot「ふあ」のマルチエージェントシステムにおいて、変更がキャラクター品質とエージェント設計に悪影響を与えないかを検証します。

--- a/.claude/agents/correctness-reviewer.md
+++ b/.claude/agents/correctness-reviewer.md
@@ -2,7 +2,7 @@
 name: correctness-reviewer
 description: コード変更の正確性をレビューする。バグ、型安全性の問題、ロジックエラー、エッジケースの未処理を検出する。
 tools: Glob, Grep, Read, Bash(git diff:*), Bash(git log:*)
-model: sonnet
+model: opus
 ---
 
 あなたはコードの正確性を検証するレビュアーです。変更差分を分析し、**実際に問題となるバグやエラーのみ**を報告してください。

--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -2,7 +2,7 @@
 name: design-reviewer
 description: コード変更の設計品質をレビューする。YAGNI/KISS/DRY 違反、既存パターンとの不一致、過剰な複雑さを検出する。
 tools: Glob, Grep, Read, Bash(git diff:*), Bash(git log:*)
-model: sonnet
+model: opus
 ---
 
 あなたはコード設計品質のレビュアーです。変更が既存のコードベースのパターンと一貫しているか、不必要な複雑さが入り込んでいないかを検証します。

--- a/.claude/agents/spec-compliance-reviewer.md
+++ b/.claude/agents/spec-compliance-reviewer.md
@@ -2,7 +2,7 @@
 name: spec-compliance-reviewer
 description: コード変更が README.md の仕様や *.spec.ts の契約と整合しているかをレビューする。
 tools: Glob, Grep, Read, Bash(git diff:*), Bash(nr test:*)
-model: sonnet
+model: opus
 ---
 
 あなたは仕様整合性の検証を行うレビュアーです。コード変更が既存の仕様・契約と矛盾していないかを確認します。


### PR DESCRIPTION
## Summary
- 4つのレビューサブエージェント（correctness, design, spec-compliance, agent-architecture）の `model` を `sonnet` → `opus` に変更

## Test plan
- [ ] `/review` でレビューサブエージェントが Opus で動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)