### PR TITLE
spec: hang_detected reason の仕様テストを追加

### DIFF
--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -82,11 +82,12 @@ function createContextBuilder(): ContextBuilderPort {
 	return { build: mock(() => Promise.resolve("system prompt")) };
 }
 
-function createSessionStore() {
-	let sessionId: string | undefined;
+function createSessionStore(existingSessionId?: string) {
+	let sessionId: string | undefined = existingSessionId;
+	const createdAt: number | undefined = existingSessionId ? Date.now() : undefined;
 	return {
 		get: mock(() => sessionId),
-		getRow: mock(() => (sessionId ? { key: "k", sessionId, createdAt: Date.now() } : undefined)),
+		getRow: mock(() => (sessionId && createdAt ? { key: "k", sessionId, createdAt } : undefined)),
 		save: mock((_profile: string, _key: string, nextSessionId: string) => {
 			sessionId = nextSessionId;
 		}),
@@ -803,5 +804,40 @@ describe("SESSION_RESTARTS reason ラベルの分類", () => {
 
 		runner.stop();
 		session2.resolve({ type: "cancelled" });
+	});
+
+	test("ハング検知によるローテーションは reason=hang_detected", async () => {
+		const eventBuffer = createEventBuffer(() => new Promise(() => {}));
+		const sessionPort = createSessionPortWithSessions([new Promise(() => {})]);
+		const metrics = createMockMetrics();
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore("existing-session-id") as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+			hangTimeoutMs: 100,
+			metrics,
+		});
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		await Bun.sleep(150);
+
+		const incrementCalls = (metrics.incrementCounter as ReturnType<typeof mock>).mock.calls;
+		const restartCalls = incrementCalls.filter(
+			(call: unknown[]) => call[0] === METRIC.SESSION_RESTARTS,
+		);
+		const hangRestarts = restartCalls.filter(
+			(call: unknown[]) =>
+				(call[1] as Record<string, string> | undefined)?.reason === "hang_detected",
+		);
+		expect(hangRestarts.length).toBeGreaterThanOrEqual(1);
+
+		runner.stop();
 	});
 });

--- a/spec/agent/session-error-metrics.spec.ts
+++ b/spec/agent/session-error-metrics.spec.ts
@@ -363,4 +363,41 @@ describe("Runner: session restart メトリクス記録", () => {
 		runner.stop();
 		secondSessionDone.resolve({ type: "cancelled" });
 	});
+
+	test("ハング検知によるセッションローテーション時に SESSION_RESTARTS がインクリメントされる", async () => {
+		const eventBuffer = createEventBuffer(() => new Promise(() => {}));
+		const sessionPort = createSessionPortWithControlledResult(
+			new Promise(() => {}),
+			new Promise(() => {}),
+		);
+		const metrics = createMockMetrics();
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore("existing-session-id") as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			eventBuffer,
+			sessionMaxAgeMs: 3_600_000,
+			hangTimeoutMs: 100,
+			metrics,
+		});
+		activeRunners.add(runner);
+
+		runner.ensurePolling();
+		await Bun.sleep(150);
+
+		const incrementCalls = (metrics.incrementCounter as ReturnType<typeof mock>).mock.calls;
+		const restartCalls = incrementCalls.filter(
+			(call: unknown[]) => call[0] === METRIC.SESSION_RESTARTS,
+		);
+		const hangRestarts = restartCalls.filter(
+			(call: unknown[]) =>
+				(call[1] as Record<string, string> | undefined)?.reason === "hang_detected",
+		);
+		expect(hangRestarts.length).toBeGreaterThanOrEqual(1);
+
+		runner.stop();
+	});
 });


### PR DESCRIPTION
## Summary

Closes #695

- `spec/agent/session-error-metrics.spec.ts` に仕様4（ハング検知時の SESSION_RESTARTS 記録）のテストケースを追加
- `spec/agent/runner-error-strategy.spec.ts` に `hang_detected` reason ラベルの分類テストを追加
- `runner-error-strategy.spec.ts` の `createSessionStore` ヘルパーに `existingSessionId` パラメータを追加（`runner-test-helpers.ts` と同パターン）

## Test plan

- [x] `bun test spec/agent/session-error-metrics.spec.ts` — 全 pass
- [x] `bun test spec/agent/runner-error-strategy.spec.ts` — 全 pass
- [x] `bun test` (全テスト) — 1945 pass, 0 fail
- [x] `nr validate` — lint/fmt 問題なし（tsgo の既知エラーのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)