### PR TITLE
fix: bot-interaction-hint の文言を内発的判断を促す汎用表現に変更

### DIFF
--- a/packages/agent/src/discord/message-formatter.ts
+++ b/packages/agent/src/discord/message-formatter.ts
@@ -30,7 +30,7 @@ export function formatDiscordMessage(msg: IncomingMessage): string {
 	parts.push(`[action: ${hint}]`);
 	if (msg.isBot) {
 		parts.push(
-			"[bot-interaction-hint: このメッセージはbotからです。会話を自然に終結させることを意識してください。相手の発言を繰り返すだけの応答や、新たな質問で会話を引き延ばすことは避けてください。話題が一段落したら、返答せずに会話を終えても構いません。]",
+			"[bot-interaction-hint: このメッセージはbotによるものです。返事をするかどうかはあなた次第です。同じ話の繰り返しや義務的な相槌は要りません。話が一段落したなら、黙っていても構いません。]",
 		);
 	}
 


### PR DESCRIPTION
## Summary

- bot-interaction-hint の文言を外部制約的な「～してください」形式から、自律的判断の情報提供に変更
- キャラクター固有名（「ふあ」等）を使わず、人格差し替えに対応可能な汎用文言にした
- 無限ループ防止の機能要件（返事しなくてよい旨の伝達）は維持

### 変更内容

| 旧 | 新 |
|---|---|
| 会話を自然に終結させることを意識してください | 返事をするかどうかはあなた次第です |
| 相手の発言を繰り返すだけの応答や、新たな質問で会話を引き延ばすことは避けてください | 同じ話の繰り返しや義務的な相槌は要りません |
| 話題が一段落したら、返答せずに会話を終えても構いません | 話が一段落したなら、黙っていても構いません |

## Test plan

- [x] `message-formatter.test.ts` — 8 pass
- [x] `message-formatter.spec.ts` — 21 pass
- [x] `nr validate` — pass

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)