### PR TITLE
fix(discord): shutdown ハンドラにエラー分離を追加

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -601,24 +601,33 @@ export async function bootstrap(): Promise<void> {
 		logger.info("[bootstrap] Shutting down...");
 		// Force exit after 5 seconds if graceful shutdown hangs
 		const forceTimer = setTimeout(() => process.exit(1), 5000);
-		try {
-			clearInterval(sessionGaugeTimer);
-			await memoryResources?.consolidationScheduler.stop();
-			heartbeatScheduler.stop();
-			gateway.stop();
-			await gatewayServer.stop();
-			mcBrainManager?.stop();
-			heartbeatRouter.stop();
-			routingAgent.stop();
-			metrics.server.stop();
-			await factReader.close();
-			memoryResources?.chatAdapter.close();
-			await memoryResources?.recorder.close();
-			mcProcess?.kill();
-			closeDb(db);
-		} catch (err) {
-			logger.error("[bootstrap] Error during shutdown:", err);
-		}
+
+		const safe = async (label: string, fn: () => void | Promise<void>) => {
+			try {
+				await fn();
+			} catch (err) {
+				logger.error(`[bootstrap] ${label}:`, err);
+			}
+		};
+
+		await safe("sessionGauge", () => clearInterval(sessionGaugeTimer));
+		await safe("consolidation", () => memoryResources?.consolidationScheduler.stop());
+		await safe("heartbeatScheduler", () => heartbeatScheduler.stop());
+		await safe("gateway", () => gateway.stop());
+		await safe("gatewayServer", async () => void (await gatewayServer.stop()));
+		await safe("mcBrainManager", () => mcBrainManager?.stop());
+		// heartbeatRouter.stop() -> each AgentRunner.stop() -> sessionPort.close() (SIGTERM to opencode child)
+		await safe("heartbeatRouter", () => heartbeatRouter.stop());
+		// routingAgent.stop() -> GuildRouter.stop() -> each AgentRunner.stop() -> sessionPort.close()
+		await safe("routingAgent", () => routingAgent.stop());
+		await safe("metrics", () => metrics.server.stop());
+		await safe("factReader", () => factReader.close());
+		// chatAdapter.close() -> MemoryChatAdapter.close() -> memorySessionPort.close()
+		await safe("chatAdapter", () => memoryResources?.chatAdapter.close());
+		await safe("recorder", () => memoryResources?.recorder.close());
+		await safe("mcProcess", () => mcProcess?.kill());
+		await safe("db", () => closeDb(db));
+
 		clearTimeout(forceTimer);
 		process.exit(0);
 	};


### PR DESCRIPTION
## Summary

Closes #629

- shutdown ハンドラの各 cleanup ステップを独立した try-catch でラップし、1つのステップの失敗が後続の cleanup をスキップしないようにした
- 暗黙の `sessionPort.close()` チェーン（`routingAgent.stop()` → `AgentRunner.stop()` → `sessionPort.close()`）をコメントで明示化

## 調査結果

Issue の元の懸念（`sessionPort.close()` が呼ばれていない）は実際には対処済みだった:
- `routingAgent.stop()` / `heartbeatRouter.stop()` → `AgentRunner.stop()` → `sessionPort.close()` で SIGTERM が送られる
- `chatAdapter.close()` → `MemoryChatAdapter.close()` → `memorySessionPort.close()` も呼ばれている

ただし、shutdown ハンドラが単一の try ブロック内にあったため、途中で例外が発生すると後続の cleanup（`routingAgent.stop()` 含む）がスキップされ、結果として子プロセスにSIGTERMが届かないリスクがあった。

## Test plan

- [x] `nr validate` (fmt:check + lint + type check) 通過
- [x] `nr test` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)