### PR TITLE
feat: 会話ブレイク検出による compaction / session rotation の自動発動

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -313,6 +313,7 @@ function setupEventHandlers(deps: {
 				sessionKey: "home",
 				message: formatDiscordMessage(msg),
 				attachments: msg.attachments,
+				channelId: msg.channelId,
 			});
 		}
 		return Promise.resolve();
@@ -332,6 +333,7 @@ function setupEventHandlers(deps: {
 				sessionKey: "mention",
 				message: formatDiscordMessage(msg),
 				attachments: msg.attachments,
+				channelId: msg.channelId,
 			});
 		}
 		return Promise.resolve();

--- a/packages/agent/src/discord/discord-agent.test.ts
+++ b/packages/agent/src/discord/discord-agent.test.ts
@@ -1,0 +1,329 @@
+/* oxlint-disable max-lines, max-lines-per-function -- テストファイルはケース数に応じて長くなるため許容 */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { OpencodeSessionPort } from "@vicissitude/shared/types";
+
+import {
+	createContextBuilder,
+	createProfile,
+	createSessionStore,
+} from "../../../../spec/agent/runner-test-helpers.ts";
+import { createMockLogger } from "../../../../spec/test-helpers.ts";
+import type { AgentRunner } from "../runner.ts";
+import { DiscordAgent, type DiscordAgentDeps } from "./discord-agent.ts";
+
+// ─── テスト用 DiscordAgent サブクラス ─────────────────────────────
+
+class TestDiscordAgent extends DiscordAgent {
+	sleepSpy: ((ms: number) => Promise<void>) | null = null;
+
+	/** pendingCompaction フラグへの公開アクセス */
+	get isPendingCompaction(): boolean {
+		return (this as unknown as { pendingCompaction: boolean }).pendingCompaction;
+	}
+
+	/** lastActivityAt への公開アクセス */
+	get currentLastActivityAt(): number | null {
+		return (this as unknown as { lastActivityAt: number | null }).lastActivityAt;
+	}
+
+	/** lastChannelId への公開アクセス */
+	get currentLastChannelId(): string | null {
+		return (this as unknown as { lastChannelId: string | null }).lastChannelId;
+	}
+
+	/** compactionGapMs への公開アクセス */
+	get currentCompactionGapMs(): number {
+		return (this as unknown as { compactionGapMs: number }).compactionGapMs;
+	}
+
+	/** rotationGapMs への公開アクセス */
+	get currentRotationGapMs(): number {
+		return (this as unknown as { rotationGapMs: number }).rotationGapMs;
+	}
+
+	/** getNow への公開アクセス */
+	get currentGetNow(): () => number {
+		return (this as unknown as { getNow: () => number }).getNow;
+	}
+
+	readonly requestSessionRotationMock = mock((): Promise<void> => Promise.resolve());
+
+	// oxlint-disable-next-line no-useless-constructor -- DiscordAgentDeps 型を受け取るために必要
+	constructor(deps: DiscordAgentDeps) {
+		super(deps);
+	}
+
+	override requestSessionRotation(): Promise<void> {
+		const result: Promise<void> = this.requestSessionRotationMock();
+		return result;
+	}
+
+	/** テスト用: polling loop を起動しない（pendingCompaction フラグが消費されるのを防ぐ） */
+	override ensurePolling(): void {}
+
+	protected override sleep(ms: number): Promise<void> {
+		if (this.sleepSpy) return this.sleepSpy(ms);
+		return super.sleep(ms);
+	}
+}
+
+// ─── ヘルパー ─────────────────────────────────────────────────────
+
+function createSessionPort(): OpencodeSessionPort {
+	return {
+		createSession: mock(() => Promise.resolve("session-1")),
+		sessionExists: mock(() => Promise.resolve(false)),
+		prompt: mock(() => Promise.resolve({ text: "", tokens: undefined })),
+		promptAsync: mock(() => Promise.resolve()),
+		promptAsyncAndWatchSession: mock(() => Promise.resolve({ type: "idle" as const })),
+		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
+		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
+		close: mock(() => {}),
+	} as unknown as OpencodeSessionPort;
+}
+
+function createAgent(
+	opts: {
+		nowProvider?: () => number;
+		conversationBreak?: { compactionGapMs?: number; rotationGapMs?: number };
+	} = {},
+): TestDiscordAgent {
+	const agent = new TestDiscordAgent({
+		guildId: "guild-1",
+		profile: createProfile(),
+		sessionStore: createSessionStore() as never,
+		contextBuilder: createContextBuilder(),
+		logger: createMockLogger(),
+		sessionPort: createSessionPort(),
+		sessionMaxAgeMs: 86_400_000,
+		nowProvider: opts.nowProvider,
+		conversationBreak: opts.conversationBreak,
+	});
+	agent.sleepSpy = () => Promise.resolve();
+	return agent;
+}
+
+const activeRunners = new Set<AgentRunner>();
+
+afterEach(() => {
+	for (const runner of activeRunners) {
+		runner.stop();
+	}
+	activeRunners.clear();
+});
+
+// ─── lastActivityAt の更新 ───────────────────────────────────────
+
+describe("lastActivityAt の更新", () => {
+	test("send() 後に lastActivityAt が nowProvider の返す値に更新される", async () => {
+		const agent = createAgent({ nowProvider: () => 42_000 });
+		activeRunners.add(agent);
+
+		expect(agent.currentLastActivityAt).toBeNull();
+
+		await agent.send({ sessionKey: "k", message: "hello" });
+		await Bun.sleep(0);
+
+		expect(agent.currentLastActivityAt).toBe(42_000);
+	});
+
+	test("2回目の send() で lastActivityAt が最新の時刻に更新される", async () => {
+		let now = 1_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+		expect(agent.currentLastActivityAt).toBe(1_000);
+
+		now = 5_000;
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+		expect(agent.currentLastActivityAt).toBe(5_000);
+	});
+});
+
+// ─── lastChannelId の更新 ────────────────────────────────────────
+
+describe("lastChannelId の更新", () => {
+	test("channelId 付き send() 後に lastChannelId が更新される", async () => {
+		const agent = createAgent({ nowProvider: () => 1_000 });
+		activeRunners.add(agent);
+
+		expect(agent.currentLastChannelId).toBeNull();
+
+		await agent.send({ sessionKey: "k", message: "hello", channelId: "ch-x" });
+		await Bun.sleep(0);
+
+		expect(agent.currentLastChannelId).toBe("ch-x");
+	});
+
+	test("channelId なしのメッセージでは lastChannelId は更新されない", async () => {
+		let now = 1_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		await agent.send({ sessionKey: "k", message: "first", channelId: "ch-a" });
+		await Bun.sleep(0);
+		expect(agent.currentLastChannelId).toBe("ch-a");
+
+		now = 2_000;
+		// channelId なし
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+
+		// 前の値が保持される
+		expect(agent.currentLastChannelId).toBe("ch-a");
+	});
+
+	test("channelId が undefined の場合も lastChannelId は更新されない", async () => {
+		let now = 1_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		await agent.send({ sessionKey: "k", message: "first", channelId: "ch-a" });
+		await Bun.sleep(0);
+
+		now = 2_000;
+		await agent.send({ sessionKey: "k", message: "second", channelId: undefined });
+		await Bun.sleep(0);
+
+		expect(agent.currentLastChannelId).toBe("ch-a");
+	});
+});
+
+// ─── デフォルト設定値 ────────────────────────────────────────────
+
+describe("ConversationBreakConfig デフォルト値", () => {
+	test("conversationBreak 省略時の compactionGapMs は 1_800_000 (30分)", () => {
+		const agent = createAgent();
+		activeRunners.add(agent);
+
+		expect(agent.currentCompactionGapMs).toBe(1_800_000);
+	});
+
+	test("conversationBreak 省略時の rotationGapMs は 21_600_000 (6時間)", () => {
+		const agent = createAgent();
+		activeRunners.add(agent);
+
+		expect(agent.currentRotationGapMs).toBe(21_600_000);
+	});
+
+	test("conversationBreak が空オブジェクトの場合もデフォルト値が適用される", () => {
+		const agent = createAgent({ conversationBreak: {} });
+		activeRunners.add(agent);
+
+		expect(agent.currentCompactionGapMs).toBe(1_800_000);
+		expect(agent.currentRotationGapMs).toBe(21_600_000);
+	});
+});
+
+// ─── rotation と compaction の排他 ───────────────────────────────
+
+describe("rotation と compaction の排他", () => {
+	test("rotation 条件を満たす場合、pendingCompaction は false のまま", async () => {
+		const SIX_HOURS = 21_600_000;
+		let now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+
+		now += SIX_HOURS;
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+
+		expect(agent.requestSessionRotationMock).toHaveBeenCalledTimes(1);
+		expect(agent.isPendingCompaction).toBe(false);
+	});
+
+	test("rotation ギャップ直前のメッセージは compaction になる", async () => {
+		const JUST_UNDER_SIX_HOURS = 21_600_000 - 1;
+		let now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+
+		now += JUST_UNDER_SIX_HOURS;
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+
+		expect(agent.requestSessionRotationMock).not.toHaveBeenCalled();
+		expect(agent.isPendingCompaction).toBe(true);
+	});
+});
+
+// ─── getNow の使用 ───────────────────────────────────────────────
+
+describe("getNow の使用", () => {
+	test("nowProvider が注入された場合、その関数が使われる", async () => {
+		const customNow = mock(() => 99_999);
+		const agent = createAgent({ nowProvider: customNow });
+		activeRunners.add(agent);
+
+		await agent.send({ sessionKey: "k", message: "hello" });
+		await Bun.sleep(0);
+
+		// nowProvider が send() 内で呼ばれた
+		expect(customNow).toHaveBeenCalled();
+		expect(agent.currentLastActivityAt).toBe(99_999);
+	});
+
+	test("nowProvider 省略時のデフォルトは Date.now と同じ型の関数", () => {
+		const agent = createAgent();
+		activeRunners.add(agent);
+
+		const result = agent.currentGetNow();
+		expect(typeof result).toBe("number");
+		// Date.now と近い値（100ms 以内）
+		expect(Math.abs(result - Date.now())).toBeLessThan(100);
+	});
+});
+
+// ─── super.send() の呼び出し ────────────────────────────────────
+
+describe("super.send() の呼び出し", () => {
+	test("ブレイク検出後に親クラスの send() が呼ばれ Promise を返す", async () => {
+		let now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		// 初回
+		const result1 = agent.send({ sessionKey: "k", message: "first" });
+		expect(result1).toBeInstanceOf(Promise);
+		await result1;
+		await Bun.sleep(0);
+
+		// compaction トリガー後も send() が正常に完了する
+		now += 1_800_000;
+		const result2 = agent.send({ sessionKey: "k", message: "second" });
+		expect(result2).toBeInstanceOf(Promise);
+		await result2;
+		await Bun.sleep(0);
+
+		expect(agent.isPendingCompaction).toBe(true);
+	});
+
+	test("rotation トリガー後も send() が正常に完了する", async () => {
+		let now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+
+		now += 21_600_000;
+		// rotation が発生しても send() は完了する
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+
+		expect(agent.requestSessionRotationMock).toHaveBeenCalledTimes(1);
+		// lastActivityAt は更新されている
+		expect(agent.currentLastActivityAt).toBe(now);
+	});
+});

--- a/packages/agent/src/discord/discord-agent.test.ts
+++ b/packages/agent/src/discord/discord-agent.test.ts
@@ -42,9 +42,9 @@ class TestDiscordAgent extends DiscordAgent {
 		return (this as unknown as { rotationGapMs: number }).rotationGapMs;
 	}
 
-	/** getNow への公開アクセス */
-	get currentGetNow(): () => number {
-		return (this as unknown as { getNow: () => number }).getNow;
+	/** nowProvider への公開アクセス */
+	get currentNowProvider(): () => number {
+		return this.nowProvider;
 	}
 
 	readonly requestSessionRotationMock = mock((): Promise<void> => Promise.resolve());
@@ -278,7 +278,7 @@ describe("getNow の使用", () => {
 		const agent = createAgent();
 		activeRunners.add(agent);
 
-		const result = agent.currentGetNow();
+		const result = agent.currentNowProvider();
 		expect(typeof result).toBe("number");
 		// Date.now と近い値（100ms 以内）
 		expect(Math.abs(result - Date.now())).toBeLessThan(100);

--- a/packages/agent/src/discord/discord-agent.ts
+++ b/packages/agent/src/discord/discord-agent.ts
@@ -44,7 +44,6 @@ export class DiscordAgent extends AgentRunner {
 	private lastChannelId: string | null = null;
 	private readonly compactionGapMs: number;
 	private readonly rotationGapMs: number;
-	private readonly getNow: () => number;
 
 	constructor(deps: DiscordAgentDeps) {
 		const agentId = `${deps.agentIdPrefix ?? "discord"}:${deps.guildId}`;
@@ -65,11 +64,10 @@ export class DiscordAgent extends AgentRunner {
 		});
 		this.compactionGapMs = deps.conversationBreak?.compactionGapMs ?? 1_800_000;
 		this.rotationGapMs = deps.conversationBreak?.rotationGapMs ?? 21_600_000;
-		this.getNow = deps.nowProvider ?? Date.now;
 	}
 
 	override send(options: SendOptions): Promise<AgentResponse> {
-		const now = this.getNow();
+		const now = this.nowProvider();
 		const channelId = options.channelId ?? null;
 
 		if (this.lastActivityAt !== null) {

--- a/packages/agent/src/discord/discord-agent.ts
+++ b/packages/agent/src/discord/discord-agent.ts
@@ -1,14 +1,21 @@
 import type {
+	AgentResponse,
 	ContextBuilderPort,
 	Logger,
 	MetricsCollector,
 	OpencodeSessionPort,
+	SendOptions,
 	SessionStorePort,
 	SessionSummaryWriter,
 } from "@vicissitude/shared/types";
 
 import type { AgentProfile } from "../profile.ts";
 import { AgentRunner } from "../runner.ts";
+
+export interface ConversationBreakConfig {
+	compactionGapMs?: number;
+	rotationGapMs?: number;
+}
 
 export interface DiscordAgentDeps {
 	guildId: string;
@@ -26,9 +33,19 @@ export interface DiscordAgentDeps {
 	compactionTokenThreshold?: number;
 	/** compaction 間のクールダウン（ms）。デフォルト: 1_800_000 (30分) */
 	compactionCooldownMs?: number;
+	/** テスト用時刻プロバイダー。デフォルト: Date.now */
+	nowProvider?: () => number;
+	/** 会話ブレイク検出設定 */
+	conversationBreak?: ConversationBreakConfig;
 }
 
 export class DiscordAgent extends AgentRunner {
+	private lastActivityAt: number | null = null;
+	private lastChannelId: string | null = null;
+	private readonly compactionGapMs: number;
+	private readonly rotationGapMs: number;
+	private readonly getNow: () => number;
+
 	constructor(deps: DiscordAgentDeps) {
 		const agentId = `${deps.agentIdPrefix ?? "discord"}:${deps.guildId}`;
 		super({
@@ -44,6 +61,32 @@ export class DiscordAgent extends AgentRunner {
 			summaryWriter: deps.summaryWriter,
 			compactionTokenThreshold: deps.compactionTokenThreshold,
 			compactionCooldownMs: deps.compactionCooldownMs,
+			nowProvider: deps.nowProvider,
 		});
+		this.compactionGapMs = deps.conversationBreak?.compactionGapMs ?? 1_800_000;
+		this.rotationGapMs = deps.conversationBreak?.rotationGapMs ?? 21_600_000;
+		this.getNow = deps.nowProvider ?? Date.now;
+	}
+
+	override send(options: SendOptions): Promise<AgentResponse> {
+		const now = this.getNow();
+		const channelId = options.channelId ?? null;
+
+		if (this.lastActivityAt !== null) {
+			const gap = now - this.lastActivityAt;
+			const channelChanged =
+				channelId !== null && this.lastChannelId !== null && channelId !== this.lastChannelId;
+
+			if (gap >= this.rotationGapMs) {
+				void this.requestSessionRotation();
+			} else if (gap >= this.compactionGapMs || (channelChanged && gap > 0)) {
+				this.pendingCompaction = true;
+			}
+		}
+
+		this.lastActivityAt = now;
+		if (channelId !== null) this.lastChannelId = channelId;
+
+		return super.send(options);
 	}
 }

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -319,7 +319,7 @@ export class AgentRunner implements AiAgent {
 
 		if (this.pendingCompaction) {
 			this.pendingCompaction = false;
-			await this.triggerCompaction(signal);
+			if (await this.triggerCompaction(signal)) return;
 		}
 
 		let text: string;

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -76,8 +76,9 @@ export class AgentRunner implements AiAgent {
 	private readonly summaryTimeoutMs: number;
 	private readonly compactionTokenThreshold?: number;
 	private readonly compactionCooldownMs: number;
-	private readonly nowProvider: () => number;
+	protected readonly nowProvider: () => number;
 	private lastCompactionAt: number | null = null;
+	protected pendingCompaction = false;
 
 	private get sessionKey(): string {
 		return `__polling__:${this.agentId}`;
@@ -316,6 +317,11 @@ export class AgentRunner implements AiAgent {
 	private async ensureSessionStarted(signal: AbortSignal): Promise<void> {
 		if (this.sessionWatch) return;
 
+		if (this.pendingCompaction) {
+			this.pendingCompaction = false;
+			await this.triggerCompaction(signal);
+		}
+
 		let text: string;
 		let attachments: Attachment[];
 		if (this.lastPromptText) {
@@ -497,6 +503,29 @@ export class AgentRunner implements AiAgent {
 			retryable: typeof event.retryable === "boolean" ? String(event.retryable) : "unknown",
 			error_class: event.errorClass ?? "unknown",
 		});
+	}
+
+	/** 会話ブレイクによる compaction を試行する */
+	protected async triggerCompaction(signal: AbortSignal): Promise<boolean> {
+		const now = this.nowProvider();
+		if (this.lastCompactionAt !== null && now - this.lastCompactionAt < this.compactionCooldownMs) {
+			return false;
+		}
+		const sessionId = this.sessionStore.get(this.profile.name, this.sessionKey);
+		if (!sessionId) return false;
+		try {
+			await this.sessionPort.summarizeSession(sessionId);
+			this.lastCompactionAt = now;
+			this.logger.info(`[${this.profile.name}:${this.agentId}] break-triggered compaction`);
+			this.rewatchSession(signal);
+			return true;
+		} catch (err) {
+			this.logger.warn(
+				`[${this.profile.name}:${this.agentId}] break-triggered compaction failed`,
+				err,
+			);
+			return false;
+		}
 	}
 
 	/** proactive compaction を試行し、成功して rewatch を開始した場合に true を返す */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -170,6 +170,7 @@ export interface SendOptions {
 	message: string;
 	guildId?: string;
 	attachments?: Attachment[];
+	channelId?: string;
 }
 
 export interface AiAgent {

--- a/spec/agent/discord/conversation-break.spec.ts
+++ b/spec/agent/discord/conversation-break.spec.ts
@@ -1,0 +1,300 @@
+/**
+ * 会話ブレイク検出の仕様テスト
+ *
+ * DiscordAgent の send() オーバーライドで以下を検出する:
+ * 1. 時間ギャップによる compaction (デフォルト: 30分)
+ * 2. 時間ギャップによる session rotation (デフォルト: 6時間)
+ * 3. チャンネル変更 + 時間ギャップによる compaction
+ * 4. 初回メッセージではブレイク検出を行わない
+ */
+/* oxlint-disable max-lines, max-lines-per-function -- テストファイルはケース数に応じて長くなるため許容 */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { DiscordAgent } from "@vicissitude/agent/discord/discord-agent";
+import type { AgentRunner } from "@vicissitude/agent/runner";
+import type { OpencodeSessionPort } from "@vicissitude/shared/types";
+
+import { createMockLogger } from "../../test-helpers.ts";
+import { createContextBuilder, createProfile, createSessionStore } from "../runner-test-helpers.ts";
+
+// ─── 型定義 ───────────────────────────────────────────────────────
+
+interface ConversationBreakConfig {
+	compactionGapMs?: number;
+	rotationGapMs?: number;
+}
+
+// ─── テスト用 DiscordAgent サブクラス ─────────────────────────────
+
+class TestDiscordAgent extends DiscordAgent {
+	sleepSpy: ((ms: number) => Promise<void>) | null = null;
+
+	/** pendingCompaction フラグへの公開アクセス */
+	get isPendingCompaction(): boolean {
+		return (this as unknown as { pendingCompaction: boolean }).pendingCompaction;
+	}
+
+	/** requestSessionRotation のモック */
+	readonly requestSessionRotationMock = mock(() => Promise.resolve());
+
+	// oxlint-disable-next-line no-useless-constructor -- DiscordAgentDeps に nowProvider/conversationBreak を含めるために必要
+	constructor(
+		deps: ConstructorParameters<typeof DiscordAgent>[0] & {
+			nowProvider?: () => number;
+			conversationBreak?: ConversationBreakConfig;
+		},
+	) {
+		super(deps);
+	}
+
+	override requestSessionRotation(): Promise<void> {
+		return this.requestSessionRotationMock();
+	}
+
+	/** テスト用: polling loop を起動しない（pendingCompaction フラグが消費されるのを防ぐ） */
+	override ensurePolling(): void {}
+
+	protected override sleep(ms: number): Promise<void> {
+		if (this.sleepSpy) return this.sleepSpy(ms);
+		return super.sleep(ms);
+	}
+}
+
+// ─── ヘルパー ─────────────────────────────────────────────────────
+
+function createSessionPort(): OpencodeSessionPort & {
+	summarizeSession: ReturnType<typeof mock>;
+} {
+	return {
+		createSession: mock(() => Promise.resolve("session-1")),
+		sessionExists: mock(() => Promise.resolve(false)),
+		prompt: mock(() => Promise.resolve({ text: "", tokens: undefined })),
+		promptAsync: mock(() => Promise.resolve()),
+		promptAsyncAndWatchSession: mock(() => Promise.resolve({ type: "idle" as const })),
+		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
+		deleteSession: mock(() => Promise.resolve()),
+		summarizeSession: mock(() => Promise.resolve()),
+		close: mock(() => {}),
+	} as unknown as OpencodeSessionPort & {
+		summarizeSession: ReturnType<typeof mock>;
+	};
+}
+
+function createAgent(opts: {
+	nowProvider?: () => number;
+	conversationBreak?: ConversationBreakConfig;
+}): TestDiscordAgent {
+	const agent = new TestDiscordAgent({
+		guildId: "guild-1",
+		profile: createProfile(),
+		sessionStore: createSessionStore() as never,
+		contextBuilder: createContextBuilder(),
+		logger: createMockLogger(),
+		sessionPort: createSessionPort() as unknown as OpencodeSessionPort,
+		sessionMaxAgeMs: 86_400_000,
+		nowProvider: opts.nowProvider,
+		conversationBreak: opts.conversationBreak,
+	});
+	agent.sleepSpy = () => Promise.resolve();
+	return agent;
+}
+
+const activeRunners = new Set<AgentRunner>();
+
+afterEach(() => {
+	for (const runner of activeRunners) {
+		runner.stop();
+	}
+	activeRunners.clear();
+});
+
+// ─── 時間ギャップ ─────────────────────────────────────────────────
+
+describe("時間ギャップによるブレイク検出", () => {
+	test("30分以上のギャップ後にメッセージが来たら pendingCompaction が true になる", async () => {
+		const THIRTY_MIN = 1_800_000;
+		let now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		// 初回メッセージ
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+
+		// 30分後
+		now += THIRTY_MIN;
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+
+		expect(agent.isPendingCompaction).toBe(true);
+	});
+
+	test("30分未満のギャップでは pendingCompaction は false のまま", async () => {
+		const TWENTY_NINE_MIN = 1_800_000 - 1;
+		let now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		// 初回メッセージ
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+
+		// 29分59秒999ms後
+		now += TWENTY_NINE_MIN;
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+
+		expect(agent.isPendingCompaction).toBe(false);
+	});
+
+	test("6時間以上のギャップ後にメッセージが来たら requestSessionRotation() が呼ばれる", async () => {
+		const SIX_HOURS = 21_600_000;
+		let now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		// 初回メッセージ
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+
+		// 6時間後
+		now += SIX_HOURS;
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+
+		expect(agent.requestSessionRotationMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("6時間ギャップでは pendingCompaction は立たない（rotation が優先）", async () => {
+		const SIX_HOURS = 21_600_000;
+		let now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		// 初回メッセージ
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+
+		// 6時間後
+		now += SIX_HOURS;
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+
+		expect(agent.isPendingCompaction).toBe(false);
+	});
+});
+
+// ─── チャンネル変更 ───────────────────────────────────────────────
+
+describe("チャンネル変更によるブレイク検出", () => {
+	test("チャンネル変更 + 時間ギャップありで pendingCompaction が true になる", async () => {
+		let now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		// 初回メッセージ（チャンネルA）
+		await agent.send({ sessionKey: "k", message: "first", channelId: "ch-a" });
+		await Bun.sleep(0);
+
+		// 1ms 後に別チャンネル
+		now += 1;
+		await agent.send({ sessionKey: "k", message: "second", channelId: "ch-b" });
+		await Bun.sleep(0);
+
+		expect(agent.isPendingCompaction).toBe(true);
+	});
+
+	test("チャンネル変更 + 時間ギャップなし（同タイミング）では何も起きない", async () => {
+		const now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		// 初回メッセージ（チャンネルA）
+		await agent.send({ sessionKey: "k", message: "first", channelId: "ch-a" });
+		await Bun.sleep(0);
+
+		// 同時刻に別チャンネル
+		await agent.send({ sessionKey: "k", message: "second", channelId: "ch-b" });
+		await Bun.sleep(0);
+
+		expect(agent.isPendingCompaction).toBe(false);
+		expect(agent.requestSessionRotationMock).not.toHaveBeenCalled();
+	});
+
+	test("同じチャンネルで時間ギャップなしでは何も起きない", async () => {
+		const now = 1_000_000;
+		const agent = createAgent({ nowProvider: () => now });
+		activeRunners.add(agent);
+
+		// 初回メッセージ
+		await agent.send({ sessionKey: "k", message: "first", channelId: "ch-a" });
+		await Bun.sleep(0);
+
+		// 同時刻・同チャンネル
+		await agent.send({ sessionKey: "k", message: "second", channelId: "ch-a" });
+		await Bun.sleep(0);
+
+		expect(agent.isPendingCompaction).toBe(false);
+		expect(agent.requestSessionRotationMock).not.toHaveBeenCalled();
+	});
+});
+
+// ─── 初回メッセージ ───────────────────────────────────────────────
+
+describe("初回メッセージ", () => {
+	test("最初のメッセージではブレイク検出は行われない", async () => {
+		const agent = createAgent({ nowProvider: () => 1_000_000 });
+		activeRunners.add(agent);
+
+		// 初回メッセージのみ
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+
+		expect(agent.isPendingCompaction).toBe(false);
+		expect(agent.requestSessionRotationMock).not.toHaveBeenCalled();
+	});
+});
+
+// ─── カスタム設定 ─────────────────────────────────────────────────
+
+describe("ConversationBreakConfig によるカスタマイズ", () => {
+	test("compactionGapMs をカスタマイズできる", async () => {
+		let now = 1_000_000;
+		const agent = createAgent({
+			nowProvider: () => now,
+			// 1分
+			conversationBreak: { compactionGapMs: 60_000 },
+		});
+		activeRunners.add(agent);
+
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+
+		// 1分後
+		now += 60_000;
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+
+		expect(agent.isPendingCompaction).toBe(true);
+	});
+
+	test("rotationGapMs をカスタマイズできる", async () => {
+		let now = 1_000_000;
+		const agent = createAgent({
+			nowProvider: () => now,
+			// 1時間
+			conversationBreak: { rotationGapMs: 3_600_000 },
+		});
+		activeRunners.add(agent);
+
+		await agent.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+
+		// 1時間後
+		now += 3_600_000;
+		await agent.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+
+		expect(agent.requestSessionRotationMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/spec/agent/discord/conversation-break.spec.ts
+++ b/spec/agent/discord/conversation-break.spec.ts
@@ -10,19 +10,15 @@
 /* oxlint-disable max-lines, max-lines-per-function -- テストファイルはケース数に応じて長くなるため許容 */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { DiscordAgent } from "@vicissitude/agent/discord/discord-agent";
+import {
+	DiscordAgent,
+	type ConversationBreakConfig,
+} from "@vicissitude/agent/discord/discord-agent";
 import type { AgentRunner } from "@vicissitude/agent/runner";
 import type { OpencodeSessionPort } from "@vicissitude/shared/types";
 
 import { createMockLogger } from "../../test-helpers.ts";
 import { createContextBuilder, createProfile, createSessionStore } from "../runner-test-helpers.ts";
-
-// ─── 型定義 ───────────────────────────────────────────────────────
-
-interface ConversationBreakConfig {
-	compactionGapMs?: number;
-	rotationGapMs?: number;
-}
 
 // ─── テスト用 DiscordAgent サブクラス ─────────────────────────────
 


### PR DESCRIPTION
## Summary

- 時間ギャップ（30分で compaction、6時間で session rotation）とチャンネル変更を検出し、OpenCode セッションのコンテキスト膨張を抑制する
- `SendOptions` に `channelId` を追加し、`DiscordAgent.send()` でブレイク検出ロジックを実装
- `AgentRunner` に `triggerCompaction()` を `protected` メソッドとして抽出し、polling loop 内で `pendingCompaction` フラグに基づいて実行

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `packages/shared/src/types.ts` | `SendOptions.channelId` 追加 |
| `packages/agent/src/runner.ts` | `triggerCompaction()` 抽出、`pendingCompaction` フラグ、`nowProvider` を protected 化 |
| `packages/agent/src/discord/discord-agent.ts` | ブレイク検出ロジック、`ConversationBreakConfig` |
| `apps/discord/src/bootstrap.ts` | `channelId` を send に渡す |

## Test plan

- [x] `nr test` — 全2086テスト通過（spec + unit）
- [x] `nr validate` — fmt:check + lint + check 全通過
- [x] 仕様テスト (`spec/agent/discord/conversation-break.spec.ts`) — 10ケース
- [x] ユニットテスト (`packages/agent/src/discord/discord-agent.test.ts`) — 14ケース

🤖 Generated with [Claude Code](https://claude.com/claude-code)