### PR TITLE
spec: image content parts の text 後配置を契約として明示

### DIFF
--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -380,6 +380,8 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 		}
 		const moodContent = buildMoodContent(moodReader, moodKey);
 		if (moodContent) content.unshift(moodContent);
+		// 順序契約: text content parts が先、image content parts が末尾に続く。
+		// この順序は event-buffer-image.spec.ts で検証されている。
 		if (imageFetcher) {
 			const images = await buildImageContents(events, imageFetcher, logger);
 			content.push(...images);

--- a/spec/mcp/tools/event-buffer-image.spec.ts
+++ b/spec/mcp/tools/event-buffer-image.spec.ts
@@ -200,4 +200,34 @@ describe("wait_for_events への画像同梱", () => {
 			"https://cdn.example.com/e2b.png",
 		]);
 	});
+
+	test("image content parts は全ての text content parts の後に配置される", async () => {
+		const db = createTestDb();
+		const agentId = "agent-img-order";
+		insertEventWithImages(db, agentId, [
+			{
+				url: "https://cdn.example.com/order1.png",
+				contentType: "image/png",
+				filename: "order1.png",
+			},
+			{
+				url: "https://cdn.example.com/order2.png",
+				contentType: "image/png",
+				filename: "order2.png",
+			},
+		]);
+
+		const { fetcher } = createStubImageFetcher({ base64: "DATA", mimeType: "image/png" });
+		const result = await callWaitForEvents({ db, agentId, imageFetcher: fetcher });
+
+		const lastTextIndex = result.content.reduce(
+			(max, part, i) => (part.type === "text" ? i : max),
+			-1,
+		);
+		const firstImageIndex = result.content.findIndex(isImagePart);
+
+		expect(firstImageIndex).toBeGreaterThan(-1);
+		expect(lastTextIndex).toBeGreaterThan(-1);
+		expect(lastTextIndex).toBeLessThan(firstImageIndex);
+	});
 });


### PR DESCRIPTION
## Summary
- image content parts が全ての text content parts の後に配置されることを検証する spec テストを `event-buffer-image.spec.ts` に追加
- `buildResponseContent` に順序契約のコメントを追記

Closes #681

## Test plan
- [ ] `nr test:spec` で新規テスト `"image content parts は全ての text content parts の後に配置される"` が pass すること
- [ ] 既存テストにリグレッションがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)