### PR TITLE
refactor: hang check ログを debug レベルに下げ、LOG_LEVEL を削除

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -67,7 +67,6 @@ services:
     init: true
     environment:
       APP_ROOT: /app
-      LOG_LEVEL: debug
     env_file:
       - .env
     ports:

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -153,7 +153,7 @@ export class AgentRunner implements AiAgent {
 			const mcpHeartbeat = this.heartbeatReader?.getLastSeenAt(this.agentId) ?? 0;
 			const lastAlive = Math.max(this.lastWaitForEventsAt, mcpHeartbeat);
 			const elapsed = Date.now() - lastAlive;
-			this.logger.info(
+			this.logger.debug(
 				`[${this.profile.name}:${this.agentId}] hang check: elapsed=${elapsed}ms threshold=${this.hangTimeoutMs}ms lastWaitForEvents=${this.lastWaitForEventsAt} mcpHeartbeat=${mcpHeartbeat}`,
 			);
 			if (elapsed >= this.hangTimeoutMs) {


### PR DESCRIPTION
## Summary
- `runner.ts` の hang check ログを info → debug レベルに変更（60秒ごとの全エージェント分出力がノイズのため）
- `compose.yaml` の `LOG_LEVEL: debug` を削除（`.env` で制御する形に統一）
- session-adapter.ts のログは方針通り現状維持

Closes #533

## Test plan
- [x] 既存 spec テスト全 1478 件 PASS（ログレベルに依存するアサーションなし）
- [x] 変更は info→debug の1行 + LOG_LEVEL 削除の1行のみ、振る舞いへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)