### PR TITLE
feat: CriticAuditor によるキャラクター一貫性監査

### DIFF
--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -19,6 +19,7 @@
 		"./segmenter": "./src/segmenter.ts",
 		"./consolidation": "./src/consolidation.ts",
 		"./fsrs": "./src/fsrs.ts",
-		"./drift-score": "./src/drift-score.ts"
+		"./drift-score": "./src/drift-score.ts",
+		"./critic-auditor": "./src/critic-auditor.ts"
 	}
 }

--- a/packages/memory/src/critic-auditor.ts
+++ b/packages/memory/src/critic-auditor.ts
@@ -1,0 +1,172 @@
+import type { DriftScore, DriftScoreCalculator } from "./drift-score.ts";
+import type { MemoryLlmPort, Schema } from "./llm-port.ts";
+import type { SemanticFact } from "./semantic-fact.ts";
+import { createFact } from "./semantic-fact.ts";
+import type { MemoryStorage } from "./storage.ts";
+import type { ChatMessage } from "./types.ts";
+import { escapeXmlContent } from "./utils.ts";
+
+// ─── Public types ───────────────────────────────────────────────
+
+export type CriticSeverity = "none" | "minor" | "major";
+
+export interface CriticResult {
+	severity: CriticSeverity;
+	summary: string;
+	guidelineFact?: string;
+	guidelineKeywords?: string[];
+	issueTitle?: string;
+	issueBody?: string;
+}
+
+// ─── Constants ──────────────────────────────────────────────────
+
+const NINETY_MINUTES_MS = 90 * 60_000;
+const RECENT_EPISODE_LIMIT = 20;
+const DRIFT_SKIP_THRESHOLD = 0.03;
+const MIN_EPISODES_FOR_CHEAP_SKIP = 3;
+
+const VALID_SEVERITIES = new Set<string>(["none", "minor", "major"]);
+
+// ─── CriticAuditor ──────────────────────────────────────────────
+
+export class CriticAuditor {
+	constructor(
+		private readonly llm: MemoryLlmPort,
+		private readonly storage: MemoryStorage,
+		private readonly driftCalculator: DriftScoreCalculator,
+		private readonly characterDefinition: string,
+	) {}
+
+	/** 直近の応答を監査し、キャラクター一貫性を評価する */
+	async audit(userId: string): Promise<CriticResult | null> {
+		const sinceMs = Date.now() - NINETY_MINUTES_MS;
+		const episodes = await this.storage.getRecentEpisodes(userId, sinceMs, RECENT_EPISODE_LIMIT);
+
+		// assistant メッセージを抽出
+		const assistantMessages: ChatMessage[] = episodes.flatMap((ep) =>
+			ep.messages.filter((m) => m.role === "assistant"),
+		);
+		if (assistantMessages.length === 0) return null;
+
+		// ドリフトスコア計算
+		const driftScore = this.driftCalculator.computeFromMessages(assistantMessages);
+
+		// コスト最適化: スコアが低くエピソード数も少ない場合はスキップ
+		if (driftScore.score < DRIFT_SKIP_THRESHOLD && episodes.length < MIN_EPISODES_FOR_CHEAP_SKIP) {
+			return null;
+		}
+
+		// 既存ガイドラインを取得
+		const guidelines = await this.storage.getFactsByCategory(userId, "guideline");
+
+		// LLM に監査を依頼
+		const result = await this.llm.chatStructured<CriticResult>(
+			buildCriticMessages(this.characterDefinition, driftScore, guidelines, assistantMessages),
+			criticResultSchema,
+		);
+
+		// minor の場合、guideline fact を保存
+		if (result.severity === "minor" && result.guidelineFact) {
+			const embedding = await this.llm.embed(result.guidelineFact);
+			const fact = createFact({
+				userId,
+				category: "guideline",
+				fact: result.guidelineFact,
+				keywords: result.guidelineKeywords ?? [],
+				sourceEpisodicIds: [],
+				embedding,
+			});
+			await this.storage.saveFact(userId, fact);
+		}
+
+		return result;
+	}
+}
+
+// ─── Prompt construction ────────────────────────────────────────
+
+function buildCriticMessages(
+	characterDefinition: string,
+	driftScore: DriftScore,
+	guidelines: SemanticFact[],
+	assistantMessages: ChatMessage[],
+): ChatMessage[] {
+	const guidelineSection =
+		guidelines.length > 0
+			? guidelines.map((g) => `- ${escapeXmlContent(g.fact)}`).join("\n")
+			: "(なし)";
+
+	const featuresText = Object.entries(driftScore.features)
+		.map(([k, v]) => `  ${k}: ${String(v)}`)
+		.join("\n");
+
+	const system = `You are a character consistency auditor. You evaluate whether an AI character's responses stay true to their defined persona.
+
+<character_definition>
+${escapeXmlContent(characterDefinition)}
+</character_definition>
+
+<drift_analysis>
+score: ${String(driftScore.score.toFixed(4))}
+features:
+${featuresText}
+</drift_analysis>
+
+<existing_guidelines>
+${guidelineSection}
+</existing_guidelines>
+
+## 評価基準
+- チャッピー口調（丁寧すぎる、AIアシスタント的な表現）の検出
+- 感情の平坦化（常に同じトーンで応答する）の検出
+- 問題解決モード侵入（ユーザーの話を聞く代わりに解決策を提示する）の検出
+- キャラクター定義からの逸脱全般
+
+## 出力形式
+JSON で以下のフィールドを含めてください:
+- severity: "none" | "minor" | "major"
+- summary: 評価結果の要約（日本語）
+- guidelineFact: severity が "minor" の場合、保存すべきガイドライン（日本語、省略可）
+- guidelineKeywords: ガイドラインのキーワード配列（省略可）
+- issueTitle: severity が "major" の場合の Issue タイトル（省略可）
+- issueBody: severity が "major" の場合の Issue 本文（省略可）
+
+日本語で回答してください。`;
+
+	const userContent = assistantMessages.map((m) => escapeXmlContent(m.content)).join("\n---\n");
+
+	return [
+		{ role: "system", content: system },
+		{ role: "user", content: userContent },
+	];
+}
+
+// ─── Schema validation ──────────────────────────────────────────
+
+const criticResultSchema: Schema<CriticResult> = {
+	parse(data: unknown): CriticResult {
+		if (typeof data !== "object" || data === null) {
+			throw new TypeError("Expected object");
+		}
+		const obj = data as Record<string, unknown>;
+
+		if (typeof obj["severity"] !== "string" || !VALID_SEVERITIES.has(obj["severity"])) {
+			throw new TypeError(`severity: expected one of none, minor, major`);
+		}
+		if (typeof obj["summary"] !== "string" || obj["summary"] === "") {
+			throw new TypeError("summary: expected non-empty string");
+		}
+
+		return {
+			severity: obj["severity"] as CriticSeverity,
+			summary: obj["summary"],
+			guidelineFact: typeof obj["guidelineFact"] === "string" ? obj["guidelineFact"] : undefined,
+			guidelineKeywords: Array.isArray(obj["guidelineKeywords"])
+				? (obj["guidelineKeywords"] as string[])
+				: undefined,
+			issueTitle: typeof obj["issueTitle"] === "string" ? obj["issueTitle"] : undefined,
+			issueBody: typeof obj["issueBody"] === "string" ? obj["issueBody"] : undefined,
+		};
+	},
+};

--- a/packages/memory/src/storage.ts
+++ b/packages/memory/src/storage.ts
@@ -218,6 +218,16 @@ export class MemoryStorage {
 		return rows.map((r) => rowToEpisode(r));
 	}
 
+	async getRecentEpisodes(userId: string, sinceMs: number, limit = 20): Promise<Episode[]> {
+		const lim = clampLimit(limit);
+		const rows = this.db
+			.prepare(
+				"SELECT * FROM episodes WHERE user_id = ? AND end_at >= ? ORDER BY end_at DESC LIMIT ?",
+			)
+			.all(userId, sinceMs, lim) as EpisodeRow[];
+		return rows.map((r) => rowToEpisode(r));
+	}
+
 	async updateEpisodeFSRS(userId: string, episodeId: string, card: FSRSCard): Promise<void> {
 		this.db
 			.prepare(

--- a/packages/observability/src/metrics.ts
+++ b/packages/observability/src/metrics.ts
@@ -38,6 +38,9 @@ export const METRIC = {
 	MC_COOLDOWNS: "mc_cooldowns_total",
 	MC_FAILURE_STREAKS: "mc_failure_streaks_total",
 	MC_AUTO_NOTIFICATIONS: "mc_auto_notifications_total",
+	// Drift metrics
+	DRIFT_SCORE: "drift_score",
+	DRIFT_AUDITS: "drift_audits_total",
 	// Cost metrics
 	LLM_COST_DOLLARS: "llm_cost_dollars_total",
 	// Session error metrics

--- a/packages/scheduling/src/consolidation-scheduler.ts
+++ b/packages/scheduling/src/consolidation-scheduler.ts
@@ -1,7 +1,12 @@
 import { METRIC } from "@vicissitude/observability/metrics";
 import { delayResolve, withTimeout } from "@vicissitude/shared/functions";
-import { namespaceKey } from "@vicissitude/shared/namespace";
+import { defaultSubject, namespaceKey } from "@vicissitude/shared/namespace";
 import type { Logger, MemoryConsolidator, MetricsCollector } from "@vicissitude/shared/types";
+
+/** CriticAuditor interface to avoid circular dependency */
+export interface CriticAuditorPort {
+	audit(userId: string): Promise<{ severity: string; summary: string } | null>;
+}
 
 /** 30 minutes */
 const CONSOLIDATION_TICK_INTERVAL_MS = 30 * 60_000;
@@ -20,6 +25,7 @@ export class ConsolidationScheduler {
 		private readonly consolidator: MemoryConsolidator,
 		private readonly logger: Logger,
 		private readonly metrics?: MetricsCollector,
+		private readonly criticAuditor?: CriticAuditorPort,
 	) {}
 
 	start(): void {
@@ -106,9 +112,30 @@ export class ConsolidationScheduler {
 						`[memory-consolidation] ns=${key}: ${String(result.processedEpisodes)} episodes processed, new=${String(result.newFacts)} reinforce=${String(result.reinforced)} update=${String(result.updated)} invalidate=${String(result.invalidated)}`,
 					);
 				}
+				/* oxlint-disable-next-line no-await-in-loop -- sequential: critic audit after consolidation */
+				await this.runCriticAudit(namespace, key);
 			} catch (err) {
 				this.logger.error(`[memory-consolidation] ns=${key} failed:`, err);
 			}
+		}
+	}
+
+	private async runCriticAudit(
+		namespace: Parameters<typeof defaultSubject>[0],
+		key: string,
+	): Promise<void> {
+		if (!this.criticAuditor) return;
+		try {
+			const userId = defaultSubject(namespace);
+			const result = await this.criticAuditor.audit(userId);
+			if (result) {
+				this.metrics?.incrementCounter(METRIC.DRIFT_AUDITS);
+				if (result.severity === "major") {
+					this.logger.warn(`[critic-audit] ns=${key}: MAJOR drift detected — ${result.summary}`);
+				}
+			}
+		} catch (err) {
+			this.logger.error(`[critic-audit] ns=${key} failed:`, err);
 		}
 	}
 }

--- a/spec/memory/critic-auditor.spec.ts
+++ b/spec/memory/critic-auditor.spec.ts
@@ -1,0 +1,183 @@
+/* oxlint-disable require-await, no-non-null-assertion -- test assertions */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { CriticResult } from "@vicissitude/memory/critic-auditor";
+import { CriticAuditor } from "@vicissitude/memory/critic-auditor";
+import { DriftScoreCalculator } from "@vicissitude/memory/drift-score";
+import type { MemoryLlmPort, Schema } from "@vicissitude/memory/llm-port";
+import { MemoryStorage } from "@vicissitude/memory/storage";
+import type { ChatMessage } from "@vicissitude/memory/types";
+
+import { makeEpisode } from "./test-helpers.ts";
+
+const userId = "user-1";
+const characterDefinition = "You are hua, a casual and snarky girl.";
+
+function createCriticLLM(criticResponse: CriticResult): MemoryLlmPort {
+	return {
+		async chat(): Promise<string> {
+			return "mock";
+		},
+		async chatStructured<T>(_: ChatMessage[], schema: Schema<T>): Promise<T> {
+			return schema.parse(criticResponse);
+		},
+		async embed(): Promise<number[]> {
+			return [0.1, 0.2, 0.3];
+		},
+	};
+}
+
+/** LLM that records calls for inspection */
+function createSpyLLM(criticResponse: CriticResult) {
+	const calls: { messages: ChatMessage[] }[] = [];
+	const llm: MemoryLlmPort = {
+		async chat(): Promise<string> {
+			return "mock";
+		},
+		async chatStructured<T>(messages: ChatMessage[], schema: Schema<T>): Promise<T> {
+			calls.push({ messages });
+			return schema.parse(criticResponse);
+		},
+		async embed(): Promise<number[]> {
+			return [0.1, 0.2, 0.3];
+		},
+	};
+	return { llm, calls };
+}
+
+describe("CriticAuditor", () => {
+	let storage: MemoryStorage;
+	const drift = new DriftScoreCalculator();
+
+	beforeEach(() => {
+		storage = new MemoryStorage(":memory:");
+	});
+
+	afterEach(() => {
+		storage.close();
+	});
+
+	test("assistant メッセージがない場合は null を返す", async () => {
+		// エピソードはあるが assistant メッセージがない
+		const episode = makeEpisode({
+			messages: [{ role: "user", content: "hello" }],
+			endAt: new Date(),
+		});
+		await storage.saveEpisode(userId, episode);
+
+		const llm = createCriticLLM({ severity: "none", summary: "ok" });
+		const auditor = new CriticAuditor(llm, storage, drift, characterDefinition);
+		const result = await auditor.audit(userId);
+
+		expect(result).toBeNull();
+	});
+
+	test("ドリフトスコアが低く(< 0.03)エピソード数が少ない(< 3)場合はスキップして null", async () => {
+		// 低ドリフトの assistant メッセージ 1 件のみ
+		const episode = makeEpisode({
+			messages: [
+				{ role: "user", content: "hello" },
+				{ role: "assistant", content: "うん" },
+			],
+			endAt: new Date(),
+		});
+		await storage.saveEpisode(userId, episode);
+
+		const llm = createCriticLLM({ severity: "none", summary: "ok" });
+		const auditor = new CriticAuditor(llm, storage, drift, characterDefinition);
+		const result = await auditor.audit(userId);
+
+		expect(result).toBeNull();
+	});
+
+	test("ドリフトスコアが閾値以上の場合は LLM を呼んで CriticResult を返す", async () => {
+		// 高ドリフトの assistant メッセージ
+		const episode = makeEpisode({
+			messages: [
+				{ role: "user", content: "hello" },
+				{
+					role: "assistant",
+					content:
+						"お手伝いします。素晴らしいご質問ですね。了解しました。もちろんです。確認してみますね。",
+				},
+			],
+			endAt: new Date(),
+		});
+		await storage.saveEpisode(userId, episode);
+
+		const criticResult: CriticResult = {
+			severity: "major",
+			summary: "AI assistant-like response detected",
+		};
+		const { llm, calls } = createSpyLLM(criticResult);
+		const auditor = new CriticAuditor(llm, storage, drift, characterDefinition);
+		const result = await auditor.audit(userId);
+
+		expect(result).not.toBeNull();
+		expect(result!.severity).toBe("major");
+		expect(result!.summary).toBe("AI assistant-like response detected");
+		expect(calls).toHaveLength(1);
+	});
+
+	test('severity "minor" の場合、guideline fact が storage に保存される', async () => {
+		// 十分なエピソード数(3件)を用意してコスト最適化スキップを回避
+		for (let i = 0; i < 3; i++) {
+			const ep = makeEpisode({
+				messages: [
+					{ role: "user", content: `question ${i}` },
+					{ role: "assistant", content: `answer ${i}` },
+				],
+				endAt: new Date(),
+			});
+			/* oxlint-disable-next-line no-await-in-loop -- test setup */
+			await storage.saveEpisode(userId, ep);
+		}
+
+		const criticResult: CriticResult = {
+			severity: "minor",
+			summary: "Slightly too polite",
+			guidelineFact: "ふあは丁寧語を使わない",
+			guidelineKeywords: ["tone", "casual"],
+		};
+		const llm = createCriticLLM(criticResult);
+		const auditor = new CriticAuditor(llm, storage, drift, characterDefinition);
+		const result = await auditor.audit(userId);
+
+		expect(result).not.toBeNull();
+		expect(result!.severity).toBe("minor");
+
+		const guidelines = await storage.getFactsByCategory(userId, "guideline");
+		expect(guidelines).toHaveLength(1);
+		expect(guidelines[0]!.fact).toBe("ふあは丁寧語を使わない");
+		expect(guidelines[0]!.keywords).toEqual(["tone", "casual"]);
+	});
+
+	test('severity "none" の場合、fact は保存されない', async () => {
+		// 十分なエピソード数を用意
+		for (let i = 0; i < 3; i++) {
+			const ep = makeEpisode({
+				messages: [
+					{ role: "user", content: `question ${i}` },
+					{ role: "assistant", content: `answer ${i}` },
+				],
+				endAt: new Date(),
+			});
+			/* oxlint-disable-next-line no-await-in-loop -- test setup */
+			await storage.saveEpisode(userId, ep);
+		}
+
+		const criticResult: CriticResult = {
+			severity: "none",
+			summary: "Character is consistent",
+		};
+		const llm = createCriticLLM(criticResult);
+		const auditor = new CriticAuditor(llm, storage, drift, characterDefinition);
+		const result = await auditor.audit(userId);
+
+		expect(result).not.toBeNull();
+		expect(result!.severity).toBe("none");
+
+		const guidelines = await storage.getFactsByCategory(userId, "guideline");
+		expect(guidelines).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary
- `CriticAuditor` クラスを追加（`packages/memory/src/critic-auditor.ts`）: 直近90分のエピソードからassistantメッセージを抽出し、ドリフトスコア + LLM評価でキャラクター逸脱を検出
- `MemoryStorage.getRecentEpisodes()` メソッドを追加: `end_at >= sinceMs` で直近エピソードを取得
- `ConsolidationScheduler` に `CriticAuditorPort` を統合: consolidation tick の末尾で各 namespace に対して監査を実行
- `METRIC.DRIFT_SCORE` / `METRIC.DRIFT_AUDITS` をメトリクス定義に追加
- 仕様テスト 5 件追加（`spec/memory/critic-auditor.spec.ts`）

## 設計ポイント
- コスト最適化: ドリフトスコア < 0.03 かつエピソード数 < 3 の場合は LLM 呼び出しをスキップ
- severity "minor" の場合は `guidelineFact` を自動保存し、以降の consolidation で活用される
- severity "major" の場合はログ警告（GitHub Issue 作成は後日拡張）
- `ConsolidationScheduler` への統合はオプショナルパラメータ（後方互換性あり）

## Test plan
- [x] `nr test:spec -- spec/memory/critic-auditor.spec.ts` — 5 tests pass
- [x] `nr test:spec` — 全 1577 tests pass
- [x] `nr validate` — fmt:check, lint, type check すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)