### PR TITLE
spec(bootstrap): shutdown ハンドラの仕様テストを追加

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -42,7 +42,7 @@ import type {
 	SessionSummaryWriter,
 } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
-import { createDb, closeDb } from "@vicissitude/store/db";
+import { createDb } from "@vicissitude/store/db";
 import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
 import { SqliteMoodStore } from "@vicissitude/store/mood-store";
 import { incrementEmoji } from "@vicissitude/store/queries";
@@ -58,6 +58,7 @@ import {
 	syncMcCheckReminder,
 } from "./migrations.ts";
 import { createPortLayout } from "./port-allocator.ts";
+import { createShutdown } from "./shutdown.ts";
 
 // ─── Store Layer ────────────────────────────────────────────────
 
@@ -594,43 +595,23 @@ export async function bootstrap(): Promise<void> {
 	}
 
 	// Graceful shutdown
-	let shuttingDown = false;
-	const shutdown = async () => {
-		if (shuttingDown) return;
-		shuttingDown = true;
-		logger.info("[bootstrap] Shutting down...");
-		// Force exit after 5 seconds if graceful shutdown hangs
-		const forceTimer = setTimeout(() => process.exit(1), 5000);
-
-		const safe = async (label: string, fn: () => void | Promise<void>) => {
-			try {
-				await fn();
-			} catch (err) {
-				logger.error(`[bootstrap] ${label}:`, err);
-			}
-		};
-
-		await safe("sessionGauge", () => clearInterval(sessionGaugeTimer));
-		await safe("consolidation", () => memoryResources?.consolidationScheduler.stop());
-		await safe("heartbeatScheduler", () => heartbeatScheduler.stop());
-		await safe("gateway", () => gateway.stop());
-		await safe("gatewayServer", async () => void (await gatewayServer.stop()));
-		await safe("mcBrainManager", () => mcBrainManager?.stop());
-		// heartbeatRouter.stop() -> each AgentRunner.stop() -> sessionPort.close() (SIGTERM to opencode child)
-		await safe("heartbeatRouter", () => heartbeatRouter.stop());
-		// routingAgent.stop() -> GuildRouter.stop() -> each AgentRunner.stop() -> sessionPort.close()
-		await safe("routingAgent", () => routingAgent.stop());
-		await safe("metrics", () => metrics.server.stop());
-		await safe("factReader", () => factReader.close());
-		// chatAdapter.close() -> MemoryChatAdapter.close() -> memorySessionPort.close()
-		await safe("chatAdapter", () => memoryResources?.chatAdapter.close());
-		await safe("recorder", () => memoryResources?.recorder.close());
-		await safe("mcProcess", () => mcProcess?.kill());
-		await safe("db", () => closeDb(db));
-
-		clearTimeout(forceTimer);
-		process.exit(0);
-	};
+	const shutdown = createShutdown({
+		logger,
+		sessionGaugeTimer,
+		consolidationScheduler: memoryResources?.consolidationScheduler,
+		heartbeatScheduler,
+		gateway,
+		gatewayServer,
+		mcBrainManager,
+		heartbeatRouter,
+		routingAgent,
+		metricsServer: metrics.server,
+		factReader,
+		chatAdapter: memoryResources?.chatAdapter,
+		recorder: memoryResources?.recorder,
+		mcProcess,
+		db,
+	});
 	process.on("SIGINT", () => void shutdown());
 	process.on("SIGTERM", () => void shutdown());
 

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -42,7 +42,7 @@ import type {
 	SessionSummaryWriter,
 } from "@vicissitude/shared/types";
 import type { StoreDb } from "@vicissitude/store/db";
-import { createDb } from "@vicissitude/store/db";
+import { closeDb, createDb } from "@vicissitude/store/db";
 import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
 import { SqliteMoodStore } from "@vicissitude/store/mood-store";
 import { incrementEmoji } from "@vicissitude/store/queries";
@@ -610,7 +610,7 @@ export async function bootstrap(): Promise<void> {
 		chatAdapter: memoryResources?.chatAdapter,
 		recorder: memoryResources?.recorder,
 		mcProcess,
-		db,
+		closeDb: () => closeDb(db),
 	});
 	process.on("SIGINT", () => void shutdown());
 	process.on("SIGTERM", () => void shutdown());

--- a/apps/discord/src/shutdown.ts
+++ b/apps/discord/src/shutdown.ts
@@ -1,0 +1,62 @@
+import type { Logger } from "@vicissitude/shared/types";
+import type { StoreDb } from "@vicissitude/store/db";
+import { closeDb } from "@vicissitude/store/db";
+
+export interface ShutdownDeps {
+	logger: Logger;
+	sessionGaugeTimer: ReturnType<typeof setInterval>;
+	consolidationScheduler?: { stop(): void };
+	heartbeatScheduler: { stop(): void };
+	gateway: { stop(): void };
+	gatewayServer: { stop(): Promise<unknown> };
+	mcBrainManager?: { stop(): void };
+	heartbeatRouter: { stop(): void };
+	routingAgent: { stop(): void };
+	metricsServer: { stop(): void };
+	factReader: { close(): void };
+	chatAdapter?: { close(): void };
+	recorder?: { close(): void };
+	mcProcess?: { kill(): void } | null;
+	db: StoreDb;
+}
+
+export function createShutdown(deps: ShutdownDeps): () => Promise<void> {
+	let shuttingDown = false;
+
+	return async () => {
+		if (shuttingDown) return;
+		shuttingDown = true;
+		deps.logger.info("[bootstrap] Shutting down...");
+		// Force exit after 5 seconds if graceful shutdown hangs
+		const forceTimer = setTimeout(() => process.exit(1), 5000);
+
+		const safe = async (label: string, fn: () => void | Promise<void>) => {
+			try {
+				await fn();
+			} catch (err) {
+				deps.logger.error(`[bootstrap] ${label}:`, err);
+			}
+		};
+
+		await safe("sessionGauge", () => clearInterval(deps.sessionGaugeTimer));
+		await safe("consolidation", () => deps.consolidationScheduler?.stop());
+		await safe("heartbeatScheduler", () => deps.heartbeatScheduler.stop());
+		await safe("gateway", () => deps.gateway.stop());
+		await safe("gatewayServer", async () => void (await deps.gatewayServer.stop()));
+		await safe("mcBrainManager", () => deps.mcBrainManager?.stop());
+		// heartbeatRouter.stop() -> each AgentRunner.stop() -> sessionPort.close() (SIGTERM to opencode child)
+		await safe("heartbeatRouter", () => deps.heartbeatRouter.stop());
+		// routingAgent.stop() -> GuildRouter.stop() -> each AgentRunner.stop() -> sessionPort.close()
+		await safe("routingAgent", () => deps.routingAgent.stop());
+		await safe("metrics", () => deps.metricsServer.stop());
+		await safe("factReader", () => deps.factReader.close());
+		// chatAdapter.close() -> MemoryChatAdapter.close() -> memorySessionPort.close()
+		await safe("chatAdapter", () => deps.chatAdapter?.close());
+		await safe("recorder", () => deps.recorder?.close());
+		await safe("mcProcess", () => deps.mcProcess?.kill());
+		await safe("db", () => closeDb(deps.db));
+
+		clearTimeout(forceTimer);
+		process.exit(0);
+	};
+}

--- a/apps/discord/src/shutdown.ts
+++ b/apps/discord/src/shutdown.ts
@@ -1,6 +1,4 @@
 import type { Logger } from "@vicissitude/shared/types";
-import type { StoreDb } from "@vicissitude/store/db";
-import { closeDb } from "@vicissitude/store/db";
 
 export interface ShutdownDeps {
 	logger: Logger;
@@ -17,7 +15,7 @@ export interface ShutdownDeps {
 	chatAdapter?: { close(): void };
 	recorder?: { close(): void };
 	mcProcess?: { kill(): void } | null;
-	db: StoreDb;
+	closeDb: () => void;
 }
 
 export function createShutdown(deps: ShutdownDeps): () => Promise<void> {
@@ -54,7 +52,7 @@ export function createShutdown(deps: ShutdownDeps): () => Promise<void> {
 		await safe("chatAdapter", () => deps.chatAdapter?.close());
 		await safe("recorder", () => deps.recorder?.close());
 		await safe("mcProcess", () => deps.mcProcess?.kill());
-		await safe("db", () => closeDb(deps.db));
+		await safe("db", () => deps.closeDb());
 
 		clearTimeout(forceTimer);
 		process.exit(0);

--- a/spec/discord/bootstrap-shutdown.spec.ts
+++ b/spec/discord/bootstrap-shutdown.spec.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+import type { ShutdownDeps } from "../../apps/discord/src/shutdown.ts";
+
+// closeDb をモック
+const closeDbMock = mock(() => {});
+mock.module("@vicissitude/store/db", () => ({
+	closeDb: closeDbMock,
+}));
+
+// モック後にインポート
+const { createShutdown } = await import("../../apps/discord/src/shutdown.ts");
+
+function makeDeps(overrides: Partial<ShutdownDeps> = {}): ShutdownDeps & { callOrder: string[] } {
+	const callOrder: string[] = [];
+	const track = (name: string) => () => {
+		callOrder.push(name);
+	};
+
+	return {
+		callOrder,
+		logger: { info: mock(), error: mock(), warn: mock(), debug: mock() },
+		sessionGaugeTimer: setInterval(() => {}, 100_000),
+		consolidationScheduler: { stop: mock(track("consolidation")) },
+		heartbeatScheduler: { stop: mock(track("heartbeatScheduler")) },
+		gateway: { stop: mock(track("gateway")) },
+		gatewayServer: {
+			stop: mock(() => {
+				callOrder.push("gatewayServer");
+				return Promise.resolve();
+			}),
+		},
+		mcBrainManager: { stop: mock(track("mcBrainManager")) },
+		heartbeatRouter: { stop: mock(track("heartbeatRouter")) },
+		routingAgent: { stop: mock(track("routingAgent")) },
+		metricsServer: { stop: mock(track("metrics")) },
+		factReader: { close: mock(track("factReader")) },
+		chatAdapter: { close: mock(track("chatAdapter")) },
+		recorder: { close: mock(track("recorder")) },
+		mcProcess: { kill: mock(track("mcProcess")) },
+		db: {} as ShutdownDeps["db"],
+		...overrides,
+	};
+}
+
+describe("createShutdown()", () => {
+	let exitSpy: ReturnType<typeof spyOn>;
+	let clearIntervalSpy: ReturnType<typeof spyOn>;
+	let setTimeoutSpy: ReturnType<typeof spyOn>;
+	let clearTimeoutSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(() => {
+		exitSpy = spyOn(process, "exit").mockImplementation((() => {}) as unknown as (
+			code?: number,
+		) => never);
+		clearIntervalSpy = spyOn(globalThis, "clearInterval");
+		setTimeoutSpy = spyOn(globalThis, "setTimeout").mockReturnValue(
+			42 as unknown as ReturnType<typeof setTimeout>,
+		);
+		clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
+		closeDbMock.mockReset();
+	});
+
+	afterEach(() => {
+		exitSpy.mockRestore();
+		clearIntervalSpy.mockRestore();
+		setTimeoutSpy.mockRestore();
+		clearTimeoutSpy.mockRestore();
+	});
+
+	describe("シャットダウン順序", () => {
+		it("14 コンポーネントが定義順にシャットダウンされる", async () => {
+			const deps = makeDeps();
+			closeDbMock.mockImplementation(() => {
+				deps.callOrder.push("db");
+			});
+			// clearInterval のスパイで sessionGauge の順序を記録
+			clearIntervalSpy.mockImplementation((..._args: unknown[]) => {
+				deps.callOrder.push("sessionGauge");
+			});
+
+			const shutdown = createShutdown(deps);
+			await shutdown();
+
+			expect(deps.callOrder).toEqual([
+				"sessionGauge",
+				"consolidation",
+				"heartbeatScheduler",
+				"gateway",
+				"gatewayServer",
+				"mcBrainManager",
+				"heartbeatRouter",
+				"routingAgent",
+				"metrics",
+				"factReader",
+				"chatAdapter",
+				"recorder",
+				"mcProcess",
+				"db",
+			]);
+		});
+	});
+
+	describe("エラー分離", () => {
+		it("一部コンポーネントがエラーをスローしても残りのシャットダウン処理が続行される", async () => {
+			const deps = makeDeps({
+				gateway: {
+					stop: mock(() => {
+						throw new Error("gateway error");
+					}),
+				},
+				heartbeatRouter: {
+					stop: mock(() => {
+						throw new Error("heartbeatRouter error");
+					}),
+				},
+			});
+			closeDbMock.mockImplementation(() => {
+				deps.callOrder.push("db");
+			});
+			clearIntervalSpy.mockImplementation((..._args: unknown[]) => {
+				deps.callOrder.push("sessionGauge");
+			});
+
+			const shutdown = createShutdown(deps);
+			await shutdown();
+
+			// gateway と heartbeatRouter がエラーでも、後続のコンポーネントがシャットダウンされる
+			expect(deps.callOrder).toContain("metrics");
+			expect(deps.callOrder).toContain("factReader");
+			expect(deps.callOrder).toContain("db");
+			// process.exit(0) が呼ばれる（正常終了）
+			expect(exitSpy).toHaveBeenCalledWith(0);
+			// エラーがログに記録される
+			expect(deps.logger.error).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("強制終了タイマーのキャンセル", () => {
+		it("正常終了時に 5 秒後の強制終了タイマーがキャンセルされる", async () => {
+			const deps = makeDeps();
+			const shutdown = createShutdown(deps);
+			await shutdown();
+
+			// setTimeout で 5000ms の強制終了タイマーが設定される
+			expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
+			// clearTimeout で強制終了タイマーがキャンセルされる
+			expect(clearTimeoutSpy).toHaveBeenCalledWith(42);
+			// process.exit(0) が呼ばれる
+			expect(exitSpy).toHaveBeenCalledWith(0);
+		});
+	});
+
+	describe("二重呼び出し防止", () => {
+		it("shuttingDown フラグにより二度目の呼び出しが無視される", async () => {
+			const deps = makeDeps();
+			const shutdown = createShutdown(deps);
+
+			await shutdown();
+			// 一度目の呼び出しで exit が呼ばれる
+			expect(exitSpy).toHaveBeenCalledTimes(1);
+
+			exitSpy.mockClear();
+			closeDbMock.mockClear();
+
+			// 二度目の呼び出しは無視される
+			await shutdown();
+			expect(exitSpy).not.toHaveBeenCalled();
+			expect(closeDbMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("オプショナル依存", () => {
+		it("consolidationScheduler が undefined でも正常にスキップされる", async () => {
+			const deps = makeDeps({ consolidationScheduler: undefined });
+			const shutdown = createShutdown(deps);
+			await shutdown();
+			expect(exitSpy).toHaveBeenCalledWith(0);
+		});
+
+		it("mcBrainManager が undefined でも正常にスキップされる", async () => {
+			const deps = makeDeps({ mcBrainManager: undefined });
+			const shutdown = createShutdown(deps);
+			await shutdown();
+			expect(exitSpy).toHaveBeenCalledWith(0);
+		});
+
+		it("chatAdapter が undefined でも正常にスキップされる", async () => {
+			const deps = makeDeps({ chatAdapter: undefined });
+			const shutdown = createShutdown(deps);
+			await shutdown();
+			expect(exitSpy).toHaveBeenCalledWith(0);
+		});
+
+		it("recorder が undefined でも正常にスキップされる", async () => {
+			const deps = makeDeps({ recorder: undefined });
+			const shutdown = createShutdown(deps);
+			await shutdown();
+			expect(exitSpy).toHaveBeenCalledWith(0);
+		});
+
+		it("mcProcess が undefined でも正常にスキップされる", async () => {
+			const deps = makeDeps({ mcProcess: undefined });
+			const shutdown = createShutdown(deps);
+			await shutdown();
+			expect(exitSpy).toHaveBeenCalledWith(0);
+		});
+
+		it("mcProcess が null でも正常にスキップされる", async () => {
+			const deps = makeDeps({ mcProcess: null });
+			const shutdown = createShutdown(deps);
+			await shutdown();
+			expect(exitSpy).toHaveBeenCalledWith(0);
+		});
+
+		it("全オプショナル依存が undefined でも正常にシャットダウンされる", async () => {
+			const deps = makeDeps({
+				consolidationScheduler: undefined,
+				mcBrainManager: undefined,
+				chatAdapter: undefined,
+				recorder: undefined,
+				mcProcess: undefined,
+			});
+			closeDbMock.mockImplementation(() => {
+				deps.callOrder.push("db");
+			});
+			clearIntervalSpy.mockImplementation((..._args: unknown[]) => {
+				deps.callOrder.push("sessionGauge");
+			});
+
+			const shutdown = createShutdown(deps);
+			await shutdown();
+
+			// オプショナルはスキップされ、必須コンポーネントのみシャットダウンされる
+			expect(deps.callOrder).toEqual([
+				"sessionGauge",
+				"heartbeatScheduler",
+				"gateway",
+				"gatewayServer",
+				"heartbeatRouter",
+				"routingAgent",
+				"metrics",
+				"factReader",
+				"db",
+			]);
+			expect(exitSpy).toHaveBeenCalledWith(0);
+		});
+	});
+});

--- a/spec/discord/bootstrap-shutdown.spec.ts
+++ b/spec/discord/bootstrap-shutdown.spec.ts
@@ -4,7 +4,7 @@ import type { ShutdownDeps } from "../../apps/discord/src/shutdown.ts";
 
 // closeDb をモック
 const closeDbMock = mock(() => {});
-mock.module("@vicissitude/store/db", () => ({
+void mock.module("@vicissitude/store/db", () => ({
 	closeDb: closeDbMock,
 }));
 

--- a/spec/discord/bootstrap-shutdown.spec.ts
+++ b/spec/discord/bootstrap-shutdown.spec.ts
@@ -1,15 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 
-import type { ShutdownDeps } from "../../apps/discord/src/shutdown.ts";
-
-// closeDb をモック
-const closeDbMock = mock(() => {});
-void mock.module("@vicissitude/store/db", () => ({
-	closeDb: closeDbMock,
-}));
-
-// モック後にインポート
-const { createShutdown } = await import("../../apps/discord/src/shutdown.ts");
+import { createShutdown, type ShutdownDeps } from "../../apps/discord/src/shutdown.ts";
 
 function makeDeps(overrides: Partial<ShutdownDeps> = {}): ShutdownDeps & { callOrder: string[] } {
 	const callOrder: string[] = [];
@@ -38,7 +29,7 @@ function makeDeps(overrides: Partial<ShutdownDeps> = {}): ShutdownDeps & { callO
 		chatAdapter: { close: mock(track("chatAdapter")) },
 		recorder: { close: mock(track("recorder")) },
 		mcProcess: { kill: mock(track("mcProcess")) },
-		db: {} as ShutdownDeps["db"],
+		closeDb: mock(track("db")),
 		...overrides,
 	};
 }
@@ -58,7 +49,6 @@ describe("createShutdown()", () => {
 			42 as unknown as ReturnType<typeof setTimeout>,
 		);
 		clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
-		closeDbMock.mockReset();
 	});
 
 	afterEach(() => {
@@ -71,9 +61,6 @@ describe("createShutdown()", () => {
 	describe("シャットダウン順序", () => {
 		it("14 コンポーネントが定義順にシャットダウンされる", async () => {
 			const deps = makeDeps();
-			closeDbMock.mockImplementation(() => {
-				deps.callOrder.push("db");
-			});
 			// clearInterval のスパイで sessionGauge の順序を記録
 			clearIntervalSpy.mockImplementation((..._args: unknown[]) => {
 				deps.callOrder.push("sessionGauge");
@@ -114,9 +101,6 @@ describe("createShutdown()", () => {
 						throw new Error("heartbeatRouter error");
 					}),
 				},
-			});
-			closeDbMock.mockImplementation(() => {
-				deps.callOrder.push("db");
 			});
 			clearIntervalSpy.mockImplementation((..._args: unknown[]) => {
 				deps.callOrder.push("sessionGauge");
@@ -161,12 +145,11 @@ describe("createShutdown()", () => {
 			expect(exitSpy).toHaveBeenCalledTimes(1);
 
 			exitSpy.mockClear();
-			closeDbMock.mockClear();
 
 			// 二度目の呼び出しは無視される
 			await shutdown();
 			expect(exitSpy).not.toHaveBeenCalled();
-			expect(closeDbMock).not.toHaveBeenCalled();
+			expect(deps.closeDb).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -220,9 +203,6 @@ describe("createShutdown()", () => {
 				chatAdapter: undefined,
 				recorder: undefined,
 				mcProcess: undefined,
-			});
-			closeDbMock.mockImplementation(() => {
-				deps.callOrder.push("db");
 			});
 			clearIntervalSpy.mockImplementation((..._args: unknown[]) => {
 				deps.callOrder.push("sessionGauge");


### PR DESCRIPTION
## Summary

- `bootstrap.ts` の `shutdown()` クロージャを `createShutdown()` ファクトリとして `shutdown.ts` に抽出
- `spec/discord/bootstrap-shutdown.spec.ts` に仕様テスト (11 件) を追加

### 検証する契約
- 14 コンポーネントが定義順にシャットダウンされること
- エラー分離: 一部がスローしても残りが続行されること
- 5 秒後の強制終了タイマーが正常終了時にキャンセルされること
- `shuttingDown` フラグによる二重呼び出し防止
- オプショナル依存 (consolidationScheduler, mcBrainManager, chatAdapter, recorder, mcProcess) が undefined/null でもスキップされること

Closes #714

## Test plan

- [x] `bun test spec/discord/bootstrap-shutdown.spec.ts` — 11 pass / 0 fail
- [x] `nr lint` — 自変更にエラーなし
- [x] `nr check` — 自変更にエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)