### PR TITLE
feat(observability): Prometheus / Grafana のデプロイ構成を compose.yaml に追加

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -107,6 +107,12 @@ services:
       - prometheus-data:/prometheus
     networks:
       - vicissitude-net
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     logging:
       driver: journald
       options:
@@ -137,7 +143,8 @@ services:
     networks:
       - vicissitude-net
     depends_on:
-      - prometheus
+      prometheus:
+        condition: service_healthy
     logging:
       driver: journald
       options:

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,8 @@ volumes:
   ollama-data:
   bot-node-modules:
   bot-dist:
+  prometheus-data:
+  grafana-data:
 
 services:
   # Step 1: bun install (依存が変わったときだけ実質的に仕事をする)
@@ -95,6 +97,52 @@ services:
       ollama:
         condition: service_healthy
     command: ["xvfb-run", "-a", "bun", "run", "dist/index.js"]
+
+  prometheus:
+    container_name: vicissitude-prometheus
+    image: docker.io/prom/prometheus:latest
+    profiles: [monitoring]
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    networks:
+      - vicissitude-net
+    logging:
+      driver: journald
+      options:
+        tag: vicissitude-prometheus
+    restart: unless-stopped
+
+  grafana:
+    container_name: vicissitude-grafana
+    image: docker.io/grafana/grafana:latest
+    profiles: [monitoring]
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana-dashboard.json:/tmp/dashboard-src.json:ro
+      - grafana-data:/var/lib/grafana
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        mkdir -p /var/lib/grafana/dashboards
+        sed 's/$${DS_PROMETHEUS}/prometheus/g; s/$${DS_LOKI}/loki/g' /tmp/dashboard-src.json > /var/lib/grafana/dashboards/dashboard.json
+        exec /run.sh
+    ports:
+      - "127.0.0.1:3000:3000"
+    networks:
+      - vicissitude-net
+    depends_on:
+      - prometheus
+    logging:
+      driver: journald
+      options:
+        tag: vicissitude-grafana
+    restart: unless-stopped
 
   ollama:
     container_name: vicissitude-ollama

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: vicissitude
+    static_configs:
+      - targets: ["vicissitude:9091"]


### PR DESCRIPTION
## Summary
- `compose.yaml` に Prometheus / Grafana サービスを `--profile monitoring` で追加
- `monitoring/prometheus.yml` で bot の `:9091/metrics` スクレイプ設定
- `monitoring/grafana/provisioning/` でデータソース・ダッシュボードの自動プロビジョニング
- エクスポート形式のダッシュボード JSON を起動時に sed で UID 変換

Closes #722

## Test plan
- [ ] `podman compose --profile monitoring up -d` で Prometheus・Grafana が起動すること
- [ ] `http://localhost:9090/targets` で vicissitude ターゲットが UP であること
- [ ] `http://localhost:3000` でダッシュボードが自動プロビジョニングされていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)