### PR TITLE
chore: CriticAuditor 周辺のコード品質改善 (#825)

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -37,14 +37,12 @@ import {
 import { OllamaEmbeddingAdapter } from "@vicissitude/ollama";
 import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
-import {
-	ConsolidationScheduler,
-	type CriticAuditorPort,
-} from "@vicissitude/scheduling/consolidation-scheduler";
+import { ConsolidationScheduler } from "@vicissitude/scheduling/consolidation-scheduler";
 import { JsonHeartbeatConfigRepository } from "@vicissitude/scheduling/heartbeat-config";
 import { HEARTBEAT_CONFIG_RELATIVE_PATH } from "@vicissitude/scheduling/heartbeat-helpers";
 import { HeartbeatScheduler } from "@vicissitude/scheduling/heartbeat-scheduler";
 import type { MemoryNamespace } from "@vicissitude/shared/namespace";
+import type { CriticAuditorPort } from "@vicissitude/shared/ports";
 import type {
 	AiAgent,
 	ContextBuilderPort,

--- a/packages/memory/src/critic-auditor.ts
+++ b/packages/memory/src/critic-auditor.ts
@@ -106,7 +106,7 @@ function buildCriticMessages(
 		.map(([k, v]) => `  ${k}: ${String(v)}`)
 		.join("\n");
 
-	const system = `You are a character consistency auditor. You evaluate whether an AI character's responses stay true to their defined persona.
+	const system = `あなたはキャラクター一貫性の監査者です。AIキャラクターの応答が定義されたペルソナに忠実であるかを評価します。
 
 <character_definition>
 ${escapeXmlContent(characterDefinition)}

--- a/packages/memory/src/critic-auditor.ts
+++ b/packages/memory/src/critic-auditor.ts
@@ -31,16 +31,21 @@ const VALID_SEVERITIES = new Set<string>(["none", "minor", "major"]);
 // ─── CriticAuditor ──────────────────────────────────────────────
 
 export class CriticAuditor {
+	private readonly nowProvider: () => number;
+
 	constructor(
 		private readonly llm: MemoryLlmPort,
 		private readonly storage: MemoryStorage,
 		private readonly driftCalculator: DriftScoreCalculator,
 		private readonly characterDefinition: string,
-	) {}
+		nowProvider?: () => number,
+	) {
+		this.nowProvider = nowProvider ?? Date.now;
+	}
 
 	/** 直近の応答を監査し、キャラクター一貫性を評価する */
 	async audit(userId: string): Promise<CriticResult | null> {
-		const sinceMs = Date.now() - NINETY_MINUTES_MS;
+		const sinceMs = this.nowProvider() - NINETY_MINUTES_MS;
 		const episodes = await this.storage.getRecentEpisodes(userId, sinceMs, RECENT_EPISODE_LIMIT);
 
 		// assistant メッセージを抽出

--- a/packages/scheduling/src/consolidation-scheduler.ts
+++ b/packages/scheduling/src/consolidation-scheduler.ts
@@ -1,12 +1,8 @@
 import { METRIC } from "@vicissitude/observability/metrics";
 import { delayResolve, withTimeout } from "@vicissitude/shared/functions";
 import { defaultSubject, namespaceKey } from "@vicissitude/shared/namespace";
+import type { CriticAuditorPort } from "@vicissitude/shared/ports";
 import type { Logger, MemoryConsolidator, MetricsCollector } from "@vicissitude/shared/types";
-
-/** CriticAuditor interface to avoid circular dependency */
-export interface CriticAuditorPort {
-	audit(userId: string): Promise<{ severity: string; summary: string } | null>;
-}
 
 /** 30 minutes */
 const CONSOLIDATION_TICK_INTERVAL_MS = 30 * 60_000;

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -132,3 +132,13 @@ export interface HeartbeatConfigPort {
 	load(): Promise<HeartbeatConfig>;
 	save(config: HeartbeatConfig): Promise<void>;
 }
+
+// ─── CriticAuditorPort ─────────────────────────────────────────
+//
+// CriticAuditor の抽象ポート。scheduling パッケージが memory パッケージへの
+// 直接依存を避けるために使用する。
+
+/** CriticAuditor ポートインターフェース */
+export interface CriticAuditorPort {
+	audit(userId: string): Promise<{ severity: string; summary: string } | null>;
+}

--- a/spec/memory/critic-auditor.spec.ts
+++ b/spec/memory/critic-auditor.spec.ts
@@ -8,26 +8,12 @@ import type { MemoryLlmPort, Schema } from "@vicissitude/memory/llm-port";
 import { MemoryStorage } from "@vicissitude/memory/storage";
 import type { ChatMessage } from "@vicissitude/memory/types";
 
-import { makeEpisode } from "./test-helpers.ts";
+import { createMockLLM, makeEpisode } from "./test-helpers.ts";
 
 const userId = "user-1";
 const characterDefinition = "You are hua, a casual and snarky girl.";
 
-function createCriticLLM(criticResponse: CriticResult): MemoryLlmPort {
-	return {
-		async chat(): Promise<string> {
-			return "mock";
-		},
-		async chatStructured<T>(_: ChatMessage[], schema: Schema<T>): Promise<T> {
-			return schema.parse(criticResponse);
-		},
-		async embed(): Promise<number[]> {
-			return [0.1, 0.2, 0.3];
-		},
-	};
-}
-
-/** LLM that records calls for inspection */
+/** LLM that records chatStructured calls for inspection */
 function createSpyLLM(criticResponse: CriticResult) {
 	const calls: { messages: ChatMessage[] }[] = [];
 	const llm: MemoryLlmPort = {
@@ -45,28 +31,13 @@ function createSpyLLM(criticResponse: CriticResult) {
 	return { llm, calls };
 }
 
-/** テスト用の最小 LLM ポート */
-function createDriftLLM(): MemoryLlmPort {
-	return {
-		async chat() {
-			return "";
-		},
-		async chatStructured() {
-			return {} as never;
-		},
-		async embed() {
-			return [0.1, 0.2, 0.3];
-		},
-	};
-}
-
 describe("CriticAuditor", () => {
 	let storage: MemoryStorage;
 	let drift: DriftScoreCalculator;
 
 	beforeEach(async () => {
 		storage = new MemoryStorage(":memory:");
-		drift = new DriftScoreCalculator(createDriftLLM(), "");
+		drift = new DriftScoreCalculator(createMockLLM(), "");
 		await drift.init();
 	});
 
@@ -82,7 +53,7 @@ describe("CriticAuditor", () => {
 		});
 		await storage.saveEpisode(userId, episode);
 
-		const llm = createCriticLLM({ severity: "none", summary: "ok" });
+		const llm = createMockLLM({ structuredResponse: { severity: "none", summary: "ok" } });
 		const auditor = new CriticAuditor(llm, storage, drift, characterDefinition);
 		const result = await auditor.audit(userId);
 
@@ -100,7 +71,7 @@ describe("CriticAuditor", () => {
 		});
 		await storage.saveEpisode(userId, episode);
 
-		const llm = createCriticLLM({ severity: "none", summary: "ok" });
+		const llm = createMockLLM({ structuredResponse: { severity: "none", summary: "ok" } });
 		const auditor = new CriticAuditor(llm, storage, drift, characterDefinition);
 		const result = await auditor.audit(userId);
 
@@ -156,7 +127,7 @@ describe("CriticAuditor", () => {
 			guidelineFact: "ふあは丁寧語を使わない",
 			guidelineKeywords: ["tone", "casual"],
 		};
-		const llm = createCriticLLM(criticResult);
+		const llm = createMockLLM({ structuredResponse: criticResult });
 		const auditor = new CriticAuditor(llm, storage, drift, characterDefinition);
 		const result = await auditor.audit(userId);
 
@@ -187,7 +158,7 @@ describe("CriticAuditor", () => {
 			severity: "none",
 			summary: "Character is consistent",
 		};
-		const llm = createCriticLLM(criticResult);
+		const llm = createMockLLM({ structuredResponse: criticResult });
 		const auditor = new CriticAuditor(llm, storage, drift, characterDefinition);
 		const result = await auditor.audit(userId);
 

--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -1,10 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import { discordGuildNamespace } from "@vicissitude/memory/namespace";
-import {
-	ConsolidationScheduler,
-	type CriticAuditorPort,
-} from "@vicissitude/scheduling/consolidation-scheduler";
+import { ConsolidationScheduler } from "@vicissitude/scheduling/consolidation-scheduler";
+import type { CriticAuditorPort } from "@vicissitude/shared/ports";
 import type { ConsolidationResult, MemoryConsolidator } from "@vicissitude/shared/types";
 
 import { createMockLogger, createMockMetrics } from "../test-helpers.ts";


### PR DESCRIPTION
## Summary
- `CriticAuditorPort` を `scheduling` パッケージの inline 定義から `shared/ports.ts` に移動し、既存の Port 配置パターンに統一
- `CriticAuditor` に `nowProvider` を注入可能にし、`Date.now()` ハードコードを解消（デフォルト値付きで後方互換）
- `critic-auditor.spec.ts` の独自ヘルパー `createCriticLLM` / `createDriftLLM` を共通 `createMockLLM` に統一
- システムプロンプトの冒頭英語文を日本語に統一し、言語混在を解消

Closes #825

## Test plan
- [x] `bun test spec/memory/critic-auditor.spec.ts` — 5/5 pass
- [x] `bun test spec/scheduling/consolidation-scheduler.spec.ts` — 12/12 pass
- [x] `nr validate` — 今回の変更に関するエラーなし（既存の minecraft パッケージ由来のみ）
- [x] `nr test` — 今回の変更に関する失敗なし（既存の drift-score #821 由来のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)