### PR TITLE
fix: フォーマットチェック失敗を修正

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -3,8 +3,8 @@ import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { resolve } from "path";
 
 import { ContextBuilder, type ContextFileName } from "@vicissitude/agent/discord/context-builder";
-import { formatDiscordMessage } from "@vicissitude/agent/discord/message-formatter";
 import { DiscordAgent } from "@vicissitude/agent/discord/discord-agent";
+import { formatDiscordMessage } from "@vicissitude/agent/discord/message-formatter";
 import { createConversationProfile } from "@vicissitude/agent/discord/profile";
 import { GuildRouter } from "@vicissitude/agent/discord/router";
 import { mcpServerConfigs } from "@vicissitude/agent/mcp-config";

--- a/packages/agent/src/discord/message-formatter.ts
+++ b/packages/agent/src/discord/message-formatter.ts
@@ -23,9 +23,7 @@ export function formatDiscordMessage(msg: IncomingMessage): string {
 
 	const isUserMessage = msg.authorId !== "system" && !msg.isBot;
 	const escapedContent = escapeUserMessageTag(msg.content);
-	const content = isUserMessage
-		? `<user_message>${escapedContent}</user_message>`
-		: escapedContent;
+	const content = isUserMessage ? `<user_message>${escapedContent}</user_message>` : escapedContent;
 
 	const attachments = msg.attachments
 		.map((a) => `[添付: ${a.filename} (${a.contentType})]`)


### PR DESCRIPTION
## Summary
- CI の Format check ステップで失敗していた2ファイルのフォーマットを修正
- `bootstrap.ts`: import 順序を oxfmt に合わせて修正
- `message-formatter.ts`: 三項演算子を1行に整形

## Test plan
- [x] `nr fmt:check` がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)