### PR TITLE
fix: compaction 閾値と MemoryRetrieveCache を composition root で注入

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -144,6 +144,10 @@ export function createGuildAgents(
 		portOffset?: number;
 		appRoot: string;
 		coreEnvironment: Record<string, string>;
+		/** proactive compaction のトークン閾値。省略時は proactive compaction 無効 */
+		compactionTokenThreshold?: number;
+		/** compaction 間のクールダウン（ms） */
+		compactionCooldownMs?: number;
 	},
 ): Map<string, DiscordAgent> {
 	const agents = new Map<string, DiscordAgent>();
@@ -183,6 +187,8 @@ export function createGuildAgents(
 			profile,
 			summaryWriter: deps.summaryWriter,
 			agentIdPrefix: deps.agentIdPrefix,
+			compactionTokenThreshold: deps.compactionTokenThreshold,
+			compactionCooldownMs: deps.compactionCooldownMs,
 		});
 		agents.set(guildId, agent);
 	}
@@ -489,6 +495,7 @@ export async function bootstrap(): Promise<void> {
 		summaryWriter,
 		appRoot: root,
 		coreEnvironment,
+		compactionTokenThreshold: 20_000,
 	});
 
 	// Memory recording
@@ -537,6 +544,7 @@ export async function bootstrap(): Promise<void> {
 		portOffset: ports.heartbeatOffset,
 		appRoot: root,
 		coreEnvironment,
+		compactionTokenThreshold: 20_000,
 	});
 	const firstHeartbeatAgent = heartbeatAgents.values().next().value as AiAgent | undefined;
 	if (!firstHeartbeatAgent) {
@@ -581,6 +589,7 @@ export async function bootstrap(): Promise<void> {
 			sessionMaxAgeMs: config.opencode.sessionMaxAgeHours * 3_600_000,
 			mcHost: config.minecraft.host,
 			mcMcpPort: String(config.minecraft.mcpPort),
+			compactionTokenThreshold: 20_000,
 		});
 	}
 

--- a/packages/agent/src/discord/discord-agent.ts
+++ b/packages/agent/src/discord/discord-agent.ts
@@ -27,6 +27,10 @@ export interface DiscordAgentDeps {
 	summaryWriter?: SessionSummaryWriter;
 	/** agentId のプレフィックス（デフォルト: "discord"）。Heartbeat 専用エージェントなどでセッション分離に使用 */
 	agentIdPrefix?: string;
+	/** proactive compaction のトークン閾値。省略時は proactive compaction 無効 */
+	compactionTokenThreshold?: number;
+	/** compaction 間のクールダウン（ms）。デフォルト: 1_800_000 (30分) */
+	compactionCooldownMs?: number;
 }
 
 export class DiscordAgent extends AgentRunner {
@@ -44,6 +48,8 @@ export class DiscordAgent extends AgentRunner {
 			metrics: deps.metrics,
 			contextGuildId: deps.guildId,
 			summaryWriter: deps.summaryWriter,
+			compactionTokenThreshold: deps.compactionTokenThreshold,
+			compactionCooldownMs: deps.compactionCooldownMs,
 			heartbeatReader: {
 				getLastSeenAt: (id) => getHeartbeat(deps.db, id),
 			},

--- a/packages/agent/src/minecraft/brain-manager.ts
+++ b/packages/agent/src/minecraft/brain-manager.ts
@@ -31,6 +31,10 @@ export interface McBrainManagerDeps {
 	lifecyclePollMs?: number;
 	mcHost?: string;
 	mcMcpPort?: string;
+	/** proactive compaction のトークン閾値。省略時は proactive compaction 無効 */
+	compactionTokenThreshold?: number;
+	/** compaction 間のクールダウン（ms）。デフォルト: 1_800_000 (30分) */
+	compactionCooldownMs?: number;
 }
 
 /**
@@ -121,6 +125,8 @@ export class McBrainManager {
 			logger: deps.logger,
 			sessionMaxAgeMs: deps.sessionMaxAgeMs,
 			profile,
+			compactionTokenThreshold: deps.compactionTokenThreshold,
+			compactionCooldownMs: deps.compactionCooldownMs,
 		});
 		// 初期イベントを挿入してポーリングループの最初の waitForEvents を通過させる
 		const bootstrapEvent = {

--- a/packages/agent/src/minecraft/minecraft-agent.ts
+++ b/packages/agent/src/minecraft/minecraft-agent.ts
@@ -18,6 +18,10 @@ export interface MinecraftAgentDeps {
 	contextBuilder: ContextBuilderPort;
 	sessionMaxAgeMs: number;
 	profile: AgentProfile;
+	/** proactive compaction のトークン閾値。省略時は proactive compaction 無効 */
+	compactionTokenThreshold?: number;
+	/** compaction 間のクールダウン（ms）。デフォルト: 1_800_000 (30分) */
+	compactionCooldownMs?: number;
 }
 
 export class MinecraftAgent extends AgentRunner {
@@ -31,6 +35,8 @@ export class MinecraftAgent extends AgentRunner {
 			sessionPort: deps.sessionPort,
 			eventBuffer: deps.eventBuffer,
 			sessionMaxAgeMs: deps.sessionMaxAgeMs,
+			compactionTokenThreshold: deps.compactionTokenThreshold,
+			compactionCooldownMs: deps.compactionCooldownMs,
 		});
 	}
 }

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -29,6 +29,7 @@ import { SqliteMoodStore } from "@vicissitude/store/mood-store";
 import { Client } from "discord.js";
 
 import { MemoryInstanceCache } from "./memory-cache.ts";
+import { MemoryRetrieveCache } from "./memory-retrieve-cache.ts";
 import { registerDiscordTools } from "./tools/discord.ts";
 import { registerEventBufferTools } from "./tools/event-buffer.ts";
 import { registerListeningTools } from "./tools/listening.ts";
@@ -175,7 +176,10 @@ async function main(): Promise<void> {
 		imageFetcher: createHttpImageFetcher({ logger }),
 	});
 
-	registerMemoryTools(server, { getOrCreateMemory }, boundNamespace);
+	const retrieveCache = new MemoryRetrieveCache<{ content: Array<{ type: "text"; text: string }> }>(
+		{ ttlMs: 30 * 60 * 1_000, maxSize: 100 },
+	);
+	registerMemoryTools(server, { getOrCreateMemory, cache: retrieveCache }, boundNamespace);
 	if (process.env.MC_HOST) {
 		registerDiscordBridgeTools(server, { db }, boundGuildId);
 	}
@@ -225,6 +229,7 @@ async function main(): Promise<void> {
 	async function shutdown() {
 		await server.close();
 		void discordClient.destroy();
+		retrieveCache.dispose();
 		memoryCache.closeAll();
 		closeDb(db);
 		process.exit(0);


### PR DESCRIPTION
## Summary
- `DiscordAgentDeps` / `MinecraftAgentDeps` / `McBrainManagerDeps` に `compactionTokenThreshold` / `compactionCooldownMs` を追加し、`super()` へ伝播
- `bootstrap.ts` で `compactionTokenThreshold: 20_000` を注入（通常・heartbeat・Minecraft エージェント全て）
- `core-server.ts` で `MemoryRetrieveCache` を生成し `registerMemoryTools` に渡す。shutdown 時に `dispose()` で後始末

Closes #670

## Test plan
- [x] `nr test` — 全 1941 テスト通過
- [x] `nr test:spec` — 全 1461 spec テスト通過
- [x] `nr validate` — lint 0 errors, 型チェック対象ファイルにエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)