### PR TITLE
refactor: ループラッパー共通関数を loop-runner.ts に抽出

### DIFF
--- a/scripts/auto-triage.ts
+++ b/scripts/auto-triage.ts
@@ -1,6 +1,8 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { extractAssistantText, formatTimestamp, tee } from "./lib/loop-runner";
+
 const PROJECT_DIR = resolve(import.meta.dirname, "..");
 const LOG_DIR = resolve(PROJECT_DIR, "logs/auto-triage");
 const MAX_BUDGET_USD = 10;
@@ -8,35 +10,6 @@ const MAX_BUDGET_USD = 10;
 const INTERVAL_SEC = 1 * 60 * 60;
 /** 30 minutes — kill claude if no stdout output for this duration */
 const STALL_TIMEOUT_MS = 30 * 60 * 1000;
-
-const pad2 = (n: number) => String(n).padStart(2, "0");
-
-function formatTimestamp(): string {
-	const now = new Date();
-	return `${now.getFullYear()}${pad2(now.getMonth() + 1)}${pad2(now.getDate())}-${pad2(now.getHours())}${pad2(now.getMinutes())}${pad2(now.getSeconds())}`;
-}
-
-function tee(msg: string, logFile: string): void {
-	console.log(msg);
-	appendFileSync(logFile, `${msg}\n`);
-}
-
-function extractAssistantText(line: string): string[] {
-	try {
-		const obj = JSON.parse(line);
-		if (obj.type !== "assistant") return [];
-		const contents: unknown[] = obj.message?.content ?? [];
-		return contents
-			.filter(
-				(c): c is { type: "text"; text: string } =>
-					(c as { type: string }).type === "text" &&
-					typeof (c as { text: unknown }).text === "string",
-			)
-			.map((c) => c.text);
-	} catch {
-		return [];
-	}
-}
 
 /** gh issue list から help wanted を除いた issue があるか、または CI が失敗しているかを返す */
 async function hasWork(): Promise<{ hasCiFailure: boolean; hasIssue: boolean }> {

--- a/scripts/character-audit.ts
+++ b/scripts/character-audit.ts
@@ -9,6 +9,8 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { extractAssistantText, formatTimestamp, tee } from "./lib/loop-runner";
+
 const PROJECT_DIR = resolve(import.meta.dirname, "..");
 const LOG_DIR = resolve(PROJECT_DIR, "logs/character-audit");
 const MAX_BUDGET_USD = 5;
@@ -16,35 +18,6 @@ const MAX_BUDGET_USD = 5;
 const INTERVAL_SEC = 12 * 60 * 60;
 /** 30 minutes — kill claude if no stdout output for this duration */
 const STALL_TIMEOUT_MS = 30 * 60 * 1000;
-
-const pad2 = (n: number) => String(n).padStart(2, "0");
-
-function formatTimestamp(): string {
-	const now = new Date();
-	return `${now.getFullYear()}${pad2(now.getMonth() + 1)}${pad2(now.getDate())}-${pad2(now.getHours())}${pad2(now.getMinutes())}${pad2(now.getSeconds())}`;
-}
-
-function tee(msg: string, logFile: string): void {
-	console.log(msg);
-	appendFileSync(logFile, `${msg}\n`);
-}
-
-function extractAssistantText(line: string): string[] {
-	try {
-		const obj = JSON.parse(line);
-		if (obj.type !== "assistant") return [];
-		const contents: unknown[] = obj.message?.content ?? [];
-		return contents
-			.filter(
-				(c): c is { type: "text"; text: string } =>
-					(c as { type: string }).type === "text" &&
-					typeof (c as { text: unknown }).text === "string",
-			)
-			.map((c) => c.text);
-	} catch {
-		return [];
-	}
-}
 
 /** extract-audit-data.ts を実行して、評価対象のエピソードがあるか確認する */
 async function hasData(): Promise<boolean> {

--- a/scripts/lib/loop-runner.ts
+++ b/scripts/lib/loop-runner.ts
@@ -1,0 +1,35 @@
+/**
+ * loop-runner.ts — ループラッパースクリプト共通ユーティリティ。
+ *
+ * auto-triage.ts / character-audit.ts 等で共有される関数群。
+ */
+import { appendFileSync } from "node:fs";
+
+export const pad2 = (n: number) => String(n).padStart(2, "0");
+
+export function formatTimestamp(): string {
+	const now = new Date();
+	return `${now.getFullYear()}${pad2(now.getMonth() + 1)}${pad2(now.getDate())}-${pad2(now.getHours())}${pad2(now.getMinutes())}${pad2(now.getSeconds())}`;
+}
+
+export function tee(msg: string, logFile: string): void {
+	console.log(msg);
+	appendFileSync(logFile, `${msg}\n`);
+}
+
+export function extractAssistantText(line: string): string[] {
+	try {
+		const obj = JSON.parse(line);
+		if (obj.type !== "assistant") return [];
+		const contents: unknown[] = obj.message?.content ?? [];
+		return contents
+			.filter(
+				(c): c is { type: "text"; text: string } =>
+					(c as { type: string }).type === "text" &&
+					typeof (c as { text: unknown }).text === "string",
+			)
+			.map((c) => c.text);
+	} catch {
+		return [];
+	}
+}


### PR DESCRIPTION
## Summary
- `scripts/auto-triage.ts` と `scripts/character-audit.ts` で完全重複していた 4 関数 (`pad2`, `formatTimestamp`, `tee`, `extractAssistantText`) を `scripts/lib/loop-runner.ts` に抽出
- 両ファイルから関数定義を削除し、import に置換

Closes #800

## Test plan
- [x] `nr validate` — scripts 関連のエラーなし（既存の minecraft/web エラーのみ）
- [x] `nr test` — scripts 関連の失敗なし（既存の minecraft 依存エラーのみ）
- [x] correctness-reviewer による差分レビュー済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)