### PR TITLE
chore: 既存 spec のセッションポートモックに summarizeSession を追加

### DIFF
--- a/spec/agent/hang-detection.spec.ts
+++ b/spec/agent/hang-detection.spec.ts
@@ -70,6 +70,7 @@ function createSimpleSessionPort(): OpencodeSessionPort & {
 		promptAsyncAndWatchSession: mock(() => Promise.resolve({ type: "idle" as const })),
 		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
 		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
 		close: mock(() => {}),
 	} as unknown as OpencodeSessionPort & { deleteSession: ReturnType<typeof mock> };
 }

--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -133,6 +133,7 @@ function createSessionPortWithSessions(
 			return sessions[idx];
 		}),
 		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
 		close: mock(() => {}),
 	} as unknown as OpencodeSessionPort & {
 		deleteSession: ReturnType<typeof mock>;

--- a/spec/agent/runner.spec.ts
+++ b/spec/agent/runner.spec.ts
@@ -32,6 +32,7 @@ function createSimpleSessionPort(): OpencodeSessionPort & {
 		promptAsyncAndWatchSession: mock(() => Promise.resolve({ type: "idle" as const })),
 		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
 		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
 		close: mock(() => {}),
 	} as unknown as OpencodeSessionPort & {
 		deleteSession: ReturnType<typeof mock>;
@@ -55,6 +56,7 @@ function createSessionPortWithTwoSessions(
 		}),
 		waitForSessionIdle: mock(() => (callCount === 1 ? firstDone : secondDone)),
 		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
 		close: mock(() => {}),
 	} as unknown as OpencodeSessionPort & { close: ReturnType<typeof mock> };
 }

--- a/spec/agent/session-error-metrics.spec.ts
+++ b/spec/agent/session-error-metrics.spec.ts
@@ -44,6 +44,7 @@ function createSessionPortWithControlledResult(
 			return callCount <= 2 ? firstDone : secondDone;
 		}),
 		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
 		close: mock(() => {}),
 	} as unknown as OpencodeSessionPort & { close: ReturnType<typeof mock> };
 }

--- a/spec/agent/session-rotation-summary-isolation.spec.ts
+++ b/spec/agent/session-rotation-summary-isolation.spec.ts
@@ -138,6 +138,7 @@ function createSimpleSessionPort(): OpencodeSessionPort & {
 		promptAsyncAndWatchSession: mock(() => Promise.resolve({ type: "idle" as const })),
 		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
 		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
 		close: mock(() => {}),
 	} as unknown as OpencodeSessionPort & {
 		prompt: ReturnType<typeof mock>;
@@ -168,6 +169,7 @@ function createSessionPortForPollingLoop(
 		}),
 		waitForSessionIdle: mock(() => (callCount === 1 ? firstDone : secondDone)),
 		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
 		close: mock(() => {}),
 	} as unknown as OpencodeSessionPort & {
 		prompt: ReturnType<typeof mock>;

--- a/spec/agent/session-summary.spec.ts
+++ b/spec/agent/session-summary.spec.ts
@@ -96,6 +96,7 @@ function createSessionPortWithTwoSessions(
 		}),
 		waitForSessionIdle: mock(() => (callCount === 1 ? firstDone : secondDone)),
 		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
 		close: mock(() => {}),
 	} as unknown as OpencodeSessionPort & { prompt: ReturnType<typeof mock> };
 }
@@ -125,6 +126,7 @@ function createSimpleSessionPort(): OpencodeSessionPort & {
 		promptAsyncAndWatchSession: mock(() => Promise.resolve({ type: "idle" as const })),
 		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
 		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
 		close: mock(() => {}),
 	} as unknown as OpencodeSessionPort & { prompt: ReturnType<typeof mock> };
 }


### PR DESCRIPTION
## Summary
- #615 で `OpencodeSessionPort` に追加された `summarizeSession` が 6 ファイル 9 箇所のモックに欠落していたため補完
- 将来 `compactionTokenThreshold` がデフォルト有効化された際のランタイムエラーを予防

Closes #673

## Test plan
- [x] `nr test:spec` — 全 1461 spec テスト通過（0 fail）

🤖 Generated with [Claude Code](https://claude.com/claude-code)