### PR TITLE
fix: memory_retrieve キャッシュキーのコロン区切り衝突リスクを修正

### DIFF
--- a/packages/mcp/src/tools/memory.ts
+++ b/packages/mcp/src/tools/memory.ts
@@ -57,7 +57,7 @@ export function registerMemoryTools(
 				}
 
 				const effectiveLimit = limit ?? 10;
-				const cacheKey = `${namespaceKey(ns)}:${query}:${effectiveLimit}`;
+				const cacheKey = `${namespaceKey(ns)}\0${query}\0${effectiveLimit}`;
 				const cached = cache?.get(cacheKey);
 				if (cached) {
 					return cached;


### PR DESCRIPTION
## Summary
- memory_retrieve のキャッシュキー区切り文字を `:` から `\0`（ヌル文字）に変更
- コロン区切りでは namespace・query・limit の異なる組み合わせが同一キーに衝突する可能性があった

Closes #674

## Test plan
- [x] 既存の memory-retrieve-cache spec テスト（12件）全通過
- [x] 全テスト 1933 pass（1 fail は既存の vec3 環境依存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)