### PR TITLE
fix: ツール呼び出しログに引数と結果を追加

### DIFF
--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -241,14 +241,16 @@ export function logPartActivity(event: Event, sessionId: string, logger: Logger 
 		logger.info(`[opencode:activity] text: ${preview}`);
 	} else if (part.type === "tool") {
 		const status = part.state.status;
+		const inputPreview = JSON.stringify(part.state.input).slice(0, TEXT_LOG_MAX);
 		if (status === "running") {
-			logger.info(`[opencode:activity] tool-start: ${part.tool}`);
+			logger.info(`[opencode:activity] tool-start: ${part.tool} ${inputPreview}`);
 		} else if (status === "completed") {
 			const elapsed = part.state.time ? `${part.state.time.end - part.state.time.start}ms` : "?";
-			logger.info(`[opencode:activity] tool-done: ${part.tool} (${elapsed})`);
+			const outPreview = part.state.output.slice(0, TEXT_LOG_MAX);
+			logger.info(`[opencode:activity] tool-done: ${part.tool} (${elapsed}) → ${outPreview}`);
 		} else if (status === "error") {
 			const errMsg = "error" in part.state ? part.state.error : "unknown";
-			logger.error(`[opencode:activity] tool-error: ${part.tool}: ${errMsg}`);
+			logger.error(`[opencode:activity] tool-error: ${part.tool}: ${errMsg} input=${inputPreview}`);
 		}
 	} else if (part.type === "step-finish") {
 		const { input: i, output: o, reasoning: r } = part.tokens;


### PR DESCRIPTION
## Summary
- ツール開始時に `part.state.input` (引数) をログ出力
- ツール完了時に `part.state.output` (結果) をログ出力
- ツールエラー時にも引数をログ出力
- スレッド返信失敗の原因調査のため（LLM が渡す channel_id を確認）

## Test plan
- [ ] デプロイ後にスレッドでメッセージを送り、ログに channel_id と結果が出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)