### PR TITLE
fix: logPartActivity の undefined input/output で TypeError が発生する問題を修正

### DIFF
--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -241,12 +241,12 @@ export function logPartActivity(event: Event, sessionId: string, logger: Logger 
 		logger.info(`[opencode:activity] text: ${preview}`);
 	} else if (part.type === "tool") {
 		const status = part.state.status;
-		const inputPreview = JSON.stringify(part.state.input).slice(0, TEXT_LOG_MAX);
+		const inputPreview = (JSON.stringify(part.state.input) ?? "").slice(0, TEXT_LOG_MAX);
 		if (status === "running") {
 			logger.info(`[opencode:activity] tool-start: ${part.tool} ${inputPreview}`);
 		} else if (status === "completed") {
 			const elapsed = part.state.time ? `${part.state.time.end - part.state.time.start}ms` : "?";
-			const outPreview = part.state.output.slice(0, TEXT_LOG_MAX);
+			const outPreview = (part.state.output ?? "").slice(0, TEXT_LOG_MAX);
 			logger.info(`[opencode:activity] tool-done: ${part.tool} (${elapsed}) → ${outPreview}`);
 		} else if (status === "error") {
 			const errMsg = "error" in part.state ? part.state.error : "unknown";


### PR DESCRIPTION
## Summary
- `logPartActivity` で `part.state.input` / `part.state.output` が undefined の場合、`JSON.stringify(undefined)` が `undefined`（非文字列）を返し `.slice()` が TypeError になっていた
- nullish coalescing (`?? ""`) で空文字にフォールバックさせて修正

Closes CI failure on main (runs #24730438326, #24730020042)

## Test plan
- [x] `spec/opencode/stream-helpers.spec.ts` の 3 つの失敗テストが通過することを確認
- [x] 全 2015 テスト通過（`nr test`）
- [x] `nr validate` でリグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)