### PR TITLE
refactor: TestAgent / ヘルパーの重複を runner-test-helpers.ts に集約

### DIFF
--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -2,74 +2,16 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { createMockLogger } from "@vicissitude/shared/test-helpers";
-import type {
-	ContextBuilderPort,
-	OpencodeSessionEvent,
-	OpencodeSessionPort,
-} from "@vicissitude/shared/types";
+import type { OpencodeSessionEvent, OpencodeSessionPort } from "@vicissitude/shared/types";
 
-import type { AgentProfile } from "./profile.ts";
+import {
+	TestAgent,
+	createContextBuilder,
+	createProfile,
+	createSessionStore,
+	deferred,
+} from "../../../spec/agent/runner-test-helpers.ts";
 import { AgentRunner, type RunnerDeps } from "./runner.ts";
-
-/** テスト用サブクラス: protected constructor を公開し、sleep をオーバーライド可能にする */
-class TestAgent extends AgentRunner {
-	sleepSpy: ((ms: number) => Promise<void>) | null = null;
-
-	// oxlint-disable-next-line no-useless-constructor -- protected → public に昇格させるために必要
-	constructor(deps: RunnerDeps) {
-		super(deps);
-	}
-
-	protected override sleep(ms: number): Promise<void> {
-		if (this.sleepSpy) return this.sleepSpy(ms);
-		return super.sleep(ms);
-	}
-
-	protected override waitForDebounce(_signal: AbortSignal): Promise<void> {
-		return Promise.resolve();
-	}
-}
-
-function deferred<T>() {
-	let resolveDeferred!: (value: T) => void;
-	let rejectDeferred!: (reason?: unknown) => void;
-	const promise = new Promise<T>((resolve, reject) => {
-		resolveDeferred = resolve;
-		rejectDeferred = reject;
-	});
-	return { promise, resolve: resolveDeferred, reject: rejectDeferred };
-}
-
-function createProfile(): AgentProfile {
-	return {
-		name: "conversation",
-		mcpServers: {},
-		builtinTools: {},
-		pollingPrompt: "loop forever",
-		model: { providerId: "test-provider", modelId: "test-model" },
-	};
-}
-
-function createContextBuilder(): ContextBuilderPort {
-	return { build: mock(() => Promise.resolve("system prompt")) };
-}
-
-function createSessionStore() {
-	let sessionId: string | undefined;
-	let createdAt: number | undefined;
-	return {
-		get: mock(() => sessionId),
-		getRow: mock(() => (sessionId && createdAt ? { key: "k", sessionId, createdAt } : undefined)),
-		save: mock((_profile: string, _key: string, nextSessionId: string) => {
-			sessionId = nextSessionId;
-			createdAt = Date.now();
-		}),
-		delete: mock(() => {
-			sessionId = undefined;
-			createdAt = undefined;
-		}),
-	};
-}
 
 function createSessionPort(
 	promptAsyncAndWatchSessionImpl: () => Promise<OpencodeSessionEvent>,

--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -24,79 +24,21 @@
 /* oxlint-disable max-lines, max-lines-per-function, no-await-in-loop -- テストファイルはケース数に応じて長くなるため許容 */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { AgentRunner, type RunnerDeps } from "@vicissitude/agent/runner";
 import { METRIC } from "@vicissitude/observability/metrics";
 import type {
-	ContextBuilderPort,
 	OpencodeSessionEvent,
 	OpencodeSessionPort,
 	SessionSummaryWriter,
 } from "@vicissitude/shared/types";
 
-import type { AgentProfile } from "../../packages/agent/src/profile.ts";
 import { createMockLogger, createMockMetrics } from "../test-helpers.ts";
-
-// ─── テスト用サブクラス ───────────────────────────────────────────
-
-class TestAgent extends AgentRunner {
-	sleepSpy: ((ms: number) => Promise<void>) | null = null;
-
-	// oxlint-disable-next-line no-useless-constructor -- protected → public に昇格させるために必要
-	constructor(deps: RunnerDeps) {
-		super(deps);
-	}
-
-	protected override sleep(ms: number): Promise<void> {
-		if (this.sleepSpy) return this.sleepSpy(ms);
-		return super.sleep(ms);
-	}
-
-	protected override waitForDebounce(_signal: AbortSignal): Promise<void> {
-		return Promise.resolve();
-	}
-}
-
-// ─── ヘルパー ─────────────────────────────────────────────────────
-
-function deferred<T>() {
-	let resolveDeferred!: (value: T) => void;
-	let rejectDeferred!: (reason?: unknown) => void;
-	const promise = new Promise<T>((resolve, reject) => {
-		resolveDeferred = resolve;
-		rejectDeferred = reject;
-	});
-	return { promise, resolve: resolveDeferred, reject: rejectDeferred };
-}
-
-function createProfile(overrides: Partial<AgentProfile> = {}): AgentProfile {
-	return {
-		name: "conversation",
-		mcpServers: {},
-		builtinTools: {},
-		pollingPrompt: "loop forever",
-		model: { providerId: "test-provider", modelId: "test-model" },
-		...overrides,
-	};
-}
-
-function createContextBuilder(): ContextBuilderPort {
-	return { build: mock(() => Promise.resolve("system prompt")) };
-}
-
-function createSessionStore(existingSessionId?: string) {
-	let sessionId: string | undefined = existingSessionId;
-	const createdAt: number | undefined = existingSessionId ? Date.now() : undefined;
-	return {
-		get: mock(() => sessionId),
-		getRow: mock(() => (sessionId && createdAt ? { key: "k", sessionId, createdAt } : undefined)),
-		save: mock((_profile: string, _key: string, nextSessionId: string) => {
-			sessionId = nextSessionId;
-		}),
-		delete: mock(() => {
-			sessionId = undefined;
-		}),
-	};
-}
+import {
+	TestAgent,
+	createContextBuilder,
+	createProfile,
+	createSessionStore,
+	deferred,
+} from "./runner-test-helpers.ts";
 
 /**
  * promptAsyncAndWatchSession が毎回 sessions 配列から順番に Promise を返す sessionPort を作成する。

--- a/spec/agent/runner-retry-metrics.spec.ts
+++ b/spec/agent/runner-retry-metrics.spec.ts
@@ -22,78 +22,17 @@
 /* oxlint-disable max-lines, max-lines-per-function, no-await-in-loop, no-non-null-assertion -- テストファイルはケース数に応じて長くなるため許容。non-null は length チェック後のインデックスアクセスに使用 */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { AgentRunner, type RunnerDeps } from "@vicissitude/agent/runner";
 import { METRIC } from "@vicissitude/observability/metrics";
-import type {
-	ContextBuilderPort,
-	OpencodeSessionEvent,
-	OpencodeSessionPort,
-} from "@vicissitude/shared/types";
+import type { OpencodeSessionEvent, OpencodeSessionPort } from "@vicissitude/shared/types";
 
-import type { AgentProfile } from "../../packages/agent/src/profile.ts";
 import { createMockLogger, createMockMetrics } from "../test-helpers.ts";
-
-// ─── テスト用サブクラス ───────────────────────────────────────────
-
-class TestAgent extends AgentRunner {
-	sleepSpy: ((ms: number) => Promise<void>) | null = null;
-
-	// oxlint-disable-next-line no-useless-constructor -- protected → public に昇格させるために必要
-	constructor(deps: RunnerDeps) {
-		super(deps);
-	}
-
-	protected override sleep(ms: number): Promise<void> {
-		if (this.sleepSpy) return this.sleepSpy(ms);
-		return super.sleep(ms);
-	}
-
-	protected override waitForDebounce(_signal: AbortSignal): Promise<void> {
-		return Promise.resolve();
-	}
-}
-
-// ─── ヘルパー ─────────────────────────────────────────────────────
-
-function deferred<T>() {
-	let resolveDeferred!: (value: T) => void;
-	let rejectDeferred!: (reason?: unknown) => void;
-	const promise = new Promise<T>((resolve, reject) => {
-		resolveDeferred = resolve;
-		rejectDeferred = reject;
-	});
-	return { promise, resolve: resolveDeferred, reject: rejectDeferred };
-}
-
-function createProfile(overrides: Partial<AgentProfile> = {}): AgentProfile {
-	return {
-		name: "conversation",
-		mcpServers: {},
-		builtinTools: {},
-		pollingPrompt: "loop forever",
-		model: { providerId: "test-provider", modelId: "test-model" },
-		...overrides,
-	};
-}
-
-function createContextBuilder(): ContextBuilderPort {
-	return { build: mock(() => Promise.resolve("system prompt")) };
-}
-
-function createSessionStore(existingSessionId?: string) {
-	let sessionId: string | undefined = existingSessionId;
-	const createdAt: number | undefined = existingSessionId ? Date.now() : undefined;
-	return {
-		get: mock(() => sessionId),
-		getRow: mock(() => (sessionId && createdAt ? { key: "k", sessionId, createdAt } : undefined)),
-		save: mock((_profile: string, _key: string, nextSessionId: string) => {
-			sessionId = nextSessionId;
-		}),
-		delete: mock(() => {
-			sessionId = undefined;
-		}),
-	};
-}
+import {
+	TestAgent,
+	createContextBuilder,
+	createProfile,
+	createSessionStore,
+	deferred,
+} from "./runner-test-helpers.ts";
 
 /**
  * promptAsyncAndWatchSession が毎回 sessions 配列から順番に Promise を返す sessionPort を作成する。

--- a/spec/agent/runner-test-helpers.ts
+++ b/spec/agent/runner-test-helpers.ts
@@ -59,17 +59,24 @@ export function createContextBuilder(): ContextBuilderPort {
 	return { build: mock(() => Promise.resolve("system prompt")) };
 }
 
-export function createSessionStore(existingSessionId?: string) {
+export function createSessionStore(
+	existingSessionId?: string,
+	options?: { createdAtOffset?: number },
+) {
 	let sessionId: string | undefined = existingSessionId;
-	const createdAt: number | undefined = existingSessionId ? Date.now() : undefined;
+	let createdAt: number | undefined = existingSessionId
+		? Date.now() + (options?.createdAtOffset ?? 0)
+		: undefined;
 	return {
 		get: mock(() => sessionId),
 		getRow: mock(() => (sessionId && createdAt ? { key: "k", sessionId, createdAt } : undefined)),
 		save: mock((_profile: string, _key: string, nextSessionId: string) => {
 			sessionId = nextSessionId;
+			createdAt = Date.now();
 		}),
 		delete: mock(() => {
 			sessionId = undefined;
+			createdAt = undefined;
 		}),
 	};
 }

--- a/spec/agent/session-rotation-summary-isolation.spec.ts
+++ b/spec/agent/session-rotation-summary-isolation.spec.ts
@@ -25,9 +25,7 @@
 /* oxlint-disable max-lines, max-lines-per-function -- テストファイルはケース数に応じて長くなるため許容 */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { AgentRunner, type RunnerDeps } from "@vicissitude/agent/runner";
 import type {
-	ContextBuilderPort,
 	OpencodeSessionEvent,
 	OpencodeSessionPort,
 	PromptResult,
@@ -36,26 +34,13 @@ import type {
 
 import type { AgentProfile } from "../../packages/agent/src/profile.ts";
 import { createMockLogger } from "../test-helpers.ts";
-
-// ─── テスト用サブクラス ───────────────────────────────────────────
-
-class TestAgent extends AgentRunner {
-	sleepSpy: ((ms: number) => Promise<void>) | null = null;
-
-	// oxlint-disable-next-line no-useless-constructor -- protected → public に昇格させるために必要
-	constructor(deps: RunnerDeps) {
-		super(deps);
-	}
-
-	protected override sleep(ms: number): Promise<void> {
-		if (this.sleepSpy) return this.sleepSpy(ms);
-		return super.sleep(ms);
-	}
-
-	protected override waitForDebounce(_signal: AbortSignal): Promise<void> {
-		return Promise.resolve();
-	}
-}
+import {
+	TestAgent,
+	createContextBuilder,
+	createProfile as createBaseProfile,
+	createSessionStore as createBaseSessionStore,
+	deferred,
+} from "./runner-test-helpers.ts";
 
 // ─── ヘルパー ─────────────────────────────────────────────────────
 
@@ -63,48 +48,12 @@ const TEST_SUMMARY_PROMPT = "要約してください";
 /** summary prompt がハングしても現実時間内にテストが終わるよう十分短い値 */
 const SHORT_SUMMARY_TIMEOUT_MS = 100;
 
-function deferred<T>() {
-	let resolveDeferred!: (value: T) => void;
-	let rejectDeferred!: (reason?: unknown) => void;
-	const promise = new Promise<T>((resolve, reject) => {
-		resolveDeferred = resolve;
-		rejectDeferred = reject;
-	});
-	return { promise, resolve: resolveDeferred, reject: rejectDeferred };
-}
-
-function createProfile(overrides: Partial<AgentProfile> = {}): AgentProfile {
-	return {
-		name: "conversation",
-		mcpServers: {},
-		builtinTools: {},
-		pollingPrompt: "loop forever",
-		model: { providerId: "test-provider", modelId: "test-model" },
-		summaryPrompt: TEST_SUMMARY_PROMPT,
-		...overrides,
-	};
-}
-
-function createContextBuilder(): ContextBuilderPort {
-	return { build: mock(() => Promise.resolve("system prompt")) };
+function createProfile(overrides: Partial<AgentProfile> = {}) {
+	return createBaseProfile({ summaryPrompt: TEST_SUMMARY_PROMPT, ...overrides });
 }
 
 function createSessionStore(existingSessionId?: string) {
-	let sessionId: string | undefined = existingSessionId;
-	// age 超過経路では createdAt を過去に寄せる。ここでは未指定時 undefined のまま。
-	let createdAt: number | undefined = existingSessionId ? Date.now() - 7_200_000 : undefined;
-	return {
-		get: mock(() => sessionId),
-		getRow: mock(() => (sessionId && createdAt ? { key: "k", sessionId, createdAt } : undefined)),
-		save: mock((_profile: string, _key: string, nextSessionId: string) => {
-			sessionId = nextSessionId;
-			createdAt = Date.now();
-		}),
-		delete: mock(() => {
-			sessionId = undefined;
-			createdAt = undefined;
-		}),
-	};
+	return createBaseSessionStore(existingSessionId, { createdAtOffset: -7_200_000 });
 }
 
 function createSummaryWriter(): SessionSummaryWriter & { write: ReturnType<typeof mock> } {

--- a/spec/agent/session-summary.spec.ts
+++ b/spec/agent/session-summary.spec.ts
@@ -1,81 +1,31 @@
 /* oxlint-disable max-lines, max-lines-per-function -- テストファイルはケース数に応じて長くなるため許容 */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { AgentRunner, type RunnerDeps } from "@vicissitude/agent/runner";
 import type {
-	ContextBuilderPort,
 	OpencodeSessionEvent,
 	OpencodeSessionPort,
 	SessionSummaryWriter,
 } from "@vicissitude/shared/types";
 
-import type { AgentProfile } from "../../packages/agent/src/profile.ts";
 import { createMockLogger } from "../test-helpers.ts";
-
-// ─── テスト用サブクラス ───────────────────────────────────────────
-
-class TestAgent extends AgentRunner {
-	sleepSpy: ((ms: number) => Promise<void>) | null = null;
-
-	// oxlint-disable-next-line no-useless-constructor -- protected → public に昇格させるために必要
-	constructor(deps: RunnerDeps) {
-		super(deps);
-	}
-
-	protected override sleep(ms: number): Promise<void> {
-		if (this.sleepSpy) return this.sleepSpy(ms);
-		return super.sleep(ms);
-	}
-
-	protected override waitForDebounce(_signal: AbortSignal): Promise<void> {
-		return Promise.resolve();
-	}
-}
+import {
+	TestAgent,
+	createContextBuilder,
+	createProfile as createBaseProfile,
+	createSessionStore as createBaseSessionStore,
+	deferred,
+} from "./runner-test-helpers.ts";
 
 // ─── ヘルパー ─────────────────────────────────────────────────────
 
-function deferred<T>() {
-	let resolveDeferred!: (value: T) => void;
-	let rejectDeferred!: (reason?: unknown) => void;
-	const promise = new Promise<T>((resolve, reject) => {
-		resolveDeferred = resolve;
-		rejectDeferred = reject;
-	});
-	return { promise, resolve: resolveDeferred, reject: rejectDeferred };
-}
-
 const TEST_SUMMARY_PROMPT = "テスト用要約プロンプト";
 
-function createProfile(): AgentProfile {
-	return {
-		name: "conversation",
-		mcpServers: {},
-		builtinTools: {},
-		pollingPrompt: "loop forever",
-		model: { providerId: "test-provider", modelId: "test-model" },
-		summaryPrompt: TEST_SUMMARY_PROMPT,
-	};
-}
-
-function createContextBuilder(): ContextBuilderPort {
-	return { build: mock(() => Promise.resolve("system prompt")) };
+function createProfile() {
+	return createBaseProfile({ summaryPrompt: TEST_SUMMARY_PROMPT });
 }
 
 function createSessionStore(existingSessionId?: string) {
-	let sessionId: string | undefined = existingSessionId;
-	let createdAt: number | undefined = existingSessionId ? Date.now() - 7_200_000 : undefined;
-	return {
-		get: mock(() => sessionId),
-		getRow: mock(() => (sessionId && createdAt ? { key: "k", sessionId, createdAt } : undefined)),
-		save: mock((_profile: string, _key: string, nextSessionId: string) => {
-			sessionId = nextSessionId;
-			createdAt = Date.now();
-		}),
-		delete: mock(() => {
-			sessionId = undefined;
-			createdAt = undefined;
-		}),
-	};
+	return createBaseSessionStore(existingSessionId, { createdAtOffset: -7_200_000 });
 }
 
 /**


### PR DESCRIPTION
## Summary
- 5ファイルに散在していたローカル `TestAgent` サブクラスと `deferred` / `createProfile` / `createContextBuilder` / `createSessionStore` を共通の `runner-test-helpers.ts` からインポートする形に統一
- `createSessionStore` を save/delete で `createdAt` を追跡する上位互換に拡張し、`createdAtOffset` オプションで age 超過テスト用の過去タイムスタンプをサポート
- 324行削除、53行追加で大幅に重複コードを削減

Closes #769

## Test plan
- [x] 変更対象5ファイルの全81テストがパス
- [x] 既存の共通ヘルパー利用ファイル（runner.spec.ts, runner-debounce.spec.ts 等）の全43テストがパス
- [x] 変更ファイルの lint エラーゼロ
- [x] 全テスト2022件中、失敗は無関係の minecraft パッケージのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)