### PR TITLE
fix: テキストなし・画像添付のみメッセージのスキップを修正

### DIFF
--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -335,7 +335,7 @@ export class AgentRunner implements AiAgent {
 			await this.waitForDebounce(signal);
 			if (signal.aborted) return;
 			const drained = this.drainMessages();
-			if (!drained.text) return;
+			if (!drained.text && drained.attachments.length === 0) return;
 			text = drained.text;
 			attachments = drained.attachments;
 		}

--- a/spec/agent/runner.spec.ts
+++ b/spec/agent/runner.spec.ts
@@ -176,6 +176,43 @@ describe("attachments の伝搬", () => {
 		]);
 	});
 
+	test("テキスト空・画像添付のみのメッセージがスキップされず promptAsyncAndWatchSession に渡される", async () => {
+		const sessionPort = createSimpleSessionPort();
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		await runner.send({
+			sessionKey: "k",
+			message: "",
+			attachments: [
+				{
+					url: "https://cdn.example.com/photo.png",
+					contentType: "image/png",
+					filename: "photo.png",
+				},
+			],
+		});
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const calls = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBeGreaterThanOrEqual(1);
+		const params = calls[0]?.[0] as { attachments?: unknown[] };
+		expect(params.attachments).toBeDefined();
+		expect(params.attachments).toEqual([
+			{ url: "https://cdn.example.com/photo.png", contentType: "image/png", filename: "photo.png" },
+		]);
+	});
+
 	test("attachments なしの send() では params.attachments が undefined または空", async () => {
 		const sessionPort = createSimpleSessionPort();
 		const runner = new TestAgent({


### PR DESCRIPTION
## Summary
- `ensureSessionStarted` の guard 条件を `!drained.text` → `!drained.text && drained.attachments.length === 0` に変更し、テキスト空でも attachments があればプロンプトを送信するようにした
- 再現テスト（spec）を追加

Closes #782

## Test plan
- [x] 再現テストが修正前に失敗、修正後に成功することを確認
- [x] `nr test` で全 2055 テストが pass
- [x] `nr validate` で既存以外のエラーなし

## 関連 Issue
- #783: `lastPromptText` が空文字で保存されリトライが機能しない（レビューで発見、別途対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)