### PR TITLE
feat(observability): Logger.child() と classifyErrorType の導入

### DIFF
--- a/apps/discord/src/gateway/discord.test.ts
+++ b/apps/discord/src/gateway/discord.test.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable require-await, no-constructor-return, typescript/no-floating-promises -- テスト用モック */
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
+import type { Logger } from "@vicissitude/shared/types";
 import { Events } from "discord.js";
 
 import { DiscordGateway } from "./discord";
@@ -56,13 +57,15 @@ type LogLevel = "debug" | "info" | "warn" | "error";
 
 function createSpyLogger() {
 	const calls: { level: LogLevel; args: unknown[] }[] = [];
+	const logger: Logger = {
+		debug: (...args: unknown[]) => calls.push({ level: "debug", args }),
+		info: (...args: unknown[]) => calls.push({ level: "info", args }),
+		warn: (...args: unknown[]) => calls.push({ level: "warn", args }),
+		error: (...args: unknown[]) => calls.push({ level: "error", args }),
+		child: () => logger,
+	};
 	return {
-		logger: {
-			debug: (...args: unknown[]) => calls.push({ level: "debug", args }),
-			info: (...args: unknown[]) => calls.push({ level: "info", args }),
-			warn: (...args: unknown[]) => calls.push({ level: "warn", args }),
-			error: (...args: unknown[]) => calls.push({ level: "error", args }),
-		},
+		logger,
 		calls,
 		warnCalls: () => calls.filter((c) => c.level === "warn"),
 	};

--- a/packages/agent/src/minecraft/brain-manager.test.ts
+++ b/packages/agent/src/minecraft/brain-manager.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { createMockLogger } from "@vicissitude/shared/test-helpers";
 import type { MetricsCollector } from "@vicissitude/shared/types";
 import { clearSessionLock, tryAcquireSessionLock } from "@vicissitude/store/mc-bridge";
 import { createTestDb } from "@vicissitude/store/test-helpers";
@@ -16,12 +17,7 @@ function createTestDeps(overrides?: Partial<McBrainManagerDeps>): McBrainManager
 		db: createTestDb(),
 		// oxlint-disable-next-line no-explicit-any -- テスト用の最小モック
 		sessionStore: { get: mock(() => null), set: mock(() => {}), count: mock(() => 0) } as any,
-		logger: {
-			debug: mock(() => {}),
-			info: mock(() => {}),
-			warn: mock(() => {}),
-			error: mock(() => {}),
-		},
+		logger: createMockLogger(),
 		root: "/tmp/test-mc-sub",
 		opencodePort: 9999,
 		providerId: "test-provider",

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -1,5 +1,5 @@
 /* oxlint-disable max-lines, max-lines-per-function -- AgentRunner のポーリングループ・セッション管理が密結合のため分割困難 */
-import { METRIC, recordTokenMetrics } from "@vicissitude/observability/metrics";
+import { classifyErrorType, METRIC, recordTokenMetrics } from "@vicissitude/observability/metrics";
 import { JST_OFFSET_MS, raceAbort } from "@vicissitude/shared/functions";
 import type {
 	AgentResponse,
@@ -467,7 +467,7 @@ export class AgentRunner implements AiAgent {
 		this.logger.error(`[${this.profile.name}:${this.agentId}] session error event`, event.message);
 		this.metrics?.incrementCounter(METRIC.SESSION_ERRORS, {
 			source: "session_event",
-			error_type: "session_error",
+			error_type: classifyErrorType(event),
 			http_status: typeof event.status === "number" ? String(event.status) : "unknown",
 			retryable: typeof event.retryable === "boolean" ? String(event.retryable) : "unknown",
 			error_class: event.errorClass ?? "unknown",

--- a/packages/observability/src/classify-error-type.test.ts
+++ b/packages/observability/src/classify-error-type.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { classifyErrorType } from "./metrics";
+
+describe("classifyErrorType", () => {
+	describe("status 429 → rate_limit", () => {
+		test("status が 429 のとき rate_limit を返す", () => {
+			expect(classifyErrorType({ status: 429 })).toBe("rate_limit");
+		});
+
+		test("status 429 は message パターンより優先される", () => {
+			expect(classifyErrorType({ status: 429, message: "context_length exceeded" })).toBe(
+				"rate_limit",
+			);
+			expect(classifyErrorType({ status: 429, message: "timeout" })).toBe("rate_limit");
+		});
+	});
+
+	describe("status が 429 以外のとき rate_limit にならない", () => {
+		test.each([200, 400, 500, 0])("status %d は rate_limit にならない", (status) => {
+			expect(classifyErrorType({ status })).toBe("session_error");
+		});
+	});
+
+	describe("message が undefined の場合", () => {
+		test("message なしのとき session_error を返す", () => {
+			expect(classifyErrorType({})).toBe("session_error");
+		});
+
+		test("message が undefined で status も 429 以外のとき session_error を返す", () => {
+			expect(classifyErrorType({ status: 500, message: undefined })).toBe("session_error");
+		});
+	});
+
+	describe("大文字小文字の混在", () => {
+		test("CONTEXT_LENGTH（大文字）→ context_length_exceeded", () => {
+			expect(classifyErrorType({ message: "CONTEXT_LENGTH exceeded" })).toBe(
+				"context_length_exceeded",
+			);
+		});
+
+		test("Max_Tokens（混在ケース）→ context_length_exceeded", () => {
+			expect(classifyErrorType({ message: "Max_Tokens limit reached" })).toBe(
+				"context_length_exceeded",
+			);
+		});
+
+		test("TIMED OUT（大文字）→ timeout", () => {
+			expect(classifyErrorType({ message: "TIMED OUT" })).toBe("timeout");
+		});
+
+		test("CONTENT_FILTER（大文字）→ content_filter", () => {
+			expect(classifyErrorType({ message: "CONTENT_FILTER triggered" })).toBe("content_filter");
+		});
+
+		test("Content_Management（混在ケース）→ content_filter", () => {
+			expect(classifyErrorType({ message: "Content_Management policy" })).toBe("content_filter");
+		});
+	});
+
+	describe("複数パターンが同時に含まれる場合の優先順位", () => {
+		test("context_length と timeout が両方含まれる → context_length_exceeded（先にマッチ）", () => {
+			expect(classifyErrorType({ message: "context_length timeout error" })).toBe(
+				"context_length_exceeded",
+			);
+		});
+
+		test("max_tokens と content_filter が両方含まれる → context_length_exceeded（先にマッチ）", () => {
+			expect(classifyErrorType({ message: "max_tokens content_filter" })).toBe(
+				"context_length_exceeded",
+			);
+		});
+
+		test("content_filter と timeout が両方含まれる → content_filter（先にマッチ）", () => {
+			expect(classifyErrorType({ message: "content_filter timed out" })).toBe("content_filter");
+		});
+	});
+
+	describe("timeout の部分一致", () => {
+		test("read_timeout_error → timeout に分類される", () => {
+			expect(classifyErrorType({ message: "read_timeout_error" })).toBe("timeout");
+		});
+
+		test("connection_timed out → timeout に分類される", () => {
+			expect(classifyErrorType({ message: "connection_timed out" })).toBe("timeout");
+		});
+	});
+
+	describe("retryable・errorClass は分類に影響しない", () => {
+		test("retryable: true でも message ベースの分類が変わらない", () => {
+			expect(classifyErrorType({ retryable: true, message: "timeout" })).toBe("timeout");
+		});
+
+		test("retryable: false でも message ベースの分類が変わらない", () => {
+			expect(classifyErrorType({ retryable: false, message: "context_length" })).toBe(
+				"context_length_exceeded",
+			);
+		});
+
+		test("errorClass が指定されていても分類に影響しない", () => {
+			expect(
+				classifyErrorType({ errorClass: "RateLimitError", message: "something failed" }),
+			).toBe("session_error");
+		});
+
+		test("retryable と errorClass の両方があっても message ベースで分類される", () => {
+			expect(
+				classifyErrorType({
+					retryable: true,
+					errorClass: "TimeoutError",
+					message: "content_filter blocked",
+				}),
+			).toBe("content_filter");
+		});
+	});
+
+	describe("デフォルト分類", () => {
+		test("どのパターンにもマッチしない message → session_error", () => {
+			expect(classifyErrorType({ message: "unknown error occurred" })).toBe("session_error");
+		});
+
+		test("空文字の message → session_error", () => {
+			expect(classifyErrorType({ message: "" })).toBe("session_error");
+		});
+	});
+});

--- a/packages/observability/src/classify-error-type.test.ts
+++ b/packages/observability/src/classify-error-type.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+
 import { classifyErrorType } from "./metrics";
 
 describe("classifyErrorType", () => {
@@ -97,9 +98,9 @@ describe("classifyErrorType", () => {
 		});
 
 		test("errorClass が指定されていても分類に影響しない", () => {
-			expect(
-				classifyErrorType({ errorClass: "RateLimitError", message: "something failed" }),
-			).toBe("session_error");
+			expect(classifyErrorType({ errorClass: "RateLimitError", message: "something failed" })).toBe(
+				"session_error",
+			);
 		});
 
 		test("retryable と errorClass の両方があっても message ベースで分類される", () => {

--- a/packages/observability/src/logger.test.ts
+++ b/packages/observability/src/logger.test.ts
@@ -102,4 +102,55 @@ describe("ConsoleLogger", () => {
 		const entry = JSON.parse(stdoutCapture.calls[0]!);
 		expect(entry.extra).toEqual(["a", 42]);
 	});
+
+	// ─── child() 内部詳細 ────────────────────────────────────────
+
+	describe("child() 内部詳細", () => {
+		test("child() は ConsoleLogger のインスタンスを返す", () => {
+			setup();
+			const parent = new ConsoleLogger({ level: "info" });
+			const child = parent.child({ trace_id: "abc" });
+
+			expect(child).toBeInstanceOf(ConsoleLogger);
+		});
+
+		test("child() で生成した logger は親とは別の内部 pino インスタンスを持つ", () => {
+			setup();
+			const parent = new ConsoleLogger({ level: "info" });
+			const child = parent.child({ trace_id: "xyz" });
+
+			// Object.create パターンで作られた child は独自の pino フィールドを持つ
+			const parentPino = (parent as unknown as { pino: unknown }).pino;
+			const childPino = (child as unknown as { pino: unknown }).pino;
+
+			expect(childPino).not.toBe(parentPino);
+		});
+
+		test("child() 後も parent の出力に child の bindings が混入しない", () => {
+			setup();
+			const parent = new ConsoleLogger({ level: "info" });
+			parent.child({ trace_id: "child-only" });
+
+			parent.info("parent message");
+
+			const entry = JSON.parse(stdoutCapture.calls[0]!);
+			expect(entry.msg).toBe("parent message");
+			expect(entry.trace_id).toBeUndefined();
+		});
+
+		test("destination: 'stderr' の parent から child() した場合 stdout には出力されない", () => {
+			setup();
+			const parent = new ConsoleLogger({
+				level: "info",
+				destination: "stderr",
+			});
+			const child = parent.child({ trace_id: "stderr-test" });
+
+			child.info("stderr child message");
+
+			// pino.destination(2) は fd 2 に直接書き込むため process.stderr.write は経由しない
+			// stdout に出力されないことで、child が親の destination を引き継いでいることを確認
+			expect(stdoutCapture.calls).toHaveLength(0);
+		});
+	});
 });

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -14,6 +14,12 @@ export class ConsoleLogger implements Logger {
 		this.pino = pino({ level }, opts.destination === "stderr" ? pino.destination(2) : undefined);
 	}
 
+	private static fromPino(instance: pino.Logger): ConsoleLogger {
+		const logger = Object.create(ConsoleLogger.prototype) as ConsoleLogger;
+		(logger as unknown as { pino: pino.Logger }).pino = instance;
+		return logger;
+	}
+
 	debug(message: string, ...args: unknown[]): void {
 		this.log("debug", message, args);
 	}
@@ -28,6 +34,10 @@ export class ConsoleLogger implements Logger {
 
 	warn(message: string, ...args: unknown[]): void {
 		this.log("warn", message, args);
+	}
+
+	child(bindings: Record<string, unknown>): ConsoleLogger {
+		return ConsoleLogger.fromPino(this.pino.child(bindings));
 	}
 
 	private log(level: pino.Level, message: string, args: unknown[]): void {

--- a/packages/observability/src/metrics.ts
+++ b/packages/observability/src/metrics.ts
@@ -69,6 +69,24 @@ export function recordTokenMetrics(
 		metrics.addCounter(METRIC.LLM_CACHE_READ_TOKENS, tokens.cacheRead, labels);
 }
 
+// ─── Error Classification ───────────────────────────────────────
+
+export function classifyErrorType(event: {
+	status?: number;
+	retryable?: boolean;
+	errorClass?: string;
+	message?: string;
+}): string {
+	if (event.status === 429) return "rate_limit";
+	const msg = event.message?.toLowerCase() ?? "";
+	if (msg.includes("context_length") || msg.includes("max_tokens"))
+		return "context_length_exceeded";
+	if (msg.includes("content_filter") || msg.includes("content_management"))
+		return "content_filter";
+	if (msg.includes("timed out") || msg.includes("timeout")) return "timeout";
+	return "session_error";
+}
+
 // ─── Prometheus Collector ───────────────────────────────────────
 
 interface MetricMeta {

--- a/packages/observability/src/metrics.ts
+++ b/packages/observability/src/metrics.ts
@@ -81,8 +81,7 @@ export function classifyErrorType(event: {
 	const msg = event.message?.toLowerCase() ?? "";
 	if (msg.includes("context_length") || msg.includes("max_tokens"))
 		return "context_length_exceeded";
-	if (msg.includes("content_filter") || msg.includes("content_management"))
-		return "content_filter";
+	if (msg.includes("content_filter") || msg.includes("content_management")) return "content_filter";
 	if (msg.includes("timed out") || msg.includes("timeout")) return "timeout";
 	return "session_error";
 }

--- a/packages/shared/src/test-helpers.ts
+++ b/packages/shared/src/test-helpers.ts
@@ -3,12 +3,14 @@ import { mock } from "bun:test";
 import type { Logger, MetricsCollector } from "./types";
 
 export function createMockLogger(): Logger {
-	return {
+	const logger: Logger = {
 		debug: mock(() => {}),
 		info: mock(() => {}),
 		error: mock(() => {}),
 		warn: mock(() => {}),
+		child: () => createMockLogger(),
 	};
+	return logger;
 }
 
 export function createMockMetrics(): MetricsCollector {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -158,6 +158,7 @@ export interface Logger {
 	info(message: string, ...args: unknown[]): void;
 	error(message: string, ...args: unknown[]): void;
 	warn(message: string, ...args: unknown[]): void;
+	child(bindings: Record<string, unknown>): Logger;
 }
 
 // ─── Conversation Recorder ───────────────────────────────────────

--- a/packages/store/src/event-buffer.test.ts
+++ b/packages/store/src/event-buffer.test.ts
@@ -80,7 +80,9 @@ describe("SqliteEventBuffer (internal: onPollError callback)", () => {
 			info: mock(() => {}),
 			warn: mock(() => {}),
 			error: mock(() => {}),
-			child() { return logger as Logger; },
+			child() {
+				return logger as Logger;
+			},
 		};
 		const callback = mock((_err: unknown) => {});
 		const buffer = new SqliteEventBuffer(db, "agent-1", logger, (err) => {
@@ -116,7 +118,9 @@ describe("SqliteEventBuffer (internal: onPollError callback)", () => {
 			info: mock(() => {}),
 			warn: mock(() => {}),
 			error: mock(() => {}),
-			child() { return logger as Logger; },
+			child() {
+				return logger as Logger;
+			},
 		};
 		const buffer = new SqliteEventBuffer(db, "agent-1", logger);
 

--- a/packages/store/src/event-buffer.test.ts
+++ b/packages/store/src/event-buffer.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
+import type { Logger } from "@vicissitude/shared/types";
+
 import { SqliteEventBuffer } from "./event-buffer.ts";
 import { appendEvent } from "./queries.ts";
 import { createTestDb } from "./test-helpers.ts";
@@ -78,6 +80,7 @@ describe("SqliteEventBuffer (internal: onPollError callback)", () => {
 			info: mock(() => {}),
 			warn: mock(() => {}),
 			error: mock(() => {}),
+			child() { return logger as Logger; },
 		};
 		const callback = mock((_err: unknown) => {});
 		const buffer = new SqliteEventBuffer(db, "agent-1", logger, (err) => {
@@ -113,6 +116,7 @@ describe("SqliteEventBuffer (internal: onPollError callback)", () => {
 			info: mock(() => {}),
 			warn: mock(() => {}),
 			error: mock(() => {}),
+			child() { return logger as Logger; },
 		};
 		const buffer = new SqliteEventBuffer(db, "agent-1", logger);
 

--- a/spec/discord/bootstrap-shutdown.spec.ts
+++ b/spec/discord/bootstrap-shutdown.spec.ts
@@ -10,7 +10,15 @@ function makeDeps(overrides: Partial<ShutdownDeps> = {}): ShutdownDeps & { callO
 
 	return {
 		callOrder,
-		logger: { info: mock(), error: mock(), warn: mock(), debug: mock(), child() { return this; } },
+		logger: {
+			info: mock(),
+			error: mock(),
+			warn: mock(),
+			debug: mock(),
+			child() {
+				return this;
+			},
+		},
 		sessionGaugeTimer: setInterval(() => {}, 100_000),
 		consolidationScheduler: { stop: mock(track("consolidation")) },
 		heartbeatScheduler: { stop: mock(track("heartbeatScheduler")) },

--- a/spec/discord/bootstrap-shutdown.spec.ts
+++ b/spec/discord/bootstrap-shutdown.spec.ts
@@ -10,7 +10,7 @@ function makeDeps(overrides: Partial<ShutdownDeps> = {}): ShutdownDeps & { callO
 
 	return {
 		callOrder,
-		logger: { info: mock(), error: mock(), warn: mock(), debug: mock() },
+		logger: { info: mock(), error: mock(), warn: mock(), debug: mock(), child() { return this; } },
 		sessionGaugeTimer: setInterval(() => {}, 100_000),
 		consolidationScheduler: { stop: mock(track("consolidation")) },
 		heartbeatScheduler: { stop: mock(track("heartbeatScheduler")) },

--- a/spec/discord/gateway/discord-gateway-thread.spec.ts
+++ b/spec/discord/gateway/discord-gateway-thread.spec.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable require-await, no-constructor-return, typescript/no-floating-promises -- テスト用モック */
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
-import type { IncomingMessage } from "@vicissitude/shared/types";
+import type { IncomingMessage, Logger } from "@vicissitude/shared/types";
 import { Collection, Events } from "discord.js";
 
 import { DiscordGateway } from "../../../apps/discord/src/gateway/discord";
@@ -97,13 +97,15 @@ function createMockThreadChannel(
 	};
 }
 
-function createSilentLogger() {
-	return {
+function createSilentLogger(): Logger {
+	const logger: Logger = {
 		debug: () => {},
 		info: () => {},
 		error: () => {},
 		warn: () => {},
+		child: () => logger,
 	};
+	return logger;
 }
 
 // ─── Client コンストラクタをモックで差し替える ───────────────────

--- a/spec/gateway/discord-presence.spec.ts
+++ b/spec/gateway/discord-presence.spec.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable require-await, no-constructor-return, typescript/no-extraneous-class -- テスト用モック */
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
+import type { Logger } from "@vicissitude/shared/types";
 import { ActivityType, Events } from "discord.js";
 
 import { DiscordGateway } from "../../apps/discord/src/gateway/discord";
@@ -8,7 +9,8 @@ import { DiscordGateway } from "../../apps/discord/src/gateway/discord";
 // ─── Helpers ─────────────────────────────────────────────────────
 
 function createSilentLogger() {
-	return { debug: () => {}, info: () => {}, error: () => {}, warn: () => {} };
+	const l: Logger = { debug: () => {}, info: () => {}, error: () => {}, warn: () => {}, child: () => l };
+	return l;
 }
 
 function createMockClient() {

--- a/spec/gateway/discord-presence.spec.ts
+++ b/spec/gateway/discord-presence.spec.ts
@@ -9,7 +9,13 @@ import { DiscordGateway } from "../../apps/discord/src/gateway/discord";
 // ─── Helpers ─────────────────────────────────────────────────────
 
 function createSilentLogger() {
-	const l: Logger = { debug: () => {}, info: () => {}, error: () => {}, warn: () => {}, child: () => l };
+	const l: Logger = {
+		debug: () => {},
+		info: () => {},
+		error: () => {},
+		warn: () => {},
+		child: () => l,
+	};
 	return l;
 }
 

--- a/spec/mcp/tools/event-buffer.spec.ts
+++ b/spec/mcp/tools/event-buffer.spec.ts
@@ -3,7 +3,6 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { Logger } from "@vicissitude/shared/types";
 import {
 	MAX_POLL_TIMEOUT_SECONDS,
 	classifyActionHint,
@@ -16,6 +15,7 @@ import {
 	registerEventBufferTools,
 } from "@vicissitude/mcp/tools/event-buffer";
 import type { ErrorEvent, ParsedEvent, RecentMessage } from "@vicissitude/mcp/tools/event-buffer";
+import type { Logger } from "@vicissitude/shared/types";
 import { CREATE_TABLES_SQL } from "@vicissitude/store/db";
 import { appendEvent } from "@vicissitude/store/queries";
 import { createTestDb } from "@vicissitude/store/test-helpers";
@@ -816,7 +816,9 @@ describe("pollEvents", () => {
 			info: mock(() => {}),
 			warn: mock(() => {}),
 			error: errorFn,
-			child() { return logger; },
+			child() {
+				return logger;
+			},
 		};
 
 		const deadline = Date.now() + 200;

--- a/spec/mcp/tools/event-buffer.spec.ts
+++ b/spec/mcp/tools/event-buffer.spec.ts
@@ -3,6 +3,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Logger } from "@vicissitude/shared/types";
 import {
 	MAX_POLL_TIMEOUT_SECONDS,
 	classifyActionHint,
@@ -810,11 +811,12 @@ describe("pollEvents", () => {
 		db.run("DROP TABLE event_buffer");
 
 		const errorFn = mock(() => {});
-		const logger = {
+		const logger: Logger = {
 			debug: mock(() => {}),
 			info: mock(() => {}),
 			warn: mock(() => {}),
 			error: errorFn,
+			child() { return logger; },
 		};
 
 		const deadline = Date.now() + 200;

--- a/spec/observability/error-classification.spec.ts
+++ b/spec/observability/error-classification.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * classifyErrorType: エラー種別の分類仕様テスト
+ *
+ * 期待仕様:
+ * 1. status === 429 → "rate_limit"
+ * 2. message に "context_length" or "max_tokens" (case-insensitive) → "context_length_exceeded"
+ * 3. message に "content_filter" or "content_management" (case-insensitive) → "content_filter"
+ * 4. message に "timed out" or "timeout" (case-insensitive) → "timeout"
+ * 5. それ以外 → "session_error"（後方互換）
+ *
+ * 優先順位: 上記の番号順（status=429 が最優先）
+ */
+import { describe, expect, it } from "bun:test";
+
+import { classifyErrorType } from "@vicissitude/observability/metrics";
+
+// ─── rate_limit ─────────────────────────────────────────────────
+
+describe("classifyErrorType: rate_limit", () => {
+	it("status=429 の場合 rate_limit を返す", () => {
+		expect(classifyErrorType({ status: 429 })).toBe("rate_limit");
+	});
+
+	it("status=429 で message が他のパターンに一致する場合でも rate_limit が優先される", () => {
+		expect(
+			classifyErrorType({ status: 429, message: "context_length exceeded" }),
+		).toBe("rate_limit");
+		expect(
+			classifyErrorType({ status: 429, message: "content_filter triggered" }),
+		).toBe("rate_limit");
+		expect(
+			classifyErrorType({ status: 429, message: "request timed out" }),
+		).toBe("rate_limit");
+	});
+});
+
+// ─── context_length_exceeded ────────────────────────────────────
+
+describe("classifyErrorType: context_length_exceeded", () => {
+	it("message に 'context_length' を含む場合 context_length_exceeded を返す", () => {
+		expect(
+			classifyErrorType({ status: 400, message: "context_length limit reached" }),
+		).toBe("context_length_exceeded");
+	});
+
+	it("message に 'max_tokens' を含む場合（大文字小文字混在）context_length_exceeded を返す", () => {
+		expect(
+			classifyErrorType({ message: "Max_Tokens exceeded the model limit" }),
+		).toBe("context_length_exceeded");
+	});
+});
+
+// ─── content_filter ─────────────────────────────────────────────
+
+describe("classifyErrorType: content_filter", () => {
+	it("message に 'content_filter' を含む場合 content_filter を返す", () => {
+		expect(
+			classifyErrorType({ message: "blocked by content_filter policy" }),
+		).toBe("content_filter");
+	});
+
+	it("message に 'content_management' を含む場合 content_filter を返す", () => {
+		expect(
+			classifyErrorType({ message: "content_management restriction applied" }),
+		).toBe("content_filter");
+	});
+});
+
+// ─── timeout ────────────────────────────────────────────────────
+
+describe("classifyErrorType: timeout", () => {
+	it("message に 'timed out' を含む場合 timeout を返す", () => {
+		expect(
+			classifyErrorType({ message: "request timed out after 30s" }),
+		).toBe("timeout");
+	});
+
+	it("message に 'timeout' を含む場合 timeout を返す", () => {
+		expect(
+			classifyErrorType({ message: "connection timeout" }),
+		).toBe("timeout");
+	});
+});
+
+// ─── session_error（デフォルト）──────────────────────────────────
+
+describe("classifyErrorType: session_error（デフォルト）", () => {
+	it("status=500 で message がどのパターンにも一致しない場合 session_error を返す", () => {
+		expect(
+			classifyErrorType({ status: 500, message: "internal server error" }),
+		).toBe("session_error");
+	});
+
+	it("全フィールドが undefined の場合 session_error を返す", () => {
+		expect(classifyErrorType({})).toBe("session_error");
+	});
+
+	it("message が空文字列の場合 session_error を返す", () => {
+		expect(classifyErrorType({ message: "" })).toBe("session_error");
+	});
+});

--- a/spec/observability/error-classification.spec.ts
+++ b/spec/observability/error-classification.spec.ts
@@ -22,15 +22,13 @@ describe("classifyErrorType: rate_limit", () => {
 	});
 
 	it("status=429 で message が他のパターンに一致する場合でも rate_limit が優先される", () => {
-		expect(
-			classifyErrorType({ status: 429, message: "context_length exceeded" }),
-		).toBe("rate_limit");
-		expect(
-			classifyErrorType({ status: 429, message: "content_filter triggered" }),
-		).toBe("rate_limit");
-		expect(
-			classifyErrorType({ status: 429, message: "request timed out" }),
-		).toBe("rate_limit");
+		expect(classifyErrorType({ status: 429, message: "context_length exceeded" })).toBe(
+			"rate_limit",
+		);
+		expect(classifyErrorType({ status: 429, message: "content_filter triggered" })).toBe(
+			"rate_limit",
+		);
+		expect(classifyErrorType({ status: 429, message: "request timed out" })).toBe("rate_limit");
 	});
 });
 
@@ -38,15 +36,15 @@ describe("classifyErrorType: rate_limit", () => {
 
 describe("classifyErrorType: context_length_exceeded", () => {
 	it("message に 'context_length' を含む場合 context_length_exceeded を返す", () => {
-		expect(
-			classifyErrorType({ status: 400, message: "context_length limit reached" }),
-		).toBe("context_length_exceeded");
+		expect(classifyErrorType({ status: 400, message: "context_length limit reached" })).toBe(
+			"context_length_exceeded",
+		);
 	});
 
 	it("message に 'max_tokens' を含む場合（大文字小文字混在）context_length_exceeded を返す", () => {
-		expect(
-			classifyErrorType({ message: "Max_Tokens exceeded the model limit" }),
-		).toBe("context_length_exceeded");
+		expect(classifyErrorType({ message: "Max_Tokens exceeded the model limit" })).toBe(
+			"context_length_exceeded",
+		);
 	});
 });
 
@@ -54,15 +52,15 @@ describe("classifyErrorType: context_length_exceeded", () => {
 
 describe("classifyErrorType: content_filter", () => {
 	it("message に 'content_filter' を含む場合 content_filter を返す", () => {
-		expect(
-			classifyErrorType({ message: "blocked by content_filter policy" }),
-		).toBe("content_filter");
+		expect(classifyErrorType({ message: "blocked by content_filter policy" })).toBe(
+			"content_filter",
+		);
 	});
 
 	it("message に 'content_management' を含む場合 content_filter を返す", () => {
-		expect(
-			classifyErrorType({ message: "content_management restriction applied" }),
-		).toBe("content_filter");
+		expect(classifyErrorType({ message: "content_management restriction applied" })).toBe(
+			"content_filter",
+		);
 	});
 });
 
@@ -70,15 +68,11 @@ describe("classifyErrorType: content_filter", () => {
 
 describe("classifyErrorType: timeout", () => {
 	it("message に 'timed out' を含む場合 timeout を返す", () => {
-		expect(
-			classifyErrorType({ message: "request timed out after 30s" }),
-		).toBe("timeout");
+		expect(classifyErrorType({ message: "request timed out after 30s" })).toBe("timeout");
 	});
 
 	it("message に 'timeout' を含む場合 timeout を返す", () => {
-		expect(
-			classifyErrorType({ message: "connection timeout" }),
-		).toBe("timeout");
+		expect(classifyErrorType({ message: "connection timeout" })).toBe("timeout");
 	});
 });
 
@@ -86,9 +80,9 @@ describe("classifyErrorType: timeout", () => {
 
 describe("classifyErrorType: session_error（デフォルト）", () => {
 	it("status=500 で message がどのパターンにも一致しない場合 session_error を返す", () => {
-		expect(
-			classifyErrorType({ status: 500, message: "internal server error" }),
-		).toBe("session_error");
+		expect(classifyErrorType({ status: 500, message: "internal server error" })).toBe(
+			"session_error",
+		);
 	});
 
 	it("全フィールドが undefined の場合 session_error を返す", () => {

--- a/spec/observability/logger.spec.ts
+++ b/spec/observability/logger.spec.ts
@@ -120,4 +120,56 @@ describe("ConsoleLogger", () => {
 			expect(output()).toContain("no extra");
 		});
 	});
+
+	// ─── child() によるコンテキスト付きロガー ────────────────────
+
+	describe("child() によるコンテキスト付きロガー", () => {
+		it("child() で新しい Logger インスタンスが返る", () => {
+			const logger = new ConsoleLogger({ level: "info" });
+			const child = logger.child({ trace_id: "abc-123" });
+
+			expect(child).not.toBe(logger);
+		});
+
+		it("child logger の出力に trace_id フィールドが含まれる", () => {
+			const logger = new ConsoleLogger({ level: "info" });
+			const child = logger.child({ trace_id: "trace-xyz" });
+			child.info("hello from child");
+
+			const out = output();
+			expect(out).toContain("hello from child");
+			expect(out).toContain("trace_id");
+			expect(out).toContain("trace-xyz");
+		});
+
+		it("child logger のログレベルは親から引き継がれる", () => {
+			const logger = new ConsoleLogger({ level: "info" });
+			const child = logger.child({ trace_id: "lvl-test" });
+			child.debug("should be suppressed");
+
+			expect(output()).toBe("");
+		});
+
+		it("child() を連鎖できる（両方のフィールドが出力に含まれる）", () => {
+			const logger = new ConsoleLogger({ level: "info" });
+			const child = logger.child({ a: 1 }).child({ b: 2 });
+			child.info("chained");
+
+			const out = output();
+			expect(out).toContain("chained");
+			expect(out).toContain('"a":1');
+			expect(out).toContain('"b":2');
+		});
+
+		it("child logger は Logger インターフェースを満たす", () => {
+			const logger = new ConsoleLogger({ level: "debug" });
+			const child = logger.child({ trace_id: "iface-check" });
+
+			expect(typeof child.debug).toBe("function");
+			expect(typeof child.info).toBe("function");
+			expect(typeof child.warn).toBe("function");
+			expect(typeof child.error).toBe("function");
+			expect(typeof child.child).toBe("function");
+		});
+	});
 });

--- a/spec/opencode/session-error-logging.spec.ts
+++ b/spec/opencode/session-error-logging.spec.ts
@@ -9,8 +9,8 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2";
-import type { Logger } from "@vicissitude/shared/types";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
+import type { Logger } from "@vicissitude/shared/types";
 
 // ─── テストヘルパー ──────────────────────────────────────────────
 
@@ -38,7 +38,9 @@ function createAdapterWithLoggerSpy(client: OpencodeClient) {
 		info: mock(() => {}),
 		warn: mock(() => {}),
 		error: mock(() => {}),
-		child() { return loggerSpy as Logger; },
+		child() {
+			return loggerSpy as Logger;
+		},
 	};
 	const adapter = new OpencodeSessionAdapter({
 		port: 4096,

--- a/spec/opencode/session-error-logging.spec.ts
+++ b/spec/opencode/session-error-logging.spec.ts
@@ -9,6 +9,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2";
+import type { Logger } from "@vicissitude/shared/types";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 
 // ─── テストヘルパー ──────────────────────────────────────────────
@@ -37,6 +38,7 @@ function createAdapterWithLoggerSpy(client: OpencodeClient) {
 		info: mock(() => {}),
 		warn: mock(() => {}),
 		error: mock(() => {}),
+		child() { return loggerSpy as Logger; },
 	};
 	const adapter = new OpencodeSessionAdapter({
 		port: 4096,

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -608,7 +608,9 @@ describe("logPartActivity", () => {
 			}),
 			warn: mock(() => {}),
 			debug: mock(() => {}),
-			child() { return logger; },
+			child() {
+				return logger;
+			},
 			infoMessages,
 			errorMessages,
 		};

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -599,7 +599,7 @@ describe("logPartActivity", () => {
 	function makeLogger() {
 		const infoMessages: string[] = [];
 		const errorMessages: string[] = [];
-		return {
+		const logger = {
 			info: mock((msg: string) => {
 				infoMessages.push(msg);
 			}),
@@ -608,9 +608,11 @@ describe("logPartActivity", () => {
 			}),
 			warn: mock(() => {}),
 			debug: mock(() => {}),
+			child() { return logger; },
 			infoMessages,
 			errorMessages,
 		};
+		return logger;
 	}
 
 	function makePartEvent(partProps: Record<string, unknown>, sid: string = sessionId): Event {

--- a/spec/store/event-buffer.spec.ts
+++ b/spec/store/event-buffer.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { Logger } from "@vicissitude/shared/types";
 import { CREATE_TABLES_SQL } from "@vicissitude/store/db";
 import { SqliteEventBuffer } from "@vicissitude/store/event-buffer";
 import { appendEvent } from "@vicissitude/store/queries";
@@ -7,23 +8,22 @@ import { createTestDb } from "@vicissitude/store/test-helpers";
 
 function createMockLogger() {
 	const calls = { debug: 0, info: 0, warn: 0, error: 0 };
-	return {
-		calls,
-		logger: {
-			debug: (..._args: unknown[]) => {
-				calls.debug++;
-			},
-			info: (..._args: unknown[]) => {
-				calls.info++;
-			},
-			warn: (..._args: unknown[]) => {
-				calls.warn++;
-			},
-			error: (..._args: unknown[]) => {
-				calls.error++;
-			},
+	const logger: Logger = {
+		debug: (..._args: unknown[]) => {
+			calls.debug++;
 		},
+		info: (..._args: unknown[]) => {
+			calls.info++;
+		},
+		warn: (..._args: unknown[]) => {
+			calls.warn++;
+		},
+		error: (..._args: unknown[]) => {
+			calls.error++;
+		},
+		child: () => logger,
 	};
+	return { calls, logger };
 }
 
 /** テスト用: DB の event_buffer テーブルを DROP してポーリングエラーを発生させる */


### PR DESCRIPTION
## Summary

- **Logger.child(bindings)** を追加し、trace_id 等のコンテキストを child logger に伝播できるようにした (#717)
- **classifyErrorType()** を追加し、session_errors_total の error_type ラベルを rate_limit / context_length_exceeded / content_filter / timeout / session_error に細分化した (#719)
- 既存モック Logger の child メソッド追加（インターフェース変更に伴う修正）

## Test plan

- [x] 仕様テスト 26 件パス (`spec/observability/logger.spec.ts`, `spec/observability/error-classification.spec.ts`)
- [x] ユニットテスト 35 件パス (`packages/observability/src/logger.test.ts`, `packages/observability/src/classify-error-type.test.ts`)
- [x] 全テスト 2022 件パス (`nr test`)
- [x] 型チェック通過 (`nr check`)
- [x] lint 通過 (`nr lint`)

Closes #717, Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)