### PR TITLE
test(spec): LLM プロンプト/出力のログ記録の仕様テストを作成

### DIFF
--- a/spec/memory/llm-logging.spec.ts
+++ b/spec/memory/llm-logging.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * MemoryChatAdapter LLM プロンプト/出力のログ記録 仕様テスト
+ *
+ * 期待仕様:
+ * 1. chat() でリクエスト送信時に debug ログでプロンプト内容を記録する
+ * 2. chat() でレスポンス受信時に debug ログで出力内容を記録する
+ * 3. debug ログにモデル情報が含まれる
+ */
+import { describe, expect, it, mock } from "bun:test";
+
+import { MemoryChatAdapter } from "@vicissitude/memory/chat-adapter";
+import type { ChatMessage } from "@vicissitude/memory/types";
+import { createMockLogger } from "@vicissitude/shared/test-helpers";
+import type { OpencodeSessionPort } from "@vicissitude/shared/types";
+
+// --- テストヘルパー ---
+
+function createMockSessionPort(responseText: string): OpencodeSessionPort {
+	return {
+		createSession: mock(() => Promise.resolve("test-session-id")),
+		sessionExists: mock(() => Promise.resolve(true)),
+		prompt: mock(() => Promise.resolve({ text: responseText })),
+		promptAsync: mock(() => Promise.resolve()),
+		promptAsyncAndWatchSession: mock(() =>
+			Promise.resolve({ type: "idle" as const, messages: [] }),
+		),
+		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const, messages: [] })),
+		deleteSession: mock(() => Promise.resolve()),
+		close: mock(() => {}),
+	} as unknown as OpencodeSessionPort;
+}
+
+const testMessages: ChatMessage[] = [
+	{ role: "system", content: "あなたはアシスタントです" },
+	{ role: "user", content: "ユーザーからの質問内容" },
+];
+
+describe("MemoryChatAdapter chat() LLM ログ記録", () => {
+	it("リクエスト送信時にプロンプト内容を debug ログで記録する", async () => {
+		const logger = createMockLogger();
+		const port = createMockSessionPort("応答テキスト");
+		const adapter = new MemoryChatAdapter(port, "test-provider", "test-model", logger);
+
+		await adapter.chat(testMessages);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasPromptLog = allArgs.some((arg: string) => arg.includes("ユーザーからの質問内容"));
+		expect(hasPromptLog).toBe(true);
+	});
+
+	it("レスポンス受信時に出力内容を debug ログで記録する", async () => {
+		const logger = createMockLogger();
+		const port = createMockSessionPort("LLMからの応答テキスト");
+		const adapter = new MemoryChatAdapter(port, "test-provider", "test-model", logger);
+
+		await adapter.chat(testMessages);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasResponseLog = allArgs.some((arg: string) => arg.includes("LLMからの応答テキスト"));
+		expect(hasResponseLog).toBe(true);
+	});
+
+	it("debug ログにモデル情報が含まれる", async () => {
+		const logger = createMockLogger();
+		const port = createMockSessionPort("ok");
+		const adapter = new MemoryChatAdapter(port, "test-provider", "test-model", logger);
+
+		await adapter.chat(testMessages);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasModel = allArgs.some(
+			(arg: string) => arg.includes("test-provider") || arg.includes("test-model"),
+		);
+		expect(hasModel).toBe(true);
+	});
+});

--- a/spec/ollama/llm-logging.spec.ts
+++ b/spec/ollama/llm-logging.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * OllamaChatAdapter LLM プロンプト/出力のログ記録 仕様テスト
+ *
+ * 期待仕様:
+ * 1. prompt() でリクエスト送信時に debug ログでプロンプト内容を記録する
+ * 2. prompt() でレスポンス受信時に debug ログで出力内容を記録する
+ * 3. debug ログにモデル情報が含まれる
+ * 4. Logger が未設定（optional）の場合にエラーにならない
+ */
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+import { OllamaChatAdapter } from "@vicissitude/ollama/ollama-chat-adapter";
+import { createMockLogger } from "@vicissitude/shared/test-helpers";
+
+// --- テストヘルパー ---
+
+function mockFetch(responseBody: unknown) {
+	globalThis.fetch = (() =>
+		Promise.resolve({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			json: () => Promise.resolve(responseBody),
+		} as Response)) as unknown as typeof fetch;
+}
+
+describe("OllamaChatAdapter prompt() LLM ログ記録", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("リクエスト送信時にプロンプト内容を debug ログで記録する", async () => {
+		mockFetch({ response: "回答テキスト" });
+		const logger = createMockLogger();
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3", logger);
+
+		await adapter.prompt("テスト入力プロンプト");
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasPromptLog = allArgs.some((arg: string) => arg.includes("テスト入力プロンプト"));
+		expect(hasPromptLog).toBe(true);
+	});
+
+	it("レスポンス受信時に出力内容を debug ログで記録する", async () => {
+		mockFetch({ response: "Ollamaからの回答" });
+		const logger = createMockLogger();
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3", logger);
+
+		await adapter.prompt("入力");
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasResponseLog = allArgs.some((arg: string) => arg.includes("Ollamaからの回答"));
+		expect(hasResponseLog).toBe(true);
+	});
+
+	it("debug ログにモデル情報が含まれる", async () => {
+		mockFetch({ response: "ok" });
+		const logger = createMockLogger();
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3", logger);
+
+		await adapter.prompt("入力");
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasModel = allArgs.some((arg: string) => arg.includes("gemma3"));
+		expect(hasModel).toBe(true);
+	});
+
+	it("Logger 未設定でもエラーにならない", async () => {
+		mockFetch({ response: "回答テキスト" });
+		// Logger を渡さずにインスタンス生成
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+
+		const result = await adapter.prompt("テスト");
+		expect(result).toBe("回答テキスト");
+	});
+});

--- a/spec/opencode/llm-logging.spec.ts
+++ b/spec/opencode/llm-logging.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * OpencodeSessionAdapter LLM プロンプト/出力のログ記録 仕様テスト
+ *
+ * 期待仕様:
+ * 1. prompt() でリクエスト送信時に debug ログでプロンプト内容を記録する
+ * 2. prompt() でレスポンス受信時に debug ログで出力内容を記録する
+ * 3. debug ログにモデル情報が含まれる
+ * 4. Logger が未設定の場合にエラーにならない
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { OpencodeClient } from "@opencode-ai/sdk/v2";
+import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
+import { createMockLogger } from "@vicissitude/shared/test-helpers";
+
+// --- テストヘルパー ---
+
+function createMockClient() {
+	return {
+		event: {
+			subscribe: mock(() =>
+				Promise.resolve({
+					stream: {
+						next: mock(() => new Promise<IteratorResult<never, void>>(() => {})),
+						return: mock(() => Promise.resolve({ done: true, value: undefined })),
+						[Symbol.asyncIterator]() {
+							return this;
+						},
+					},
+				}),
+			),
+		},
+		session: {
+			create: mock(() => Promise.resolve({ data: { id: "session-1" }, error: null })),
+			get: mock(() => Promise.resolve({ data: { id: "session-1" }, error: null })),
+			prompt: mock(() =>
+				Promise.resolve({
+					data: {
+						parts: [{ type: "text", text: "LLM応答テキスト" }],
+						info: {},
+					},
+					error: null,
+				}),
+			),
+			promptAsync: mock(() => Promise.resolve({ data: {}, error: null })),
+			abort: mock(() => Promise.resolve({ data: {}, error: null })),
+			delete: mock(() => Promise.resolve({ data: {}, error: null })),
+		},
+	} as unknown as OpencodeClient;
+}
+
+function createAdapter(opts: { logger?: ReturnType<typeof createMockLogger> } = {}) {
+	const logger = opts.logger ?? createMockLogger();
+	const client = createMockClient();
+	const adapter = new OpencodeSessionAdapter({
+		port: 4096,
+		mcpServers: {},
+		builtinTools: {},
+		logger,
+		clientFactory: mock(() =>
+			Promise.resolve({
+				client,
+				server: { url: "http://localhost", close: mock(() => {}) },
+			}),
+		),
+	});
+	return { adapter, logger, client };
+}
+
+const promptParams = {
+	sessionId: "session-1",
+	text: "ユーザーからのプロンプト",
+	model: { providerId: "test-provider", modelId: "test-model" },
+};
+
+// --- prompt() のログ記録 ---
+
+describe("OpencodeSessionAdapter prompt() LLM ログ記録", () => {
+	test("リクエスト送信時にプロンプト内容を debug ログで記録する", async () => {
+		const { adapter, logger } = createAdapter();
+
+		await adapter.prompt(promptParams);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasPromptLog = allArgs.some((arg: string) => arg.includes("ユーザーからのプロンプト"));
+		expect(hasPromptLog).toBe(true);
+	});
+
+	test("レスポンス受信時に出力内容を debug ログで記録する", async () => {
+		const { adapter, logger } = createAdapter();
+
+		await adapter.prompt(promptParams);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasResponseLog = allArgs.some((arg: string) => arg.includes("LLM応答テキスト"));
+		expect(hasResponseLog).toBe(true);
+	});
+
+	test("debug ログにモデル情報が含まれる", async () => {
+		const { adapter, logger } = createAdapter();
+
+		await adapter.prompt(promptParams);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasModel = allArgs.some(
+			(arg: string) => arg.includes("test-provider") || arg.includes("test-model"),
+		);
+		expect(hasModel).toBe(true);
+	});
+
+	test("Logger 未設定でもエラーにならない", async () => {
+		const client = createMockClient();
+		const adapter = new OpencodeSessionAdapter({
+			port: 4096,
+			mcpServers: {},
+			builtinTools: {},
+			// logger を渡さない
+			clientFactory: mock(() =>
+				Promise.resolve({
+					client,
+					server: { url: "http://localhost", close: mock(() => {}) },
+				}),
+			),
+		});
+
+		const result = await adapter.prompt(promptParams);
+		expect(result.text).toBe("LLM応答テキスト");
+	});
+});


### PR DESCRIPTION
## Summary
- OpencodeSessionAdapter, OllamaChatAdapter, MemoryChatAdapter の 3 アダプターに対して、LLM リクエスト/レスポンスの debug ログ記録を検証する仕様テストを追加
- 各テストは TDD の RED フェーズ（実装前に失敗する状態）で作成済み
- Logger 未設定時にエラーにならないことも検証

Closes #718

## Test plan
- [ ] `nr test:spec` で 3 ファイルがコンパイル・実行されることを確認（現時点では実装未着手のため fail が正常）
- [ ] impl-agent による実装後、全テストが pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)