### PR TITLE
test: pollingPrompt に core_send_message 必須指示の検証テストを追加

### DIFF
--- a/spec/agent/discord/profile.spec.ts
+++ b/spec/agent/discord/profile.spec.ts
@@ -13,6 +13,16 @@ describe("createConversationProfile", () => {
 		expect(profile.pollingPrompt).toContain("Discord bot");
 	});
 
+	test("pollingPrompt が core_send_message の使用を必須指示として含む", () => {
+		const profile = createConversationProfile({
+			providerId: "provider",
+			modelId: "model",
+			mcpServers: {},
+		});
+
+		expect(profile.pollingPrompt).toContain("core_send_message");
+	});
+
 	test("pollingPrompt に action ヒントの説明が含まれる", () => {
 		const profile = createConversationProfile({
 			providerId: "provider",


### PR DESCRIPTION
## Summary
- `profile.spec.ts` に `pollingPrompt` が `core_send_message` への言及を含むことを検証するテストケースを追加
- 既存テストパターンに準拠（`createConversationProfile` 最小引数 + `toContain`）

Closes #754

## Test plan
- [x] 新規テスト通過（`bun test spec/agent/discord/profile.spec.ts` → 3 pass）
- [x] 全 2016 テスト通過（`nr test`）
- [x] `nr validate` でリグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)