### PR TITLE
fix: runner-test-helpers の型 re-export 漏れを修正して CI を復旧

### DIFF
--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -10,6 +10,8 @@ import {
 	createProfile,
 	createSessionStore,
 	deferred,
+	type AgentProfile,
+	type ContextBuilderPort,
 } from "../../../spec/agent/runner-test-helpers.ts";
 import { AgentRunner, type RunnerDeps } from "./runner.ts";
 

--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -33,6 +33,7 @@ import type {
 
 import { createMockLogger, createMockMetrics } from "../test-helpers.ts";
 import {
+	type AgentRunner,
 	TestAgent,
 	createContextBuilder,
 	createProfile,

--- a/spec/agent/runner-retry-metrics.spec.ts
+++ b/spec/agent/runner-retry-metrics.spec.ts
@@ -27,6 +27,7 @@ import type { OpencodeSessionEvent, OpencodeSessionPort } from "@vicissitude/sha
 
 import { createMockLogger, createMockMetrics } from "../test-helpers.ts";
 import {
+	type AgentRunner,
 	TestAgent,
 	createContextBuilder,
 	createProfile,

--- a/spec/agent/runner-test-helpers.ts
+++ b/spec/agent/runner-test-helpers.ts
@@ -11,6 +11,9 @@ import type { ContextBuilderPort } from "@vicissitude/shared/types";
 
 import type { AgentProfile } from "../../packages/agent/src/profile.ts";
 
+export { AgentRunner };
+export type { ContextBuilderPort, AgentProfile };
+
 /**
  * `AgentRunner` のサブクラス。`sleep` を差し替え可能にすることでテストの待機を制御する。
  */

--- a/spec/agent/session-rotation-summary-isolation.spec.ts
+++ b/spec/agent/session-rotation-summary-isolation.spec.ts
@@ -35,6 +35,7 @@ import type {
 import type { AgentProfile } from "../../packages/agent/src/profile.ts";
 import { createMockLogger } from "../test-helpers.ts";
 import {
+	type AgentRunner,
 	TestAgent,
 	createContextBuilder,
 	createProfile as createBaseProfile,

--- a/spec/agent/session-summary.spec.ts
+++ b/spec/agent/session-summary.spec.ts
@@ -9,6 +9,7 @@ import type {
 
 import { createMockLogger } from "../test-helpers.ts";
 import {
+	type AgentRunner,
 	TestAgent,
 	createContextBuilder,
 	createProfile as createBaseProfile,


### PR DESCRIPTION
## Summary
- #772 のリファクタで `runner-test-helpers.ts` に集約した際、`AgentRunner` / `ContextBuilderPort` / `AgentProfile` の re-export が漏れ、`tsgo --noEmit` が CI で失敗していた
- `runner-test-helpers.ts` で 3 型を re-export し、6 つの消費ファイルでそこから import するよう修正

## Test plan
- [x] `nr test:spec` — 1507 pass / 0 fail
- [x] `bun test packages/agent/src/runner.test.ts` — 42 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)