### PR TITLE
fix(spec): hang_detected → hang_rotation に reason ラベルを修正

### DIFF
--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -806,7 +806,7 @@ describe("SESSION_RESTARTS reason ラベルの分類", () => {
 		session2.resolve({ type: "cancelled" });
 	});
 
-	test("ハング検知によるローテーションは reason=hang_detected", async () => {
+	test("ハング検知によるローテーションは reason=hang_rotation", async () => {
 		const eventBuffer = createEventBuffer(() => new Promise(() => {}));
 		const sessionPort = createSessionPortWithSessions([new Promise(() => {})]);
 		const metrics = createMockMetrics();
@@ -834,7 +834,7 @@ describe("SESSION_RESTARTS reason ラベルの分類", () => {
 		);
 		const hangRestarts = restartCalls.filter(
 			(call: unknown[]) =>
-				(call[1] as Record<string, string> | undefined)?.reason === "hang_detected",
+				(call[1] as Record<string, string> | undefined)?.reason === "hang_rotation",
 		);
 		expect(hangRestarts.length).toBeGreaterThanOrEqual(1);
 

--- a/spec/agent/session-error-metrics.spec.ts
+++ b/spec/agent/session-error-metrics.spec.ts
@@ -394,7 +394,7 @@ describe("Runner: session restart メトリクス記録", () => {
 		);
 		const hangRestarts = restartCalls.filter(
 			(call: unknown[]) =>
-				(call[1] as Record<string, string> | undefined)?.reason === "hang_detected",
+				(call[1] as Record<string, string> | undefined)?.reason === "hang_rotation",
 		);
 		expect(hangRestarts.length).toBeGreaterThanOrEqual(1);
 


### PR DESCRIPTION
## Summary
- #694 で reason ラベルが `hang_rotation` に統一されたが、#696 で追加された仕様テストが旧い `hang_detected` を期待していたため CI が失敗していた
- spec の reason 文字列を `hang_rotation` に修正

## Test plan
- [x] `nr test -- spec/agent/session-error-metrics.spec.ts spec/agent/runner-error-strategy.spec.ts` 通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)