### PR TITLE
fix(lint): CI を失敗させていた lint エラー 4 件を修正

### DIFF
--- a/packages/observability/src/correlation.ts
+++ b/packages/observability/src/correlation.ts
@@ -23,10 +23,10 @@ export function generateCorrelationId(): string {
 	bytes[5] = now & 0xff;
 
 	// version: 上位 4 ビットを 0111 に設定
-	bytes[6] = (bytes[6]! & 0x0f) | 0x70;
+	bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x70;
 
 	// variant: 上位 2 ビットを 10 に設定
-	bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+	bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
 
 	const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;

--- a/spec/discord/bootstrap-shutdown.spec.ts
+++ b/spec/discord/bootstrap-shutdown.spec.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 
+import type { Logger } from "@vicissitude/shared/types";
+
 import { createShutdown, type ShutdownDeps } from "../../apps/discord/src/shutdown.ts";
 
 function makeDeps(overrides: Partial<ShutdownDeps> = {}): ShutdownDeps & { callOrder: string[] } {
@@ -11,7 +13,7 @@ function makeDeps(overrides: Partial<ShutdownDeps> = {}): ShutdownDeps & { callO
 	return {
 		callOrder,
 		logger: (() => {
-			const l: import("@vicissitude/shared/types").Logger = {
+			const l: Logger = {
 				info: mock(),
 				error: mock(),
 				warn: mock(),

--- a/spec/observability/logger.spec.ts
+++ b/spec/observability/logger.spec.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { ConsoleLogger } from "@vicissitude/observability/logger";
-import type { Logger } from "@vicissitude/shared/types";
 
 function captureWrite(stream: "stdout" | "stderr") {
 	const original = process[stream].write;


### PR DESCRIPTION
## Summary
- `correlation.ts`: non-null assertion (`!`) を nullish coalescing (`?? 0`) に変更
- `bootstrap-shutdown.spec.ts`: `import()` type annotation を通常の `import type` に変更
- `logger.spec.ts`: 未使用の `Logger` import を削除

## Test plan
- [x] `nr lint` でエラー 0 件を確認
- [x] `nr test` で全 2025 テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)