### PR TITLE
spec(discord): pollingPrompt のツール名を仕様テストで契約化

### DIFF
--- a/spec/agent/discord/profile.spec.ts
+++ b/spec/agent/discord/profile.spec.ts
@@ -12,4 +12,14 @@ describe("createConversationProfile", () => {
 
 		expect(profile.restartPolicy).toBe("wait_for_events");
 	});
+
+	test("pollingPrompt に core_wait_for_events ツール名が含まれる", () => {
+		const profile = createConversationProfile({
+			providerId: "provider",
+			modelId: "model",
+			mcpServers: {},
+		});
+
+		expect(profile.pollingPrompt).toContain("core_wait_for_events");
+	});
 });


### PR DESCRIPTION
## Summary
- `pollingPrompt` に `core_wait_for_events` が含まれることを検証する spec テストを追加
- ツール名誤りによるセッションローテーションループ (#698) の再発防止

Closes #700

## Test plan
- [x] `bun test spec/agent/discord/profile.spec.ts` — 2 tests pass
- [x] 全 spec テスト — 1466 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)