### PR TITLE
feat: CriticAuditor の bootstrap.ts DI 配線

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -17,7 +17,16 @@ import { WsConnectionManager } from "@vicissitude/gateway/ws-handler";
 import { MemoryChatAdapter } from "@vicissitude/memory/chat-adapter";
 import { CompositeLLMAdapter } from "@vicissitude/memory/composite-llm-adapter";
 import { MemoryConversationRecorder } from "@vicissitude/memory/conversation-recorder";
+import { CriticAuditor } from "@vicissitude/memory/critic-auditor";
+import { DriftScoreCalculator } from "@vicissitude/memory/drift-score";
 import { MemoryFactReaderImpl } from "@vicissitude/memory/fact-reader";
+import {
+	discordGuildNamespace,
+	HUA_SELF_SUBJECT,
+	INTERNAL_NAMESPACE,
+	resolveMemoryDbPath,
+} from "@vicissitude/memory/namespace";
+import { MemoryStorage } from "@vicissitude/memory/storage";
 import { ConsoleLogger } from "@vicissitude/observability/logger";
 import {
 	PrometheusCollector,
@@ -28,10 +37,14 @@ import {
 import { OllamaEmbeddingAdapter } from "@vicissitude/ollama";
 import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
-import { ConsolidationScheduler } from "@vicissitude/scheduling/consolidation-scheduler";
+import {
+	ConsolidationScheduler,
+	type CriticAuditorPort,
+} from "@vicissitude/scheduling/consolidation-scheduler";
 import { JsonHeartbeatConfigRepository } from "@vicissitude/scheduling/heartbeat-config";
 import { HEARTBEAT_CONFIG_RELATIVE_PATH } from "@vicissitude/scheduling/heartbeat-helpers";
 import { HeartbeatScheduler } from "@vicissitude/scheduling/heartbeat-scheduler";
+import type { MemoryNamespace } from "@vicissitude/shared/namespace";
 import type {
 	AiAgent,
 	ContextBuilderPort,
@@ -245,15 +258,16 @@ interface MemoryResources {
 	consolidationScheduler: ConsolidationScheduler;
 }
 
-export function setupMemoryRecording(
+export async function setupMemoryRecording(
 	config: AppConfig,
 	logger: Logger,
 	opts: {
 		memoryPort: number;
 		metricsCollector?: PrometheusCollector;
 		embeddingAdapter?: OllamaEmbeddingAdapter;
+		root: string;
 	},
-): MemoryResources | undefined {
+): Promise<MemoryResources | undefined> {
 	const dataDir = resolve(config.dataDir, "memory");
 
 	try {
@@ -273,11 +287,39 @@ export function setupMemoryRecording(
 			opts.embeddingAdapter ??
 			new OllamaEmbeddingAdapter(config.memory.ollamaBaseUrl, config.memory.embeddingModel);
 		const llm = new CompositeLLMAdapter(chatAdapter, ollama);
+
+		// SOUL.md の読み込み（graceful degradation: なければ criticAuditor なし）
+		let criticAuditor: CriticAuditorPort | undefined;
+		const soulPath = resolve(opts.root, "context/SOUL.md");
+		const soulFile = Bun.file(soulPath);
+		if (await soulFile.exists()) {
+			const characterDefinition = await soulFile.text();
+			const driftCalculator = new DriftScoreCalculator();
+			// Namespace-aware adapter: userId から namespace を解決して per-namespace の MemoryStorage を使う
+			const storageCache = new Map<string, MemoryStorage>();
+			const adapter = {
+				characterDefinition,
+				audit(userId: string) {
+					let storage = storageCache.get(userId);
+					if (!storage) {
+						const namespace: MemoryNamespace =
+							userId === HUA_SELF_SUBJECT ? INTERNAL_NAMESPACE : discordGuildNamespace(userId);
+						storage = new MemoryStorage(resolveMemoryDbPath(dataDir, namespace));
+						storageCache.set(userId, storage);
+					}
+					const auditor = new CriticAuditor(llm, storage, driftCalculator, characterDefinition);
+					return auditor.audit(userId);
+				},
+			};
+			criticAuditor = adapter;
+		}
+
 		const recorder = new MemoryConversationRecorder(llm, dataDir);
 		const consolidationScheduler = new ConsolidationScheduler(
 			recorder,
 			logger,
 			opts.metricsCollector,
+			criticAuditor,
 		);
 
 		logger.info(`[bootstrap] Memory auto-recording enabled (port=${opts.memoryPort})`);
@@ -507,10 +549,11 @@ export async function bootstrap(): Promise<void> {
 	});
 
 	// Memory recording
-	const memoryResources = setupMemoryRecording(config, logger, {
+	const memoryResources = await setupMemoryRecording(config, logger, {
 		memoryPort: ports.memory(),
 		metricsCollector: metrics.collector,
 		embeddingAdapter: ollamaEmbedding,
+		root,
 	});
 	const ingestionService = new MessageIngestionService({
 		logger,

--- a/spec/discord/bootstrap-memory.spec.ts
+++ b/spec/discord/bootstrap-memory.spec.ts
@@ -1,0 +1,195 @@
+/* oxlint-disable require-await -- spec file */
+/**
+ * setupMemoryRecording() の仕様テスト
+ *
+ * Issue #815: CriticAuditor の DI 配線を追加する。
+ *
+ * 検証する公開契約:
+ *   1. SOUL.md が存在する場合 → MemoryResources を返し、ConsolidationScheduler が CriticAuditorPort を保持する
+ *   2. SOUL.md が存在しない場合 → エラーにならず MemoryResources を返す（graceful degradation）
+ *   3. 戻り値が Promise<MemoryResources | undefined> になっている（async 化）
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+
+import { setupMemoryRecording } from "../../apps/discord/src/bootstrap.ts";
+import type { AppConfig } from "../../apps/discord/src/config.ts";
+import { createMockLogger } from "../test-helpers.ts";
+
+// ─── Test fixtures ──────────────────────────────────────────────
+
+function makeConfig(dataDir: string): AppConfig {
+	return {
+		discordToken: "test-token",
+		webPort: 3000,
+		gatewayPort: 3001,
+		opencode: {
+			providerId: "test-provider",
+			modelId: "test-model",
+			basePort: 5000,
+			sessionMaxAgeHours: 1,
+		},
+		memory: {
+			providerId: "memory-provider",
+			modelId: "memory-model",
+			ollamaBaseUrl: "http://localhost:11434",
+			embeddingModel: "nomic-embed-text",
+		},
+		mcBrain: {
+			providerId: "mc-provider",
+			modelId: "mc-model",
+		},
+		dataDir,
+		contextDir: "/tmp/test-context",
+	} as AppConfig;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+describe("setupMemoryRecording()", () => {
+	let testDir: string;
+	let logger: ReturnType<typeof createMockLogger>;
+
+	beforeEach(() => {
+		testDir = resolve(
+			tmpdir(),
+			`bootstrap-memory-spec-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		mkdirSync(resolve(testDir, "data/memory"), { recursive: true });
+		logger = createMockLogger();
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	test("戻り値が Promise である（async 化の確認）", () => {
+		const config = makeConfig(resolve(testDir, "data"));
+		const result = setupMemoryRecording(config, logger, {
+			memoryPort: 19999,
+			root: testDir,
+		});
+
+		// async 関数の戻り値は Promise
+		expect(result).toBeInstanceOf(Promise);
+	});
+
+	test("正常系: MemoryResources を返す", async () => {
+		const config = makeConfig(resolve(testDir, "data"));
+		const result = await setupMemoryRecording(config, logger, {
+			memoryPort: 19999,
+			root: testDir,
+		});
+
+		// setupMemoryRecording は MemoryResources | undefined を返す
+		// ポートに接続できなくてもオブジェクト構築自体は成功するはず
+		if (result !== undefined) {
+			expect(result).toHaveProperty("chatAdapter");
+			expect(result).toHaveProperty("recorder");
+			expect(result).toHaveProperty("consolidationScheduler");
+		}
+	});
+
+	test("SOUL.md が存在する場合: consolidationScheduler が CriticAuditorPort を保持する", async () => {
+		// context/SOUL.md を作成
+		const contextDir = resolve(testDir, "context");
+		mkdirSync(contextDir, { recursive: true });
+		writeFileSync(resolve(contextDir, "SOUL.md"), "# Character\nYou are hua, a casual girl.");
+
+		const config = makeConfig(resolve(testDir, "data"));
+		const result = await setupMemoryRecording(config, logger, {
+			memoryPort: 19999,
+			root: testDir,
+		});
+
+		// MemoryResources が返される
+		expect(result).not.toBeUndefined();
+		if (!result) return;
+
+		// consolidationScheduler が存在する
+		expect(result.consolidationScheduler).toBeDefined();
+
+		// criticAuditor が内部に保持されていることを検証
+		// ConsolidationScheduler の private フィールドにアクセスして確認
+		const scheduler = result.consolidationScheduler as unknown as { criticAuditor?: unknown };
+		expect(scheduler.criticAuditor).toBeDefined();
+		expect(scheduler.criticAuditor).not.toBeNull();
+
+		// CriticAuditorPort の audit メソッドを持つことを確認
+		const auditor = scheduler.criticAuditor as { audit?: unknown };
+		expect(typeof auditor.audit).toBe("function");
+	});
+
+	test("SOUL.md が存在しない場合: MemoryResources を返すが criticAuditor なしで動作する（graceful degradation）", async () => {
+		// context/ ディレクトリは存在するが SOUL.md がない
+		mkdirSync(resolve(testDir, "context"), { recursive: true });
+
+		const config = makeConfig(resolve(testDir, "data"));
+		const result = await setupMemoryRecording(config, logger, {
+			memoryPort: 19999,
+			root: testDir,
+		});
+
+		// エラーにならず MemoryResources が返される
+		expect(result).not.toBeUndefined();
+		if (!result) return;
+
+		expect(result.consolidationScheduler).toBeDefined();
+
+		// criticAuditor は undefined（SOUL.md がないため）
+		const scheduler = result.consolidationScheduler as unknown as { criticAuditor?: unknown };
+		expect(scheduler.criticAuditor).toBeUndefined();
+	});
+
+	test("SOUL.md が存在しない場合: エラーログを出さずに正常に動作する", async () => {
+		mkdirSync(resolve(testDir, "context"), { recursive: true });
+
+		const config = makeConfig(resolve(testDir, "data"));
+		await setupMemoryRecording(config, logger, {
+			memoryPort: 19999,
+			root: testDir,
+		});
+
+		// error ログが呼ばれていないことを確認
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	test("SOUL.md の内容が characterDefinition として CriticAuditor に渡される", async () => {
+		const soulContent = "# ふあ\n自由奔放で砕けた性格のキャラクター。";
+		const contextDir = resolve(testDir, "context");
+		mkdirSync(contextDir, { recursive: true });
+		writeFileSync(resolve(contextDir, "SOUL.md"), soulContent);
+
+		const config = makeConfig(resolve(testDir, "data"));
+		const result = await setupMemoryRecording(config, logger, {
+			memoryPort: 19999,
+			root: testDir,
+		});
+
+		expect(result).not.toBeUndefined();
+		if (!result) return;
+
+		// CriticAuditor の characterDefinition を検証
+		const scheduler = result.consolidationScheduler as unknown as { criticAuditor?: unknown };
+		expect(scheduler.criticAuditor).toBeDefined();
+
+		const auditor = scheduler.criticAuditor as { characterDefinition?: string };
+		expect(auditor.characterDefinition).toBe(soulContent);
+	});
+
+	test("opts.root が必須パラメータとして使用される", async () => {
+		const config = makeConfig(resolve(testDir, "data"));
+
+		// root を指定して呼び出し → エラーにならない
+		const result = await setupMemoryRecording(config, logger, {
+			memoryPort: 19999,
+			root: testDir,
+		});
+
+		// 結果が返される（undefined でもエラーでなければOK）
+		// Promise が resolve することそのものが検証
+		expect(result === undefined || typeof result === "object").toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- `setupMemoryRecording()` を `async` 化し、SOUL.md を読み込んで CriticAuditor の DI 配線を実装
- `DriftScoreCalculator` と namespace-aware な `CriticAuditorPort` アダプターを構築し `ConsolidationScheduler` に渡す
- SOUL.md が存在しない場合は criticAuditor なしで graceful degradation

Closes #815

## Test plan

- [x] `bun test spec/discord/bootstrap-memory.spec.ts` — 全7テスト通過
- [x] `nr lint` — bootstrap.ts のエラー 0 件
- [x] `nr check` — bootstrap.ts の型エラー 0 件（worktree 由来の既存エラーは除く）

🤖 Generated with [Claude Code](https://claude.com/claude-code)