### PR TITLE
feat(observability): PII/シークレットのログマスキング (#723)

### DIFF
--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -4,6 +4,7 @@
 	"exports": {
 		"./logger": "./src/logger.ts",
 		"./metrics": "./src/metrics.ts",
-		"./correlation": "./src/correlation.ts"
+		"./correlation": "./src/correlation.ts",
+		"./log-redact": "./src/log-redact.ts"
 	}
 }

--- a/packages/observability/src/log-redact.test.ts
+++ b/packages/observability/src/log-redact.test.ts
@@ -56,9 +56,10 @@ describe("redactObject - 内部ロジック", () => {
 			const obj: Record<string, unknown> = { name: "user@test.com" };
 			obj.self = obj;
 
-			// 無限再帰しなければ正常に返る
 			const result = redactObject(obj) as Record<string, unknown>;
 			expect(result.name).toBe("[REDACTED]");
+			// 循環参照はセンチネル値に置換される
+			expect(result.self).toBe("[circular]");
 		});
 
 		test("相互参照オブジェクトで無限再帰しない", () => {
@@ -71,6 +72,8 @@ describe("redactObject - 内部ロジック", () => {
 			expect(result.email).toBe("[REDACTED]");
 			const bResult = result.ref as Record<string, unknown>;
 			expect(bResult.email).toBe("[REDACTED]");
+			// 循環参照先はセンチネル値（元データがリークしない）
+			expect(bResult.ref).toBe("[circular]");
 		});
 
 		test("配列内の循環参照で無限再帰しない", () => {
@@ -79,6 +82,7 @@ describe("redactObject - 内部ロジック", () => {
 
 			const result = redactObject(arr) as unknown[];
 			expect(result[0]).toBe("[REDACTED]");
+			expect(result[1]).toBe("[circular]");
 		});
 	});
 

--- a/packages/observability/src/log-redact.test.ts
+++ b/packages/observability/src/log-redact.test.ts
@@ -122,14 +122,16 @@ describe("redactObject - 内部ロジック", () => {
 			const input = {};
 			const result = redactObject(input);
 			expect(result).toEqual({});
-			expect(result).not.toBe(input); // 別オブジェクトであること
+			// 別オブジェクトであること
+			expect(result).not.toBe(input);
 		});
 
 		test("空配列はコピーされて返る", () => {
 			const input: unknown[] = [];
 			const result = redactObject(input);
 			expect(result).toEqual([]);
-			expect(result).not.toBe(input); // 別配列であること
+			// 別配列であること
+			expect(result).not.toBe(input);
 		});
 	});
 
@@ -143,7 +145,8 @@ describe("redactObject - 内部ロジック", () => {
 		});
 
 		test("undefined を直接渡した場合はそのまま返る", () => {
-			expect(redactObject(undefined)).toBeUndefined();
+			const undef: unknown = void 0;
+			expect(redactObject(undef)).toBeUndefined();
 		});
 	});
 });

--- a/packages/observability/src/log-redact.test.ts
+++ b/packages/observability/src/log-redact.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+
+import { maskSecrets, redactObject } from "./log-redact.ts";
+
+// ─── maskSecrets: 内部ロジック ──────────────────────────────────────
+
+describe("maskSecrets - 内部ロジック", () => {
+	// ─── 正規表現の優先順位 ─────────────────────────────────────
+	describe("正規表現の優先順位", () => {
+		test("sk- キーがメールパターンに誤マッチしない", () => {
+			// sk- キーは API キーパターンで先にマスキングされ、
+			// メールパターンで二重マッチしないことを確認
+			const input = "sk-abcdefghij1234";
+			const result = maskSecrets(input);
+			expect(result).toBe("[REDACTED]");
+			// メールパターンのみだと sk- キーはマッチしない
+			const emailOnly = /\b[\w.+-]+@[\w.-]+\.\w{2,}\b/g;
+			expect(input.match(emailOnly)).toBeNull();
+		});
+
+		test("sk- キーの直後にメールが続く場合、両方が個別にマスキングされる", () => {
+			const input = "sk-abcdefghij1234 user@example.com";
+			const result = maskSecrets(input);
+			expect(result).toBe("[REDACTED] [REDACTED]");
+		});
+	});
+
+	// ─── replaceAll の g フラグ: 同一パターン複数出現 ────────────
+	describe("同一パターンの複数出現がすべて置換される", () => {
+		test("同一メールアドレスが複数回出現する場合すべて置換される", () => {
+			const input = "from: a@b.com to: a@b.com cc: a@b.com";
+			const result = maskSecrets(input);
+			expect(result).toBe("from: [REDACTED] to: [REDACTED] cc: [REDACTED]");
+		});
+
+		test("異なる API キーが複数出現する場合すべて置換される", () => {
+			const input = "keys: ghp_AAAAAAAAAA ghp_BBBBBBBBBB";
+			const result = maskSecrets(input);
+			expect(result).toBe("keys: [REDACTED] [REDACTED]");
+		});
+
+		test("同一電話番号が複数回出現する場合すべて置換される", () => {
+			const input = "tel1: 090-1111-2222 tel2: 090-1111-2222";
+			const result = maskSecrets(input);
+			expect(result).toBe("tel1: [REDACTED] tel2: [REDACTED]");
+		});
+	});
+});
+
+// ─── redactObject: 内部ロジック ─────────────────────────────────────
+
+describe("redactObject - 内部ロジック", () => {
+	// ─── 循環参照ガード ─────────────────────────────────────────
+	describe("循環参照ガード", () => {
+		test("自己参照オブジェクトで無限再帰しない", () => {
+			const obj: Record<string, unknown> = { name: "user@test.com" };
+			obj.self = obj;
+
+			// 無限再帰しなければ正常に返る
+			const result = redactObject(obj) as Record<string, unknown>;
+			expect(result.name).toBe("[REDACTED]");
+		});
+
+		test("相互参照オブジェクトで無限再帰しない", () => {
+			const a: Record<string, unknown> = { email: "a@test.com" };
+			const b: Record<string, unknown> = { email: "b@test.com" };
+			a.ref = b;
+			b.ref = a;
+
+			const result = redactObject(a) as Record<string, unknown>;
+			expect(result.email).toBe("[REDACTED]");
+			const bResult = result.ref as Record<string, unknown>;
+			expect(bResult.email).toBe("[REDACTED]");
+		});
+
+		test("配列内の循環参照で無限再帰しない", () => {
+			const arr: unknown[] = ["ghp_AAAAAAAAAA"];
+			arr.push(arr);
+
+			const result = redactObject(arr) as unknown[];
+			expect(result[0]).toBe("[REDACTED]");
+		});
+	});
+
+	// ─── 深くネストしたオブジェクト ─────────────────────────────
+	describe("深くネストしたオブジェクト", () => {
+		test("5段以上ネストした文字列もマスキングされる", () => {
+			const input = {
+				l1: {
+					l2: {
+						l3: {
+							l4: {
+								l5: {
+									l6: {
+										secret: "sk-deep-nested-key-12345",
+									},
+								},
+							},
+						},
+					},
+				},
+			};
+
+			const result = redactObject(input) as typeof input;
+			expect(result.l1.l2.l3.l4.l5.l6.secret).toBe("[REDACTED]");
+		});
+
+		test("深いネスト内の配列もマスキングされる", () => {
+			const input = {
+				a: { b: { c: { d: { e: ["user@deep.com", "safe"] } } } },
+			};
+
+			const result = redactObject(input) as typeof input;
+			expect(result.a.b.c.d.e[0]).toBe("[REDACTED]");
+			expect(result.a.b.c.d.e[1]).toBe("safe");
+		});
+	});
+
+	// ─── 空オブジェクト / 空配列 ────────────────────────────────
+	describe("空オブジェクト / 空配列", () => {
+		test("空オブジェクトはコピーされて返る", () => {
+			const input = {};
+			const result = redactObject(input);
+			expect(result).toEqual({});
+			expect(result).not.toBe(input); // 別オブジェクトであること
+		});
+
+		test("空配列はコピーされて返る", () => {
+			const input: unknown[] = [];
+			const result = redactObject(input);
+			expect(result).toEqual([]);
+			expect(result).not.toBe(input); // 別配列であること
+		});
+	});
+
+	// ─── undefined 値 ───────────────────────────────────────────
+	describe("undefined 値", () => {
+		test("値が undefined のプロパティはそのまま保持される", () => {
+			const input = { key: undefined, name: "normal" };
+			const result = redactObject(input) as Record<string, unknown>;
+			expect(result.key).toBeUndefined();
+			expect(result.name).toBe("normal");
+		});
+
+		test("undefined を直接渡した場合はそのまま返る", () => {
+			expect(redactObject(undefined)).toBeUndefined();
+		});
+	});
+});

--- a/packages/observability/src/log-redact.ts
+++ b/packages/observability/src/log-redact.ts
@@ -1,0 +1,59 @@
+const REDACTED = "[REDACTED]";
+
+const patterns: RegExp[] = [
+	// API キー / トークン（メールより先にマッチさせる）
+	/\b(?:sk-[\w-]{10,}|ghp_[\w]{10,}|gho_[\w]{10,}|xoxb-[\w-]{10,}|xoxp-[\w-]{10,}|glpat-[\w]{10,}|AKIA[\w]{12,})\b/g,
+
+	// メールアドレス
+	/\b[\w.+-]+@[\w.-]+\.\w{2,}\b/g,
+
+	// 国際電話番号 (+81..., +1...)
+	/\+\d{1,3}[\d-]{7,14}\d/g,
+
+	// 日本の携帯電話番号 (090/080/070)
+	/\b0[789]0-?\d{4}-?\d{4}\b/g,
+];
+
+/**
+ * 文字列中の PII・シークレットを `[REDACTED]` に置換する。
+ */
+export function maskSecrets(value: string): string {
+	let result = value;
+	for (const pattern of patterns) {
+		result = result.replaceAll(pattern, REDACTED);
+	}
+	return result;
+}
+
+/**
+ * オブジェクトを再帰的に走査し、文字列値に {@link maskSecrets} を適用する。
+ * 循環参照は `WeakSet` で検出し、そのまま返す。
+ */
+export function redactObject(obj: unknown): unknown {
+	return redactRecursive(obj, new WeakSet());
+}
+
+function redactRecursive(obj: unknown, seen: WeakSet<object>): unknown {
+	if (typeof obj === "string") {
+		return maskSecrets(obj);
+	}
+
+	if (obj === null || typeof obj !== "object") {
+		return obj;
+	}
+
+	if (seen.has(obj)) {
+		return obj;
+	}
+	seen.add(obj);
+
+	if (Array.isArray(obj)) {
+		return obj.map((item) => redactRecursive(item, seen));
+	}
+
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(obj)) {
+		result[key] = redactRecursive(value, seen);
+	}
+	return result;
+}

--- a/packages/observability/src/log-redact.ts
+++ b/packages/observability/src/log-redact.ts
@@ -43,7 +43,7 @@ function redactRecursive(obj: unknown, seen: WeakSet<object>): unknown {
 	}
 
 	if (seen.has(obj)) {
-		return obj;
+		return "[circular]";
 	}
 	seen.add(obj);
 

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -1,6 +1,8 @@
 import type { Logger } from "@vicissitude/shared/types";
 import pino from "pino";
 
+import { maskSecrets, redactObject } from "./log-redact.ts";
+
 export class ConsoleLogger implements Logger {
 	// oxlint-disable-next-line typescript/no-explicit-any -- pino の child() が返す型パラメータが親と異なるため any で統一
 	private readonly pino: pino.Logger<any>;
@@ -45,10 +47,15 @@ export class ConsoleLogger implements Logger {
 	}
 
 	private log(level: pino.Level, message: string, args: unknown[]): void {
+		const maskedMessage = maskSecrets(message);
 		if (args.length > 0) {
-			this.pino[level]({ extra: args.length === 1 ? args[0] : args }, message);
+			const maskedArgs = args.map((a) => redactObject(a));
+			this.pino[level](
+				{ extra: maskedArgs.length === 1 ? maskedArgs[0] : maskedArgs },
+				maskedMessage,
+			);
 		} else {
-			this.pino[level](message);
+			this.pino[level](maskedMessage);
 		}
 	}
 }

--- a/spec/observability/log-redact.spec.ts
+++ b/spec/observability/log-redact.spec.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "bun:test";
+
+import { maskSecrets, redactObject } from "@vicissitude/observability/log-redact";
+
+// ─── maskSecrets ────────────────────────────────────────────────────
+
+describe("maskSecrets", () => {
+	// ─── メールアドレス ─────────────────────────────────────────
+
+	describe("メールアドレスのマスキング", () => {
+		it("メールアドレスが [REDACTED] に置換される", () => {
+			expect(maskSecrets("contact user@example.com please")).toBe("contact [REDACTED] please");
+		});
+
+		it("サブドメイン付きメールアドレスもマスキングされる", () => {
+			expect(maskSecrets("send to admin@mail.corp.co.jp")).toBe("send to [REDACTED]");
+		});
+	});
+
+	// ─── 日本の電話番号 ─────────────────────────────────────────
+
+	describe("日本の電話番号のマスキング", () => {
+		it("ハイフン付き携帯番号がマスキングされる", () => {
+			expect(maskSecrets("tel: 090-1234-5678")).toBe("tel: [REDACTED]");
+		});
+
+		it("ハイフンなし携帯番号がマスキングされる", () => {
+			expect(maskSecrets("tel: 09012345678")).toBe("tel: [REDACTED]");
+		});
+
+		it("080 で始まる番号もマスキングされる", () => {
+			expect(maskSecrets("080-9876-5432")).toBe("[REDACTED]");
+		});
+
+		it("070 で始まる番号もマスキングされる", () => {
+			expect(maskSecrets("070-1111-2222")).toBe("[REDACTED]");
+		});
+	});
+
+	// ─── 国際電話番号 ───────────────────────────────────────────
+
+	describe("国際電話番号のマスキング", () => {
+		it("+81 で始まる番号がマスキングされる", () => {
+			expect(maskSecrets("call +81901234567")).toBe("call [REDACTED]");
+		});
+
+		it("+1 で始まる番号がマスキングされる", () => {
+			expect(maskSecrets("phone: +12025551234")).toBe("phone: [REDACTED]");
+		});
+	});
+
+	// ─── API キー / トークン ────────────────────────────────────
+
+	describe("API キー / トークンのマスキング", () => {
+		it("sk- プレフィックスのキーがマスキングされる", () => {
+			expect(maskSecrets("key=sk-proj-abcdefghij1234567890abcdef")).toBe("key=[REDACTED]");
+		});
+
+		it("ghp_ プレフィックスのトークンがマスキングされる", () => {
+			expect(maskSecrets("token: ghp_ABCDEFghijklmnopqrstuvwxyz1234567890")).toBe(
+				"token: [REDACTED]",
+			);
+		});
+
+		it("xoxb- プレフィックスの Slack Bot トークンがマスキングされる", () => {
+			expect(maskSecrets("SLACK_TOKEN=xoxb-1234-5678-abcdef")).toBe("SLACK_TOKEN=[REDACTED]");
+		});
+
+		it("xoxp- プレフィックスの Slack User トークンがマスキングされる", () => {
+			expect(maskSecrets("token=xoxp-1234-5678-abcdef")).toBe("token=[REDACTED]");
+		});
+
+		it("gho_ プレフィックスの GitHub OAuth トークンがマスキングされる", () => {
+			expect(maskSecrets("auth gho_abcdefghijklmnop")).toBe("auth [REDACTED]");
+		});
+
+		it("glpat- プレフィックスの GitLab トークンがマスキングされる", () => {
+			expect(maskSecrets("GL_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx")).toBe("GL_TOKEN=[REDACTED]");
+		});
+
+		it("AKIA プレフィックスの AWS アクセスキーがマスキングされる", () => {
+			expect(maskSecrets("aws_key=AKIAIOSFODNN7EXAMPLE")).toBe("aws_key=[REDACTED]");
+		});
+	});
+
+	// ─── 複合パターン ───────────────────────────────────────────
+
+	describe("複数パターンが混在するテキスト", () => {
+		it("メールと電話番号が同時にマスキングされる", () => {
+			const input = "Email: user@example.com, Tel: 090-1234-5678";
+			const result = maskSecrets(input);
+
+			expect(result).not.toContain("user@example.com");
+			expect(result).not.toContain("090-1234-5678");
+			expect(result).toContain("[REDACTED]");
+		});
+
+		it("API キーとメールが同時にマスキングされる", () => {
+			const input = "key=sk-abc123def456 owner=admin@corp.com";
+			const result = maskSecrets(input);
+
+			expect(result).not.toContain("sk-abc123def456");
+			expect(result).not.toContain("admin@corp.com");
+		});
+	});
+
+	// ─── 非マスキング対象 ───────────────────────────────────────
+
+	describe("PII/シークレットを含まないテキスト", () => {
+		it("通常テキストは変更されない", () => {
+			const input = "Hello, this is a normal log message.";
+			expect(maskSecrets(input)).toBe(input);
+		});
+
+		it("数値のみの文字列は変更されない", () => {
+			const input = "count=42";
+			expect(maskSecrets(input)).toBe(input);
+		});
+
+		it("空文字列は変更されない", () => {
+			expect(maskSecrets("")).toBe("");
+		});
+	});
+});
+
+// ─── redactObject ───────────────────────────────────────────────────
+
+describe("redactObject", () => {
+	// ─── immutability ───────────────────────────────────────────
+
+	it("元オブジェクトを変更しない", () => {
+		const original = { email: "user@example.com", count: 1 };
+		const originalCopy = structuredClone(original);
+
+		redactObject(original);
+
+		expect(original).toEqual(originalCopy);
+	});
+
+	// ─── ネスト ─────────────────────────────────────────────────
+
+	it("ネストしたオブジェクト内の文字列もマスキングする", () => {
+		const input = {
+			user: {
+				contact: {
+					email: "deep@nested.com",
+				},
+			},
+		};
+		const result = redactObject(input) as typeof input;
+
+		expect(result.user.contact.email).toBe("[REDACTED]");
+	});
+
+	// ─── 配列 ───────────────────────────────────────────────────
+
+	it("配列内の文字列もマスキングする", () => {
+		const input = {
+			tokens: ["ghp_secrettoken123", "normal-text"],
+		};
+		const result = redactObject(input) as typeof input;
+
+		expect(result.tokens[0]).toBe("[REDACTED]");
+		expect(result.tokens[1]).toBe("normal-text");
+	});
+
+	// ─── 非文字列値の保持 ───────────────────────────────────────
+
+	describe("非文字列値をそのまま保持する", () => {
+		it("number はそのまま保持される", () => {
+			const result = redactObject({ port: 8080 }) as { port: number };
+			expect(result.port).toBe(8080);
+		});
+
+		it("boolean はそのまま保持される", () => {
+			const result = redactObject({ active: true }) as { active: boolean };
+			expect(result.active).toBe(true);
+		});
+
+		it("null はそのまま保持される", () => {
+			const result = redactObject({ data: null }) as { data: null };
+			expect(result.data).toBeNull();
+		});
+	});
+
+	// ─── プリミティブ入力 ───────────────────────────────────────
+
+	it("文字列を直接渡した場合もマスキングされる", () => {
+		expect(redactObject("user@example.com")).toBe("[REDACTED]");
+	});
+
+	it("数値を直接渡した場合はそのまま返る", () => {
+		expect(redactObject(42)).toBe(42);
+	});
+});


### PR DESCRIPTION
## Summary

- `maskSecrets` / `redactObject` を `packages/observability/src/log-redact.ts` に新規実装
- `ConsoleLogger.log()` にマスキングを統合し、ログ出力時に PII・シークレットを `[REDACTED]` に置換
- 対象パターン: メールアドレス、日本の携帯番号、国際電話番号、API キー（sk-, ghp_, xoxb-, xoxp-, gho_, glpat-, AKIA）
- `WeakSet` による循環参照ガード付き（`"[circular]"` センチネル値を返す）

Closes #723

## Test plan

- [x] spec テスト 28 件 pass（`spec/observability/log-redact.spec.ts`）
- [x] unit テスト 14 件 pass（`packages/observability/src/log-redact.test.ts`）
- [x] 既存の logger spec テストが壊れていないことを確認
- [x] lint エラーなし（今回の変更ファイル）
- [x] 型チェックエラーなし（今回の変更ファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)