### PR TITLE
feat(observability): トークンコストの自動計算・集計 (#720)

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -222,6 +222,8 @@ export function createMetrics(logger: Logger, port: number) {
 	collector.registerCounter(METRIC.LLM_INPUT_TOKENS, "LLM input tokens total");
 	collector.registerCounter(METRIC.LLM_OUTPUT_TOKENS, "LLM output tokens total");
 	collector.registerCounter(METRIC.LLM_CACHE_READ_TOKENS, "LLM cache read tokens total");
+	// Cost metrics
+	collector.registerCounter(METRIC.LLM_COST_DOLLARS, "LLM cost in US dollars");
 	// Session error metrics
 	collector.registerCounter(METRIC.SESSION_ERRORS, "Session errors total");
 	collector.registerCounter(METRIC.SESSION_RESTARTS, "Session restarts total");

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -428,10 +428,15 @@ export class AgentRunner implements AiAgent {
 				`[${this.profile.name}:${this.agentId}] long-lived session went idle, will restart`,
 			);
 			if (event.tokens && this.metrics) {
-				recordTokenMetrics(this.metrics, event.tokens, {
-					agent_type: "polling",
-					trigger: "polling",
-				});
+				recordTokenMetrics(
+					this.metrics,
+					event.tokens,
+					{
+						agent_type: "polling",
+						trigger: "polling",
+					},
+					this.profile.model.modelId,
+				);
 			}
 			return;
 		}
@@ -451,10 +456,15 @@ export class AgentRunner implements AiAgent {
 				error_class: "unknown",
 			});
 			if (event.tokens && this.metrics) {
-				recordTokenMetrics(this.metrics, event.tokens, {
-					agent_type: "polling",
-					trigger: "polling",
-				});
+				recordTokenMetrics(
+					this.metrics,
+					event.tokens,
+					{
+						agent_type: "polling",
+						trigger: "polling",
+					},
+					this.profile.model.modelId,
+				);
 			}
 			return;
 		}

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -5,6 +5,7 @@
 		"./logger": "./src/logger.ts",
 		"./metrics": "./src/metrics.ts",
 		"./correlation": "./src/correlation.ts",
-		"./log-redact": "./src/log-redact.ts"
+		"./log-redact": "./src/log-redact.ts",
+		"./model-pricing": "./src/model-pricing.ts"
 	}
 }

--- a/packages/observability/src/metrics.ts
+++ b/packages/observability/src/metrics.ts
@@ -1,4 +1,4 @@
-/* oxlint-disable max-classes-per-file -- metrics module consolidates related classes */
+/* oxlint-disable max-classes-per-file, max-lines -- metrics module consolidates related classes */
 import type {
 	AgentResponse,
 	AiAgent,
@@ -7,6 +7,8 @@ import type {
 	SendOptions,
 	TokenUsage,
 } from "@vicissitude/shared/types";
+
+import { calculateCost, getModelPricing } from "./model-pricing.ts";
 
 // ─── Metric Names ───────────────────────────────────────────────
 
@@ -36,6 +38,8 @@ export const METRIC = {
 	MC_COOLDOWNS: "mc_cooldowns_total",
 	MC_FAILURE_STREAKS: "mc_failure_streaks_total",
 	MC_AUTO_NOTIFICATIONS: "mc_auto_notifications_total",
+	// Cost metrics
+	LLM_COST_DOLLARS: "llm_cost_dollars_total",
 	// Session error metrics
 	SESSION_ERRORS: "session_errors_total",
 	SESSION_RESTARTS: "session_restarts_total",
@@ -62,11 +66,22 @@ export function recordTokenMetrics(
 	metrics: MetricsCollector,
 	tokens: TokenUsage,
 	labels: Record<string, string>,
+	modelId?: string,
 ): void {
 	if (tokens.input > 0) metrics.addCounter(METRIC.LLM_INPUT_TOKENS, tokens.input, labels);
 	if (tokens.output > 0) metrics.addCounter(METRIC.LLM_OUTPUT_TOKENS, tokens.output, labels);
 	if (tokens.cacheRead > 0)
 		metrics.addCounter(METRIC.LLM_CACHE_READ_TOKENS, tokens.cacheRead, labels);
+
+	if (modelId) {
+		const pricing = getModelPricing(modelId);
+		if (pricing) {
+			const cost = calculateCost(tokens, pricing);
+			if (cost > 0) {
+				metrics.addCounter(METRIC.LLM_COST_DOLLARS, cost, { ...labels, model: modelId });
+			}
+		}
+	}
 }
 
 // ─── Error Classification ───────────────────────────────────────
@@ -323,6 +338,7 @@ export class InstrumentedAiAgent implements AiAgent {
 		private readonly inner: AiAgent,
 		private readonly metrics: MetricsCollector,
 		private readonly agentType: AgentType,
+		private readonly modelId?: string,
 	) {}
 
 	async send(options: SendOptions): Promise<AgentResponse> {
@@ -335,7 +351,7 @@ export class InstrumentedAiAgent implements AiAgent {
 			const response = await this.inner.send(options);
 			this.metrics.incrementCounter(METRIC.AI_REQUESTS, { ...labels, outcome: "success" });
 			if (response.tokens) {
-				recordTokenMetrics(this.metrics, response.tokens, labels);
+				recordTokenMetrics(this.metrics, response.tokens, labels, this.modelId);
 			}
 			return response;
 		} catch (error) {

--- a/packages/observability/src/model-pricing.test.ts
+++ b/packages/observability/src/model-pricing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+
+import type { TokenUsage } from "@vicissitude/shared/types";
+
+import { calculateCost, getModelPricing } from "./model-pricing";
+
+describe("getModelPricing", () => {
+	it("gpt-4o の具体的な単価値を返す", () => {
+		const pricing = getModelPricing("gpt-4o");
+		expect(pricing).toEqual({
+			inputPerMillionTokens: 2.5,
+			outputPerMillionTokens: 10.0,
+			cacheReadPerMillionTokens: 1.25,
+		});
+	});
+
+	it("gpt-4o-mini の具体的な単価値を返す", () => {
+		const pricing = getModelPricing("gpt-4o-mini");
+		expect(pricing).toEqual({
+			inputPerMillionTokens: 0.15,
+			outputPerMillionTokens: 0.6,
+			cacheReadPerMillionTokens: 0.075,
+		});
+	});
+
+	it("空文字列の場合は undefined を返す", () => {
+		expect(getModelPricing("")).toBeUndefined();
+	});
+});
+
+describe("calculateCost", () => {
+	const pricing = {
+		inputPerMillionTokens: 2.0,
+		outputPerMillionTokens: 8.0,
+		cacheReadPerMillionTokens: 1.0,
+	};
+
+	it("input トークンのみの場合、input 単価だけが効く", () => {
+		const tokens: TokenUsage = { input: 1_000_000, output: 0, cacheRead: 0 };
+		expect(calculateCost(tokens, pricing)).toBe(2.0);
+	});
+
+	it("output トークンのみの場合、output 単価だけが効く", () => {
+		const tokens: TokenUsage = { input: 0, output: 1_000_000, cacheRead: 0 };
+		expect(calculateCost(tokens, pricing)).toBe(8.0);
+	});
+
+	it("cacheRead トークンのみの場合、cacheRead 単価だけが効く", () => {
+		const tokens: TokenUsage = { input: 0, output: 0, cacheRead: 1_000_000 };
+		expect(calculateCost(tokens, pricing)).toBe(1.0);
+	});
+
+	it("全トークンが 0 の場合はコストが 0 である", () => {
+		const tokens: TokenUsage = { input: 0, output: 0, cacheRead: 0 };
+		expect(calculateCost(tokens, pricing)).toBe(0);
+	});
+});

--- a/packages/observability/src/model-pricing.ts
+++ b/packages/observability/src/model-pricing.ts
@@ -1,0 +1,40 @@
+import type { TokenUsage } from "@vicissitude/shared/types";
+
+// ─── Model Pricing ─────────────────────────────────────────────
+
+export interface ModelPricing {
+	/** USD per 1M input tokens */
+	inputPerMillionTokens: number;
+	/** USD per 1M output tokens */
+	outputPerMillionTokens: number;
+	/** USD per 1M cache-read tokens */
+	cacheReadPerMillionTokens: number;
+}
+
+/**
+ * 既知モデルの単価テーブル（2024 年時点の概算）。
+ * 未知モデルは undefined を返す。
+ */
+const PRICING_TABLE: ReadonlyMap<string, ModelPricing> = new Map<string, ModelPricing>([
+	[
+		"gpt-4o",
+		{ inputPerMillionTokens: 2.5, outputPerMillionTokens: 10.0, cacheReadPerMillionTokens: 1.25 },
+	],
+	[
+		"gpt-4o-mini",
+		{ inputPerMillionTokens: 0.15, outputPerMillionTokens: 0.6, cacheReadPerMillionTokens: 0.075 },
+	],
+]);
+
+export function getModelPricing(modelId: string): ModelPricing | undefined {
+	return PRICING_TABLE.get(modelId);
+}
+
+export function calculateCost(tokens: TokenUsage, pricing: ModelPricing): number {
+	return (
+		(tokens.input * pricing.inputPerMillionTokens +
+			tokens.output * pricing.outputPerMillionTokens +
+			tokens.cacheRead * pricing.cacheReadPerMillionTokens) /
+		1_000_000
+	);
+}

--- a/spec/observability/cost-metrics.spec.ts
+++ b/spec/observability/cost-metrics.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import {
+	InstrumentedAiAgent,
+	PrometheusCollector,
+	METRIC,
+	recordTokenMetrics,
+} from "@vicissitude/observability/metrics";
+import type { AgentResponse } from "@vicissitude/shared/types";
+
+const LLM_COST_METRIC = "llm_cost_dollars_total";
+
+function createSetup() {
+	const collector = new PrometheusCollector();
+	collector.registerCounter(METRIC.AI_REQUESTS, "AI requests");
+	collector.registerGauge(METRIC.LLM_BUSY_SESSIONS, "Busy sessions");
+	collector.registerHistogram(METRIC.AI_REQUEST_DURATION, "Duration", [1, 5]);
+	collector.registerCounter(METRIC.LLM_INPUT_TOKENS, "Input tokens");
+	collector.registerCounter(METRIC.LLM_OUTPUT_TOKENS, "Output tokens");
+	collector.registerCounter(METRIC.LLM_CACHE_READ_TOKENS, "Cache read tokens");
+	collector.registerCounter(LLM_COST_METRIC, "LLM cost in USD");
+	return collector;
+}
+
+describe("recordTokenMetrics とコストメトリクス", () => {
+	it("modelId を渡すと llm_cost_dollars_total カウンターが記録される", () => {
+		const collector = createSetup();
+		const tokens = { input: 1000, output: 500, cacheRead: 200 };
+		const labels = { agent_type: "polling", trigger: "home" };
+
+		recordTokenMetrics(collector, tokens, labels, "gpt-4o");
+
+		const output = collector.serialize();
+		expect(output).toContain("llm_cost_dollars_total{");
+		// model ラベルが含まれること
+		expect(output).toContain('model="gpt-4o"');
+	});
+
+	it("modelId を渡さない場合はコストメトリクスが記録されない（後方互換性）", () => {
+		const collector = createSetup();
+		const tokens = { input: 1000, output: 500, cacheRead: 200 };
+		const labels = { agent_type: "polling", trigger: "home" };
+
+		recordTokenMetrics(collector, tokens, labels);
+
+		const output = collector.serialize();
+		expect(output).not.toContain("llm_cost_dollars_total{");
+	});
+
+	it("未知のモデルID の場合はコストメトリクスが記録されない", () => {
+		const collector = createSetup();
+		const tokens = { input: 1000, output: 500, cacheRead: 200 };
+		const labels = { agent_type: "polling", trigger: "home" };
+
+		recordTokenMetrics(collector, tokens, labels, "unknown-model-xyz");
+
+		const output = collector.serialize();
+		expect(output).not.toContain("llm_cost_dollars_total{");
+	});
+});
+
+describe("InstrumentedAiAgent とコストメトリクス", () => {
+	it("modelId を渡すと、成功時にコストメトリクスが記録される", async () => {
+		const collector = createSetup();
+		const inner = {
+			send: mock(
+				(): Promise<AgentResponse> =>
+					Promise.resolve({
+						text: "ok",
+						sessionId: "s1",
+						tokens: { input: 1000, output: 500, cacheRead: 200 },
+					}),
+			),
+			stop: mock(() => {}),
+		};
+		const agent = new InstrumentedAiAgent(inner, collector, "polling", "gpt-4o");
+
+		await agent.send({ sessionKey: "discord:ch:_channel", message: "hi" });
+
+		const output = collector.serialize();
+		expect(output).toContain("llm_cost_dollars_total{");
+		expect(output).toContain('model="gpt-4o"');
+	});
+
+	it("modelId なしの InstrumentedAiAgent では成功時にもコストメトリクスが記録されない", async () => {
+		const collector = createSetup();
+		const inner = {
+			send: mock(
+				(): Promise<AgentResponse> =>
+					Promise.resolve({
+						text: "ok",
+						sessionId: "s1",
+						tokens: { input: 1000, output: 500, cacheRead: 200 },
+					}),
+			),
+			stop: mock(() => {}),
+		};
+		const agent = new InstrumentedAiAgent(inner, collector, "polling");
+
+		await agent.send({ sessionKey: "discord:ch:_channel", message: "hi" });
+
+		const output = collector.serialize();
+		expect(output).not.toContain("llm_cost_dollars_total{");
+	});
+});

--- a/spec/observability/model-pricing.spec.ts
+++ b/spec/observability/model-pricing.spec.ts
@@ -6,9 +6,9 @@ describe("getModelPricing", () => {
 	it("既知モデル（gpt-4o）の単価が取得できる", () => {
 		const pricing = getModelPricing("gpt-4o");
 		expect(pricing).toBeDefined();
-		expect(pricing!.inputPerMillionTokens).toBeGreaterThan(0);
-		expect(pricing!.outputPerMillionTokens).toBeGreaterThan(0);
-		expect(pricing!.cacheReadPerMillionTokens).toBeGreaterThanOrEqual(0);
+		expect(pricing?.inputPerMillionTokens).toBeGreaterThan(0);
+		expect(pricing?.outputPerMillionTokens).toBeGreaterThan(0);
+		expect(pricing?.cacheReadPerMillionTokens).toBeGreaterThanOrEqual(0);
 	});
 
 	it("未知モデルでは undefined が返る", () => {

--- a/spec/observability/model-pricing.spec.ts
+++ b/spec/observability/model-pricing.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+
+import { getModelPricing, calculateCost } from "@vicissitude/observability/model-pricing";
+
+describe("getModelPricing", () => {
+	it("既知モデル（gpt-4o）の単価が取得できる", () => {
+		const pricing = getModelPricing("gpt-4o");
+		expect(pricing).toBeDefined();
+		expect(pricing!.inputPerMillionTokens).toBeGreaterThan(0);
+		expect(pricing!.outputPerMillionTokens).toBeGreaterThan(0);
+		expect(pricing!.cacheReadPerMillionTokens).toBeGreaterThanOrEqual(0);
+	});
+
+	it("未知モデルでは undefined が返る", () => {
+		const pricing = getModelPricing("unknown-model-xyz");
+		expect(pricing).toBeUndefined();
+	});
+});
+
+describe("calculateCost", () => {
+	it("トークン数と単価から正しいコスト（USD）を計算する", () => {
+		const pricing = {
+			inputPerMillionTokens: 2.5,
+			outputPerMillionTokens: 10.0,
+			cacheReadPerMillionTokens: 1.25,
+		};
+		const tokens = { input: 1_000_000, output: 500_000, cacheRead: 200_000 };
+
+		const cost = calculateCost(tokens, pricing);
+
+		// input:  1_000_000 * 2.5  / 1_000_000 = 2.5
+		// output:   500_000 * 10.0 / 1_000_000 = 5.0
+		// cache:    200_000 * 1.25 / 1_000_000 = 0.25
+		// total = 7.75
+		expect(cost).toBeCloseTo(7.75, 10);
+	});
+
+	it("トークン数が全て 0 の場合はコストが 0 である", () => {
+		const pricing = {
+			inputPerMillionTokens: 2.5,
+			outputPerMillionTokens: 10.0,
+			cacheReadPerMillionTokens: 1.25,
+		};
+		const tokens = { input: 0, output: 0, cacheRead: 0 };
+
+		const cost = calculateCost(tokens, pricing);
+
+		expect(cost).toBe(0);
+	});
+
+	it("小数点以下の精度が保たれる", () => {
+		const pricing = {
+			inputPerMillionTokens: 3.0,
+			outputPerMillionTokens: 15.0,
+			cacheReadPerMillionTokens: 0.0,
+		};
+		const tokens = { input: 150, output: 80, cacheRead: 0 };
+
+		const cost = calculateCost(tokens, pricing);
+
+		// input:  150 * 3.0  / 1_000_000 = 0.00045
+		// output:  80 * 15.0 / 1_000_000 = 0.0012
+		// total = 0.00165
+		expect(cost).toBeCloseTo(0.00165, 10);
+	});
+});


### PR DESCRIPTION
## Summary
- モデル別の単価テーブル (`model-pricing.ts`) を新規追加し、`gpt-4o` / `gpt-4o-mini` の単価を定義
- `recordTokenMetrics` に `modelId` パラメータを追加し、既知モデルのコストを `llm_cost_dollars_total` カウンターに自動記録
- `InstrumentedAiAgent` / `AgentRunner` からモデルIDを渡してコスト記録を有効化
- Grafana ダッシュボードは #722 に依存するためスコープ外

Closes #720

## Test plan
- [x] `spec/observability/model-pricing.spec.ts` — 単価取得・コスト計算の仕様テスト (5 tests)
- [x] `spec/observability/cost-metrics.spec.ts` — コストメトリクス記録の仕様テスト (5 tests)
- [x] `packages/observability/src/model-pricing.test.ts` — 単価テーブルのユニットテスト (7 tests)
- [x] 既存テスト全 2103 pass、0 fail を確認
- [x] `nr validate` で既存 lint エラー以外の新規エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)