### PR TITLE
feat: マルチモーダル対応 — 画像 URL をエージェントに渡す経路を構築

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -309,7 +309,11 @@ function setupEventHandlers(deps: {
 			if (!agent) {
 				logger.warn(`[bootstrap] no agent for guild ${msg.guildId}, message will not be processed`);
 			}
-			void agent?.send({ sessionKey: "home", message: formatDiscordMessage(msg) });
+			void agent?.send({
+				sessionKey: "home",
+				message: formatDiscordMessage(msg),
+				attachments: msg.attachments,
+			});
 		}
 		return Promise.resolve();
 	});
@@ -324,7 +328,11 @@ function setupEventHandlers(deps: {
 			if (!agent) {
 				logger.warn(`[bootstrap] no agent for guild ${msg.guildId}, mention will not be processed`);
 			}
-			void agent?.send({ sessionKey: "mention", message: formatDiscordMessage(msg) });
+			void agent?.send({
+				sessionKey: "mention",
+				message: formatDiscordMessage(msg),
+				attachments: msg.attachments,
+			});
 		}
 		return Promise.resolve();
 	});

--- a/packages/agent/src/discord/message-formatter.test.ts
+++ b/packages/agent/src/discord/message-formatter.test.ts
@@ -1,0 +1,76 @@
+/* oxlint-disable max-lines-per-function -- テストファイルはケース数に応じて長くなるため許容 */
+import { describe, expect, test } from "bun:test";
+
+import type { IncomingMessage } from "@vicissitude/shared/types";
+
+import { formatDiscordMessage } from "./message-formatter.ts";
+
+function createMessage(overrides: Partial<IncomingMessage> = {}): IncomingMessage {
+	return {
+		platform: "discord",
+		channelId: "ch-1",
+		channelName: "general",
+		authorId: "user-1",
+		authorName: "Alice",
+		messageId: "msg-1",
+		content: "hello",
+		attachments: [],
+		timestamp: new Date("2025-01-01T12:00:00+09:00"),
+		isBot: false,
+		isMentioned: false,
+		isThread: false,
+		reply: () => Promise.resolve(),
+		react: () => Promise.resolve(),
+		...overrides,
+	};
+}
+
+describe("formatDiscordMessage 添付フォーマット", () => {
+	test("url が undefined の添付は [添付: filename (contentType) undefined] としてフォーマットされる", () => {
+		const msg = createMessage({
+			attachments: [
+				{ url: undefined as unknown as string, contentType: "image/png", filename: "photo.png" },
+			],
+		});
+		const result = formatDiscordMessage(msg);
+		expect(result).toContain("[添付: photo.png (image/png) undefined]");
+	});
+
+	test("contentType が undefined の添付は (undefined) としてフォーマットされる", () => {
+		const msg = createMessage({
+			attachments: [
+				{ url: "https://example.com/file.bin", contentType: undefined, filename: "file.bin" },
+			],
+		});
+		const result = formatDiscordMessage(msg);
+		expect(result).toContain("[添付: file.bin (undefined) https://example.com/file.bin]");
+	});
+
+	test("filename が undefined の添付は undefined としてフォーマットされる", () => {
+		const msg = createMessage({
+			attachments: [
+				{ url: "https://example.com/img.png", contentType: "image/png", filename: undefined },
+			],
+		});
+		const result = formatDiscordMessage(msg);
+		expect(result).toContain("[添付: undefined (image/png) https://example.com/img.png]");
+	});
+
+	test("attachments が空配列の場合、添付テキストは出力に含まれない", () => {
+		const msg = createMessage({ attachments: [] });
+		const result = formatDiscordMessage(msg);
+		expect(result).not.toContain("[添付:");
+	});
+
+	test("複数の添付はスペース区切りで連結される", () => {
+		const msg = createMessage({
+			attachments: [
+				{ url: "https://example.com/a.png", contentType: "image/png", filename: "a.png" },
+				{ url: "https://example.com/b.jpg", contentType: "image/jpeg", filename: "b.jpg" },
+			],
+		});
+		const result = formatDiscordMessage(msg);
+		expect(result).toContain("[添付: a.png (image/png) https://example.com/a.png]");
+		expect(result).toContain("[添付: b.jpg (image/jpeg) https://example.com/b.jpg]");
+	});
+});

--- a/packages/agent/src/discord/message-formatter.ts
+++ b/packages/agent/src/discord/message-formatter.ts
@@ -22,7 +22,7 @@ export function formatDiscordMessage(msg: IncomingMessage): string {
 	const content = isUserMessage ? `<user_message>${escapedContent}</user_message>` : escapedContent;
 
 	const attachments = msg.attachments
-		.map((a) => `[添付: ${a.filename} (${a.contentType})]`)
+		.map((a) => `[添付: ${a.filename} (${a.contentType}) ${a.url}]`)
 		.join(" ");
 
 	const parts = [`[${ts} JST ${channel}] ${msg.authorName}: ${content}`];

--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -2,7 +2,11 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { createMockLogger } from "@vicissitude/shared/test-helpers";
-import type { OpencodeSessionEvent, OpencodeSessionPort } from "@vicissitude/shared/types";
+import type {
+	Attachment,
+	OpencodeSessionEvent,
+	OpencodeSessionPort,
+} from "@vicissitude/shared/types";
 
 import {
 	TestAgent,
@@ -1753,5 +1757,228 @@ describe("AgentRunner デバウンス機構（内部ロジック）", () => {
 		expect(sleepCalls.length).toBe(2); // deadline 超過で 3回目は呼ばれない
 
 		runner.stop();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// マルチモーダル対応: attachments の伝搬（ホワイトボックス）
+// drainMessages / lastPromptAttachments / ensureSessionStarted
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AgentRunner attachments 伝搬（内部ロジック）", () => {
+	test("send() の attachments が promptAsyncAndWatchSession に渡される", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => sessionDone.promise);
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		activeRunners.add(runner);
+
+		const attachments: Attachment[] = [
+			{ url: "https://example.com/img.png", contentType: "image/png", filename: "img.png" },
+		];
+		await runner.send({ sessionKey: "k", message: "test", attachments });
+		await Bun.sleep(0);
+
+		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(1);
+		const callArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[0] as unknown[];
+		const params = callArgs[0] as { attachments?: Attachment[] };
+		expect(params.attachments).toEqual(attachments);
+
+		runner.stop();
+		sessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("attachments なしの send() では attachments が undefined で渡される", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => sessionDone.promise);
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		activeRunners.add(runner);
+
+		await runner.send({ sessionKey: "k", message: "test" });
+		await Bun.sleep(0);
+
+		const callArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[0] as unknown[];
+		const params = callArgs[0] as { attachments?: Attachment[] };
+		expect(params.attachments).toBeUndefined();
+
+		runner.stop();
+		sessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("複数メッセージの attachments がマージされる", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => sessionDone.promise);
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.enableDebounce = true;
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		const att1: Attachment[] = [
+			{ url: "https://example.com/a.png", contentType: "image/png", filename: "a.png" },
+		];
+		const att2: Attachment[] = [
+			{ url: "https://example.com/b.jpg", contentType: "image/jpeg", filename: "b.jpg" },
+		];
+		// 2つのメッセージをキューに入れる（debounce で一括処理される）
+		await runner.send({ sessionKey: "k", message: "msg1", attachments: att1 });
+		await runner.send({ sessionKey: "k", message: "msg2", attachments: att2 });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(1);
+		const callArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[0] as unknown[];
+		const params = callArgs[0] as { attachments?: Attachment[] };
+		expect(params.attachments).toEqual([...att1, ...att2]);
+
+		runner.stop();
+		sessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("attachments ありとなしの混在: attachments がある分だけマージされる", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => sessionDone.promise);
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.enableDebounce = true;
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		const att: Attachment[] = [
+			{ url: "https://example.com/img.png", contentType: "image/png", filename: "img.png" },
+		];
+		await runner.send({ sessionKey: "k", message: "msg-no-att" });
+		await runner.send({ sessionKey: "k", message: "msg-with-att", attachments: att });
+		await runner.send({ sessionKey: "k", message: "msg-no-att-2" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const callArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[0] as unknown[];
+		const params = callArgs[0] as { attachments?: Attachment[] };
+		expect(params.attachments).toEqual(att);
+
+		runner.stop();
+		sessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("リトライ時に lastPromptAttachments が再利用される", async () => {
+		const _firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		let sessionWatchCount = 0;
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			if (sessionWatchCount === 1) return Promise.reject(new Error("session error"));
+			return secondSessionDone.promise;
+		});
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		const att: Attachment[] = [
+			{ url: "https://example.com/img.png", contentType: "image/png", filename: "img.png" },
+		];
+		await runner.send({ sessionKey: "k", message: "test", attachments: att });
+
+		// エラー → バックオフ sleep → リトライ
+		for (let i = 0; i < 10; i++) {
+			// eslint-disable-next-line no-await-in-loop
+			await Bun.sleep(0);
+		}
+
+		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(2);
+		// リトライ時の呼び出し（2回目）でも attachments が渡されている
+		const retryCallArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[1] as unknown[];
+		const retryParams = retryCallArgs[0] as { attachments?: Attachment[] };
+		expect(retryParams.attachments).toEqual(att);
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("idle 後に lastPromptAttachments がクリアされる", async () => {
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		let sessionWatchCount = 0;
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			return sessionWatchCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+		});
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		const att: Attachment[] = [
+			{ url: "https://example.com/img.png", contentType: "image/png", filename: "img.png" },
+		];
+		await runner.send({ sessionKey: "k", message: "msg1", attachments: att });
+		await Bun.sleep(0);
+
+		// idle → lastPromptAttachments がクリアされる
+		firstSessionDone.resolve({ type: "idle" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 2回目のメッセージ（attachments なし）
+		await runner.send({ sessionKey: "k", message: "msg2" });
+		await Bun.sleep(0);
+
+		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(2);
+		const secondCallArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[1] as unknown[];
+		const secondParams = secondCallArgs[0] as { attachments?: Attachment[] };
+		// idle 後なので前回の attachments は含まれない
+		expect(secondParams.attachments).toBeUndefined();
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
 	});
 });

--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -1766,60 +1766,8 @@ describe("AgentRunner デバウンス機構（内部ロジック）", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("AgentRunner attachments 伝搬（内部ロジック）", () => {
-	test("send() の attachments が promptAsyncAndWatchSession に渡される", async () => {
-		const sessionDone = deferred<OpencodeSessionEvent>();
-		const sessionPort = createSessionPort(() => sessionDone.promise);
-		const runner = new TestAgent({
-			profile: createProfile(),
-			agentId: "guild-1",
-			sessionStore: createSessionStore() as never,
-			contextBuilder: createContextBuilder(),
-			logger: createMockLogger(),
-			sessionPort,
-			sessionMaxAgeMs: 3_600_000,
-		});
-		activeRunners.add(runner);
-
-		const attachments: Attachment[] = [
-			{ url: "https://example.com/img.png", contentType: "image/png", filename: "img.png" },
-		];
-		await runner.send({ sessionKey: "k", message: "test", attachments });
-		await Bun.sleep(0);
-
-		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(1);
-		const callArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[0] as unknown[];
-		const params = callArgs[0] as { attachments?: Attachment[] };
-		expect(params.attachments).toEqual(attachments);
-
-		runner.stop();
-		sessionDone.resolve({ type: "cancelled" });
-	});
-
-	test("attachments なしの send() では attachments が undefined で渡される", async () => {
-		const sessionDone = deferred<OpencodeSessionEvent>();
-		const sessionPort = createSessionPort(() => sessionDone.promise);
-		const runner = new TestAgent({
-			profile: createProfile(),
-			agentId: "guild-1",
-			sessionStore: createSessionStore() as never,
-			contextBuilder: createContextBuilder(),
-			logger: createMockLogger(),
-			sessionPort,
-			sessionMaxAgeMs: 3_600_000,
-		});
-		activeRunners.add(runner);
-
-		await runner.send({ sessionKey: "k", message: "test" });
-		await Bun.sleep(0);
-
-		const callArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[0] as unknown[];
-		const params = callArgs[0] as { attachments?: Attachment[] };
-		expect(params.attachments).toBeUndefined();
-
-		runner.stop();
-		sessionDone.resolve({ type: "cancelled" });
-	});
-
+	// NOTE: 基本的な伝搬テスト (attachments あり/なし) は spec/agent/runner.spec.ts に存在。
+	// ここでは内部ロジック (マージ・リトライ・クリア) のみをテストする。
 	test("複数メッセージの attachments がマージされる", async () => {
 		const sessionDone = deferred<OpencodeSessionEvent>();
 		const sessionPort = createSessionPort(() => sessionDone.promise);

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -4,6 +4,7 @@ import { JST_OFFSET_MS, raceAbort } from "@vicissitude/shared/functions";
 import type {
 	AgentResponse,
 	AiAgent,
+	Attachment,
 	ContextBuilderPort,
 	Logger,
 	MetricsCollector,
@@ -55,10 +56,11 @@ export class AgentRunner implements AiAgent {
 	private lastRotationRequestAt: number | null = null;
 	private readonly minRotationIntervalMs = 300_000;
 	private retryAttempt = 0;
-	private pendingMessages: string[] = [];
+	private pendingMessages: Array<{ text: string; attachments?: Attachment[] }> = [];
 	private pendingResolve: (() => void) | null = null;
 	/** エラー時にリトライするために直前のプロンプトテキストを保持する */
 	private lastPromptText: string | null = null;
+	private lastPromptAttachments: Attachment[] | null = null;
 	private pendingDebounceResolve: (() => void) | null = null;
 
 	private readonly profile: AgentProfile;
@@ -99,7 +101,7 @@ export class AgentRunner implements AiAgent {
 	}
 
 	send(options: SendOptions): Promise<AgentResponse> {
-		this.pendingMessages.push(options.message);
+		this.pendingMessages.push({ text: options.message, attachments: options.attachments });
 		this.pendingResolve?.();
 		this.pendingDebounceResolve?.();
 		this.ensurePolling();
@@ -190,6 +192,7 @@ export class AgentRunner implements AiAgent {
 
 				if (event.type !== "error") {
 					this.lastPromptText = null;
+					this.lastPromptAttachments = null;
 					resetBackoffState();
 					// eslint-disable-next-line no-await-in-loop -- cooldown after idle to prevent busy loop
 					await this.sleep(IDLE_COOLDOWN_MS);
@@ -314,10 +317,12 @@ export class AgentRunner implements AiAgent {
 		if (this.sessionWatch) return;
 
 		let text: string;
+		let attachments: Attachment[];
 		if (this.lastPromptText) {
 			// リトライ: 前回のテキストを再利用し、新着メッセージがあれば追加
-			const newText = this.drainMessages();
-			text = newText ? `${this.lastPromptText}\n---\n${newText}` : this.lastPromptText;
+			const drained = this.drainMessages();
+			text = drained.text ? `${this.lastPromptText}\n---\n${drained.text}` : this.lastPromptText;
+			attachments = [...(this.lastPromptAttachments ?? []), ...drained.attachments];
 		} else {
 			this.logger.info(
 				`[${this.profile.name}:${this.agentId}] waiting for messages... (hasStartedSession=${this.hasStartedSession})`,
@@ -329,14 +334,17 @@ export class AgentRunner implements AiAgent {
 			}
 			await this.waitForDebounce(signal);
 			if (signal.aborted) return;
-			text = this.drainMessages();
-			if (!text) return;
+			const drained = this.drainMessages();
+			if (!drained.text) return;
+			text = drained.text;
+			attachments = drained.attachments;
 		}
 
 		this.logger.info(`[${this.profile.name}:${this.agentId}] messages received, sending prompt`);
 
-		// lastPromptText にはメッセージ本文のみを保存し、リトライ時の二重注入を防ぐ
+		// lastPromptText / lastPromptAttachments にはメッセージ本文のみを保存し、リトライ時の二重注入を防ぐ
 		this.lastPromptText = text;
+		this.lastPromptAttachments = attachments;
 
 		const promptText = this.profile.pollingPrompt
 			? `${this.profile.pollingPrompt}\n\n${text}`
@@ -361,6 +369,7 @@ export class AgentRunner implements AiAgent {
 					modelId: this.profile.model.modelId,
 				},
 				system,
+				attachments: attachments.length > 0 ? attachments : undefined,
 			},
 			signal,
 		);
@@ -417,8 +426,12 @@ export class AgentRunner implements AiAgent {
 		if (onAbort) signal.removeEventListener("abort", onAbort);
 	}
 
-	private drainMessages(): string {
-		return this.pendingMessages.splice(0).join("\n---\n");
+	private drainMessages(): { text: string; attachments: Attachment[] } {
+		const items = this.pendingMessages.splice(0);
+		return {
+			text: items.map((m) => m.text).join("\n---\n"),
+			attachments: items.flatMap((m) => m.attachments ?? []),
+		};
 	}
 
 	private handleSessionEnd(event: OpencodeSessionEvent): void {

--- a/packages/opencode/src/session-adapter.test.ts
+++ b/packages/opencode/src/session-adapter.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines, max-lines-per-function -- テストファイルはケース数に応じて長くなるため許容 */
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2";
@@ -305,5 +306,215 @@ describe("OpencodeSessionAdapter", () => {
 
 		await expect(watch).rejects.toThrow("transport down");
 		expect(stream.return).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildParts の内部ロジック（ホワイトボックス）
+// prompt / promptAsync 経由で buildParts の画像フィルタリングを検証する
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("OpencodeSessionAdapter buildParts（画像フィルタリング）", () => {
+	function createBuildPartsAdapter() {
+		const promptParts: unknown[] = [];
+		const promptAsyncParts: unknown[] = [];
+		const client = {
+			event: {
+				subscribe: mock(() =>
+					Promise.resolve({
+						stream: {
+							// oxlint-disable-next-line no-return-wrap -- AsyncGenerator の next/return は Promise を返す必要がある
+							next: mock(() => Promise.resolve({ done: true, value: undefined })),
+							// oxlint-disable-next-line no-return-wrap -- AsyncGenerator の next/return は Promise を返す必要がある
+							return: mock(() => Promise.resolve({ done: true, value: undefined })),
+							[Symbol.asyncIterator]() {
+								return this;
+							},
+						},
+					}),
+				),
+			},
+			session: {
+				create: mock(() => Promise.resolve({ data: { id: "session-1" }, error: null })),
+				get: mock(() => Promise.resolve({ data: null, error: { message: "missing" } })),
+				prompt: mock((params: { parts: unknown[] }) => {
+					promptParts.push(...params.parts);
+					return Promise.resolve({ data: { parts: [], info: {} }, error: null });
+				}),
+				promptAsync: mock((params: { parts: unknown[] }) => {
+					promptAsyncParts.push(...params.parts);
+					return Promise.resolve({ data: {}, error: null });
+				}),
+				abort: mock(() => Promise.resolve({ data: {}, error: null })),
+				delete: mock(() => Promise.resolve({ data: {}, error: null })),
+			},
+		};
+		const adapter = new OpencodeSessionAdapter({
+			port: 4096,
+			mcpServers: {},
+			builtinTools: {},
+			clientFactory: mock(() =>
+				Promise.resolve({
+					client: client as unknown as OpencodeClient,
+					server: { url: "http://localhost", close: mock(() => {}) },
+				}),
+			),
+		});
+		return { adapter, promptParts, promptAsyncParts };
+	}
+
+	const baseParams = {
+		sessionId: "session-1",
+		text: "hello",
+		model: { providerId: "provider", modelId: "model" },
+	};
+
+	test("image/png の添付は FilePartInput に変換される（prompt 経由）", async () => {
+		const { adapter, promptParts } = createBuildPartsAdapter();
+		await adapter.prompt({
+			...baseParams,
+			attachments: [
+				{ url: "https://example.com/img.png", contentType: "image/png", filename: "img.png" },
+			],
+		});
+
+		expect(promptParts).toEqual([
+			{ type: "text", text: "hello" },
+			{ type: "file", mime: "image/png", filename: "img.png", url: "https://example.com/img.png" },
+		]);
+	});
+
+	test("image/jpeg, image/gif, image/webp もすべて FilePartInput に変換される", async () => {
+		const { adapter, promptParts } = createBuildPartsAdapter();
+		await adapter.prompt({
+			...baseParams,
+			attachments: [
+				{ url: "https://example.com/a.jpg", contentType: "image/jpeg", filename: "a.jpg" },
+				{ url: "https://example.com/b.gif", contentType: "image/gif", filename: "b.gif" },
+				{ url: "https://example.com/c.webp", contentType: "image/webp", filename: "c.webp" },
+			],
+		});
+
+		expect(promptParts).toEqual([
+			{ type: "text", text: "hello" },
+			{ type: "file", mime: "image/jpeg", filename: "a.jpg", url: "https://example.com/a.jpg" },
+			{ type: "file", mime: "image/gif", filename: "b.gif", url: "https://example.com/b.gif" },
+			{ type: "file", mime: "image/webp", filename: "c.webp", url: "https://example.com/c.webp" },
+		]);
+	});
+
+	test("application/pdf は FilePartInput に変換されない（フィルタアウト）", async () => {
+		const { adapter, promptParts } = createBuildPartsAdapter();
+		await adapter.prompt({
+			...baseParams,
+			attachments: [
+				{ url: "https://example.com/doc.pdf", contentType: "application/pdf", filename: "doc.pdf" },
+			],
+		});
+
+		expect(promptParts).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	test("text/plain は FilePartInput に変換されない（フィルタアウト）", async () => {
+		const { adapter, promptParts } = createBuildPartsAdapter();
+		await adapter.prompt({
+			...baseParams,
+			attachments: [
+				{ url: "https://example.com/note.txt", contentType: "text/plain", filename: "note.txt" },
+			],
+		});
+
+		expect(promptParts).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	test("contentType が undefined の添付は FilePartInput に変換されない", async () => {
+		const { adapter, promptParts } = createBuildPartsAdapter();
+		await adapter.prompt({
+			...baseParams,
+			attachments: [
+				{ url: "https://example.com/unknown", contentType: undefined, filename: "unknown" },
+			],
+		});
+
+		expect(promptParts).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	test("filename が undefined でも image 添付は正しく変換される", async () => {
+		const { adapter, promptParts } = createBuildPartsAdapter();
+		await adapter.prompt({
+			...baseParams,
+			attachments: [
+				{ url: "https://example.com/img.png", contentType: "image/png", filename: undefined },
+			],
+		});
+
+		expect(promptParts).toEqual([
+			{ type: "text", text: "hello" },
+			{
+				type: "file",
+				mime: "image/png",
+				filename: undefined,
+				url: "https://example.com/img.png",
+			},
+		]);
+	});
+
+	test("attachments が空配列の場合は text のみの parts", async () => {
+		const { adapter, promptParts } = createBuildPartsAdapter();
+		await adapter.prompt({
+			...baseParams,
+			attachments: [],
+		});
+
+		expect(promptParts).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	test("attachments が undefined の場合は text のみの parts", async () => {
+		const { adapter, promptParts } = createBuildPartsAdapter();
+		await adapter.prompt({
+			...baseParams,
+			// attachments フィールドなし
+		});
+
+		expect(promptParts).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	test("画像と非画像が混在する場合、画像のみ FilePartInput に変換される", async () => {
+		const { adapter, promptParts } = createBuildPartsAdapter();
+		await adapter.prompt({
+			...baseParams,
+			attachments: [
+				{ url: "https://example.com/img.png", contentType: "image/png", filename: "img.png" },
+				{ url: "https://example.com/doc.pdf", contentType: "application/pdf", filename: "doc.pdf" },
+				{ url: "https://example.com/photo.jpg", contentType: "image/jpeg", filename: "photo.jpg" },
+			],
+		});
+
+		expect(promptParts).toEqual([
+			{ type: "text", text: "hello" },
+			{ type: "file", mime: "image/png", filename: "img.png", url: "https://example.com/img.png" },
+			{
+				type: "file",
+				mime: "image/jpeg",
+				filename: "photo.jpg",
+				url: "https://example.com/photo.jpg",
+			},
+		]);
+	});
+
+	test("promptAsync 経由でも buildParts が同じフィルタリングを適用する", async () => {
+		const { adapter, promptAsyncParts } = createBuildPartsAdapter();
+		await adapter.promptAsync({
+			...baseParams,
+			attachments: [
+				{ url: "https://example.com/img.png", contentType: "image/png", filename: "img.png" },
+				{ url: "https://example.com/doc.pdf", contentType: "application/pdf", filename: "doc.pdf" },
+			],
+		});
+
+		expect(promptAsyncParts).toEqual([
+			{ type: "text", text: "hello" },
+			{ type: "file", mime: "image/png", filename: "img.png", url: "https://example.com/img.png" },
+		]);
 	});
 });

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -69,19 +69,23 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 	): Array<
 		{ type: "text"; text: string } | { type: "file"; mime: string; filename?: string; url: string }
 	> {
-		return [
-			{ type: "text", text: params.text },
-			...(params.attachments ?? [])
-				.filter(
-					(a): a is typeof a & { contentType: string } => !!a.contentType?.startsWith("image/"),
-				)
-				.map((a) => ({
+		const imageAttachments: Array<{ type: "file"; mime: string; filename?: string; url: string }> =
+			[];
+		for (const a of params.attachments ?? []) {
+			if (a.contentType?.startsWith("image/")) {
+				imageAttachments.push({
 					type: "file" as const,
 					mime: a.contentType,
 					filename: a.filename,
 					url: a.url,
-				})),
-		];
+				});
+			} else {
+				this.logger?.debug(
+					`[opencode] buildParts: skipping non-image attachment (contentType=${a.contentType ?? "undefined"}, filename=${a.filename ?? "undefined"})`,
+				);
+			}
+		}
+		return [{ type: "text", text: params.text }, ...imageAttachments];
 	}
 
 	async prompt(params: OpencodePromptParams, signal?: AbortSignal): Promise<PromptResult> {

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -64,6 +64,26 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		return !result.error && !!result.data;
 	}
 
+	private buildParts(
+		params: OpencodePromptParams,
+	): Array<
+		{ type: "text"; text: string } | { type: "file"; mime: string; filename?: string; url: string }
+	> {
+		return [
+			{ type: "text", text: params.text },
+			...(params.attachments ?? [])
+				.filter(
+					(a): a is typeof a & { contentType: string } => !!a.contentType?.startsWith("image/"),
+				)
+				.map((a) => ({
+					type: "file" as const,
+					mime: a.contentType,
+					filename: a.filename,
+					url: a.url,
+				})),
+		];
+	}
+
 	async prompt(params: OpencodePromptParams, signal?: AbortSignal): Promise<PromptResult> {
 		const modelLabel = `${params.model.providerId}/${params.model.modelId}`;
 		this.logger?.debug("[opencode] llm_request", {
@@ -75,7 +95,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		const result = await oc.session.prompt(
 			{
 				sessionID: params.sessionId,
-				parts: [{ type: "text", text: params.text }],
+				parts: this.buildParts(params),
 				model: { providerID: params.model.providerId, modelID: params.model.modelId },
 				system: params.system,
 				tools: params.tools ?? {},
@@ -99,7 +119,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		const oc = await this.getClient();
 		const result = await oc.session.promptAsync({
 			sessionID: params.sessionId,
-			parts: [{ type: "text", text: params.text }],
+			parts: this.buildParts(params),
 			model: { providerID: params.model.providerId, modelID: params.model.modelId },
 			system: params.system,
 		});
@@ -127,7 +147,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		try {
 			const result = await oc.session.promptAsync({
 				sessionID: params.sessionId,
-				parts: [{ type: "text", text: params.text }],
+				parts: this.buildParts(params),
 				model: { providerID: params.model.providerId, modelID: params.model.modelId },
 				system: params.system,
 			});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -169,6 +169,7 @@ export interface SendOptions {
 	sessionKey: string;
 	message: string;
 	guildId?: string;
+	attachments?: Attachment[];
 }
 
 export interface AiAgent {
@@ -214,6 +215,7 @@ export interface OpencodePromptParams {
 	model: { providerId: string; modelId: string };
 	system?: string;
 	tools?: Record<string, boolean>;
+	attachments?: Attachment[];
 }
 
 export type OpencodeSessionEvent =

--- a/spec/agent/discord/message-formatter.spec.ts
+++ b/spec/agent/discord/message-formatter.spec.ts
@@ -141,7 +141,7 @@ describe("formatDiscordMessage", () => {
 		expect(result).not.toContain("</user_message>");
 	});
 
-	test("添付ファイルがある場合は [添付: filename (mime)] を含む", () => {
+	test("添付ファイルがある場合は [添付: filename (mime) url] を含む", () => {
 		const msg = createMessage({
 			attachments: [
 				{ url: "https://example.com/image.png", filename: "image.png", contentType: "image/png" },
@@ -149,10 +149,10 @@ describe("formatDiscordMessage", () => {
 		});
 		const result = formatDiscordMessage(msg);
 
-		expect(result).toContain("[添付: image.png (image/png)]");
+		expect(result).toContain("[添付: image.png (image/png) https://example.com/image.png]");
 	});
 
-	test("複数の添付ファイルがすべて含まれる", () => {
+	test("複数の添付ファイルがすべて含まれる（URL 付き）", () => {
 		const msg = createMessage({
 			attachments: [
 				{ url: "https://example.com/a.txt", filename: "a.txt", contentType: "text/plain" },
@@ -161,8 +161,8 @@ describe("formatDiscordMessage", () => {
 		});
 		const result = formatDiscordMessage(msg);
 
-		expect(result).toContain("[添付: a.txt (text/plain)]");
-		expect(result).toContain("[添付: b.jpg (image/jpeg)]");
+		expect(result).toContain("[添付: a.txt (text/plain) https://example.com/a.txt]");
+		expect(result).toContain("[添付: b.jpg (image/jpeg) https://example.com/b.jpg]");
 	});
 
 	test("mentioned メッセージは [action: respond] を含む", () => {

--- a/spec/agent/runner.spec.ts
+++ b/spec/agent/runner.spec.ts
@@ -138,6 +138,72 @@ describe("send()", () => {
 	});
 });
 
+describe("attachments の伝搬", () => {
+	test("send() で渡した attachments が promptAsyncAndWatchSession の params.attachments に含まれる", async () => {
+		const sessionPort = createSimpleSessionPort();
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		await runner.send({
+			sessionKey: "k",
+			message: "この画像を見て",
+			attachments: [
+				{
+					url: "https://cdn.example.com/photo.png",
+					contentType: "image/png",
+					filename: "photo.png",
+				},
+			],
+		});
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const calls = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBeGreaterThanOrEqual(1);
+		const params = calls[0]?.[0] as { attachments?: unknown[] };
+		expect(params.attachments).toBeDefined();
+		expect(params.attachments).toEqual([
+			{ url: "https://cdn.example.com/photo.png", contentType: "image/png", filename: "photo.png" },
+		]);
+	});
+
+	test("attachments なしの send() では params.attachments が undefined または空", async () => {
+		const sessionPort = createSimpleSessionPort();
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		await runner.send({ sessionKey: "k", message: "hello" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const calls = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBeGreaterThanOrEqual(1);
+		const params = calls[0]?.[0] as { attachments?: unknown[] };
+		// attachments がないか空配列
+		if (params.attachments !== undefined) {
+			expect(params.attachments).toEqual([]);
+		}
+	});
+});
+
 describe("pollingPrompt の注入", () => {
 	test("ensureSessionStarted で pollingPrompt が promptAsyncAndWatchSession の text に含まれる", async () => {
 		const customPrompt = "CUSTOM_POLLING_PROMPT_FOR_TEST";

--- a/spec/opencode/session-adapter.spec.ts
+++ b/spec/opencode/session-adapter.spec.ts
@@ -190,6 +190,269 @@ describe("promptAsyncAndWatchSession: SSE 切断時のトークン保持", () =>
 	});
 });
 
+// ─── マルチモーダル: attachments → FilePartInput 変換 ─────────
+
+describe("promptAsync: attachments の FilePartInput 変換", () => {
+	test("attachments がない場合、parts は text のみ", async () => {
+		const stream = {
+			next: mock(
+				() =>
+					new Promise<IteratorResult<Event, void>>(() => {
+						/* never resolves */
+					}),
+			),
+			return: mock(() => Promise.resolve({ done: true, value: undefined })),
+			[Symbol.asyncIterator]() {
+				return this;
+			},
+		} as unknown as AsyncGenerator<Event, void, unknown>;
+
+		const client = createClient(stream);
+		const adapter = createAdapter(client);
+
+		await adapter.promptAsync({
+			sessionId: "session-1",
+			text: "hello",
+			model: { providerId: "provider", modelId: "model" },
+		});
+
+		const calls = (client.session.promptAsync as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(1);
+		const params = calls[0]?.[0] as { parts: unknown[] };
+		expect(params.parts).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	test("画像 attachments がある場合、parts に FilePartInput が含まれる", async () => {
+		const stream = {
+			next: mock(
+				() =>
+					new Promise<IteratorResult<Event, void>>(() => {
+						/* never resolves */
+					}),
+			),
+			return: mock(() => Promise.resolve({ done: true, value: undefined })),
+			[Symbol.asyncIterator]() {
+				return this;
+			},
+		} as unknown as AsyncGenerator<Event, void, unknown>;
+
+		const client = createClient(stream);
+		const adapter = createAdapter(client);
+
+		await adapter.promptAsync({
+			sessionId: "session-1",
+			text: "画像を見て",
+			model: { providerId: "provider", modelId: "model" },
+			attachments: [
+				{
+					url: "https://cdn.example.com/photo.png",
+					contentType: "image/png",
+					filename: "photo.png",
+				},
+			],
+		});
+
+		const calls = (client.session.promptAsync as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(1);
+		const params = calls[0]?.[0] as { parts: unknown[] };
+		expect(params.parts).toEqual([
+			{ type: "text", text: "画像を見て" },
+			{
+				type: "file",
+				mime: "image/png",
+				filename: "photo.png",
+				url: "https://cdn.example.com/photo.png",
+			},
+		]);
+	});
+
+	test("非画像 attachments は FilePartInput に変換されない（テキスト表現のみ）", async () => {
+		const stream = {
+			next: mock(
+				() =>
+					new Promise<IteratorResult<Event, void>>(() => {
+						/* never resolves */
+					}),
+			),
+			return: mock(() => Promise.resolve({ done: true, value: undefined })),
+			[Symbol.asyncIterator]() {
+				return this;
+			},
+		} as unknown as AsyncGenerator<Event, void, unknown>;
+
+		const client = createClient(stream);
+		const adapter = createAdapter(client);
+
+		await adapter.promptAsync({
+			sessionId: "session-1",
+			text: "ファイルを確認",
+			model: { providerId: "provider", modelId: "model" },
+			attachments: [
+				{
+					url: "https://cdn.example.com/doc.pdf",
+					contentType: "application/pdf",
+					filename: "doc.pdf",
+				},
+			],
+		});
+
+		const calls = (client.session.promptAsync as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(1);
+		const params = calls[0]?.[0] as { parts: unknown[] };
+		// 非画像なので parts は text のみ（FilePartInput は含まれない）
+		expect(params.parts).toEqual([{ type: "text", text: "ファイルを確認" }]);
+	});
+
+	test("画像と非画像が混在する場合、画像のみ FilePartInput に変換される", async () => {
+		const stream = {
+			next: mock(
+				() =>
+					new Promise<IteratorResult<Event, void>>(() => {
+						/* never resolves */
+					}),
+			),
+			return: mock(() => Promise.resolve({ done: true, value: undefined })),
+			[Symbol.asyncIterator]() {
+				return this;
+			},
+		} as unknown as AsyncGenerator<Event, void, unknown>;
+
+		const client = createClient(stream);
+		const adapter = createAdapter(client);
+
+		await adapter.promptAsync({
+			sessionId: "session-1",
+			text: "これを見て",
+			model: { providerId: "provider", modelId: "model" },
+			attachments: [
+				{ url: "https://cdn.example.com/img.jpg", contentType: "image/jpeg", filename: "img.jpg" },
+				{ url: "https://cdn.example.com/data.csv", contentType: "text/csv", filename: "data.csv" },
+				{
+					url: "https://cdn.example.com/logo.webp",
+					contentType: "image/webp",
+					filename: "logo.webp",
+				},
+			],
+		});
+
+		const calls = (client.session.promptAsync as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(1);
+		const params = calls[0]?.[0] as { parts: unknown[] };
+		expect(params.parts).toEqual([
+			{ type: "text", text: "これを見て" },
+			{
+				type: "file",
+				mime: "image/jpeg",
+				filename: "img.jpg",
+				url: "https://cdn.example.com/img.jpg",
+			},
+			{
+				type: "file",
+				mime: "image/webp",
+				filename: "logo.webp",
+				url: "https://cdn.example.com/logo.webp",
+			},
+		]);
+	});
+});
+
+describe("promptAsyncAndWatchSession: attachments の FilePartInput 変換", () => {
+	test("画像 attachments がある場合、promptAsync の parts に FilePartInput が含まれる", async () => {
+		let callCount = 0;
+		const stream = {
+			next: mock(() => {
+				callCount++;
+				if (callCount === 1) {
+					return Promise.resolve<IteratorResult<Event, void>>({
+						done: false,
+						value: makeMessageUpdatedEvent("session-1", "msg-1", {
+							input: 100,
+							output: 50,
+							cache: { read: 10 },
+						}),
+					});
+				}
+				return new Promise<IteratorResult<Event, void>>((_resolve, reject) => {
+					setTimeout(() => reject(new Error("stream.next() timed out after 5 minutes")), 10);
+				});
+			}),
+			return: mock(() => Promise.resolve({ done: true, value: undefined })),
+			[Symbol.asyncIterator]() {
+				return this;
+			},
+		} as unknown as AsyncGenerator<Event, void, unknown>;
+
+		const client = createClient(stream);
+		const adapter = createAdapter(client);
+
+		await adapter.promptAsyncAndWatchSession({
+			sessionId: "session-1",
+			text: "この画像は何？",
+			model: { providerId: "provider", modelId: "model" },
+			attachments: [
+				{
+					url: "https://cdn.example.com/screen.png",
+					contentType: "image/png",
+					filename: "screen.png",
+				},
+			],
+		});
+
+		const calls = (client.session.promptAsync as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(1);
+		const params = calls[0]?.[0] as { parts: unknown[] };
+		expect(params.parts).toEqual([
+			{ type: "text", text: "この画像は何？" },
+			{
+				type: "file",
+				mime: "image/png",
+				filename: "screen.png",
+				url: "https://cdn.example.com/screen.png",
+			},
+		]);
+	});
+
+	test("attachments がない場合、parts は text のみ", async () => {
+		let callCount = 0;
+		const stream = {
+			next: mock(() => {
+				callCount++;
+				if (callCount === 1) {
+					return Promise.resolve<IteratorResult<Event, void>>({
+						done: false,
+						value: makeMessageUpdatedEvent("session-1", "msg-1", {
+							input: 100,
+							output: 50,
+							cache: { read: 10 },
+						}),
+					});
+				}
+				return new Promise<IteratorResult<Event, void>>((_resolve, reject) => {
+					setTimeout(() => reject(new Error("stream.next() timed out after 5 minutes")), 10);
+				});
+			}),
+			return: mock(() => Promise.resolve({ done: true, value: undefined })),
+			[Symbol.asyncIterator]() {
+				return this;
+			},
+		} as unknown as AsyncGenerator<Event, void, unknown>;
+
+		const client = createClient(stream);
+		const adapter = createAdapter(client);
+
+		await adapter.promptAsyncAndWatchSession({
+			sessionId: "session-1",
+			text: "hello",
+			model: { providerId: "provider", modelId: "model" },
+		});
+
+		const calls = (client.session.promptAsync as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(1);
+		const params = calls[0]?.[0] as { parts: unknown[] };
+		expect(params.parts).toEqual([{ type: "text", text: "hello" }]);
+	});
+});
+
 describe("waitForSessionIdle: SSE 切断時のトークン保持", () => {
 	test("stream.next() がタイムアウトで reject した場合に蓄積トークンが streamDisconnected に含まれる", async () => {
 		let callCount = 0;


### PR DESCRIPTION
## Summary

Closes #778

- `SendOptions`, `OpencodePromptParams` に `attachments?: Attachment[]` フィールドを追加
- `AgentRunner` で複数メッセージの attachments を集約し、リトライ時も再送
- `OpencodeSessionAdapter.buildParts()` で画像 MIME type の添付のみ `FilePartInput` に変換
- `formatDiscordMessage()` の添付テキストに URL を含める
- `bootstrap.ts` の `agent.send()` に `msg.attachments` を渡す

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `packages/shared/src/types.ts` | `SendOptions`, `OpencodePromptParams` に `attachments?` 追加 |
| `packages/agent/src/runner.ts` | `pendingMessages` 型変更、`drainMessages()` で attachments 集約、`lastPromptAttachments` 追加 |
| `packages/opencode/src/session-adapter.ts` | `buildParts()` ヘルパー追加、3メソッドで画像→FilePartInput 変換 |
| `packages/agent/src/discord/message-formatter.ts` | 添付テキストに URL 追加 |
| `apps/discord/src/bootstrap.ts` | `agent.send()` に attachments を渡す |

## Test plan

- [x] `nr validate` — fmt:check + lint + type check 全パス
- [x] `nr test` — 2056 pass, 0 fail (spec 1515 + unit 541)
- [x] 仕様テスト 8 件追加（message-formatter, session-adapter, runner）
- [x] ユニットテスト 21 件追加（エッジケース・内部ロジック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)