### PR TITLE
refactor: HttpImageFetcher を class 化 (#679)

### DIFF
--- a/packages/infrastructure/src/http/image-fetcher.test.ts
+++ b/packages/infrastructure/src/http/image-fetcher.test.ts
@@ -2,11 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { FetchedImage } from "@vicissitude/shared/ports";
 
-import {
-	createHttpImageFetcher,
-	DEFAULT_MAX_IMAGE_SIZE_BYTES,
-	type FetchLike,
-} from "./image-fetcher.ts";
+import { HttpImageFetcher, DEFAULT_MAX_IMAGE_SIZE_BYTES, type FetchLike } from "./image-fetcher.ts";
 
 /** base64 文字列を復号してバイト長を返す */
 function base64ByteLength(b64: string): number {
@@ -42,48 +38,48 @@ const stubFetch = (response: Response): FetchLike => {
 	return () => Promise.resolve(response);
 };
 
-describe("createHttpImageFetcher", () => {
+describe("HttpImageFetcher", () => {
 	test("正常系: image/png を base64 + MIME type に変換する", async () => {
 		const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
-		const fetcher = createHttpImageFetcher({
+		const fetcher = new HttpImageFetcher({
 			fetchFn: stubFetch(makeResponse(bytes, { contentType: "image/png" })),
 		});
-		const result = expectFetched(await fetcher("https://example.com/a.png"));
+		const result = expectFetched(await fetcher.fetch("https://example.com/a.png"));
 
 		expect(result.mimeType).toBe("image/png");
 		expect(base64ByteLength(result.base64)).toBe(bytes.byteLength);
 	});
 
 	test("Content-Type パラメータ (charset 等) を除いて MIME type を抽出する", async () => {
-		const fetcher = createHttpImageFetcher({
+		const fetcher = new HttpImageFetcher({
 			fetchFn: stubFetch(
 				makeResponse(new Uint8Array([1, 2, 3]), { contentType: "image/jpeg; charset=binary" }),
 			),
 		});
-		const result = expectFetched(await fetcher("https://example.com/a.jpg"));
+		const result = expectFetched(await fetcher.fetch("https://example.com/a.jpg"));
 
 		expect(result.mimeType).toBe("image/jpeg");
 	});
 
 	test("HTTP エラー (4xx/5xx) は null を返す", async () => {
-		const fetcher = createHttpImageFetcher({
+		const fetcher = new HttpImageFetcher({
 			fetchFn: stubFetch(makeResponse(new Uint8Array(), { status: 404, contentType: "image/png" })),
 		});
-		expect(await fetcher("https://example.com/missing.png")).toBeNull();
+		expect(await fetcher.fetch("https://example.com/missing.png")).toBeNull();
 	});
 
 	test("非画像 MIME (application/pdf 等) は null を返す", async () => {
-		const fetcher = createHttpImageFetcher({
+		const fetcher = new HttpImageFetcher({
 			fetchFn: stubFetch(makeResponse(new Uint8Array([1]), { contentType: "application/pdf" })),
 		});
-		expect(await fetcher("https://example.com/doc.pdf")).toBeNull();
+		expect(await fetcher.fetch("https://example.com/doc.pdf")).toBeNull();
 	});
 
 	test("Content-Type ヘッダ欠落時は null を返す", async () => {
-		const fetcher = createHttpImageFetcher({
+		const fetcher = new HttpImageFetcher({
 			fetchFn: stubFetch(makeResponse(new Uint8Array([1]), {})),
 		});
-		expect(await fetcher("https://example.com/?")).toBeNull();
+		expect(await fetcher.fetch("https://example.com/?")).toBeNull();
 	});
 
 	test("Content-Length が上限を超えている場合は body を読まずに null を返す", async () => {
@@ -105,29 +101,29 @@ describe("createHttpImageFetcher", () => {
 			return Promise.resolve(res);
 		};
 
-		const fetcher = createHttpImageFetcher({ fetchFn });
-		expect(await fetcher("https://example.com/big.png")).toBeNull();
+		const fetcher = new HttpImageFetcher({ fetchFn });
+		expect(await fetcher.fetch("https://example.com/big.png")).toBeNull();
 		expect(arrayBufferCalled).toBe(false);
 	});
 
 	test("body 実サイズが上限を超える場合も null を返す (Content-Length 偽装対策)", async () => {
 		const big = new Uint8Array(10);
-		const fetcher = createHttpImageFetcher({
+		const fetcher = new HttpImageFetcher({
 			fetchFn: stubFetch(makeResponse(big, { contentType: "image/png", contentLength: null })),
 			maxSizeBytes: 5,
 		});
-		expect(await fetcher("https://example.com/big.png")).toBeNull();
+		expect(await fetcher.fetch("https://example.com/big.png")).toBeNull();
 	});
 
 	test("fetch が例外を投げた場合は null を返す (例外を伝播させない)", async () => {
-		const fetcher = createHttpImageFetcher({
+		const fetcher = new HttpImageFetcher({
 			fetchFn: () => Promise.reject(new Error("ECONNRESET")),
 		});
-		expect(await fetcher("https://example.com/a.png")).toBeNull();
+		expect(await fetcher.fetch("https://example.com/a.png")).toBeNull();
 	});
 
 	test("タイムアウト時は AbortError で null を返す", async () => {
-		const fetcher = createHttpImageFetcher({
+		const fetcher = new HttpImageFetcher({
 			fetchFn: (_input, init) =>
 				new Promise((_resolve, reject) => {
 					const signal = init?.signal;
@@ -140,7 +136,7 @@ describe("createHttpImageFetcher", () => {
 			timeoutMs: 20,
 		});
 		const start = Date.now();
-		const result = await fetcher("https://example.com/slow.png");
+		const result = await fetcher.fetch("https://example.com/slow.png");
 		const elapsed = Date.now() - start;
 
 		expect(result).toBeNull();

--- a/packages/infrastructure/src/http/image-fetcher.ts
+++ b/packages/infrastructure/src/http/image-fetcher.ts
@@ -15,7 +15,7 @@ const IMAGE_MIME_PREFIX = "image/";
  */
 export type FetchLike = (url: string, init?: { signal?: AbortSignal }) => Promise<Response>;
 
-export interface CreateHttpImageFetcherOptions {
+export interface HttpImageFetcherOptions {
 	logger?: Logger;
 	/** 個別 fetch のタイムアウト（ms）。省略時 {@link DEFAULT_FETCH_TIMEOUT_MS}。 */
 	timeoutMs?: number;
@@ -26,29 +26,36 @@ export interface CreateHttpImageFetcherOptions {
 }
 
 /**
- * `fetch` で URL を取得し base64 + MIME type に変換する {@link ImageFetcher} を生成する。
+ * `fetch` で URL を取得し base64 + MIME type に変換する {@link ImageFetcher} 実装。
  * 失敗時は例外を投げず `null` を返す（上位は filename 等の text 表記にフォールバック）。
  */
-export function createHttpImageFetcher(options: CreateHttpImageFetcherOptions = {}): ImageFetcher {
-	const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
-	const maxSize = options.maxSizeBytes ?? DEFAULT_MAX_IMAGE_SIZE_BYTES;
-	const logger = options.logger;
-	const fetchFn = options.fetchFn ?? fetch;
+export class HttpImageFetcher implements ImageFetcher {
+	private readonly timeoutMs: number;
+	private readonly maxSize: number;
+	private readonly logger: Logger | undefined;
+	private readonly fetchFn: FetchLike;
 
-	return async (url: string): Promise<FetchedImage | null> => {
+	constructor(options: HttpImageFetcherOptions = {}) {
+		this.timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+		this.maxSize = options.maxSizeBytes ?? DEFAULT_MAX_IMAGE_SIZE_BYTES;
+		this.logger = options.logger;
+		this.fetchFn = options.fetchFn ?? fetch;
+	}
+
+	async fetch(url: string): Promise<FetchedImage | null> {
 		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), timeoutMs);
+		const timer = setTimeout(() => controller.abort(), this.timeoutMs);
 		try {
-			const res = await fetchFn(url, { signal: controller.signal });
+			const res = await this.fetchFn(url, { signal: controller.signal });
 			if (!res.ok) {
-				logger?.warn(`[image-fetcher] HTTP ${res.status} for ${url}`);
+				this.logger?.warn(`[image-fetcher] HTTP ${res.status} for ${url}`);
 				return null;
 			}
 			const rawContentType = res.headers.get("content-type") ?? "";
 			const mimeType = rawContentType.split(";")[0]?.trim().toLowerCase() ?? "";
 			// "image/" だけ（subtype 空）も MCP / Claude が受け付けないので拒否する
 			if (!mimeType.startsWith(IMAGE_MIME_PREFIX) || mimeType.length <= IMAGE_MIME_PREFIX.length) {
-				logger?.warn(
+				this.logger?.warn(
 					`[image-fetcher] non-image content-type: ${rawContentType || "(empty)"} (${url})`,
 				);
 				return null;
@@ -56,23 +63,23 @@ export function createHttpImageFetcher(options: CreateHttpImageFetcherOptions = 
 			const contentLengthHeader = res.headers.get("content-length");
 			if (contentLengthHeader) {
 				const cl = Number(contentLengthHeader);
-				if (Number.isFinite(cl) && cl > maxSize) {
-					logger?.warn(`[image-fetcher] too large (content-length=${cl}): ${url}`);
+				if (Number.isFinite(cl) && cl > this.maxSize) {
+					this.logger?.warn(`[image-fetcher] too large (content-length=${cl}): ${url}`);
 					return null;
 				}
 			}
 			const buf = await res.arrayBuffer();
-			if (buf.byteLength > maxSize) {
-				logger?.warn(`[image-fetcher] too large (body=${buf.byteLength}): ${url}`);
+			if (buf.byteLength > this.maxSize) {
+				this.logger?.warn(`[image-fetcher] too large (body=${buf.byteLength}): ${url}`);
 				return null;
 			}
 			const base64 = Buffer.from(buf).toString("base64");
 			return { base64, mimeType };
 		} catch (err) {
-			logger?.warn(`[image-fetcher] fetch failed: ${url}`, err);
+			this.logger?.warn(`[image-fetcher] fetch failed: ${url}`, err);
 			return null;
 		} finally {
 			clearTimeout(timer);
 		}
-	};
+	}
 }

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -4,7 +4,7 @@ import { resolve } from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { EmotionEstimator } from "@vicissitude/agent/emotion/estimator";
-import { createHttpImageFetcher } from "@vicissitude/infrastructure/http/image-fetcher";
+import { HttpImageFetcher } from "@vicissitude/infrastructure/http/image-fetcher";
 import { GeniusClient } from "@vicissitude/listening/genius-client";
 import { ListeningMemory } from "@vicissitude/listening/listening-memory";
 import type { MemoryReadServices } from "@vicissitude/memory";
@@ -173,7 +173,7 @@ async function main(): Promise<void> {
 		recentMessagesFetcher,
 		moodReader: moodStore,
 		logger,
-		imageFetcher: createHttpImageFetcher({ logger }),
+		imageFetcher: new HttpImageFetcher({ logger }),
 	});
 
 	const retrieveCache = new LruCache<{ content: Array<{ type: "text"; text: string }> }>({

--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -340,7 +340,7 @@ async function buildImageContents(
 	const urls = collectImageUrls(events, MAX_IMAGES_PER_RESPONSE);
 	if (urls.length === 0) return [];
 
-	const fetched = await Promise.all(urls.map((u) => imageFetcher(u)));
+	const fetched = await Promise.all(urls.map((u) => imageFetcher.fetch(u)));
 	const images: ImageContent[] = [];
 	for (const r of fetched) {
 		if (r) images.push({ type: "image", data: r.base64, mimeType: r.mimeType });

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -159,4 +159,6 @@ export interface FetchedImage {
  * - ネットワーク失敗、タイムアウト、サイズ超過、非画像 MIME などは例外を投げず `null` を返す。
  * - 呼び出し側は `null` を「画像として送れなかった」と解釈してフォールバックすること。
  */
-export type ImageFetcher = (url: string) => Promise<FetchedImage | null>;
+export interface ImageFetcher {
+	fetch(url: string): Promise<FetchedImage | null>;
+}

--- a/spec/mcp/tools/event-buffer-image.spec.ts
+++ b/spec/mcp/tools/event-buffer-image.spec.ts
@@ -64,9 +64,11 @@ function createStubImageFetcher(response: FetchedImage | null): {
 } {
 	const calls: string[] = [];
 	return {
-		fetcher: (url: string) => {
-			calls.push(url);
-			return Promise.resolve(response);
+		fetcher: {
+			fetch: (url: string) => {
+				calls.push(url);
+				return Promise.resolve(response);
+			},
 		},
 		calls,
 	};


### PR DESCRIPTION
## Summary
- `createHttpImageFetcher` factory 関数を `HttpImageFetcher` class に変換（code-conventions.md §3.1, §5 準拠）
- `ImageFetcher` ポート型を関数型から `interface` に変更し、呼び出し側を `.fetch()` メソッドに統一
- `CreateHttpImageFetcherOptions` を `HttpImageFetcherOptions` にリネーム

Closes #679

## Test plan
- [x] `nr test:spec` — 1461 テスト全通過
- [x] `nr test:unit` — 480 テスト全通過（image-fetcher.test.ts 含む）
- [x] `nr validate` — fmt:check / lint / check すべて通過（既知の無関係な警告のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)