### PR TITLE
refactor: SESSION_RESTARTS の reason ラベル命名規則を統一

### DIFF
--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -162,7 +162,7 @@ export class AgentRunner implements AiAgent {
 				);
 				// ローテーション後に再度すぐ検知されないよう、タイムスタンプをリセット
 				this.lastWaitForEventsAt = Date.now();
-				this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, { reason: "hang_detected" });
+				this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, { reason: "hang_rotation" });
 				this.forceSessionRotation().catch((err) => {
 					this.logger.error(
 						`[${this.profile.name}:${this.agentId}] hang recovery rotation failed`,

--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -20,7 +20,7 @@
  * | error_retryable_backoff     | retryable:true でバックオフ中の再起動             |
  * | error_retryable_rotation    | retryable:true で cap 到達後のローテーション      |
  * | error_non_retryable_rotation| retryable:false の即時ローテーション              |
- * | hang_detected               | (既存) ハング検知によるローテーション             |
+ * | hang_rotation               | ハング検知によるローテーション                    |
  */
 /* oxlint-disable max-lines, max-lines-per-function, no-await-in-loop -- テストファイルはケース数に応じて長くなるため許容 */
 import { afterEach, describe, expect, mock, test } from "bun:test";

--- a/spec/observability/session-error-metrics.spec.ts
+++ b/spec/observability/session-error-metrics.spec.ts
@@ -72,11 +72,11 @@ describe("SESSION_RESTARTS カウンタ", () => {
 		c.registerCounter(METRIC.SESSION_RESTARTS, "session restarts");
 		c.incrementCounter(METRIC.SESSION_RESTARTS, { reason: "error" });
 		c.incrementCounter(METRIC.SESSION_RESTARTS, { reason: "error" });
-		c.incrementCounter(METRIC.SESSION_RESTARTS, { reason: "hang_detected" });
+		c.incrementCounter(METRIC.SESSION_RESTARTS, { reason: "hang_rotation" });
 
 		const output = c.serialize();
 		expect(output).toContain('session_restarts_total{reason="error"} 2');
-		expect(output).toContain('session_restarts_total{reason="hang_detected"} 1');
+		expect(output).toContain('session_restarts_total{reason="hang_rotation"} 1');
 	});
 });
 


### PR DESCRIPTION
## Summary

- `hang_detected` → `hang_rotation` にリネームし、全5つの reason ラベルを状態記述スタイルに統一
- spec テスト・コメント内の参照も合わせて更新

Closes #648

## Test plan

- [x] `nr test:spec` — 全 1463 テスト通過
- [x] `nr test:unit` — 全 480 テスト通過
- [x] `nr validate` — fmt/lint/check 全パス
- [x] `hang_detected` がコードベースに残存していないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)