### PR TITLE
fix: スレッドチャンネル解決にキャッシュ優先戦略を導入

### DIFF
--- a/packages/mcp/src/tools/discord.ts
+++ b/packages/mcp/src/tools/discord.ts
@@ -62,7 +62,10 @@ export function registerDiscordTools(
 	}
 
 	async function getSendableChannel(channelId: string) {
-		const channel = await discordClient.channels.fetch(channelId);
+		// Gateway 経由でキャッシュ済みのスレッドを優先（最も確実）
+		let channel =
+			discordClient.channels.cache.get(channelId) ??
+			(await discordClient.channels.fetch(channelId, { allowUnknownGuild: true }));
 		if (!channel || !("send" in channel) || typeof channel.send !== "function") {
 			const type = channel?.type;
 			throw new Error(`Channel ${channelId} is not sendable (type=${type ?? "null"})`);

--- a/spec/mcp/tools/discord-test-helpers.ts
+++ b/spec/mcp/tools/discord-test-helpers.ts
@@ -57,31 +57,33 @@ export function createDiscordClientStub(): DiscordDeps["discordClient"] & {
 		react: () => Promise.resolve(),
 	};
 
+	const channelObj = {
+		isTextBased: () => true,
+		send: () => Promise.resolve(sentMessage),
+		sendTyping: sendTypingMock,
+		messages: {
+			fetch: (idOrOptions: unknown) => {
+				// messages.fetch({ limit }) はコレクションを返す
+				if (typeof idOrOptions === "object" && idOrOptions !== null) {
+					const fakeCollection = [
+						{
+							author: { tag: "user#1234" },
+							content: "hello world",
+							attachments: createFakeAttachments([]),
+						},
+					];
+					return Promise.resolve(fakeCollection);
+				}
+				// messages.fetch(messageId) は単一メッセージを返す
+				return Promise.resolve(sentMessage);
+			},
+		},
+	};
+
 	const client = {
 		channels: {
-			fetch: () =>
-				Promise.resolve({
-					isTextBased: () => true,
-					send: () => Promise.resolve(sentMessage),
-					sendTyping: sendTypingMock,
-					messages: {
-						fetch: (idOrOptions: unknown) => {
-							// messages.fetch({ limit }) はコレクションを返す
-							if (typeof idOrOptions === "object" && idOrOptions !== null) {
-								const fakeCollection = [
-									{
-										author: { tag: "user#1234" },
-										content: "hello world",
-										attachments: createFakeAttachments([]),
-									},
-								];
-								return Promise.resolve(fakeCollection);
-							}
-							// messages.fetch(messageId) は単一メッセージを返す
-							return Promise.resolve(sentMessage);
-						},
-					},
-				}),
+			cache: { get: () => channelObj },
+			fetch: () => Promise.resolve(channelObj),
 		},
 		guilds: {
 			fetch: () =>
@@ -118,52 +120,54 @@ export function createDiscordClientStub(): DiscordDeps["discordClient"] & {
 /** react() が reject するスタブ（無効な絵文字等） */
 export function createClientStubWithReactError(): DiscordDeps["discordClient"] {
 	const error = new Error("Unknown Emoji");
+	const channelObj = {
+		isTextBased: () => true,
+		send: () => Promise.resolve({ id: "msg-1" }),
+		messages: {
+			fetch: (idOrOptions: unknown) => {
+				if (typeof idOrOptions === "object" && idOrOptions !== null) {
+					return Promise.resolve([]);
+				}
+				return Promise.resolve({
+					id: "msg-1",
+					reply: () => Promise.resolve({ id: "reply-msg-1" }),
+					react: () => Promise.reject(error),
+				});
+			},
+		},
+	};
 	return {
 		channels: {
-			fetch: () =>
-				Promise.resolve({
-					isTextBased: () => true,
-					send: () => Promise.resolve({ id: "msg-1" }),
-					messages: {
-						fetch: (idOrOptions: unknown) => {
-							if (typeof idOrOptions === "object" && idOrOptions !== null) {
-								return Promise.resolve([]);
-							}
-							return Promise.resolve({
-								id: "msg-1",
-								reply: () => Promise.resolve({ id: "reply-msg-1" }),
-								react: () => Promise.reject(error),
-							});
-						},
-					},
-				}),
+			cache: { get: () => channelObj },
+			fetch: () => Promise.resolve(channelObj),
 		},
 	} as unknown as DiscordDeps["discordClient"];
 }
 
 /** 画像添付ありのメッセージを返すスタブ（1枚） */
 export function createClientStubWithImageAttachments(): DiscordDeps["discordClient"] {
+	const channelObj = {
+		isTextBased: () => true,
+		send: () => Promise.resolve({ id: "msg-1" }),
+		messages: {
+			fetch: (_opts: unknown) => {
+				const msgs = [
+					{
+						author: { tag: "user#5678" },
+						content: "写真だよ",
+						attachments: createFakeAttachments([
+							{ url: "https://cdn.example.com/img.png", contentType: "image/png" },
+						]),
+					},
+				];
+				return Promise.resolve(msgs);
+			},
+		},
+	};
 	return {
 		channels: {
-			fetch: () =>
-				Promise.resolve({
-					isTextBased: () => true,
-					send: () => Promise.resolve({ id: "msg-1" }),
-					messages: {
-						fetch: (_opts: unknown) => {
-							const msgs = [
-								{
-									author: { tag: "user#5678" },
-									content: "写真だよ",
-									attachments: createFakeAttachments([
-										{ url: "https://cdn.example.com/img.png", contentType: "image/png" },
-									]),
-								},
-							];
-							return Promise.resolve(msgs);
-						},
-					},
-				}),
+			cache: { get: () => channelObj },
+			fetch: () => Promise.resolve(channelObj),
 		},
 	} as unknown as DiscordDeps["discordClient"];
 }
@@ -180,25 +184,26 @@ export function createThreadChannelClientStub(): DiscordDeps["discordClient"] {
 		react: () => Promise.resolve(),
 	};
 
+	const channelObj = {
+		isTextBased: () => true,
+		isThread: () => true,
+		parent: { type: 0, isTextBased: () => true },
+		send: () => Promise.resolve(sentMessage),
+		sendTyping: () => Promise.resolve(),
+		messages: {
+			fetch: (idOrOptions: unknown) => {
+				if (typeof idOrOptions === "object" && idOrOptions !== null) {
+					return Promise.resolve([]);
+				}
+				return Promise.resolve(sentMessage);
+			},
+		},
+	};
+
 	return {
 		channels: {
-			fetch: () =>
-				Promise.resolve({
-					isTextBased: () => true,
-					isThread: () => true,
-					// 通常テキストチャンネル配下のスレッドを模倣
-					parent: { type: 0, isTextBased: () => true },
-					send: () => Promise.resolve(sentMessage),
-					sendTyping: () => Promise.resolve(),
-					messages: {
-						fetch: (idOrOptions: unknown) => {
-							if (typeof idOrOptions === "object" && idOrOptions !== null) {
-								return Promise.resolve([]);
-							}
-							return Promise.resolve(sentMessage);
-						},
-					},
-				}),
+			cache: { get: () => channelObj },
+			fetch: () => Promise.resolve(channelObj),
 		},
 	} as unknown as DiscordDeps["discordClient"];
 }
@@ -215,53 +220,90 @@ export function createForumThreadClientStub(): DiscordDeps["discordClient"] {
 		react: () => Promise.resolve(),
 	};
 
+	const channelObj = {
+		isTextBased: () => true,
+		isThread: () => true,
+		parent: { type: 15, isTextBased: () => false },
+		send: () => Promise.resolve(sentMessage),
+		sendTyping: () => Promise.resolve(),
+		messages: {
+			fetch: (idOrOptions: unknown) => {
+				if (typeof idOrOptions === "object" && idOrOptions !== null) {
+					return Promise.resolve([]);
+				}
+				return Promise.resolve(sentMessage);
+			},
+		},
+	};
+
 	return {
 		channels: {
-			fetch: () =>
-				Promise.resolve({
-					isTextBased: () => true,
-					isThread: () => true,
-					// GuildForum (ChannelType.GuildForum = 15) 配下のスレッド
-					parent: { type: 15, isTextBased: () => false },
-					send: () => Promise.resolve(sentMessage),
-					sendTyping: () => Promise.resolve(),
-					messages: {
-						fetch: (idOrOptions: unknown) => {
-							if (typeof idOrOptions === "object" && idOrOptions !== null) {
-								return Promise.resolve([]);
-							}
-							return Promise.resolve(sentMessage);
-						},
-					},
-				}),
+			cache: { get: () => channelObj },
+			fetch: () => Promise.resolve(channelObj),
 		},
 	} as unknown as DiscordDeps["discordClient"];
 }
 
 /** 複数画像添付ありのメッセージを返すスタブ */
 export function createClientStubWithMultipleImageAttachments(): DiscordDeps["discordClient"] {
+	const channelObj = {
+		isTextBased: () => true,
+		send: () => Promise.resolve({ id: "msg-1" }),
+		messages: {
+			fetch: (_opts: unknown) => {
+				const msgs = [
+					{
+						author: { tag: "user#9999" },
+						content: "複数画像だよ",
+						attachments: createFakeAttachments([
+							{ url: "https://cdn.example.com/img1.png", contentType: "image/png" },
+							{ url: "https://cdn.example.com/img2.jpg", contentType: "image/jpeg" },
+						]),
+					},
+				];
+				return Promise.resolve(msgs);
+			},
+		},
+	};
 	return {
 		channels: {
-			fetch: () =>
-				Promise.resolve({
-					isTextBased: () => true,
-					send: () => Promise.resolve({ id: "msg-1" }),
-					messages: {
-						fetch: (_opts: unknown) => {
-							const msgs = [
-								{
-									author: { tag: "user#9999" },
-									content: "複数画像だよ",
-									attachments: createFakeAttachments([
-										{ url: "https://cdn.example.com/img1.png", contentType: "image/png" },
-										{ url: "https://cdn.example.com/img2.jpg", contentType: "image/jpeg" },
-									]),
-								},
-							];
-							return Promise.resolve(msgs);
-						},
-					},
-				}),
+			cache: { get: () => channelObj },
+			fetch: () => Promise.resolve(channelObj),
+		},
+	} as unknown as DiscordDeps["discordClient"];
+}
+
+/**
+ * channels.fetch() が null を返すが、cache にはスレッドが存在するスタブ。
+ * Gateway 経由でキャッシュされたスレッドを channels.fetch() で解決できないケースを再現する。
+ */
+export function createCacheOnlyThreadClientStub(): DiscordDeps["discordClient"] {
+	const sentMessage = {
+		id: "cache-thread-msg-1",
+		reply: () => Promise.resolve({ id: "cache-thread-reply-1" }),
+		react: () => Promise.resolve(),
+	};
+
+	const channelObj = {
+		isTextBased: () => true,
+		isThread: () => true,
+		parent: { type: 15, isTextBased: () => false },
+		send: () => Promise.resolve(sentMessage),
+		sendTyping: () => Promise.resolve(),
+		messages: {
+			fetch: (idOrOptions: unknown) => {
+				if (typeof idOrOptions === "object" && idOrOptions !== null) {
+					return Promise.resolve([]);
+				}
+				return Promise.resolve(sentMessage);
+			},
+		},
+	};
+
+	return {
+		channels: {
+			cache: { get: () => channelObj },
+			fetch: () => Promise.resolve(null),
 		},
 	} as unknown as DiscordDeps["discordClient"];
 }

--- a/spec/mcp/tools/discord.spec.ts
+++ b/spec/mcp/tools/discord.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
 	captureTools,
+	createCacheOnlyThreadClientStub,
 	createClientStubWithImageAttachments,
 	createClientStubWithMultipleImageAttachments,
 	createClientStubWithReactError,
@@ -146,6 +147,20 @@ describe("send_message (thread/forum)", () => {
 		})) as ToolResult;
 
 		expect(result.content[0]!.text).toBe("Sent message forum-sent-msg-1");
+	});
+});
+
+describe("send_message (cache fallback)", () => {
+	test("channels.fetch() が null を返してもキャッシュからスレッドを解決できる", async () => {
+		const { tools } = captureTools({ discordClient: createCacheOnlyThreadClientStub() });
+		const sendMessage = tools.get("send_message")!;
+
+		const result = (await sendMessage({
+			channel_id: "cache-thread-1",
+			content: "キャッシュ経由で送信",
+		})) as ToolResult;
+
+		expect(result.content[0]!.text).toBe("Sent message cache-thread-msg-1");
 	});
 });
 


### PR DESCRIPTION
## Summary

- `channels.fetch(threadId)` が discord.js の guild キャッシュ不整合により `type=null` を返し、スレッドへの応答が失敗する問題を修正
- `getSendableChannel()` で `channels.cache.get()` を優先し、フォールバック時は `allowUnknownGuild: true` で fetch するように変更
- キャッシュのみでスレッドを解決するケースの spec テストを追加

## Test plan

- [x] `bun test spec/mcp/tools/discord.spec.ts` — 全21テストパス
- [x] `nr check` — 型チェックパス
- [x] `nr lint` — lint パス（既存 warning のみ）
- [ ] デプロイ後に実際のフォーラムスレッドで応答を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)