### PR TITLE
fix(minecraft): EVENT_BUFFER_POLL_ERRORS メトリクスを記録

### DIFF
--- a/packages/agent/src/minecraft/brain-manager.test.ts
+++ b/packages/agent/src/minecraft/brain-manager.test.ts
@@ -184,4 +184,24 @@ describe("McBrainManager", () => {
 		);
 		expect(lifecycleErrors).toHaveLength(0);
 	});
+
+	test("metrics を渡した場合に createAgent がエラーなく動作する", async () => {
+		const metrics = {
+			incrementCounter: mock(() => {}),
+		};
+		const depsWithMetrics = createTestDeps({ metrics: metrics as any });
+		const mgr = new McBrainManager(depsWithMetrics);
+		mgr.start();
+
+		tryAcquireSessionLock(depsWithMetrics.db, "test-guild-metrics");
+		await Bun.sleep(TEST_POLL_MS * 3);
+
+		const infoCalls = (depsWithMetrics.logger.info as ReturnType<typeof mock>).mock.calls;
+		const startedLog = infoCalls.some(
+			(call: unknown[]) =>
+				typeof call[0] === "string" && call[0].includes("minecraft brain started"),
+		);
+		expect(startedLog).toBe(true);
+		mgr.stop();
+	});
 });

--- a/packages/agent/src/minecraft/brain-manager.test.ts
+++ b/packages/agent/src/minecraft/brain-manager.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { MetricsCollector } from "@vicissitude/shared/types";
 import { clearSessionLock, tryAcquireSessionLock } from "@vicissitude/store/mc-bridge";
 import { createTestDb } from "@vicissitude/store/test-helpers";
 
@@ -186,10 +187,15 @@ describe("McBrainManager", () => {
 	});
 
 	test("metrics を渡した場合に createAgent がエラーなく動作する", async () => {
-		const metrics = {
+		const metrics: MetricsCollector = {
 			incrementCounter: mock(() => {}),
+			addCounter: mock(() => {}),
+			setGauge: mock(() => {}),
+			incrementGauge: mock(() => {}),
+			decrementGauge: mock(() => {}),
+			observeHistogram: mock(() => {}),
 		};
-		const depsWithMetrics = createTestDeps({ metrics: metrics as any });
+		const depsWithMetrics = createTestDeps({ metrics });
 		const mgr = new McBrainManager(depsWithMetrics);
 		mgr.start();
 

--- a/packages/agent/src/minecraft/brain-manager.ts
+++ b/packages/agent/src/minecraft/brain-manager.ts
@@ -2,8 +2,14 @@
 import { resolve } from "path";
 
 import { MINECRAFT_AGENT_ID } from "@vicissitude/minecraft/constants";
+import { METRIC } from "@vicissitude/observability/metrics";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
-import type { EventBuffer, Logger, SessionStorePort } from "@vicissitude/shared/types";
+import type {
+	EventBuffer,
+	Logger,
+	MetricsCollector,
+	SessionStorePort,
+} from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
 import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
 import { clearSessionLock, hasSessionLock } from "@vicissitude/store/mc-bridge";
@@ -35,6 +41,8 @@ export interface McBrainManagerDeps {
 	compactionTokenThreshold?: number;
 	/** compaction 間のクールダウン（ms）。デフォルト: 1_800_000 (30分) */
 	compactionCooldownMs?: number;
+	/** MetricsCollector。省略時はメトリクス記録なし */
+	metrics?: MetricsCollector;
 }
 
 /**
@@ -115,7 +123,11 @@ export class McBrainManager {
 		const contextBuilder = new MinecraftContextBuilder(overlayDir, baseDir);
 		const eventBuffer = deps.eventBufferFactory
 			? deps.eventBufferFactory(MINECRAFT_AGENT_ID)
-			: new SqliteEventBuffer(deps.db, MINECRAFT_AGENT_ID, deps.logger);
+			: new SqliteEventBuffer(deps.db, MINECRAFT_AGENT_ID, deps.logger, () => {
+					deps.metrics?.incrementCounter(METRIC.EVENT_BUFFER_POLL_ERRORS, {
+						agent_id: MINECRAFT_AGENT_ID,
+					});
+				});
 
 		this.agent = new MinecraftAgent({
 			eventBuffer,


### PR DESCRIPTION
## Summary
- `McBrainManagerDeps` に `metrics?: MetricsCollector` を追加
- `SqliteEventBuffer` の `onPollError` コールバックで `METRIC.EVENT_BUFFER_POLL_ERRORS` をインクリメントし、Discord 側との可観測性の対称性を確保
- ユニットテストを追加（metrics モック付き）

Closes #608

## Test plan
- [x] `nr test -- packages/agent/src/minecraft/brain-manager.test.ts` — 11 pass
- [x] `spec/observability/session-error-metrics.spec.ts` — 6 pass（既存仕様テスト未破壊）
- [x] lint エラーなし（変更ファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)