### PR TITLE
spec(discord): pollingPrompt の単独呼び出し制約テスト追加

### DIFF
--- a/spec/agent/discord/profile.spec.ts
+++ b/spec/agent/discord/profile.spec.ts
@@ -22,4 +22,14 @@ describe("createConversationProfile", () => {
 
 		expect(profile.pollingPrompt).toContain("core_wait_for_events");
 	});
+
+	test("pollingPrompt に core_wait_for_events の単独呼び出し制約が含まれる", () => {
+		const profile = createConversationProfile({
+			providerId: "provider",
+			modelId: "model",
+			mcpServers: {},
+		});
+
+		expect(profile.pollingPrompt).toContain("単独で呼ぶこと");
+	});
 });


### PR DESCRIPTION
## Summary
- `/review` で検出された spec 未整備を修正
- `pollingPrompt` に追加された `core_wait_for_events` 単独呼び出し制約の存在を検証する spec テストを追加

## Test plan
- [x] `nr test:spec -- spec/agent/discord/profile.spec.ts` 通過
- [x] `nr validate` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)