### PR TITLE
refactor(mcp): image content parts をイベント単位でインターリーブ配置

### DIFF
--- a/packages/mcp/src/tools/event-buffer.ts
+++ b/packages/mcp/src/tools/event-buffer.ts
@@ -131,43 +131,43 @@ export function isErrorEvent(e: EventOrError): e is ErrorEvent {
 	return "_error" in e && "_raw" in e;
 }
 
+/** 単一の EventOrError を人間可読形式にフォーマットする */
+function formatEvent(e: EventOrError): string {
+	// エラーイベント
+	if (isErrorEvent(e)) {
+		return `[ERROR] ${e._error}: ${e._raw}`;
+	}
+
+	const dateStr = formatTimestamp(new Date(e.ts));
+	const channel = e.metadata?.channelName ? ` #${e.metadata.channelName}` : "";
+	const hint = classifyActionHint(e);
+	const extras: string[] = [];
+	if (e.attachments && e.attachments.length > 0) {
+		// 画像添付は可能な範囲で image content part として別途 vision input に同梱される。
+		// ここでは LLM が「どの添付について話しているか」を参照できるよう filename + MIME を列挙する。
+		const labels = e.attachments.map((a) => {
+			// filename / contentType はユーザー入力起源なのでタグインジェクション対策に escape する
+			const name = escapeUserMessageTag(a.filename ?? "attachment");
+			const mime = escapeUserMessageTag(a.contentType ?? "unknown");
+			return `${name} (${mime})`;
+		});
+		extras.push(`[添付: ${labels.join("; ")}]`);
+	}
+	extras.push(`[action: ${hint}]`);
+	const extraStr = ` ${extras.join(" ")}`;
+
+	const isUserMessage = e.authorId !== "system" && e.metadata?.isBot !== true;
+	const content = isUserMessage
+		? `<user_message>${escapeUserMessageTag(e.content)}</user_message>`
+		: e.content;
+
+	return `[${dateStr}${channel}] ${e.authorName}: ${content}${extraStr}`;
+}
+
 /** EventOrError 配列を人間可読形式にフォーマットする */
 export function formatEvents(events: EventOrError[]): string {
 	if (events.length === 0) return "";
-
-	return events
-		.map((e) => {
-			// エラーイベント
-			if (isErrorEvent(e)) {
-				return `[ERROR] ${e._error}: ${e._raw}`;
-			}
-
-			const dateStr = formatTimestamp(new Date(e.ts));
-			const channel = e.metadata?.channelName ? ` #${e.metadata.channelName}` : "";
-			const hint = classifyActionHint(e);
-			const extras: string[] = [];
-			if (e.attachments && e.attachments.length > 0) {
-				// 画像添付は可能な範囲で image content part として別途 vision input に同梱される。
-				// ここでは LLM が「どの添付について話しているか」を参照できるよう filename + MIME を列挙する。
-				const labels = e.attachments.map((a) => {
-					// filename / contentType はユーザー入力起源なのでタグインジェクション対策に escape する
-					const name = escapeUserMessageTag(a.filename ?? "attachment");
-					const mime = escapeUserMessageTag(a.contentType ?? "unknown");
-					return `${name} (${mime})`;
-				});
-				extras.push(`[添付: ${labels.join("; ")}]`);
-			}
-			extras.push(`[action: ${hint}]`);
-			const extraStr = ` ${extras.join(" ")}`;
-
-			const isUserMessage = e.authorId !== "system" && e.metadata?.isBot !== true;
-			const content = isUserMessage
-				? `<user_message>${escapeUserMessageTag(e.content)}</user_message>`
-				: e.content;
-
-			return `[${dateStr}${channel}] ${e.authorName}: ${content}${extraStr}`;
-		})
-		.join("\n");
+	return events.map((e) => formatEvent(e)).join("\n");
 }
 
 // ─── formatEventMetadata ─────────────────────────────────────────
@@ -328,25 +328,36 @@ function collectImageUrls(events: EventOrError[], limit: number): string[] {
 	return urls;
 }
 
+/** 単一イベントから画像 URL を抽出する */
+function collectEventImageUrls(event: EventOrError): string[] {
+	if (isErrorEvent(event)) return [];
+	const urls: string[] = [];
+	for (const a of event.attachments ?? []) {
+		if (a.contentType?.startsWith("image/")) urls.push(a.url);
+	}
+	return urls;
+}
+
 /**
- * 画像添付を並列 fetch して MCP の image content part に変換する。
- * fetch に失敗した画像は結果から除外される（text 表記のみで LLM に渡される）。
+ * 全イベントの画像 URL を一括 fetch し、URL→ImageContent のマップを返す。
+ * fetch に失敗した画像は結果から除外される。
  */
-async function buildImageContents(
-	events: EventOrError[],
+async function fetchAllImages(
+	urls: string[],
 	imageFetcher: ImageFetcher,
 	logger?: Logger,
-): Promise<ImageContent[]> {
-	const urls = collectImageUrls(events, MAX_IMAGES_PER_RESPONSE);
-	if (urls.length === 0) return [];
+): Promise<Map<string, ImageContent>> {
+	if (urls.length === 0) return new Map();
 
 	const fetched = await Promise.all(urls.map((u) => imageFetcher.fetch(u)));
-	const images: ImageContent[] = [];
-	for (const r of fetched) {
-		if (r) images.push({ type: "image", data: r.base64, mimeType: r.mimeType });
+	const map = new Map<string, ImageContent>();
+	for (let i = 0; i < urls.length; i++) {
+		const r = fetched[i];
+		const url = urls[i];
+		if (r && url) map.set(url, { type: "image", data: r.base64, mimeType: r.mimeType });
 	}
-	logger?.info(`[event-buffer] vision 入力: ${images.length}/${urls.length}枚の画像を同梱`);
-	return images;
+	logger?.info(`[event-buffer] vision 入力: ${map.size}/${urls.length}枚の画像を同梱`);
+	return map;
 }
 
 // ─── registerEventBufferTools ────────────────────────────────────
@@ -369,23 +380,38 @@ export function registerEventBufferTools(server: McpServer, deps: EventBufferDep
 	async function buildResponseContent(
 		events: EventOrError[],
 	): Promise<{ content: MessageContent[] }> {
-		const text = formatEvents(events);
-		const metadataText = formatEventMetadata(events);
-		const content: MessageContent[] = [
-			{ type: "text", text: text + (metadataText ? `\n${metadataText}` : "") },
-		];
+		const content: MessageContent[] = [];
+
+		// mood を先頭に追加
+		const moodContent = buildMoodContent(moodReader, moodKey);
+		if (moodContent) content.push(moodContent);
+
+		// recent messages を追加
 		if (recentMessagesFetcher) {
 			const ctx = await fetchRecentMessagesContext(events, recentMessagesFetcher);
-			if (ctx) content.unshift(ctx);
+			if (ctx) content.push(ctx);
 		}
-		const moodContent = buildMoodContent(moodReader, moodKey);
-		if (moodContent) content.unshift(moodContent);
-		// 順序契約: text content parts が先、image content parts が末尾に続く。
-		// この順序は event-buffer-image.spec.ts で検証されている。
+
+		// 画像を一括 fetch（イベント単位でインターリーブ配置するため）
+		let imageMap = new Map<string, ImageContent>();
 		if (imageFetcher) {
-			const images = await buildImageContents(events, imageFetcher, logger);
-			content.push(...images);
+			const allUrls = collectImageUrls(events, MAX_IMAGES_PER_RESPONSE);
+			imageMap = await fetchAllImages(allUrls, imageFetcher, logger);
 		}
+		// イベントをイテレート: 各イベントの text part + image parts をインターリーブ配置
+		for (const event of events) {
+			content.push({ type: "text", text: formatEvent(event) });
+			const eventUrls = collectEventImageUrls(event);
+			for (const url of eventUrls) {
+				const img = imageMap.get(url);
+				if (img) content.push(img);
+			}
+		}
+
+		// metadata text part を最後に追加
+		const metadataText = formatEventMetadata(events);
+		if (metadataText) content.push({ type: "text", text: metadataText });
+
 		return { content };
 	}
 

--- a/spec/mcp/tools/event-buffer-image.spec.ts
+++ b/spec/mcp/tools/event-buffer-image.spec.ts
@@ -71,6 +71,23 @@ function createStubImageFetcher(response: FetchedImage | null): {
 	};
 }
 
+/** URL ごとに異なるレスポンスを返すスタブ ImageFetcher */
+function createMappedImageFetcher(mapping: Record<string, FetchedImage | null>): {
+	fetcher: ImageFetcher;
+	calls: string[];
+} {
+	const calls: string[] = [];
+	return {
+		fetcher: {
+			fetch: (url: string) => {
+				calls.push(url);
+				return Promise.resolve(mapping[url] ?? null);
+			},
+		},
+		calls,
+	};
+}
+
 function isImagePart(c: ContentPart): c is { type: "image"; data: string; mimeType: string } {
 	return c.type === "image";
 }
@@ -201,7 +218,7 @@ describe("wait_for_events への画像同梱", () => {
 		]);
 	});
 
-	test("image content parts は全ての text content parts の後に配置される", async () => {
+	test("各イベントの image parts はそのイベントの text part の直後に配置される", async () => {
 		const db = createTestDb();
 		const agentId = "agent-img-order";
 		insertEventWithImages(db, agentId, [
@@ -217,17 +234,156 @@ describe("wait_for_events への画像同梱", () => {
 			},
 		]);
 
-		const { fetcher } = createStubImageFetcher({ base64: "DATA", mimeType: "image/png" });
+		const { fetcher } = createMappedImageFetcher({
+			"https://cdn.example.com/order1.png": { base64: "ORDER1", mimeType: "image/png" },
+			"https://cdn.example.com/order2.png": { base64: "ORDER2", mimeType: "image/png" },
+		});
 		const result = await callWaitForEvents({ db, agentId, imageFetcher: fetcher });
 
-		const lastTextIndex = result.content.reduce(
-			(max, part, i) => (part.type === "text" ? i : max),
-			-1,
+		// イベントの text part を特定（order1.png, order2.png を含む text）
+		const eventTextIndex = result.content.findIndex(
+			(c) => c.type === "text" && "text" in c && c.text.includes("order1.png"),
 		);
-		const firstImageIndex = result.content.findIndex(isImagePart);
+		expect(eventTextIndex).toBeGreaterThan(-1);
 
-		expect(firstImageIndex).toBeGreaterThan(-1);
-		expect(lastTextIndex).toBeGreaterThan(-1);
-		expect(lastTextIndex).toBeLessThan(firstImageIndex);
+		// そのイベントの text part の直後に image parts が来る
+		const afterEvent = result.content.slice(eventTextIndex + 1);
+		const firstImage = afterEvent.find((c) => isImagePart(c));
+		expect(firstImage).toBeDefined();
+
+		// image parts はイベント text part と metadata text part の間に存在する
+		const images = result.content.filter(isImagePart);
+		expect(images).toHaveLength(2);
+	});
+
+	test("複数イベントの画像がイベント単位でインターリーブ配置される", async () => {
+		const db = createTestDb();
+		const agentId = "agent-img-interleave";
+		// イベント1: 画像A
+		insertEventWithImages(db, agentId, [
+			{ url: "https://cdn.example.com/a.png", contentType: "image/png", filename: "a.png" },
+		]);
+		// イベント2: 画像B, C
+		insertEventWithImages(db, agentId, [
+			{ url: "https://cdn.example.com/b.png", contentType: "image/png", filename: "b.png" },
+			{ url: "https://cdn.example.com/c.png", contentType: "image/png", filename: "c.png" },
+		]);
+
+		const { fetcher } = createMappedImageFetcher({
+			"https://cdn.example.com/a.png": { base64: "IMG_A", mimeType: "image/png" },
+			"https://cdn.example.com/b.png": { base64: "IMG_B", mimeType: "image/png" },
+			"https://cdn.example.com/c.png": { base64: "IMG_C", mimeType: "image/png" },
+		});
+		const result = await callWaitForEvents({ db, agentId, imageFetcher: fetcher });
+
+		// content 配列から event text / image の並びを検証する
+		// 期待: [...prefix_texts, event1_text, imageA, event2_text, imageB, imageC, metadata_text]
+		const parts = result.content;
+
+		// event1 の text part を特定（a.png を含む）
+		const e1TextIdx = parts.findIndex(
+			(c) =>
+				c.type === "text" && "text" in c && c.text.includes("a.png") && !c.text.includes("b.png"),
+		);
+		expect(e1TextIdx).toBeGreaterThan(-1);
+
+		// event1 text の直後に event1 の image (IMG_A) が来る
+		const afterE1 = parts.at(e1TextIdx + 1);
+		expect(afterE1).toBeDefined();
+		expect(afterE1?.type).toBe("image");
+		expect(afterE1 && isImagePart(afterE1) && afterE1.data).toBe("IMG_A");
+
+		// event2 の text part を特定（b.png を含む）
+		const e2TextIdx = parts.findIndex(
+			(c) => c.type === "text" && "text" in c && c.text.includes("b.png"),
+		);
+		expect(e2TextIdx).toBeGreaterThan(-1);
+		// event2 text は event1 image の後に来る
+		expect(e2TextIdx).toBeGreaterThan(e1TextIdx + 1);
+
+		// event2 text の直後に event2 の images (IMG_B, IMG_C) が来る
+		const afterE2First = parts.at(e2TextIdx + 1);
+		const afterE2Second = parts.at(e2TextIdx + 2);
+		expect(afterE2First).toBeDefined();
+		expect(afterE2Second).toBeDefined();
+		expect(afterE2First?.type).toBe("image");
+		expect(afterE2Second?.type).toBe("image");
+		expect(afterE2First && isImagePart(afterE2First) && afterE2First.data).toBe("IMG_B");
+		expect(afterE2Second && isImagePart(afterE2Second) && afterE2Second.data).toBe("IMG_C");
+
+		// metadata text は最後の text part
+		const lastPart = parts.at(-1);
+		expect(lastPart).toBeDefined();
+		expect(lastPart?.type).toBe("text");
+		expect(lastPart && "text" in lastPart && lastPart.text).toContain("event-metadata");
+	});
+
+	test("画像のないイベントは text part のみで image part が挟まらない", async () => {
+		const db = createTestDb();
+		const agentId = "agent-img-no-img-event";
+		// イベント1: 画像あり
+		insertEventWithImages(db, agentId, [
+			{ url: "https://cdn.example.com/x.png", contentType: "image/png", filename: "x.png" },
+		]);
+		// イベント2: 画像なし
+		appendEvent(
+			db,
+			agentId,
+			JSON.stringify({
+				ts: "2026-04-01T00:01:00.000Z",
+				content: "テキストのみ",
+				authorId: "user-2",
+				authorName: "ユーザー2",
+				messageId: "msg-no-img",
+				attachments: [],
+				metadata: { channelId: "ch-1", channelName: "general", isMentioned: true },
+			}),
+		);
+		// イベント3: 画像あり
+		insertEventWithImages(db, agentId, [
+			{ url: "https://cdn.example.com/y.png", contentType: "image/png", filename: "y.png" },
+		]);
+
+		const { fetcher } = createMappedImageFetcher({
+			"https://cdn.example.com/x.png": { base64: "IMG_X", mimeType: "image/png" },
+			"https://cdn.example.com/y.png": { base64: "IMG_Y", mimeType: "image/png" },
+		});
+		const result = await callWaitForEvents({ db, agentId, imageFetcher: fetcher });
+
+		const parts = result.content;
+
+		// event1 text (x.png を含む) の直後に IMG_X が来る
+		const e1TextIdx = parts.findIndex(
+			(c) =>
+				c.type === "text" &&
+				"text" in c &&
+				c.text.includes("x.png") &&
+				!c.text.includes("テキストのみ"),
+		);
+		expect(e1TextIdx).toBeGreaterThan(-1);
+		const afterE1 = parts.at(e1TextIdx + 1);
+		expect(afterE1).toBeDefined();
+		expect(afterE1?.type).toBe("image");
+		expect(afterE1 && isImagePart(afterE1) && afterE1.data).toBe("IMG_X");
+
+		// event2 text (テキストのみ) の直後は image ではない
+		const e2TextIdx = parts.findIndex(
+			(c) => c.type === "text" && "text" in c && c.text.includes("テキストのみ"),
+		);
+		expect(e2TextIdx).toBeGreaterThan(-1);
+		const afterE2 = parts.at(e2TextIdx + 1);
+		expect(afterE2).toBeDefined();
+		// event2 の直後は image part ではなく、event3 の text part であるべき
+		expect(afterE2?.type).toBe("text");
+
+		// event3 text (y.png を含む) の直後に IMG_Y が来る
+		const e3TextIdx = parts.findIndex(
+			(c, i) => i > e2TextIdx && c.type === "text" && "text" in c && c.text.includes("y.png"),
+		);
+		expect(e3TextIdx).toBeGreaterThan(-1);
+		const afterE3 = parts.at(e3TextIdx + 1);
+		expect(afterE3).toBeDefined();
+		expect(afterE3?.type).toBe("image");
+		expect(afterE3 && isImagePart(afterE3) && afterE3.data).toBe("IMG_Y");
 	});
 });


### PR DESCRIPTION
## Summary

- `wait_for_events` のレスポンスで画像を末尾一括配置からイベント単位インターリーブ配置に変更
- 各イベントの text part 直後にそのイベントの image parts を配置し、構造で対応関係を表現
- `formatEvent` 関数を新設し、イベント単位のフォーマットを可能に
- `fetchAllImages` で一括並列 fetch → URL→ImageContent Map で効率的にインターリーブ

### Before
```
content: [mood?, recent_messages?, all_events_text + metadata, img1, img2, img3, ...]
```

### After
```
content: [mood?, recent_messages?, event1_text, event1_img1, event2_text, event2_img1, event2_img2, metadata_text]
```

## Test plan

- [x] 仕様テスト (`nr test:spec`): 1950 pass, 0 fail
- [x] 型チェック (`nr check`): pass
- [x] lint (`nr lint`): 0 errors
- [x] フォーマット (`nr fmt:check`): pass

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)