### PR TITLE
refactor: rotationRequestedAt カラムの削除

### DIFF
--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -65,8 +65,7 @@ CREATE TABLE IF NOT EXISTS mood_state (
 
 CREATE TABLE IF NOT EXISTS agent_heartbeat (
 	agent_id TEXT PRIMARY KEY,
-	last_seen_at INTEGER NOT NULL,
-	rotation_requested_at INTEGER NOT NULL DEFAULT 0
+	last_seen_at INTEGER NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS mc_session_lock (
@@ -113,7 +112,7 @@ function migrateDb(sqlite: Database): void {
 		}
 	}
 
-	// agent_heartbeat: rotation_requested_at カラム追加
+	// agent_heartbeat: rotation_requested_at カラム削除（#632）
 	const hasHeartbeat = sqlite
 		.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='agent_heartbeat'")
 		.get();
@@ -121,10 +120,8 @@ function migrateDb(sqlite: Database): void {
 		const columns = sqlite.prepare("PRAGMA table_info(agent_heartbeat)").all() as {
 			name: string;
 		}[];
-		if (!columns.some((c) => c.name === "rotation_requested_at")) {
-			sqlite.exec(
-				"ALTER TABLE agent_heartbeat ADD COLUMN rotation_requested_at INTEGER NOT NULL DEFAULT 0",
-			);
+		if (columns.some((c) => c.name === "rotation_requested_at")) {
+			sqlite.exec("ALTER TABLE agent_heartbeat DROP COLUMN rotation_requested_at");
 		}
 	}
 

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -39,8 +39,6 @@ export const moodState = sqliteTable("mood_state", {
 export const agentHeartbeat = sqliteTable("agent_heartbeat", {
 	agentId: text("agent_id").primaryKey(),
 	lastSeenAt: integer("last_seen_at").notNull(),
-	/** MCP 側からセッションローテーションを要求するフラグ（タイムスタンプ、0 = 要求なし） */
-	rotationRequestedAt: integer("rotation_requested_at").notNull().default(0),
 });
 
 /** MC セッション排他ロックテーブル（最大1行） */


### PR DESCRIPTION
## Summary

- `schema.ts` から `rotationRequestedAt` カラム定義を削除
- `CREATE_TABLES_SQL` から `rotation_requested_at` 行を削除
- マイグレーションを「カラム追加」→「カラム削除 (DROP COLUMN)」に書き換え

Closes #632

## Test plan

- [x] `nr validate` (fmt:check + lint + type check) 通過
- [x] `nr test` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)