### PR TITLE
fix: HEARTBEAT.md から存在しないツール set_now_playing の参照を削除

### DIFF
--- a/context/HEARTBEAT.md
+++ b/context/HEARTBEAT.md
@@ -19,7 +19,7 @@ heartbeat はふあが定期的に自律的に行動するための仕組み。
 
 ### 音楽の話題
 
-`core_spotify_pick_track` → `core_fetch_lyrics` → 自分の言葉で自然に紹介（JSON や歌詞全文は貼らない）。感想があれば `core_save_listening_fact`、紹介時は `set_now_playing` も更新。話の流れに合うときだけ使う。
+`core_spotify_pick_track` → `core_fetch_lyrics` → 自分の言葉で自然に紹介（JSON や歌詞全文は貼らない）。感想があれば `core_save_listening_fact`。話の流れに合うときだけ使う。
 
 ### mc-check の手順
 


### PR DESCRIPTION
## Summary
- HEARTBEAT.md の「音楽の話題」セクションで参照されていた `set_now_playing` ツールを削除
- TOOLS-CORE.md にもソースコードにも実装が存在しないツール名だった

Closes #766

## Test plan
- [x] `set_now_playing` がコードベースに存在しないことを grep で確認済み
- [x] HEARTBEAT.md の他の記述に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)