### PR TITLE
fix: 画像のみメッセージのリトライが機能しない問題を修正

### DIFF
--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -1883,6 +1883,49 @@ describe("AgentRunner attachments 伝搬（内部ロジック）", () => {
 		secondSessionDone.resolve({ type: "cancelled" });
 	});
 
+	test("テキスト空・画像添付のみの送信でエラー後 lastPromptText/lastPromptAttachments が再利用される", async () => {
+		const _firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		let sessionWatchCount = 0;
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			if (sessionWatchCount === 1) return Promise.reject(new Error("session error"));
+			return secondSessionDone.promise;
+		});
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		const att: Attachment[] = [
+			{ url: "https://example.com/img.png", contentType: "image/png", filename: "img.png" },
+		];
+		await runner.send({ sessionKey: "k", message: "", attachments: att });
+
+		// エラー → バックオフ sleep → リトライ
+		for (let i = 0; i < 10; i++) {
+			// eslint-disable-next-line no-await-in-loop
+			await Bun.sleep(0);
+		}
+
+		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(2);
+		// リトライ時の呼び出し（2回目）でも attachments が渡されている
+		const retryCallArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[1] as unknown[];
+		const retryParams = retryCallArgs[0] as { attachments?: Attachment[] };
+		expect(retryParams.attachments).toEqual(att);
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+
 	test("idle 後に lastPromptAttachments がクリアされる", async () => {
 		const firstSessionDone = deferred<OpencodeSessionEvent>();
 		const secondSessionDone = deferred<OpencodeSessionEvent>();

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -318,12 +318,7 @@ export class AgentRunner implements AiAgent {
 
 		let text: string;
 		let attachments: Attachment[];
-		if (this.lastPromptText !== null) {
-			// リトライ: 前回のテキストを再利用し、新着メッセージがあれば追加
-			const drained = this.drainMessages();
-			text = drained.text ? `${this.lastPromptText}\n---\n${drained.text}` : this.lastPromptText;
-			attachments = [...(this.lastPromptAttachments ?? []), ...drained.attachments];
-		} else {
+		if (this.lastPromptText === null) {
 			this.logger.info(
 				`[${this.profile.name}:${this.agentId}] waiting for messages... (hasStartedSession=${this.hasStartedSession})`,
 			);
@@ -338,6 +333,11 @@ export class AgentRunner implements AiAgent {
 			if (!drained.text && drained.attachments.length === 0) return;
 			text = drained.text;
 			attachments = drained.attachments;
+		} else {
+			// リトライ: 前回のテキストを再利用し、新着メッセージがあれば追加
+			const drained = this.drainMessages();
+			text = drained.text ? `${this.lastPromptText}\n---\n${drained.text}` : this.lastPromptText;
+			attachments = [...(this.lastPromptAttachments ?? []), ...drained.attachments];
 		}
 
 		this.logger.info(`[${this.profile.name}:${this.agentId}] messages received, sending prompt`);

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -318,7 +318,7 @@ export class AgentRunner implements AiAgent {
 
 		let text: string;
 		let attachments: Attachment[];
-		if (this.lastPromptText) {
+		if (this.lastPromptText !== null) {
 			// リトライ: 前回のテキストを再利用し、新着メッセージがあれば追加
 			const drained = this.drainMessages();
 			text = drained.text ? `${this.lastPromptText}\n---\n${drained.text}` : this.lastPromptText;

--- a/spec/agent/runner.spec.ts
+++ b/spec/agent/runner.spec.ts
@@ -213,6 +213,65 @@ describe("attachments の伝搬", () => {
 		]);
 	});
 
+	test("テキスト空・画像添付のみのメッセージがエラー後にリトライされ attachments が含まれる", async () => {
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPortWithTwoSessions(
+			firstSessionDone.promise,
+			secondSessionDone.promise,
+		);
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		// テキスト空・画像添付のみのメッセージを送信
+		await runner.send({
+			sessionKey: "k",
+			message: "",
+			attachments: [
+				{
+					url: "https://cdn.example.com/photo.png",
+					contentType: "image/png",
+					filename: "photo.png",
+				},
+			],
+		});
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 1回目の promptAsyncAndWatchSession が呼ばれたことを確認
+		const calls = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBeGreaterThanOrEqual(1);
+
+		// エラーを発生させる
+		firstSessionDone.resolve({ type: "error", message: "something went wrong" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// エラー後のリトライで promptAsyncAndWatchSession が再度呼ばれることを確認
+		expect(calls.length).toBeGreaterThanOrEqual(2);
+
+		// リトライ時の呼び出しに attachments が含まれていることを確認
+		const retryParams = calls[1]?.[0] as { attachments?: unknown[] };
+		expect(retryParams.attachments).toBeDefined();
+		expect(retryParams.attachments).toEqual([
+			{ url: "https://cdn.example.com/photo.png", contentType: "image/png", filename: "photo.png" },
+		]);
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+
 	test("attachments なしの send() では params.attachments が undefined または空", async () => {
 		const sessionPort = createSimpleSessionPort();
 		const runner = new TestAgent({


### PR DESCRIPTION
## Summary
- `runner.ts` の `ensureSessionStarted()` で `if (this.lastPromptText)` が空文字 `""` を falsy 判定し、画像のみメッセージ (`message: ""`) のリトライパスに入らなかった問題を修正
- `if (this.lastPromptText === null)` に変更し、テキスト空でも attachments があればリトライされるようにした
- spec テスト・unit テストを追加

Closes #783

## Test plan
- [ ] spec テスト: 画像のみメッセージがエラー後にリトライされ attachments が含まれることを検証
- [ ] unit テスト: テキスト空・画像のみ送信でエラー後 lastPromptText/lastPromptAttachments が再利用されることを検証
- [ ] CI (Test Quality) が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)