### PR TITLE
feat(mcp): wait_for_events に画像 content part を同梱

### DIFF
--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -4,6 +4,7 @@
 	"exports": {
 		"./discord/attachment-mapper": "./src/discord/attachment-mapper.ts",
 		"./discord/url-rewriter": "./src/discord/url-rewriter.ts",
+		"./http/image-fetcher": "./src/http/image-fetcher.ts",
 		"./store/sqlite-buffered-event-store": "./src/store/sqlite-buffered-event-store.ts"
 	},
 	"dependencies": {

--- a/packages/infrastructure/src/http/image-fetcher.test.ts
+++ b/packages/infrastructure/src/http/image-fetcher.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FetchedImage } from "@vicissitude/shared/ports";
+
+import {
+	createHttpImageFetcher,
+	DEFAULT_MAX_IMAGE_SIZE_BYTES,
+	type FetchLike,
+} from "./image-fetcher.ts";
+
+/** base64 文字列を復号してバイト長を返す */
+function base64ByteLength(b64: string): number {
+	// eslint-disable-next-line no-undef
+	return Buffer.from(b64, "base64").byteLength;
+}
+
+function makeResponse(
+	body: ArrayBuffer | Uint8Array,
+	init: { status?: number; contentType?: string; contentLength?: number | null } = {},
+): Response {
+	const headers = new Headers();
+	if (init.contentType !== undefined) headers.set("content-type", init.contentType);
+	if (init.contentLength !== null && init.contentLength !== undefined) {
+		headers.set("content-length", String(init.contentLength));
+	}
+	// new ArrayBuffer + set でコピーすることで SharedArrayBuffer 型混入を回避
+	const buf = body instanceof Uint8Array ? new ArrayBuffer(body.byteLength) : body;
+	if (body instanceof Uint8Array) new Uint8Array(buf).set(body);
+	return new Response(buf, {
+		status: init.status ?? 200,
+		headers,
+	});
+}
+
+/** null を排除してテスト本体を簡潔に書くためのアサーションヘルパー */
+function expectFetched(result: FetchedImage | null): FetchedImage {
+	if (result === null) throw new Error("expected fetched image, got null");
+	return result;
+}
+
+const stubFetch = (response: Response): FetchLike => {
+	return () => Promise.resolve(response);
+};
+
+describe("createHttpImageFetcher", () => {
+	test("正常系: image/png を base64 + MIME type に変換する", async () => {
+		const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+		const fetcher = createHttpImageFetcher({
+			fetchFn: stubFetch(makeResponse(bytes, { contentType: "image/png" })),
+		});
+		const result = expectFetched(await fetcher("https://example.com/a.png"));
+
+		expect(result.mimeType).toBe("image/png");
+		expect(base64ByteLength(result.base64)).toBe(bytes.byteLength);
+	});
+
+	test("Content-Type パラメータ (charset 等) を除いて MIME type を抽出する", async () => {
+		const fetcher = createHttpImageFetcher({
+			fetchFn: stubFetch(
+				makeResponse(new Uint8Array([1, 2, 3]), { contentType: "image/jpeg; charset=binary" }),
+			),
+		});
+		const result = expectFetched(await fetcher("https://example.com/a.jpg"));
+
+		expect(result.mimeType).toBe("image/jpeg");
+	});
+
+	test("HTTP エラー (4xx/5xx) は null を返す", async () => {
+		const fetcher = createHttpImageFetcher({
+			fetchFn: stubFetch(makeResponse(new Uint8Array(), { status: 404, contentType: "image/png" })),
+		});
+		expect(await fetcher("https://example.com/missing.png")).toBeNull();
+	});
+
+	test("非画像 MIME (application/pdf 等) は null を返す", async () => {
+		const fetcher = createHttpImageFetcher({
+			fetchFn: stubFetch(makeResponse(new Uint8Array([1]), { contentType: "application/pdf" })),
+		});
+		expect(await fetcher("https://example.com/doc.pdf")).toBeNull();
+	});
+
+	test("Content-Type ヘッダ欠落時は null を返す", async () => {
+		const fetcher = createHttpImageFetcher({
+			fetchFn: stubFetch(makeResponse(new Uint8Array([1]), {})),
+		});
+		expect(await fetcher("https://example.com/?")).toBeNull();
+	});
+
+	test("Content-Length が上限を超えている場合は body を読まずに null を返す", async () => {
+		// arrayBuffer() を直接スパイすることで「body 読み取りが回避された」ことを検証する。
+		// (Bun の Response は ReadableStream を eager に consume する場合があるため
+		// stream callback でのトラッキングは信頼できない。)
+		let arrayBufferCalled = false;
+		const fetchFn: FetchLike = () => {
+			const headers = new Headers({
+				"content-type": "image/png",
+				"content-length": String(DEFAULT_MAX_IMAGE_SIZE_BYTES + 1),
+			});
+			const res = new Response(new Uint8Array([1, 2, 3]).buffer, { headers });
+			const original = res.arrayBuffer.bind(res);
+			res.arrayBuffer = () => {
+				arrayBufferCalled = true;
+				return original();
+			};
+			return Promise.resolve(res);
+		};
+
+		const fetcher = createHttpImageFetcher({ fetchFn });
+		expect(await fetcher("https://example.com/big.png")).toBeNull();
+		expect(arrayBufferCalled).toBe(false);
+	});
+
+	test("body 実サイズが上限を超える場合も null を返す (Content-Length 偽装対策)", async () => {
+		const big = new Uint8Array(10);
+		const fetcher = createHttpImageFetcher({
+			fetchFn: stubFetch(makeResponse(big, { contentType: "image/png", contentLength: null })),
+			maxSizeBytes: 5,
+		});
+		expect(await fetcher("https://example.com/big.png")).toBeNull();
+	});
+
+	test("fetch が例外を投げた場合は null を返す (例外を伝播させない)", async () => {
+		const fetcher = createHttpImageFetcher({
+			fetchFn: () => Promise.reject(new Error("ECONNRESET")),
+		});
+		expect(await fetcher("https://example.com/a.png")).toBeNull();
+	});
+
+	test("タイムアウト時は AbortError で null を返す", async () => {
+		const fetcher = createHttpImageFetcher({
+			fetchFn: (_input, init) =>
+				new Promise((_resolve, reject) => {
+					const signal = init?.signal;
+					if (signal) {
+						signal.addEventListener("abort", () => {
+							reject(new DOMException("aborted", "AbortError"));
+						});
+					}
+				}),
+			timeoutMs: 20,
+		});
+		const start = Date.now();
+		const result = await fetcher("https://example.com/slow.png");
+		const elapsed = Date.now() - start;
+
+		expect(result).toBeNull();
+		// 20ms タイムアウトが有効に働いていることの粗い証拠
+		expect(elapsed).toBeLessThan(1000);
+	});
+});

--- a/packages/infrastructure/src/http/image-fetcher.ts
+++ b/packages/infrastructure/src/http/image-fetcher.ts
@@ -45,8 +45,9 @@ export function createHttpImageFetcher(options: CreateHttpImageFetcherOptions = 
 				return null;
 			}
 			const rawContentType = res.headers.get("content-type") ?? "";
-			const mimeType = rawContentType.split(";")[0]?.trim() ?? "";
-			if (!mimeType.startsWith(IMAGE_MIME_PREFIX)) {
+			const mimeType = rawContentType.split(";")[0]?.trim().toLowerCase() ?? "";
+			// "image/" だけ（subtype 空）も MCP / Claude が受け付けないので拒否する
+			if (!mimeType.startsWith(IMAGE_MIME_PREFIX) || mimeType.length <= IMAGE_MIME_PREFIX.length) {
 				logger?.warn(
 					`[image-fetcher] non-image content-type: ${rawContentType || "(empty)"} (${url})`,
 				);

--- a/packages/infrastructure/src/http/image-fetcher.ts
+++ b/packages/infrastructure/src/http/image-fetcher.ts
@@ -1,0 +1,77 @@
+import type { FetchedImage, ImageFetcher } from "@vicissitude/shared/ports";
+import type { Logger } from "@vicissitude/shared/types";
+
+/** Claude API の画像入力上限に合わせた既定サイズ上限（5 MiB）。 */
+export const DEFAULT_MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+
+/** wait_for_events のレスポンスを過度に遅らせないための fetch タイムアウト（ms）。 */
+export const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
+
+const IMAGE_MIME_PREFIX = "image/";
+
+/**
+ * `typeof fetch` には Bun/Node 固有の `preconnect` 等が含まれ、
+ * テスト用スタブの型付けが煩雑になるので、本ファイルが実際に呼び出す形だけに限定する。
+ */
+export type FetchLike = (url: string, init?: { signal?: AbortSignal }) => Promise<Response>;
+
+export interface CreateHttpImageFetcherOptions {
+	logger?: Logger;
+	/** 個別 fetch のタイムアウト（ms）。省略時 {@link DEFAULT_FETCH_TIMEOUT_MS}。 */
+	timeoutMs?: number;
+	/** 許容する画像バイトの最大サイズ。省略時 {@link DEFAULT_MAX_IMAGE_SIZE_BYTES}。 */
+	maxSizeBytes?: number;
+	/** fetch 実装の差し替え口（テスト用）。 */
+	fetchFn?: FetchLike;
+}
+
+/**
+ * `fetch` で URL を取得し base64 + MIME type に変換する {@link ImageFetcher} を生成する。
+ * 失敗時は例外を投げず `null` を返す（上位は filename 等の text 表記にフォールバック）。
+ */
+export function createHttpImageFetcher(options: CreateHttpImageFetcherOptions = {}): ImageFetcher {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+	const maxSize = options.maxSizeBytes ?? DEFAULT_MAX_IMAGE_SIZE_BYTES;
+	const logger = options.logger;
+	const fetchFn = options.fetchFn ?? fetch;
+
+	return async (url: string): Promise<FetchedImage | null> => {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), timeoutMs);
+		try {
+			const res = await fetchFn(url, { signal: controller.signal });
+			if (!res.ok) {
+				logger?.warn(`[image-fetcher] HTTP ${res.status} for ${url}`);
+				return null;
+			}
+			const rawContentType = res.headers.get("content-type") ?? "";
+			const mimeType = rawContentType.split(";")[0]?.trim() ?? "";
+			if (!mimeType.startsWith(IMAGE_MIME_PREFIX)) {
+				logger?.warn(
+					`[image-fetcher] non-image content-type: ${rawContentType || "(empty)"} (${url})`,
+				);
+				return null;
+			}
+			const contentLengthHeader = res.headers.get("content-length");
+			if (contentLengthHeader) {
+				const cl = Number(contentLengthHeader);
+				if (Number.isFinite(cl) && cl > maxSize) {
+					logger?.warn(`[image-fetcher] too large (content-length=${cl}): ${url}`);
+					return null;
+				}
+			}
+			const buf = await res.arrayBuffer();
+			if (buf.byteLength > maxSize) {
+				logger?.warn(`[image-fetcher] too large (body=${buf.byteLength}): ${url}`);
+				return null;
+			}
+			const base64 = Buffer.from(buf).toString("base64");
+			return { base64, mimeType };
+		} catch (err) {
+			logger?.warn(`[image-fetcher] fetch failed: ${url}`, err);
+			return null;
+		} finally {
+			clearTimeout(timer);
+		}
+	};
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,6 +25,7 @@
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.1",
 		"@vicissitude/agent": "workspace:*",
+		"@vicissitude/infrastructure": "workspace:*",
 		"@vicissitude/minecraft": "workspace:*",
 		"@vicissitude/observability": "workspace:*",
 		"@vicissitude/ollama": "workspace:*",

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -4,6 +4,7 @@ import { resolve } from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { EmotionEstimator } from "@vicissitude/agent/emotion/estimator";
+import { createHttpImageFetcher } from "@vicissitude/infrastructure/http/image-fetcher";
 import { GeniusClient } from "@vicissitude/listening/genius-client";
 import { ListeningMemory } from "@vicissitude/listening/listening-memory";
 import type { MemoryReadServices } from "@vicissitude/memory";
@@ -171,6 +172,7 @@ async function main(): Promise<void> {
 		recentMessagesFetcher,
 		moodReader: moodStore,
 		logger,
+		imageFetcher: createHttpImageFetcher({ logger }),
 	});
 
 	registerMemoryTools(server, { getOrCreateMemory }, boundNamespace);

--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -19,7 +19,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { METRIC } from "@vicissitude/observability/metrics";
 import { describeEmotion, isNeutralEmotion } from "@vicissitude/shared/emotion";
 import { formatTimestamp } from "@vicissitude/shared/functions";
-import type { MoodReader } from "@vicissitude/shared/ports";
+import type { ImageFetcher, MoodReader } from "@vicissitude/shared/ports";
 import type { Attachment, Logger, MetricsCollector } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
 import { consumeEvents, hasEvents, touchHeartbeat } from "@vicissitude/store/queries";
@@ -43,6 +43,11 @@ export interface EventBufferDeps {
 	moodReader?: MoodReader;
 	logger?: Logger;
 	metrics?: Pick<MetricsCollector, "incrementCounter">;
+	/**
+	 * 画像添付を base64 化して LLM vision input に同梱するためのポート。
+	 * 未指定なら画像は text 表記のみで渡され、LLM から画像本体は見えない。
+	 */
+	imageFetcher?: ImageFetcher;
 }
 
 /** 一度に消費するイベントの最大件数。LLM が確実に処理できる範囲に制限する。 */
@@ -50,6 +55,13 @@ export const MAX_BATCH_SIZE = 10;
 
 /** wait_for_events の timeout_seconds 上限（秒）。 */
 export const MAX_POLL_TIMEOUT_SECONDS = 200;
+
+/**
+ * 1 回の wait_for_events レスポンスに同梱する画像の最大枚数。
+ * トークンコストと応答品質のバランスで 4 枚に制限する。超過分は text 表記のみで参照され、
+ * LLM は画像を「認識はしているが見えない」状態になる。
+ */
+export const MAX_IMAGES_PER_RESPONSE = 4;
 
 // ─── ActionHint ──────────────────────────────────────────────────
 
@@ -135,7 +147,14 @@ export function formatEvents(events: EventOrError[]): string {
 			const hint = classifyActionHint(e);
 			const extras: string[] = [];
 			if (e.attachments && e.attachments.length > 0) {
-				extras.push(`[添付: ${e.attachments.length}件]`);
+				// 画像添付は可能な範囲で image content part として別途 vision input に同梱される。
+				// ここでは LLM が「どの添付について話しているか」を参照できるよう filename + MIME を列挙する。
+				const labels = e.attachments.map((a) => {
+					const name = a.filename ?? "attachment";
+					const mime = a.contentType ?? "unknown";
+					return `${name} (${mime})`;
+				});
+				extras.push(`[添付: ${labels.join("; ")}]`);
 			}
 			extras.push(`[action: ${hint}]`);
 			const extraStr = ` ${extras.join(" ")}`;
@@ -241,6 +260,8 @@ export async function pollEvents(
 // ─── fetchRecentMessagesContext ──────────────────────────────────
 
 type TextContent = { type: "text"; text: string };
+type ImageContent = { type: "image"; data: string; mimeType: string };
+type MessageContent = TextContent | ImageContent;
 
 /** EventOrError 配列からユニークな channelId + channelName ペアを抽出する（全イベント対象） */
 function extractAllChannels(events: EventOrError[]): { channelId: string; channelName: string }[] {
@@ -289,6 +310,44 @@ function countValues(values: string[]): Record<string, number> {
 	return counts;
 }
 
+// ─── buildImageContents ──────────────────────────────────────────
+
+/** EventOrError 配列に含まれる画像添付の URL を、最大件数まで出現順に抽出する */
+function collectImageUrls(events: EventOrError[], limit: number): string[] {
+	const urls: string[] = [];
+	for (const e of events) {
+		if (isErrorEvent(e)) continue;
+		for (const a of e.attachments ?? []) {
+			if (a.contentType?.startsWith("image/")) {
+				urls.push(a.url);
+				if (urls.length >= limit) return urls;
+			}
+		}
+	}
+	return urls;
+}
+
+/**
+ * 画像添付を並列 fetch して MCP の image content part に変換する。
+ * fetch に失敗した画像は結果から除外される（text 表記のみで LLM に渡される）。
+ */
+async function buildImageContents(
+	events: EventOrError[],
+	imageFetcher: ImageFetcher,
+	logger?: Logger,
+): Promise<ImageContent[]> {
+	const urls = collectImageUrls(events, MAX_IMAGES_PER_RESPONSE);
+	if (urls.length === 0) return [];
+
+	const fetched = await Promise.all(urls.map((u) => imageFetcher(u)));
+	const images: ImageContent[] = [];
+	for (const r of fetched) {
+		if (r) images.push({ type: "image", data: r.base64, mimeType: r.mimeType });
+	}
+	logger?.info(`[event-buffer] vision 入力: ${images.length}/${urls.length}枚の画像を同梱`);
+	return images;
+}
+
 // ─── registerEventBufferTools ────────────────────────────────────
 
 function buildMoodContent(moodReader: MoodReader | undefined, agentId: string): TextContent | null {
@@ -302,14 +361,16 @@ function buildMoodContent(moodReader: MoodReader | undefined, agentId: string): 
 }
 
 export function registerEventBufferTools(server: McpServer, deps: EventBufferDeps): void {
-	const { db, agentId, recentMessagesFetcher, moodReader, logger } = deps;
+	const { db, agentId, recentMessagesFetcher, moodReader, logger, imageFetcher } = deps;
 	const moodKey = deps.moodKey ?? agentId;
 
 	/** イベント配列から応答コンテンツを組み立てる共通処理 */
-	async function buildResponseContent(events: EventOrError[]): Promise<{ content: TextContent[] }> {
+	async function buildResponseContent(
+		events: EventOrError[],
+	): Promise<{ content: MessageContent[] }> {
 		const text = formatEvents(events);
 		const metadataText = formatEventMetadata(events);
-		const content: TextContent[] = [
+		const content: MessageContent[] = [
 			{ type: "text", text: text + (metadataText ? `\n${metadataText}` : "") },
 		];
 		if (recentMessagesFetcher) {
@@ -318,6 +379,10 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 		}
 		const moodContent = buildMoodContent(moodReader, moodKey);
 		if (moodContent) content.unshift(moodContent);
+		if (imageFetcher) {
+			const images = await buildImageContents(events, imageFetcher, logger);
+			content.push(...images);
+		}
 		return { content };
 	}
 

--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -150,8 +150,9 @@ export function formatEvents(events: EventOrError[]): string {
 				// 画像添付は可能な範囲で image content part として別途 vision input に同梱される。
 				// ここでは LLM が「どの添付について話しているか」を参照できるよう filename + MIME を列挙する。
 				const labels = e.attachments.map((a) => {
-					const name = a.filename ?? "attachment";
-					const mime = a.contentType ?? "unknown";
+					// filename / contentType はユーザー入力起源なのでタグインジェクション対策に escape する
+					const name = escapeUserMessageTag(a.filename ?? "attachment");
+					const mime = escapeUserMessageTag(a.contentType ?? "unknown");
 					return `${name} (${mime})`;
 				});
 				extras.push(`[添付: ${labels.join("; ")}]`);

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -139,3 +139,24 @@ export interface HeartbeatConfigPort {
 	load(): Promise<HeartbeatConfig>;
 	save(config: HeartbeatConfig): Promise<void>;
 }
+
+// ─── ImageFetcher ───────────────────────────────────────────────
+//
+// URL から画像バイト列を取得し base64 + MIME type に変換するポート。
+// event-buffer MCP ツールが Discord CDN 等から画像を fetch し、
+// Claude vision input (MCP image content part) に変換するために利用する。
+
+/** 取得成功時の画像データ */
+export interface FetchedImage {
+	/** base64 エンコードされた画像バイト列（data URL prefix は含まない） */
+	base64: string;
+	/** Content-Type ヘッダから抽出した MIME type（例: "image/png"） */
+	mimeType: string;
+}
+
+/**
+ * URL から画像を取得し base64 化するポート。
+ * - ネットワーク失敗、タイムアウト、サイズ超過、非画像 MIME などは例外を投げず `null` を返す。
+ * - 呼び出し側は `null` を「画像として送れなかった」と解釈してフォールバックすること。
+ */
+export type ImageFetcher = (url: string) => Promise<FetchedImage | null>;

--- a/spec/mcp/tools/event-buffer-image.spec.ts
+++ b/spec/mcp/tools/event-buffer-image.spec.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+	MAX_IMAGES_PER_RESPONSE,
+	registerEventBufferTools,
+} from "@vicissitude/mcp/tools/event-buffer";
+import type { FetchedImage, ImageFetcher } from "@vicissitude/shared/ports";
+import { appendEvent } from "@vicissitude/store/queries";
+import { createTestDb } from "@vicissitude/store/test-helpers";
+
+// wait_for_events のレスポンスは text と image が混在する（TextContent | ImageContent）。
+// spec では両方を緩く受けられる union 型で宣言する。
+type ContentPart =
+	| { type: "text"; text: string }
+	| { type: "image"; data: string; mimeType: string };
+
+/** registerEventBufferTools で登録された wait_for_events を直接呼び出すヘルパー */
+async function callWaitForEvents(
+	deps: Parameters<typeof registerEventBufferTools>[1],
+): Promise<{ content: ContentPart[] }> {
+	let registeredHandler: ((args: { timeout_seconds: number }) => Promise<unknown>) | undefined;
+
+	const fakeServer = {
+		registerTool(
+			_name: string,
+			_schema: unknown,
+			handler: (args: { timeout_seconds: number }) => Promise<unknown>,
+		) {
+			registeredHandler = handler;
+		},
+	} as unknown as McpServer;
+
+	registerEventBufferTools(fakeServer, deps);
+
+	if (!registeredHandler) throw new Error("handler not registered");
+	return (await registeredHandler({ timeout_seconds: 5 })) as { content: ContentPart[] };
+}
+
+function insertEventWithImages(
+	db: ReturnType<typeof createTestDb>,
+	agentId: string,
+	attachments: { url: string; contentType?: string; filename?: string }[],
+): void {
+	appendEvent(
+		db,
+		agentId,
+		JSON.stringify({
+			ts: "2026-04-01T00:00:00.000Z",
+			content: "画像添付",
+			authorId: "user-1",
+			authorName: "テスト",
+			messageId: `msg-${attachments.map((a) => a.filename ?? "").join("-")}`,
+			attachments,
+			metadata: { channelId: "ch-1", channelName: "general", isMentioned: true },
+		}),
+	);
+}
+
+/** 固定の base64/mime を返すスタブ ImageFetcher */
+function createStubImageFetcher(response: FetchedImage | null): {
+	fetcher: ImageFetcher;
+	calls: string[];
+} {
+	const calls: string[] = [];
+	return {
+		fetcher: (url: string) => {
+			calls.push(url);
+			return Promise.resolve(response);
+		},
+		calls,
+	};
+}
+
+function isImagePart(c: ContentPart): c is { type: "image"; data: string; mimeType: string } {
+	return c.type === "image";
+}
+
+describe("wait_for_events への画像同梱", () => {
+	test("imageFetcher があれば image content part が content 配列に含まれる", async () => {
+		const db = createTestDb();
+		const agentId = "agent-img-1";
+		insertEventWithImages(db, agentId, [
+			{ url: "https://cdn.example.com/a.png", contentType: "image/png", filename: "a.png" },
+		]);
+
+		const { fetcher, calls } = createStubImageFetcher({ base64: "BASE64A", mimeType: "image/png" });
+
+		const result = await callWaitForEvents({ db, agentId, imageFetcher: fetcher });
+
+		const images = result.content.filter(isImagePart);
+		expect(images).toHaveLength(1);
+		const [first] = images;
+		if (!first) throw new Error("expected first image part");
+		expect(first.data).toBe("BASE64A");
+		expect(first.mimeType).toBe("image/png");
+		expect(calls).toEqual(["https://cdn.example.com/a.png"]);
+	});
+
+	test("imageFetcher が無ければ image content part は生成されない", async () => {
+		const db = createTestDb();
+		const agentId = "agent-img-2";
+		insertEventWithImages(db, agentId, [
+			{ url: "https://cdn.example.com/a.png", contentType: "image/png", filename: "a.png" },
+		]);
+
+		const result = await callWaitForEvents({ db, agentId });
+
+		expect(result.content.some(isImagePart)).toBe(false);
+	});
+
+	test("非画像 MIME の添付は fetch されない", async () => {
+		const db = createTestDb();
+		const agentId = "agent-img-3";
+		insertEventWithImages(db, agentId, [
+			{
+				url: "https://cdn.example.com/doc.pdf",
+				contentType: "application/pdf",
+				filename: "doc.pdf",
+			},
+			{ url: "https://cdn.example.com/img.png", contentType: "image/png", filename: "img.png" },
+		]);
+
+		const { fetcher, calls } = createStubImageFetcher({ base64: "PNG", mimeType: "image/png" });
+		await callWaitForEvents({ db, agentId, imageFetcher: fetcher });
+
+		// PDF は image/ prefix に該当しないので fetcher は呼ばれない
+		expect(calls).toEqual(["https://cdn.example.com/img.png"]);
+	});
+
+	test(`1 回の応答に同梱する画像は最大 ${MAX_IMAGES_PER_RESPONSE} 枚に制限される`, async () => {
+		const db = createTestDb();
+		const agentId = "agent-img-4";
+		const overflow = MAX_IMAGES_PER_RESPONSE + 2;
+		const attachments = Array.from({ length: overflow }, (_, i) => ({
+			url: `https://cdn.example.com/img-${i}.png`,
+			contentType: "image/png",
+			filename: `img-${i}.png`,
+		}));
+		insertEventWithImages(db, agentId, attachments);
+
+		const { fetcher, calls } = createStubImageFetcher({ base64: "DATA", mimeType: "image/png" });
+		const result = await callWaitForEvents({ db, agentId, imageFetcher: fetcher });
+
+		// 上限を超えた URL は fetch されず、image part も生成されない
+		expect(calls).toHaveLength(MAX_IMAGES_PER_RESPONSE);
+		expect(result.content.filter(isImagePart)).toHaveLength(MAX_IMAGES_PER_RESPONSE);
+		// text 側には全ての filename が列挙される（LLM が「超過した画像もあった」ことを認識できるように）
+		const text = result.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map((c) => c.text)
+			.join("\n");
+		for (let i = 0; i < overflow; i++) {
+			expect(text).toContain(`img-${i}.png`);
+		}
+	});
+
+	test("fetch 失敗時は image part を省略し、text 表記だけで LLM に渡る", async () => {
+		const db = createTestDb();
+		const agentId = "agent-img-5";
+		insertEventWithImages(db, agentId, [
+			{
+				url: "https://cdn.example.com/broken.png",
+				contentType: "image/png",
+				filename: "broken.png",
+			},
+		]);
+
+		const { fetcher } = createStubImageFetcher(null);
+		const result = await callWaitForEvents({ db, agentId, imageFetcher: fetcher });
+
+		expect(result.content.some(isImagePart)).toBe(false);
+		const text = result.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map((c) => c.text)
+			.join("\n");
+		// filename は text 側に残るので、LLM は「添付はあったが見えない」ことを認識できる
+		expect(text).toContain("broken.png");
+	});
+
+	test("複数イベントに跨る画像添付も出現順に同梱される", async () => {
+		const db = createTestDb();
+		const agentId = "agent-img-6";
+		insertEventWithImages(db, agentId, [
+			{ url: "https://cdn.example.com/e1a.png", contentType: "image/png", filename: "e1a.png" },
+		]);
+		insertEventWithImages(db, agentId, [
+			{ url: "https://cdn.example.com/e2a.png", contentType: "image/png", filename: "e2a.png" },
+			{ url: "https://cdn.example.com/e2b.png", contentType: "image/png", filename: "e2b.png" },
+		]);
+
+		const { fetcher, calls } = createStubImageFetcher({ base64: "X", mimeType: "image/png" });
+		await callWaitForEvents({ db, agentId, imageFetcher: fetcher });
+
+		expect(calls).toEqual([
+			"https://cdn.example.com/e1a.png",
+			"https://cdn.example.com/e2a.png",
+			"https://cdn.example.com/e2b.png",
+		]);
+	});
+});

--- a/spec/mcp/tools/event-buffer-mood.spec.ts
+++ b/spec/mcp/tools/event-buffer-mood.spec.ts
@@ -32,10 +32,16 @@ function createSpyMoodReader(mood: Emotion): {
 	};
 }
 
+/**
+ * wait_for_events のレスポンスは text と image が混在する可能性があるため、
+ * image part 到来時に `.text` が undefined となる前提で緩い型を宣言する。
+ */
+type ContentPart = { type: string; text?: string };
+
 /** registerEventBufferTools で登録された wait_for_events を直接呼び出すヘルパー */
 async function callWaitForEvents(
 	deps: Parameters<typeof registerEventBufferTools>[1],
-): Promise<{ content: Array<{ type: string; text: string }> }> {
+): Promise<{ content: ContentPart[] }> {
 	let registeredHandler: ((args: { timeout_seconds: number }) => Promise<unknown>) | undefined;
 
 	const fakeServer = {
@@ -51,9 +57,7 @@ async function callWaitForEvents(
 	registerEventBufferTools(fakeServer, deps);
 
 	if (!registeredHandler) throw new Error("handler not registered");
-	return (await registeredHandler({ timeout_seconds: 5 })) as {
-		content: Array<{ type: string; text: string }>;
-	};
+	return (await registeredHandler({ timeout_seconds: 5 })) as { content: ContentPart[] };
 }
 
 function insertTestEvent(db: ReturnType<typeof createTestDb>, agentId: string): void {
@@ -84,7 +88,7 @@ describe("wait_for_events への mood 注入", () => {
 			moodReader: createStubMoodReader(happyMood),
 		});
 
-		const allText = result.content.map((c) => c.text).join("\n");
+		const allText = result.content.map((c) => c.text ?? "").join("\n");
 		expect(allText).toContain("<current-mood>");
 		expect(allText).toContain("</current-mood>");
 	});
@@ -100,7 +104,7 @@ describe("wait_for_events への mood 注入", () => {
 			moodReader: createStubMoodReader(NEUTRAL_EMOTION),
 		});
 
-		const allText = result.content.map((c) => c.text).join("\n");
+		const allText = result.content.map((c) => c.text ?? "").join("\n");
 		expect(allText).not.toContain("<current-mood>");
 	});
 
@@ -127,8 +131,10 @@ describe("wait_for_events への mood 注入", () => {
 
 		// content 配列内で <current-mood> を含む要素のインデックスが
 		// <recent-messages> を含む要素より前にあること
-		const moodIndex = result.content.findIndex((c) => c.text.includes("<current-mood>"));
-		const recentIndex = result.content.findIndex((c) => c.text.includes("<recent-messages>"));
+		const moodIndex = result.content.findIndex((c) => c.text?.includes("<current-mood>") ?? false);
+		const recentIndex = result.content.findIndex(
+			(c) => c.text?.includes("<recent-messages>") ?? false,
+		);
 
 		expect(moodIndex).toBeGreaterThanOrEqual(0);
 		expect(recentIndex).toBeGreaterThanOrEqual(0);

--- a/spec/mcp/tools/event-buffer.spec.ts
+++ b/spec/mcp/tools/event-buffer.spec.ts
@@ -249,7 +249,7 @@ describe("formatEvents", () => {
 		expect(result).not.toContain("</user_message>");
 	});
 
-	test("添付ファイルがあれば件数を表示する", () => {
+	test("添付ファイルがあれば filename と MIME type を列挙する", () => {
 		const events = [
 			{
 				ts: "2026-03-27T00:00:00.000Z",
@@ -257,14 +257,33 @@ describe("formatEvents", () => {
 				authorId: "user1",
 				authorName: "テスト",
 				messageId: "msg3",
-				attachments: [{ url: "https://example.com/a.png" }, { url: "https://example.com/b.png" }],
+				attachments: [
+					{ url: "https://example.com/a.png", contentType: "image/png", filename: "a.png" },
+					{ url: "https://example.com/b.jpg", contentType: "image/jpeg", filename: "b.jpg" },
+				],
 			},
 		];
 		const result = formatEvents(events);
-		expect(result).toContain("[添付: 2件]");
+		// image content part 同梱時に LLM が「どの画像について話しているか」参照できる必要がある
+		expect(result).toContain("[添付: a.png (image/png); b.jpg (image/jpeg)]");
 		// 添付ファイル付きのユーザー発言もタグで囲まれる
 		expect(result).toContain("<user_message>画像送るよ</user_message>");
 		expect(result).toContain("[action: optional]");
+	});
+
+	test("filename や contentType が欠けても安全にフォーマットする", () => {
+		const events = [
+			{
+				ts: "2026-03-27T00:00:00.000Z",
+				content: "",
+				authorId: "user1",
+				authorName: "テスト",
+				messageId: "msg-miss",
+				attachments: [{ url: "https://example.com/unknown.bin" }],
+			},
+		];
+		const result = formatEvents(events);
+		expect(result).toContain("[添付: attachment (unknown)]");
 	});
 
 	test("空配列なら空文字列を返す", () => {


### PR DESCRIPTION
## Summary

- Discord メッセージの画像添付を MCP `ImageContent` として LLM に直接渡せるようにする。OpenCode の MCP → AI SDK 変換は `ImageContent` を `FilePart` に昇格させ、Anthropic では `supportsMediaInToolResults=true` により vision 入力として直接処理される。
- `shared` に `ImageFetcher` ポート + `FetchedImage` 型を追加。`infrastructure` に `createHttpImageFetcher` を実装（5 MiB / 5s timeout / `image/` MIME 限定 / 失敗時 `null`）。
- `event-buffer` の `wait_for_events` で `image/` 添付を fetch し `ImageContent` part を content 配列に同梱（1 応答あたり最大 4 枚、超過分は filename を text に列挙）。添付の text 表記を `[添付: a.png (image/png); ...]` に変更。

## Background

これまで `wait_for_events` のレスポンスは text のみで、添付画像 URL も text に含まれていなかったため LLM は画像を「見えない」状態だった。`isMentioned=false` の `[action: optional]` が付くと「画像が見えないからスキップ」という判断に至るケースが観測されていた。MCP ImageContent を経由することで、ふあが画像を直接認識した上で応答を組み立てられるようになる。

## Test plan

- [x] `nr validate` (fmt:check + lint + typecheck) パス
- [x] `nr test` 全 1939 テスト パス
- [ ] デプロイ後、画像付きメッセージに対してふあが画像内容を踏まえた応答を返すこと
- [ ] 1 応答あたり 5 枚以上の画像が同時に来ても crash しないこと（max 4 枚で打ち切り、残りは text に filename だけ）
- [ ] 巨大画像 (>5 MiB) や fetch 失敗時に text fallback でメッセージ自体は LLM に届くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)