### PR TITLE
feat: 追いメッセージ処理改善 — デバウンス短縮・推論中断・bot対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ TypeScript + Bun で動作し、OpenCode を推論エンジンとして使用す
 
 - OpenCode SDK で推論。
 - メッセージ駆動プロンプト方式。メッセージ受信時にデバウンスで蓄積し、`promptAsyncAndWatchSession()` でプロンプトを送信する。
-  - **デバウンス**: 最後のメッセージ到着から 2 秒（`MESSAGE_DEBOUNCE_MS`）待機し、新着がなければ蓄積を確定。最大 10 秒（`MAX_DEBOUNCE_MS`）で打ち切り。蓄積メッセージは `drainMessages()` で結合してプロンプトに渡す。
+  - **デバウンス**: 最後のメッセージ到着から 500ms（`MESSAGE_DEBOUNCE_MS`）待機し、新着がなければ蓄積を確定。最大 10 秒（`MAX_DEBOUNCE_MS`）で打ち切り。bot メッセージが含まれる場合は最大 30 秒（`BOT_MAX_DEBOUNCE_MS`）に延長。蓄積メッセージは `drainMessages()` で結合してプロンプトに渡す。
+  - **推論中断**: 推論中（`promptAsyncAndWatchSession` が pending）に新メッセージが到着した場合、`sessionAbortController` でセッションを中断し、旧メッセージ + 新メッセージをまとめて再プロンプトする。
 - マルチテナント: テナント（Discord ギルド等）ごとに独立したセッションを持つ。
 - セッション ID は SQLite で永続化する。
 - セッションライフサイクル:

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -314,6 +314,7 @@ function setupEventHandlers(deps: {
 				message: formatDiscordMessage(msg),
 				attachments: msg.attachments,
 				channelId: msg.channelId,
+				isBot: msg.isBot,
 			});
 		}
 		return Promise.resolve();
@@ -334,6 +335,7 @@ function setupEventHandlers(deps: {
 				message: formatDiscordMessage(msg),
 				attachments: msg.attachments,
 				channelId: msg.channelId,
+				isBot: msg.isBot,
 			});
 		}
 		return Promise.resolve();

--- a/packages/agent/src/discord/message-formatter.test.ts
+++ b/packages/agent/src/discord/message-formatter.test.ts
@@ -25,6 +25,26 @@ function createMessage(overrides: Partial<IncomingMessage> = {}): IncomingMessag
 	};
 }
 
+describe("formatDiscordMessage bot-interaction-hint", () => {
+	test("bot メッセージの場合にヒントテキストが含まれる", () => {
+		const msg = createMessage({ isBot: true });
+		const result = formatDiscordMessage(msg);
+		expect(result).toContain("[bot-interaction-hint:");
+	});
+
+	test("非 bot メッセージの場合にヒントテキストが含まれない", () => {
+		const msg = createMessage({ isBot: false });
+		const result = formatDiscordMessage(msg);
+		expect(result).not.toContain("[bot-interaction-hint:");
+	});
+
+	test("system メッセージ（authorId === 'system'）の場合にヒントテキストが含まれない", () => {
+		const msg = createMessage({ authorId: "system", isBot: false });
+		const result = formatDiscordMessage(msg);
+		expect(result).not.toContain("[bot-interaction-hint:");
+	});
+});
+
 describe("formatDiscordMessage 添付フォーマット", () => {
 	test("url が undefined の添付は [添付: filename (contentType) undefined] としてフォーマットされる", () => {
 		const msg = createMessage({

--- a/packages/agent/src/discord/message-formatter.ts
+++ b/packages/agent/src/discord/message-formatter.ts
@@ -28,6 +28,11 @@ export function formatDiscordMessage(msg: IncomingMessage): string {
 	const parts = [`[${ts} JST ${channel}] ${msg.authorName}: ${content}`];
 	if (attachments) parts.push(attachments);
 	parts.push(`[action: ${hint}]`);
+	if (msg.isBot) {
+		parts.push(
+			"[bot-interaction-hint: このメッセージはbotからです。会話を自然に終結させることを意識してください。相手の発言を繰り返すだけの応答や、新たな質問で会話を引き延ばすことは避けてください。話題が一段落したら、返答せずに会話を終えても構いません。]",
+		);
+	}
 
 	return parts.join(" ");
 }

--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -1548,7 +1548,7 @@ class DebounceTestAgent extends AgentRunner {
 }
 
 describe("AgentRunner デバウンス機構（内部ロジック）", () => {
-	test("新メッセージが来なければ MESSAGE_DEBOUNCE_MS (2000ms) の sleep 後にデバウンス完了する", async () => {
+	test("新メッセージが来なければ MESSAGE_DEBOUNCE_MS (500ms) の sleep 後にデバウンス完了する", async () => {
 		const sleepCalls: number[] = [];
 		const sleepDeferreds: Array<{ resolve: () => void }> = [];
 		const runner = new DebounceTestAgent({
@@ -1575,9 +1575,9 @@ describe("AgentRunner デバウンス機構（内部ロジック）", () => {
 		const ac = new AbortController();
 		const debouncePromise = runner.callWaitForDebounce(ac.signal);
 
-		// sleep(2000) が呼ばれる
+		// sleep(500) が呼ばれる
 		await Bun.sleep(0);
-		expect(sleepCalls).toEqual([2000]);
+		expect(sleepCalls).toEqual([500]);
 
 		// sleep を resolve → pendingMessages が変わっていないのでデバウンス完了
 		sleepDeferreds.at(0)?.resolve();
@@ -1615,9 +1615,9 @@ describe("AgentRunner デバウンス機構（内部ロジック）", () => {
 		const debouncePromise = runner.callWaitForDebounce(ac.signal);
 		await Bun.sleep(0);
 
-		// 最初の sleep(2000) が呼ばれている
+		// 最初の sleep(500) が呼ばれている
 		expect(sleepCalls.length).toBe(1);
-		expect(sleepCalls[0]).toBe(2000);
+		expect(sleepCalls[0]).toBe(500);
 
 		// 新メッセージ送信 → pendingDebounceResolve が呼ばれて race が解決する
 		await runner.send({ sessionKey: "k", message: "msg2" });
@@ -1626,7 +1626,7 @@ describe("AgentRunner デバウンス機構（内部ロジック）", () => {
 		await Bun.sleep(0);
 		await Bun.sleep(0);
 		expect(sleepCalls.length).toBe(2);
-		expect(sleepCalls[1]).toBe(2000); // タイマーリセット: 再び 2000ms
+		expect(sleepCalls[1]).toBe(500); // タイマーリセット: 再び 500ms
 
 		// 2回目の sleep を resolve → メッセージが来ていないのでデバウンス完了
 		sleepDeferreds.at(1)?.resolve();
@@ -1665,10 +1665,10 @@ describe("AgentRunner デバウンス機構（内部ロジック）", () => {
 		await runner.send({ sessionKey: "k", message: "msg1" });
 
 		// now=0, deadline=10000
-		// ループ内: sleep(2000) → now=2000, メッセージ追加 → ループ継続
-		// sleep(2000) → now=4000, メッセージ追加 → ループ継続
+		// ループ内: sleep(500) → now=500, メッセージ追加 → ループ継続
+		// sleep(500) → now=1000, メッセージ追加 → ループ継続
 		// ...
-		// sleep(2000) → now=10000, メッセージ追加なし → remaining<=0 で break
+		// sleep(500) → now=10000, メッセージ追加なし → remaining<=0 で break
 		await runner.callWaitForDebounce(new AbortController().signal);
 
 		// MAX_DEBOUNCE_MS (10000) の範囲内でループが複数回実行された後に終了
@@ -1735,7 +1735,7 @@ describe("AgentRunner デバウンス機構（内部ロジック）", () => {
 		runner.sleepSpy = (ms) => {
 			sleepCalls.push(ms);
 			// 毎回 now を大きく進めて remaining を小さくする
-			now += 9000;
+			now += 9800;
 			sendCount += 1;
 			if (sendCount <= 2) {
 				void runner.send({ sessionKey: "k", message: `msg-${sendCount}` });
@@ -1747,14 +1747,222 @@ describe("AgentRunner デバウンス機構（内部ロジック）", () => {
 		await runner.send({ sessionKey: "k", message: "msg-start" });
 
 		// now=0, deadline=10000
-		// 1回目: remaining=10000, waitMs=min(2000,10000)=2000, now→9000, msg追加
-		// 2回目: remaining=10000-9000=1000, waitMs=min(2000,1000)=1000, now→18000, msg追加
-		// 3回目: remaining=10000-18000<0 → break
+		// 1回目: remaining=10000, waitMs=min(500,10000)=500, now→9800, msg追加
+		// 2回目: remaining=10000-9800=200, waitMs=min(500,200)=200, now→19600, msg追加
+		// 3回目: remaining=10000-19600<0 → break
 		await runner.callWaitForDebounce(new AbortController().signal);
 
-		expect(sleepCalls[0]).toBe(2000);
-		expect(sleepCalls[1]).toBe(1000); // remaining にクランプされた
+		expect(sleepCalls[0]).toBe(500);
+		expect(sleepCalls[1]).toBe(200); // remaining にクランプされた
 		expect(sleepCalls.length).toBe(2); // deadline 超過で 3回目は呼ばれない
+
+		runner.stop();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 推論中断・bot デバウンス（ホワイトボックス）
+// send() 中断 / hasBotPending / sessionAbortController
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AgentRunner 推論中断・bot デバウンス（内部ロジック）", () => {
+	test("send({ isBot: true }) で hasBotPending が true になり、drainMessages 後に false にリセットされる", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => sessionDone.promise);
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		activeRunners.add(runner);
+
+		// isBot: true でメッセージ送信
+		await runner.send({ sessionKey: "k", message: "bot msg", isBot: true });
+		// @ts-expect-error -- private フィールド。ホワイトボックステストのため許容
+		expect(runner.hasBotPending).toBe(true);
+
+		// ポーリングループが drainMessages を呼ぶまで待つ
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// drainMessages 後に hasBotPending が false にリセットされている
+		// @ts-expect-error -- private フィールド。ホワイトボックステストのため許容
+		expect(runner.hasBotPending).toBe(false);
+
+		runner.stop();
+		sessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("send({ isBot: false }) では hasBotPending が false のまま", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => sessionDone.promise);
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		activeRunners.add(runner);
+
+		await runner.send({ sessionKey: "k", message: "user msg" });
+		// @ts-expect-error -- private フィールド。ホワイトボックステストのため許容
+		expect(runner.hasBotPending).toBe(false);
+
+		runner.stop();
+		sessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("推論中に send() すると sessionAbortController が abort され、lastPromptText が pendingMessages に保全される", async () => {
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		let sessionWatchCount = 0;
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			return sessionWatchCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+		});
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		// 最初のメッセージでセッション開始
+		await runner.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(1);
+
+		// sessionWatch が pending 状態（推論中）のまま新メッセージを送信
+		await runner.send({ sessionKey: "k", message: "interrupt" });
+
+		// cancelled イベントで firstSessionDone を解決（abort による）
+		firstSessionDone.resolve({ type: "cancelled" });
+		// ループが回って2回目のプロンプトが送信されるまで待つ
+		for (let i = 0; i < 10; i++) {
+			// eslint-disable-next-line no-await-in-loop
+			await Bun.sleep(0);
+		}
+
+		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(2);
+		// 2回目のプロンプトに "first" と "interrupt" の両方が含まれている（保全されたテキスト + 新メッセージ）
+		const secondCallArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[1] as unknown[];
+		const params = secondCallArgs[0] as { text: string };
+		expect(params.text).toContain("first");
+		expect(params.text).toContain("interrupt");
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("stop() が sessionAbortController を abort する", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => sessionDone.promise);
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		activeRunners.add(runner);
+
+		await runner.send({ sessionKey: "k", message: "test" });
+		await Bun.sleep(0);
+
+		// sessionAbortController が生成されている
+		// @ts-expect-error -- private フィールド。ホワイトボックステストのため許容
+		const sac = runner.sessionAbortController;
+		expect(sac).not.toBeNull();
+
+		runner.stop();
+
+		// stop 後に sessionAbortController が null になっている
+		// @ts-expect-error -- private フィールド。ホワイトボックステストのため許容
+		expect(runner.sessionAbortController).toBeNull();
+
+		sessionDone.resolve({ type: "cancelled" });
+	});
+});
+
+describe("AgentRunner bot デバウンス: waitForDebounce の BOT_MAX_DEBOUNCE_MS 拡張", () => {
+	test("hasBotPending=true の場合、silence だけではデバウンスが終了しない（deadline まで待機）", async () => {
+		const sleepCalls: number[] = [];
+		let now = 0;
+		const runner = new DebounceTestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: createSessionPort(() => deferred<OpencodeSessionEvent>().promise),
+			sessionMaxAgeMs: 3_600_000,
+			nowProvider: () => now,
+		});
+		runner.sleepSpy = (ms) => {
+			sleepCalls.push(ms);
+			now += ms;
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		// bot メッセージ → hasBotPending = true
+		await runner.send({ sessionKey: "k", message: "bot msg", isBot: true });
+
+		const ac = new AbortController();
+		await runner.callWaitForDebounce(ac.signal);
+
+		// BOT_MAX_DEBOUNCE_MS (30000) の deadline まで sleep が繰り返される
+		const totalSleep = sleepCalls.reduce((a, b) => a + b, 0);
+		expect(totalSleep).toBe(30000);
+		// 500ms 刻みで 60 回
+		expect(sleepCalls.length).toBe(60);
+
+		runner.stop();
+	});
+
+	test("hasBotPending=false の場合、silence で即座にデバウンスが終了する", async () => {
+		const sleepCalls: number[] = [];
+		let now = 0;
+		const runner = new DebounceTestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: createSessionPort(() => deferred<OpencodeSessionEvent>().promise),
+			sessionMaxAgeMs: 3_600_000,
+			nowProvider: () => now,
+		});
+		runner.sleepSpy = (ms) => {
+			sleepCalls.push(ms);
+			now += ms;
+			return Promise.resolve();
+		};
+		activeRunners.add(runner);
+
+		// 通常メッセージ → hasBotPending = false
+		await runner.send({ sessionKey: "k", message: "user msg" });
+
+		const ac = new AbortController();
+		await runner.callWaitForDebounce(ac.signal);
+
+		// 1回の sleep(500) でデバウンス完了
+		expect(sleepCalls).toEqual([500]);
 
 		runner.stop();
 	});

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -179,9 +179,9 @@ export class AgentRunner implements AiAgent {
 				if (signal.aborted) return;
 				this.handleSessionEnd(event);
 				if (event.type === "cancelled") {
-					// runner stop による中断: ループを終了
+					// runner stop による中断
 					if (signal.aborted) return;
-					// セッション中断: 新メッセージと旧メッセージをまとめて再送するためループ継続
+					// 追いメッセージによるセッション中断 → 旧+新メッセージをまとめて再プロンプト
 					this.lastPromptText = null;
 					this.lastPromptAttachments = null;
 					this.sessionAbortController = null;

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -21,8 +21,9 @@ const MAX_RECONNECT_DELAY_MS = 10_000;
 const INITIAL_RECONNECT_DELAY_MS = 2_000;
 const IDLE_COOLDOWN_MS = 2_000;
 const DEFAULT_SUMMARY_TIMEOUT_MS = 30_000;
-const MESSAGE_DEBOUNCE_MS = 2_000;
+const MESSAGE_DEBOUNCE_MS = 500;
 const MAX_DEBOUNCE_MS = 10_000;
+const BOT_MAX_DEBOUNCE_MS = 30_000;
 
 export interface RunnerDeps {
 	profile: AgentProfile;
@@ -49,6 +50,7 @@ export interface RunnerDeps {
 
 export class AgentRunner implements AiAgent {
 	private abortController: AbortController | null = null;
+	private sessionAbortController: AbortController | null = null;
 	private running = false;
 	private sessionCreatedAt: number | null = null;
 	private sessionWatch: Promise<OpencodeSessionEvent> | null = null;
@@ -62,6 +64,7 @@ export class AgentRunner implements AiAgent {
 	private lastPromptText: string | null = null;
 	private lastPromptAttachments: Attachment[] | null = null;
 	private pendingDebounceResolve: (() => void) | null = null;
+	private hasBotPending = false;
 
 	private readonly profile: AgentProfile;
 	private readonly agentId: string;
@@ -103,8 +106,23 @@ export class AgentRunner implements AiAgent {
 
 	send(options: SendOptions): Promise<AgentResponse> {
 		this.pendingMessages.push({ text: options.message, attachments: options.attachments });
+		if (options.isBot) this.hasBotPending = true;
 		this.pendingResolve?.();
 		this.pendingDebounceResolve?.();
+
+		// 推論中（sessionWatch が pending）なら中断して旧メッセージを保全
+		if (this.sessionWatch) {
+			if (this.lastPromptText !== null) {
+				this.pendingMessages.unshift({
+					text: this.lastPromptText,
+					attachments: this.lastPromptAttachments ?? undefined,
+				});
+			}
+			this.lastPromptText = null;
+			this.lastPromptAttachments = null;
+			this.sessionAbortController?.abort();
+		}
+
 		this.ensurePolling();
 		return Promise.resolve({ text: "", sessionId: "queued" });
 	}
@@ -160,7 +178,16 @@ export class AgentRunner implements AiAgent {
 				);
 				if (signal.aborted) return;
 				this.handleSessionEnd(event);
-				if (event.type === "cancelled") return;
+				if (event.type === "cancelled") {
+					// runner stop による中断: ループを終了
+					if (signal.aborted) return;
+					// セッション中断: 新メッセージと旧メッセージをまとめて再送するためループ継続
+					this.lastPromptText = null;
+					this.lastPromptAttachments = null;
+					this.sessionAbortController = null;
+					resetBackoffState();
+					continue;
+				}
 
 				if (event.type === "deleted") {
 					this.metrics?.incrementCounter(METRIC.SESSION_RESTARTS, {
@@ -297,6 +324,8 @@ export class AgentRunner implements AiAgent {
 
 	stop(): void {
 		this.running = false;
+		this.sessionAbortController?.abort();
+		this.sessionAbortController = null;
 		this.abortController?.abort();
 		this.abortController = null;
 		this.sessionWatch = null;
@@ -366,6 +395,8 @@ export class AgentRunner implements AiAgent {
 
 		this.logger.info(`[${this.profile.name}:${this.agentId}] prompting session ${sessionId}`);
 
+		this.sessionAbortController = new AbortController();
+		const combinedSignal = AbortSignal.any([signal, this.sessionAbortController.signal]);
 		this.sessionWatch = this.sessionPort.promptAsyncAndWatchSession(
 			{
 				sessionId,
@@ -377,7 +408,7 @@ export class AgentRunner implements AiAgent {
 				system,
 				attachments: attachments.length > 0 ? attachments : undefined,
 			},
-			signal,
+			combinedSignal,
 		);
 		this.hasStartedSession = true;
 	}
@@ -396,7 +427,8 @@ export class AgentRunner implements AiAgent {
 
 	// oxlint-disable-next-line no-await-in-loop -- デバウンスループは意図的に逐次待機する
 	protected async waitForDebounce(signal: AbortSignal): Promise<void> {
-		const deadline = this.nowProvider() + MAX_DEBOUNCE_MS;
+		const deadline =
+			this.nowProvider() + (this.hasBotPending ? BOT_MAX_DEBOUNCE_MS : MAX_DEBOUNCE_MS);
 		let messageCountBefore = this.pendingMessages.length;
 
 		while (!signal.aborted) {
@@ -407,33 +439,41 @@ export class AgentRunner implements AiAgent {
 
 			// sleep と新メッセージ到着を race
 			// oxlint-disable-next-line no-await-in-loop -- デバウンスループは意図的に逐次待機する
-			await this.raceDebounce(waitMs, signal);
+			const arrived = await this.raceDebounce(waitMs, signal);
 
 			if (signal.aborted) break;
 
 			// 新メッセージが来ていなければデバウンス完了
-			if (this.pendingMessages.length === messageCountBefore) break;
+			// bot メッセージが含まれる場合は deadline まで待機し続ける
+			// （bot 応答は連続到着が多いため、短い silence で打ち切らない）
+			if (!arrived && this.pendingMessages.length === messageCountBefore && !this.hasBotPending)
+				break;
 			messageCountBefore = this.pendingMessages.length;
 		}
 	}
 
-	private async raceDebounce(waitMs: number, signal: AbortSignal): Promise<void> {
-		const sleepPromise = this.sleep(waitMs);
-		const messagePromise = new Promise<void>((resolve) => {
-			this.pendingDebounceResolve = resolve;
+	/** デバウンス待機。新メッセージが到着した場合に true を返す */
+	private async raceDebounce(waitMs: number, signal: AbortSignal): Promise<boolean> {
+		const MESSAGE = Symbol("message");
+		const TIMER = Symbol("timer");
+		const sleepPromise = this.sleep(waitMs).then(() => TIMER);
+		const messagePromise = new Promise<typeof MESSAGE>((resolve) => {
+			this.pendingDebounceResolve = () => resolve(MESSAGE);
 		});
 		let onAbort: (() => void) | undefined;
-		const abortPromise = new Promise<void>((resolve) => {
-			onAbort = () => resolve();
+		const abortPromise = new Promise<typeof TIMER>((resolve) => {
+			onAbort = () => resolve(TIMER);
 			signal.addEventListener("abort", onAbort, { once: true });
 		});
-		await Promise.race([sleepPromise, messagePromise, abortPromise]);
+		const winner = await Promise.race([sleepPromise, messagePromise, abortPromise]);
 		this.pendingDebounceResolve = null;
 		if (onAbort) signal.removeEventListener("abort", onAbort);
+		return winner === MESSAGE;
 	}
 
 	private drainMessages(): { text: string; attachments: Attachment[] } {
 		const items = this.pendingMessages.splice(0);
+		this.hasBotPending = false;
 		return {
 			text: items.map((m) => m.text).join("\n---\n"),
 			attachments: items.flatMap((m) => m.attachments ?? []),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -171,6 +171,7 @@ export interface SendOptions {
 	guildId?: string;
 	attachments?: Attachment[];
 	channelId?: string;
+	isBot?: boolean;
 }
 
 export interface AiAgent {

--- a/spec/agent/discord/message-formatter.spec.ts
+++ b/spec/agent/discord/message-formatter.spec.ts
@@ -180,4 +180,18 @@ describe("formatDiscordMessage", () => {
 		expect(result).toContain("&lt;user_message&gt;");
 		expect(result).toContain("&lt;/user_message&gt;");
 	});
+
+	test("bot メッセージ（isBot: true）には [bot-interaction-hint: を含むヒントが付加される", () => {
+		const msg = createMessage({ isBot: true, content: "bot response" });
+		const result = formatDiscordMessage(msg);
+
+		expect(result).toContain("[bot-interaction-hint:");
+	});
+
+	test("非 bot メッセージ（isBot: false）には [bot-interaction-hint が含まれない", () => {
+		const msg = createMessage({ isBot: false, content: "user message" });
+		const result = formatDiscordMessage(msg);
+
+		expect(result).not.toContain("[bot-interaction-hint");
+	});
 });

--- a/spec/agent/runner-debounce.spec.ts
+++ b/spec/agent/runner-debounce.spec.ts
@@ -184,7 +184,7 @@ describe("メッセージデバウンス", () => {
 		await Bun.sleep(0);
 
 		// デバウンス中に継続的にメッセージを送り続ける（最大待機時間を超過させる）
-		// MAX_DEBOUNCE_MS (10000ms) / MESSAGE_DEBOUNCE_MS (2000ms) = 5回以上のリセットで超過
+		// MAX_DEBOUNCE_MS (10000ms) / MESSAGE_DEBOUNCE_MS (500ms) = 20回以上のリセットで超過
 		// oxlint-disable-next-line no-await-in-loop -- テスト用の逐次送信
 		for (let i = 0; i < 8; i++) {
 			await runner.send({ sessionKey: "k", message: `追い${i}` });
@@ -300,5 +300,247 @@ describe("メッセージデバウンス", () => {
 
 		runner.stop();
 		secondSessionDone.resolve({ type: "cancelled" });
+	});
+});
+
+// ─── 推論中断 ─────────────────────────────────────────────────────
+
+describe("推論中断", () => {
+	test("推論中に send() が呼ばれたらセッションが中断され、旧メッセージ + 新メッセージがまとめて再プロンプトされる", async () => {
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		let promptCallCount = 0;
+		const sessionPort = {
+			createSession: mock(() => Promise.resolve("session-1")),
+			sessionExists: mock(() => Promise.resolve(false)),
+			prompt: mock(() => Promise.resolve({ text: "要約テキスト", tokens: undefined })),
+			promptAsync: mock(() => Promise.resolve()),
+			promptAsyncAndWatchSession: mock(() => {
+				promptCallCount += 1;
+				return promptCallCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+			}),
+			waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
+			deleteSession: mock(() => Promise.resolve()),
+			summarizeSession: mock(() => Promise.resolve()),
+			close: mock(() => {}),
+		} as unknown as OpencodeSessionPort;
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		runner.enableDebounce = true;
+		activeRunners.add(runner);
+
+		// 1通目を送信 → デバウンス → promptAsyncAndWatchSession が pending
+		await runner.send({ sessionKey: "k", message: "original question" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 推論中（promptAsyncAndWatchSession が pending の状態）に 2通目を送信
+		await runner.send({ sessionKey: "k", message: "follow up" });
+		await Bun.sleep(0);
+
+		// セッションが中断される（cancelled イベント）
+		firstSessionDone.resolve({ type: "cancelled" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 2回目のプロンプトには旧メッセージ + 新メッセージが含まれる
+		const calls = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBeGreaterThanOrEqual(2);
+		const secondParams = calls.at(1)?.[0] as { text: string } | undefined;
+		expect(secondParams?.text).toContain("original question");
+		expect(secondParams?.text).toContain("follow up");
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("推論中断後、lastPromptText は null にリセットされる（デバウンスフローに戻る）", async () => {
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		let promptCallCount = 0;
+		const sleepCalls: number[] = [];
+		const sessionPort = {
+			createSession: mock(() => Promise.resolve("session-1")),
+			sessionExists: mock(() => Promise.resolve(false)),
+			prompt: mock(() => Promise.resolve({ text: "要約テキスト", tokens: undefined })),
+			promptAsync: mock(() => Promise.resolve()),
+			promptAsyncAndWatchSession: mock(() => {
+				promptCallCount += 1;
+				return promptCallCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+			}),
+			waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
+			deleteSession: mock(() => Promise.resolve()),
+			summarizeSession: mock(() => Promise.resolve()),
+			close: mock(() => {}),
+		} as unknown as OpencodeSessionPort;
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = (ms: number) => {
+			sleepCalls.push(ms);
+			return Promise.resolve();
+		};
+		runner.enableDebounce = true;
+		activeRunners.add(runner);
+
+		// 1通目 → デバウンス → 推論開始
+		await runner.send({ sessionKey: "k", message: "msg1" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 推論中に 2通目を送信 → 中断
+		await runner.send({ sessionKey: "k", message: "msg2" });
+		await Bun.sleep(0);
+		firstSessionDone.resolve({ type: "cancelled" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 中断後はリトライパス（バックオフ sleep のみ）ではなく
+		// デバウンスフロー（waitForMessages + waitForDebounce）に戻る。
+		// つまり lastPromptText が null にリセットされている。
+		// デバウンス sleep (500ms) が呼ばれていることで確認できる。
+		const hasDebounce = sleepCalls.some((ms) => ms === 500);
+		expect(promptCallCount).toBeGreaterThanOrEqual(2);
+		// デバウンスフローを通っていれば 500ms の sleep が存在する
+		expect(hasDebounce).toBe(true);
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+});
+
+// ─── bot 用デバウンス延長 ─────────────────────────────────────────
+
+describe("bot 用デバウンス延長", () => {
+	test("isBot: true の場合、MAX_DEBOUNCE_MS が 30秒に延長される", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPortForDebounce(sessionDone.promise);
+
+		let now = 0;
+		const sleepCalls: number[] = [];
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			sessionMaxAgeMs: 3_600_000,
+			nowProvider: () => now,
+		});
+		runner.sleepSpy = (ms: number) => {
+			sleepCalls.push(ms);
+			now += ms;
+			return Promise.resolve();
+		};
+		runner.enableDebounce = true;
+		activeRunners.add(runner);
+
+		// bot メッセージを送信（isBot: true）
+		await runner.send({ sessionKey: "k", message: "bot output", isBot: true } as never);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 継続的にメッセージを送り続ける（MAX_DEBOUNCE_MS = 30000ms を超過させる）
+		// MESSAGE_DEBOUNCE_MS (500ms) で 60回以上のリセットが必要
+		for (let i = 0; i < 70; i++) {
+			await runner.send({ sessionKey: "k", message: `bot追い${i}`, isBot: true } as never);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+		}
+
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 最終的にプロンプトが送信される
+		const calls = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBeGreaterThanOrEqual(1);
+
+		// 合計待機時間が通常の MAX_DEBOUNCE_MS (10000ms) を超えていること
+		// → bot 用の延長 (30000ms) が適用されている
+		const totalSleepMs = sleepCalls.reduce((a, b) => a + b, 0);
+		expect(totalSleepMs).toBeGreaterThan(10_000);
+		expect(totalSleepMs).toBeLessThanOrEqual(30_000);
+
+		runner.stop();
+		sessionDone.resolve({ type: "cancelled" });
+	});
+
+	test("isBot: false の場合、通常の MAX_DEBOUNCE_MS (10秒) が適用される", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPortForDebounce(sessionDone.promise);
+
+		let now = 0;
+		const sleepCalls: number[] = [];
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			sessionMaxAgeMs: 3_600_000,
+			nowProvider: () => now,
+		});
+		runner.sleepSpy = (ms: number) => {
+			sleepCalls.push(ms);
+			now += ms;
+			return Promise.resolve();
+		};
+		runner.enableDebounce = true;
+		activeRunners.add(runner);
+
+		// 通常メッセージを送信（isBot: false / デフォルト）
+		await runner.send({ sessionKey: "k", message: "user msg" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		// 継続的にメッセージを送り続ける
+		for (let i = 0; i < 30; i++) {
+			await runner.send({ sessionKey: "k", message: `追い${i}` });
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+		}
+
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const calls = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBeGreaterThanOrEqual(1);
+
+		// 合計待機時間が通常の MAX_DEBOUNCE_MS (10000ms) を超えていないこと
+		const totalSleepMs = sleepCalls.reduce((a, b) => a + b, 0);
+		expect(totalSleepMs).toBeLessThanOrEqual(10_000);
+
+		runner.stop();
+		sessionDone.resolve({ type: "cancelled" });
 	});
 });


### PR DESCRIPTION
## Summary

- **デバウンス短縮**: `MESSAGE_DEBOUNCE_MS` を 2s → 500ms に変更。LLM の生成速度を考慮し、応答開始までの待ち時間を短縮
- **推論中断**: 推論中に追いメッセージが到着したら `sessionAbortController` で中断し、旧メッセージ + 新メッセージをまとめて再プロンプト。従来は推論完了後に逐一処理されていた問題を解消
- **bot メッセージ対応**: bot からのメッセージ時はデバウンス上限を 30s に延長（連続到着が多いため）。`[bot-interaction-hint]` を付加し、無限会話ループを抑制

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `packages/agent/src/runner.ts` | デバウンス短縮、推論中断（sessionAbortController）、bot用デバウンス延長 |
| `packages/shared/src/types.ts` | `SendOptions` に `isBot?: boolean` 追加 |
| `packages/agent/src/discord/message-formatter.ts` | bot メッセージに `[bot-interaction-hint]` 付加 |
| `apps/discord/src/bootstrap.ts` | `send()` に `isBot: msg.isBot` を伝播 |

## Test plan

- [x] `nr validate` (fmt + lint + check) 全 PASS
- [x] `nr test` 全 2103 テスト PASS
- [x] 仕様テスト: 推論中断2件、bot用デバウンス2件、bot-interaction-hint 2件を追加
- [x] ユニットテスト: 推論中断・bot デバウンス内部ロジック6件、bot-interaction-hint 3件を追加
- [ ] デプロイ後に実際の Discord 環境で追いメッセージ・bot間会話を動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)