### PR TITLE
fix: computePeriodRate の同一文重複時の検索位置バグを修正

### DIFF
--- a/packages/memory/src/drift-score.ts
+++ b/packages/memory/src/drift-score.ts
@@ -278,14 +278,16 @@ export class DriftScoreCalculator {
  */
 function computePeriodRate(text: string, sentences: string[]): number {
 	let periodTerminated = 0;
+	let searchFrom = 0;
 	for (const sentence of sentences) {
 		const trimmed = sentence.trim();
-		const idx = text.indexOf(trimmed);
+		const idx = text.indexOf(trimmed, searchFrom);
 		if (idx === -1) continue;
 		const afterIdx = idx + trimmed.length;
 		if (afterIdx < text.length && text[afterIdx] === "。") {
 			periodTerminated++;
 		}
+		searchFrom = afterIdx;
 	}
 	return periodTerminated / sentences.length;
 }

--- a/spec/memory/drift-score.spec.ts
+++ b/spec/memory/drift-score.spec.ts
@@ -280,6 +280,18 @@ describe("DriftScoreCalculator", () => {
 			expect(features.periodRate).toBeGreaterThan(0.0);
 			expect(features.periodRate).toBeLessThanOrEqual(1.0);
 		});
+
+		test("同一文が複数回句点で終わる場合 periodRate は 1.0 (#821)", () => {
+			const features = calc.computeTextFeatures("うん。うん。");
+
+			expect(features.periodRate).toBe(1.0);
+		});
+
+		test("同一文が句点あり・なしで混在する場合 periodRate は 0.5 (#821)", () => {
+			const features = calc.computeTextFeatures("うん！うん。");
+
+			expect(features.periodRate).toBe(0.5);
+		});
 	});
 
 	describe("computeTextFeatures — 丁寧語の検出", () => {


### PR DESCRIPTION
## Summary
- `computePeriodRate` で `text.indexOf(trimmed)` が常にテキスト先頭から検索するため、同一文が複数回出現すると2番目以降の文も最初の出現位置を参照してしまうバグを修正
- `searchFrom` 変数を導入し、前回マッチ位置以降から検索するよう変更

Closes #821

## Test plan
- [ ] `nr test` で既存テストが通ることを確認
- [ ] 同一文が複数回出現するテキストで `computePeriodRate` が正しい句点率を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)