### PR TITLE
feat(observability): LLM リクエスト/レスポンスの debug ログ記録 (#718)

### DIFF
--- a/packages/memory/src/chat-adapter.ts
+++ b/packages/memory/src/chat-adapter.ts
@@ -22,6 +22,12 @@ export class MemoryChatAdapter {
 
 	async chat(messages: ChatMessage[]): Promise<string> {
 		const { system, userContent } = separateMessages(messages);
+		const modelLabel = `${this.providerId}/${this.modelId}`;
+		this.logger.debug("[memory-chat] llm_request", {
+			model: modelLabel,
+			prompt: userContent,
+			system,
+		});
 
 		const sessionId = await this.sessionPort.createSession("memory-chat");
 
@@ -32,6 +38,10 @@ export class MemoryChatAdapter {
 				model: { providerId: this.providerId, modelId: this.modelId },
 				system,
 				tools: {},
+			});
+			this.logger.debug("[memory-chat] llm_response", {
+				model: modelLabel,
+				text: result.text,
 			});
 			return result.text;
 		} finally {

--- a/packages/ollama/src/ollama-chat-adapter.ts
+++ b/packages/ollama/src/ollama-chat-adapter.ts
@@ -1,11 +1,18 @@
+/** ollama パッケージは外部 workspace に依存できないため、必要最小限のログインターフェースをローカル定義 */
+interface OllamaLogger {
+	debug(message: string, ...args: unknown[]): void;
+}
+
 /** Ollama HTTP API generate adapter */
 export class OllamaChatAdapter {
 	constructor(
 		private readonly baseUrl: string,
 		private readonly model: string,
+		private readonly logger?: OllamaLogger,
 	) {}
 
 	async prompt(text: string): Promise<string> {
+		this.logger?.debug("[ollama] llm_request", { model: this.model, prompt: text });
 		const url = new URL("/api/generate", this.baseUrl);
 		const response = await fetch(url, {
 			method: "POST",
@@ -22,6 +29,7 @@ export class OllamaChatAdapter {
 		if (typeof data.response !== "string") {
 			throw new TypeError("Ollama generate returned no response field");
 		}
+		this.logger?.debug("[ollama] llm_response", { model: this.model, text: data.response });
 		return data.response;
 	}
 }

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -70,6 +70,12 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 	}
 
 	async prompt(params: OpencodePromptParams, signal?: AbortSignal): Promise<PromptResult> {
+		const modelLabel = `${params.model.providerId}/${params.model.modelId}`;
+		this.logger?.debug("[opencode] llm_request", {
+			model: modelLabel,
+			prompt: params.text,
+			system: params.system,
+		});
 		const oc = await this.getClient();
 		const result = await oc.session.prompt(
 			{
@@ -86,6 +92,11 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		}
 		const text = extractText(result.data.parts);
 		const tokens = extractTokens(result.data.info);
+		this.logger?.debug("[opencode] llm_response", {
+			model: modelLabel,
+			text,
+			tokens,
+		});
 		return { text, tokens };
 	}
 

--- a/spec/memory/llm-logging.spec.ts
+++ b/spec/memory/llm-logging.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * MemoryChatAdapter LLM プロンプト/出力のログ記録 仕様テスト
+ *
+ * 期待仕様:
+ * 1. chat() でリクエスト送信時に debug ログでプロンプト内容を記録する
+ * 2. chat() でレスポンス受信時に debug ログで出力内容を記録する
+ * 3. debug ログにモデル情報が含まれる
+ */
+import { describe, expect, it, mock } from "bun:test";
+
+import { MemoryChatAdapter } from "@vicissitude/memory/chat-adapter";
+import type { ChatMessage } from "@vicissitude/memory/types";
+import { createMockLogger } from "@vicissitude/shared/test-helpers";
+import type { OpencodeSessionPort } from "@vicissitude/shared/types";
+
+// --- テストヘルパー ---
+
+function createMockSessionPort(responseText: string): OpencodeSessionPort {
+	return {
+		createSession: mock(() => Promise.resolve("test-session-id")),
+		sessionExists: mock(() => Promise.resolve(true)),
+		prompt: mock(() => Promise.resolve({ text: responseText })),
+		promptAsync: mock(() => Promise.resolve()),
+		promptAsyncAndWatchSession: mock(() =>
+			Promise.resolve({ type: "idle" as const, messages: [] }),
+		),
+		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const, messages: [] })),
+		deleteSession: mock(() => Promise.resolve()),
+		close: mock(() => {}),
+	} as unknown as OpencodeSessionPort;
+}
+
+const testMessages: ChatMessage[] = [
+	{ role: "system", content: "あなたはアシスタントです" },
+	{ role: "user", content: "ユーザーからの質問内容" },
+];
+
+describe("MemoryChatAdapter chat() LLM ログ記録", () => {
+	it("リクエスト送信時にプロンプト内容を debug ログで記録する", async () => {
+		const logger = createMockLogger();
+		const port = createMockSessionPort("応答テキスト");
+		const adapter = new MemoryChatAdapter(port, "test-provider", "test-model", logger);
+
+		await adapter.chat(testMessages);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasPromptLog = allArgs.some((arg: string) => arg.includes("ユーザーからの質問内容"));
+		expect(hasPromptLog).toBe(true);
+	});
+
+	it("レスポンス受信時に出力内容を debug ログで記録する", async () => {
+		const logger = createMockLogger();
+		const port = createMockSessionPort("LLMからの応答テキスト");
+		const adapter = new MemoryChatAdapter(port, "test-provider", "test-model", logger);
+
+		await adapter.chat(testMessages);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasResponseLog = allArgs.some((arg: string) => arg.includes("LLMからの応答テキスト"));
+		expect(hasResponseLog).toBe(true);
+	});
+
+	it("debug ログにモデル情報が含まれる", async () => {
+		const logger = createMockLogger();
+		const port = createMockSessionPort("ok");
+		const adapter = new MemoryChatAdapter(port, "test-provider", "test-model", logger);
+
+		await adapter.chat(testMessages);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasModel = allArgs.some(
+			(arg: string) => arg.includes("test-provider") || arg.includes("test-model"),
+		);
+		expect(hasModel).toBe(true);
+	});
+});

--- a/spec/ollama/llm-logging.spec.ts
+++ b/spec/ollama/llm-logging.spec.ts
@@ -7,7 +7,7 @@
  * 3. debug ログにモデル情報が含まれる
  * 4. Logger が未設定（optional）の場合にエラーにならない
  */
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
 import { OllamaChatAdapter } from "@vicissitude/ollama/ollama-chat-adapter";
 import { createMockLogger } from "@vicissitude/shared/test-helpers";

--- a/spec/ollama/llm-logging.spec.ts
+++ b/spec/ollama/llm-logging.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * OllamaChatAdapter LLM プロンプト/出力のログ記録 仕様テスト
+ *
+ * 期待仕様:
+ * 1. prompt() でリクエスト送信時に debug ログでプロンプト内容を記録する
+ * 2. prompt() でレスポンス受信時に debug ログで出力内容を記録する
+ * 3. debug ログにモデル情報が含まれる
+ * 4. Logger が未設定（optional）の場合にエラーにならない
+ */
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+import { OllamaChatAdapter } from "@vicissitude/ollama/ollama-chat-adapter";
+import { createMockLogger } from "@vicissitude/shared/test-helpers";
+
+// --- テストヘルパー ---
+
+function mockFetch(responseBody: unknown) {
+	globalThis.fetch = (() =>
+		Promise.resolve({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			json: () => Promise.resolve(responseBody),
+		} as Response)) as unknown as typeof fetch;
+}
+
+describe("OllamaChatAdapter prompt() LLM ログ記録", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("リクエスト送信時にプロンプト内容を debug ログで記録する", async () => {
+		mockFetch({ response: "回答テキスト" });
+		const logger = createMockLogger();
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3", logger);
+
+		await adapter.prompt("テスト入力プロンプト");
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasPromptLog = allArgs.some((arg: string) => arg.includes("テスト入力プロンプト"));
+		expect(hasPromptLog).toBe(true);
+	});
+
+	it("レスポンス受信時に出力内容を debug ログで記録する", async () => {
+		mockFetch({ response: "Ollamaからの回答" });
+		const logger = createMockLogger();
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3", logger);
+
+		await adapter.prompt("入力");
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasResponseLog = allArgs.some((arg: string) => arg.includes("Ollamaからの回答"));
+		expect(hasResponseLog).toBe(true);
+	});
+
+	it("debug ログにモデル情報が含まれる", async () => {
+		mockFetch({ response: "ok" });
+		const logger = createMockLogger();
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3", logger);
+
+		await adapter.prompt("入力");
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasModel = allArgs.some((arg: string) => arg.includes("gemma3"));
+		expect(hasModel).toBe(true);
+	});
+
+	it("Logger 未設定でもエラーにならない", async () => {
+		mockFetch({ response: "回答テキスト" });
+		// Logger を渡さずにインスタンス生成
+		const adapter = new OllamaChatAdapter("http://localhost:11434", "gemma3");
+
+		const result = await adapter.prompt("テスト");
+		expect(result).toBe("回答テキスト");
+	});
+});

--- a/spec/opencode/llm-logging.spec.ts
+++ b/spec/opencode/llm-logging.spec.ts
@@ -22,7 +22,7 @@ function createMockClient() {
 				Promise.resolve({
 					stream: {
 						next: mock(() => new Promise<IteratorResult<never, void>>(() => {})),
-						return: mock(() => Promise.resolve({ done: true, value: undefined })),
+						return: mock(() => ({ done: true, value: undefined })),
 						[Symbol.asyncIterator]() {
 							return this;
 						},

--- a/spec/opencode/llm-logging.spec.ts
+++ b/spec/opencode/llm-logging.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * OpencodeSessionAdapter LLM プロンプト/出力のログ記録 仕様テスト
+ *
+ * 期待仕様:
+ * 1. prompt() でリクエスト送信時に debug ログでプロンプト内容を記録する
+ * 2. prompt() でレスポンス受信時に debug ログで出力内容を記録する
+ * 3. debug ログにモデル情報が含まれる
+ * 4. Logger が未設定の場合にエラーにならない
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { OpencodeClient } from "@opencode-ai/sdk/v2";
+import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
+import { createMockLogger } from "@vicissitude/shared/test-helpers";
+
+// --- テストヘルパー ---
+
+function createMockClient() {
+	return {
+		event: {
+			subscribe: mock(() =>
+				Promise.resolve({
+					stream: {
+						next: mock(() => new Promise<IteratorResult<never, void>>(() => {})),
+						return: mock(() => Promise.resolve({ done: true, value: undefined })),
+						[Symbol.asyncIterator]() {
+							return this;
+						},
+					},
+				}),
+			),
+		},
+		session: {
+			create: mock(() => Promise.resolve({ data: { id: "session-1" }, error: null })),
+			get: mock(() => Promise.resolve({ data: { id: "session-1" }, error: null })),
+			prompt: mock(() =>
+				Promise.resolve({
+					data: {
+						parts: [{ type: "text", text: "LLM応答テキスト" }],
+						info: {},
+					},
+					error: null,
+				}),
+			),
+			promptAsync: mock(() => Promise.resolve({ data: {}, error: null })),
+			abort: mock(() => Promise.resolve({ data: {}, error: null })),
+			delete: mock(() => Promise.resolve({ data: {}, error: null })),
+		},
+	} as unknown as OpencodeClient;
+}
+
+function createAdapter(opts: { logger?: ReturnType<typeof createMockLogger> } = {}) {
+	const logger = opts.logger ?? createMockLogger();
+	const client = createMockClient();
+	const adapter = new OpencodeSessionAdapter({
+		port: 4096,
+		mcpServers: {},
+		builtinTools: {},
+		logger,
+		clientFactory: mock(() =>
+			Promise.resolve({
+				client,
+				server: { url: "http://localhost", close: mock(() => {}) },
+			}),
+		),
+	});
+	return { adapter, logger, client };
+}
+
+const promptParams = {
+	sessionId: "session-1",
+	text: "ユーザーからのプロンプト",
+	model: { providerId: "test-provider", modelId: "test-model" },
+};
+
+// --- prompt() のログ記録 ---
+
+describe("OpencodeSessionAdapter prompt() LLM ログ記録", () => {
+	test("リクエスト送信時にプロンプト内容を debug ログで記録する", async () => {
+		const { adapter, logger } = createAdapter();
+
+		await adapter.prompt(promptParams);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasPromptLog = allArgs.some((arg: string) => arg.includes("ユーザーからのプロンプト"));
+		expect(hasPromptLog).toBe(true);
+	});
+
+	test("レスポンス受信時に出力内容を debug ログで記録する", async () => {
+		const { adapter, logger } = createAdapter();
+
+		await adapter.prompt(promptParams);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasResponseLog = allArgs.some((arg: string) => arg.includes("LLM応答テキスト"));
+		expect(hasResponseLog).toBe(true);
+	});
+
+	test("debug ログにモデル情報が含まれる", async () => {
+		const { adapter, logger } = createAdapter();
+
+		await adapter.prompt(promptParams);
+
+		const debugCalls = logger.debug.mock.calls;
+		const allArgs = debugCalls.map((call: unknown[]) => JSON.stringify(call));
+		const hasModel = allArgs.some(
+			(arg: string) => arg.includes("test-provider") || arg.includes("test-model"),
+		);
+		expect(hasModel).toBe(true);
+	});
+
+	test("Logger 未設定でもエラーにならない", async () => {
+		const client = createMockClient();
+		const adapter = new OpencodeSessionAdapter({
+			port: 4096,
+			mcpServers: {},
+			builtinTools: {},
+			// logger を渡さない
+			clientFactory: mock(() =>
+				Promise.resolve({
+					client,
+					server: { url: "http://localhost", close: mock(() => {}) },
+				}),
+			),
+		});
+
+		const result = await adapter.prompt(promptParams);
+		expect(result.text).toBe("LLM応答テキスト");
+	});
+});


### PR DESCRIPTION
## Summary

- OpencodeSessionAdapter, OllamaChatAdapter, MemoryChatAdapter の LLM リクエスト送信前後に `debug` レベルの構造化ログを追加
- プロンプト全文、レスポンス全文、使用モデル名を構造化フィールドとして記録
- OllamaChatAdapter に optional な Logger パラメータを追加（ローカルインターフェース定義で workspace 依存制約を回避）

Closes #718

## Test plan

- [x] `spec/opencode/llm-logging.spec.ts` — OpencodeSessionAdapter の debug ログ出力検証（4テスト）
- [x] `spec/ollama/llm-logging.spec.ts` — OllamaChatAdapter の debug ログ出力検証（4テスト）
- [x] `spec/memory/llm-logging.spec.ts` — MemoryChatAdapter の debug ログ出力検証（3テスト）
- [x] 既存 spec テスト 1479 pass（minecraft 関連の既存失敗を除く）

🤖 Generated with [Claude Code](https://claude.com/claude-code)