### PR TITLE
fix: LruCache.set() の non-null assertion を除去

### DIFF
--- a/packages/mcp/src/lru-cache.ts
+++ b/packages/mcp/src/lru-cache.ts
@@ -62,9 +62,9 @@ export class LruCache<T> {
 		if (this.entries.size >= this.maxSize) {
 			const oldestKey = this.entries.keys().next().value;
 			if (oldestKey !== undefined) {
-				const oldest = this.entries.get(oldestKey)!;
+				const oldest = this.entries.get(oldestKey);
 				this.entries.delete(oldestKey);
-				this.onEvict?.(oldestKey, oldest.value);
+				if (oldest) this.onEvict?.(oldestKey, oldest.value);
 			}
 		}
 


### PR DESCRIPTION
## Summary
- `LruCache.set()` 内の `this.entries.get(oldestKey)!` を安全な null チェックに置き換え
- CI の `typescript-eslint(no-non-null-assertion)` ルール違反を修正
- #686 で導入された `lru-cache.ts` の lint エラーを解消

## Test plan
- [x] `nr test` — 全 1941 テスト通過
- [x] `lru-cache.ts` に対する lint エラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)