### PR TITLE
fix: discord.test.ts のスタブに channels.cache を追加して CI を修正

### DIFF
--- a/packages/mcp/src/tools/discord.test.ts
+++ b/packages/mcp/src/tools/discord.test.ts
@@ -33,10 +33,12 @@ function createDiscordClientStub(): DiscordDeps["discordClient"] {
 	const sentMessage = { id: "sent-msg-1", reply: () => Promise.resolve({ id: "reply-msg-1" }) };
 	return {
 		channels: {
+			cache: new Map(),
 			fetch: () =>
 				Promise.resolve({
 					isTextBased: () => true,
 					send: () => Promise.resolve(sentMessage),
+					sendTyping: () => Promise.resolve(),
 					messages: { fetch: () => Promise.resolve(sentMessage) },
 				}),
 		},


### PR DESCRIPTION
## Summary
- `getSendableChannel` がキャッシュ優先戦略（e8a5f0f）で `discordClient.channels.cache.get()` を参照するようになったが、テストスタブに `cache` プロパティがなく TypeError で 8 テストが失敗していた
- スタブに `channels.cache: new Map()` と `sendTyping` を追加して修正

## Test plan
- [x] `nr test -- packages/mcp/src/tools/discord.test.ts` で 8 テスト全通過を確認

Closes: CI failure on main (b6f07e7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)