### PR TITLE
refactor: escapeUserMessageTag を shared/functions に集約

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -21,6 +21,7 @@
 		"@vicissitude/minecraft": "workspace:*",
 		"@vicissitude/observability": "workspace:*",
 		"@vicissitude/opencode": "workspace:*",
+		"@vicissitude/shared": "workspace:*",
 		"drizzle-orm": "^0.45.1"
 	}
 }

--- a/packages/agent/src/discord/message-formatter.ts
+++ b/packages/agent/src/discord/message-formatter.ts
@@ -10,7 +10,7 @@ export function classifyActionHint(msg: IncomingMessage): ActionHint {
 	return "optional";
 }
 
-export { escapeUserMessageTag } from "@vicissitude/shared/functions";
+export { escapeUserMessageTag };
 
 export function formatDiscordMessage(msg: IncomingMessage): string {
 	const hint = classifyActionHint(msg);

--- a/packages/agent/src/discord/message-formatter.ts
+++ b/packages/agent/src/discord/message-formatter.ts
@@ -1,4 +1,4 @@
-import { formatTimestamp } from "@vicissitude/shared/functions";
+import { escapeUserMessageTag, formatTimestamp } from "@vicissitude/shared/functions";
 import type { IncomingMessage } from "@vicissitude/shared/types";
 
 export type ActionHint = "respond" | "optional" | "read_only" | "internal";
@@ -10,11 +10,7 @@ export function classifyActionHint(msg: IncomingMessage): ActionHint {
 	return "optional";
 }
 
-export function escapeUserMessageTag(content: string): string {
-	return content
-		.replaceAll("<user_message>", "&lt;user_message&gt;")
-		.replaceAll("</user_message>", "&lt;/user_message&gt;");
-}
+export { escapeUserMessageTag } from "@vicissitude/shared/functions";
 
 export function formatDiscordMessage(msg: IncomingMessage): string {
 	const hint = classifyActionHint(msg);

--- a/packages/mcp/src/tools/event-helpers.ts
+++ b/packages/mcp/src/tools/event-helpers.ts
@@ -43,14 +43,7 @@ export function parseEvents(rows: { payload: string }[]): EventOrError[] {
 	});
 }
 
-// ─── escapeUserMessageTag ────────────────────────────────────────
-
-/** ユーザーメッセージ内の <user_message> / </user_message> タグをエスケープし、タグインジェクションを防ぐ */
-export function escapeUserMessageTag(content: string): string {
-	return content
-		.replaceAll("</user_message>", "&lt;/user_message&gt;")
-		.replaceAll("<user_message>", "&lt;user_message&gt;");
-}
+export { escapeUserMessageTag } from "@vicissitude/shared/functions";
 
 // ─── isErrorEvent ───────────────────���────────────────────────────
 

--- a/packages/shared/src/functions.ts
+++ b/packages/shared/src/functions.ts
@@ -91,7 +91,7 @@ export async function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Pr
 
 // ─── escapeUserMessageTag ───────────────────────────────────────
 
-/** ユーザーメッセージ内の &lt;user_message&gt; / &lt;/user_message&gt; タグをエスケープし、タグインジェクションを防ぐ */
+/** ユーザーメッセージ内の `<user_message>` / `</user_message>` タグをエスケープし、タグインジェクションを防ぐ */
 export function escapeUserMessageTag(content: string): string {
 	return content
 		.replaceAll("<user_message>", "&lt;user_message&gt;")

--- a/packages/shared/src/functions.ts
+++ b/packages/shared/src/functions.ts
@@ -88,3 +88,12 @@ export async function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Pr
 		if (onAbort) signal.removeEventListener("abort", onAbort);
 	}
 }
+
+// ─── escapeUserMessageTag ───────────────────────────────────────
+
+/** ユーザーメッセージ内の &lt;user_message&gt; / &lt;/user_message&gt; タグをエスケープし、タグインジェクションを防ぐ */
+export function escapeUserMessageTag(content: string): string {
+	return content
+		.replaceAll("<user_message>", "&lt;user_message&gt;")
+		.replaceAll("</user_message>", "&lt;/user_message&gt;");
+}


### PR DESCRIPTION
## Summary
- `escapeUserMessageTag` が `message-formatter.ts` と `event-helpers.ts` に重複していた定義を `@vicissitude/shared/functions` に集約
- 既存の import パスを壊さないよう、元の場所からは re-export を維持
- `packages/agent/package.json` に `@vicissitude/shared` の明示的依存を追加（既に暗黙的に使われていた）

## Test plan
- [x] `nr test:spec` — 全 1507 spec テスト通過
- [x] 既存の import パス（`@vicissitude/agent/discord/message-formatter`, `event-helpers.ts`）からの import が壊れないこと確認済み

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)