### PR TITLE
feat: Grafana ダッシュボードにドリフトスコアを可視化 (#818)

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -234,6 +234,9 @@ export function createMetrics(logger: Logger, port: number) {
 	collector.registerCounter(METRIC.SESSION_ERRORS, "Session errors total");
 	collector.registerCounter(METRIC.SESSION_RESTARTS, "Session restarts total");
 	collector.registerCounter(METRIC.SESSION_RETRIES, "Session retries total");
+	// Drift metrics
+	collector.registerGauge(METRIC.DRIFT_SCORE, "Character drift score per guild");
+	collector.registerCounter(METRIC.DRIFT_AUDITS, "Character drift audit results");
 	collector.setGauge(METRIC.BOT_INFO, 1, { bot_name: "hua" });
 	return { collector, server: new PrometheusServer(collector, logger, port) };
 }

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1813,6 +1813,231 @@
 			],
 			"title": "Retry to Rotation Ratio (1h)",
 			"type": "timeseries"
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 118
+			},
+			"id": 1000,
+			"title": "Character Drift",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "${DS_PROMETHEUS}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"lineWidth": 2,
+						"pointSize": 5,
+						"showPoints": "never",
+						"spanNulls": false
+					},
+					"max": 1,
+					"min": 0,
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "yellow",
+								"value": 0.3
+							},
+							{
+								"color": "red",
+								"value": 0.5
+							}
+						]
+					},
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 8,
+				"x": 0,
+				"y": 119
+			},
+			"id": 36,
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom"
+				},
+				"tooltip": {
+					"mode": "multi"
+				}
+			},
+			"targets": [
+				{
+					"expr": "drift_score",
+					"legendFormat": "{{namespace}}"
+				}
+			],
+			"title": "Drift Score Trend",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "${DS_PROMETHEUS}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"drawStyle": "line",
+						"fillOpacity": 30,
+						"lineWidth": 1,
+						"pointSize": 5,
+						"showPoints": "never",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "normal"
+						}
+					},
+					"unit": "short"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "none"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "green",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "minor"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "yellow",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "major"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "red",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 8,
+				"x": 8,
+				"y": 119
+			},
+			"id": 37,
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom"
+				},
+				"tooltip": {
+					"mode": "multi"
+				}
+			},
+			"targets": [
+				{
+					"expr": "sum by (severity) (increase(drift_audits_total[1h]))",
+					"legendFormat": "{{severity}}"
+				}
+			],
+			"title": "Drift Audits by Severity (1h)",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "${DS_PROMETHEUS}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"lineWidth": 2,
+						"pointSize": 5,
+						"showPoints": "never",
+						"spanNulls": false
+					},
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 8,
+				"x": 16,
+				"y": 119
+			},
+			"id": 38,
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom"
+				},
+				"tooltip": {
+					"mode": "multi"
+				}
+			},
+			"targets": [
+				{
+					"expr": "sum by (namespace) (increase(drift_audits_total[1h]))",
+					"legendFormat": "{{namespace}}"
+				}
+			],
+			"title": "Drift Audits by Namespace (1h)",
+			"type": "timeseries"
 		}
 	],
 	"schemaVersion": 39,

--- a/packages/memory/src/critic-auditor.ts
+++ b/packages/memory/src/critic-auditor.ts
@@ -13,6 +13,7 @@ export type CriticSeverity = "none" | "minor" | "major";
 export interface CriticResult {
 	severity: CriticSeverity;
 	summary: string;
+	driftScore?: number;
 	guidelineFact?: string;
 	guidelineKeywords?: string[];
 	issueTitle?: string;
@@ -95,7 +96,7 @@ export class CriticAuditor {
 			await this.storage.saveFact(userId, fact);
 		}
 
-		return result;
+		return { ...result, driftScore: driftScore.score };
 	}
 }
 

--- a/packages/scheduling/src/consolidation-scheduler.ts
+++ b/packages/scheduling/src/consolidation-scheduler.ts
@@ -127,7 +127,13 @@ export class ConsolidationScheduler {
 			const userId = defaultSubject(namespace);
 			const result = await this.criticAuditor.audit(userId);
 			if (result) {
-				this.metrics?.incrementCounter(METRIC.DRIFT_AUDITS);
+				this.metrics?.incrementCounter(METRIC.DRIFT_AUDITS, {
+					namespace: key,
+					severity: result.severity,
+				});
+				if (result.driftScore !== undefined) {
+					this.metrics?.setGauge(METRIC.DRIFT_SCORE, result.driftScore, { namespace: key });
+				}
 				if (result.severity === "major") {
 					this.logger.warn(`[critic-audit] ns=${key}: MAJOR drift detected — ${result.summary}`);
 					await this.reportIssueIfNeeded(result);

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -143,6 +143,7 @@ export interface CriticAuditorPort {
 	audit(userId: string): Promise<{
 		severity: string;
 		summary: string;
+		driftScore?: number;
 		issueTitle?: string;
 		issueBody?: string;
 	} | null>;

--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -221,7 +221,10 @@ describe("ConsolidationScheduler", () => {
 			// consolidate は呼ばれるが audit は呼ばれない（そもそも auditor がない）
 			expect(consolidator.consolidate).toHaveBeenCalledTimes(1);
 			// metrics に DRIFT_AUDITS が記録されていないことを確認
-			expect(metrics.incrementCounter).not.toHaveBeenCalledWith("drift_audits_total");
+			expect(metrics.incrementCounter).not.toHaveBeenCalledWith(
+				"drift_audits_total",
+				expect.anything(),
+			);
 		});
 
 		test("criticAuditor 指定 → consolidate 後に audit が呼ばれる", async () => {
@@ -256,7 +259,10 @@ describe("ConsolidationScheduler", () => {
 			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
 			await (scheduler as unknown as TickFn).tick();
 
-			expect(metrics.incrementCounter).toHaveBeenCalledWith("drift_audits_total");
+			expect(metrics.incrementCounter).toHaveBeenCalledWith("drift_audits_total", {
+				namespace: "discord-guild:333",
+				severity: "minor",
+			});
 		});
 
 		test('audit が severity "major" を返す → logger.warn が呼ばれる', async () => {
@@ -296,7 +302,10 @@ describe("ConsolidationScheduler", () => {
 			await (scheduler as unknown as TickFn).tick();
 
 			expect(auditor.audit).toHaveBeenCalledTimes(1);
-			expect(metrics.incrementCounter).not.toHaveBeenCalledWith("drift_audits_total");
+			expect(metrics.incrementCounter).not.toHaveBeenCalledWith(
+				"drift_audits_total",
+				expect.anything(),
+			);
 			expect(logger.warn).not.toHaveBeenCalled();
 		});
 
@@ -329,7 +338,29 @@ describe("ConsolidationScheduler", () => {
 			expect(auditor.audit).toHaveBeenCalledTimes(2);
 			expect(auditor.audit).toHaveBeenCalledWith("777");
 			// ns2 の結果がメトリクスに反映される
-			expect(metrics.incrementCounter).toHaveBeenCalledWith("drift_audits_total");
+			expect(metrics.incrementCounter).toHaveBeenCalledWith("drift_audits_total", {
+				namespace: "discord-guild:777",
+				severity: "minor",
+			});
+		});
+
+		test("audit result with driftScore triggers setGauge for DRIFT_SCORE", async () => {
+			const logger = createMockLogger();
+			const metrics = createMockMetrics();
+			const auditor = createMockCriticAuditor({
+				audit: mock(() => Promise.resolve({ severity: "minor", summary: "ok", driftScore: 0.42 })),
+			});
+			const consolidator = createMockConsolidator({
+				getActiveNamespaces: mock(() => [discordGuildNamespace("333")]),
+				consolidate: mock(() => Promise.resolve(successResult)),
+			});
+
+			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
+			await (scheduler as unknown as TickFn).tick();
+
+			expect(metrics.setGauge).toHaveBeenCalledWith("drift_score", 0.42, {
+				namespace: "discord-guild:333",
+			});
 		});
 
 		test("consolidate がエラーの namespace では audit がスキップされる", async () => {
@@ -360,199 +391,172 @@ describe("ConsolidationScheduler", () => {
 			expect(auditor.audit).not.toHaveBeenCalledWith("888");
 		});
 	});
+});
 
-	describe("GitHub Issue 自動起票 (severity major)", () => {
-		const successResult: ConsolidationResult = {
-			processedEpisodes: 1,
-			newFacts: 0,
-			reinforced: 0,
-			updated: 0,
-			invalidated: 0,
-		};
+describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", () => {
+	const successResult: ConsolidationResult = {
+		processedEpisodes: 1,
+		newFacts: 0,
+		reinforced: 0,
+		updated: 0,
+		invalidated: 0,
+	};
 
-		test("severity 'major' + issueTitle/issueBody + GitHubIssuePort → Issue が作成される", async () => {
-			const logger = createMockLogger();
-			const metrics = createMockMetrics();
-			const issuePort = createMockGitHubIssuePort();
-			const auditor = createMockCriticAuditor({
-				audit: mock(() =>
-					Promise.resolve({
-						severity: "major",
-						summary: "character drift detected",
-						issueTitle: "[character-drift] guild 111: AI assistant-like response",
-						issueBody: "## 概要\nキャラクター逸脱が検出されました。",
-					}),
-				),
-			});
-			const consolidator = createMockConsolidator({
-				getActiveNamespaces: mock(() => [discordGuildNamespace("111")]),
-				consolidate: mock(() => Promise.resolve(successResult)),
-			});
-
-			const scheduler = new ConsolidationScheduler(
-				consolidator,
-				logger,
-				metrics,
-				auditor,
-				issuePort,
-			);
-			await (scheduler as unknown as TickFn).tick();
-
-			// findRecentIssues で重複チェックが行われる
-			expect(issuePort.findRecentIssues).toHaveBeenCalledTimes(1);
-			expect(issuePort.findRecentIssues).toHaveBeenCalledWith(
-				expect.objectContaining({
-					label: "character-drift",
+	test("severity 'major' + issueTitle/issueBody + GitHubIssuePort → Issue が作成される", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const issuePort = createMockGitHubIssuePort();
+		const auditor = createMockCriticAuditor({
+			audit: mock(() =>
+				Promise.resolve({
+					severity: "major",
+					summary: "character drift detected",
+					issueTitle: "[character-drift] guild 111: AI assistant-like response",
+					issueBody: "## 概要\nキャラクター逸脱が検出されました。",
 				}),
-			);
-			// 重複なし → createIssue が呼ばれる
-			expect(issuePort.createIssue).toHaveBeenCalledTimes(1);
-			expect(issuePort.createIssue).toHaveBeenCalledWith(
-				expect.objectContaining({
-					title: "[character-drift] guild 111: AI assistant-like response",
-					body: "## 概要\nキャラクター逸脱が検出されました。",
-					labels: expect.arrayContaining(["character-drift"]),
+			),
+		});
+		const consolidator = createMockConsolidator({
+			getActiveNamespaces: mock(() => [discordGuildNamespace("111")]),
+			consolidate: mock(() => Promise.resolve(successResult)),
+		});
+
+		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor, issuePort);
+		await (scheduler as unknown as TickFn).tick();
+
+		// findRecentIssues で重複チェックが行われる
+		expect(issuePort.findRecentIssues).toHaveBeenCalledTimes(1);
+		expect(issuePort.findRecentIssues).toHaveBeenCalledWith(
+			expect.objectContaining({
+				label: "character-drift",
+			}),
+		);
+		// 重複なし → createIssue が呼ばれる
+		expect(issuePort.createIssue).toHaveBeenCalledTimes(1);
+		expect(issuePort.createIssue).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "[character-drift] guild 111: AI assistant-like response",
+				body: "## 概要\nキャラクター逸脱が検出されました。",
+				labels: expect.arrayContaining(["character-drift"]),
+			}),
+		);
+	});
+
+	test("severity 'major' + 直近24h に同タイトル Issue あり → スキップ（createIssue 呼ばれない）", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const duplicateTitle = "[character-drift] guild 222: repeated drift";
+		const issuePort = createMockGitHubIssuePort({
+			findRecentIssues: mock(() => Promise.resolve([{ number: 42, title: duplicateTitle }])),
+		});
+		const auditor = createMockCriticAuditor({
+			audit: mock(() =>
+				Promise.resolve({
+					severity: "major",
+					summary: "repeated drift",
+					issueTitle: duplicateTitle,
+					issueBody: "drift body",
 				}),
-			);
+			),
+		});
+		const consolidator = createMockConsolidator({
+			getActiveNamespaces: mock(() => [discordGuildNamespace("222")]),
+			consolidate: mock(() => Promise.resolve(successResult)),
 		});
 
-		test("severity 'major' + 直近24h に同タイトル Issue あり → スキップ（createIssue 呼ばれない）", async () => {
-			const logger = createMockLogger();
-			const metrics = createMockMetrics();
-			const duplicateTitle = "[character-drift] guild 222: repeated drift";
-			const issuePort = createMockGitHubIssuePort({
-				findRecentIssues: mock(() => Promise.resolve([{ number: 42, title: duplicateTitle }])),
-			});
-			const auditor = createMockCriticAuditor({
-				audit: mock(() =>
-					Promise.resolve({
-						severity: "major",
-						summary: "repeated drift",
-						issueTitle: duplicateTitle,
-						issueBody: "drift body",
-					}),
-				),
-			});
-			const consolidator = createMockConsolidator({
-				getActiveNamespaces: mock(() => [discordGuildNamespace("222")]),
-				consolidate: mock(() => Promise.resolve(successResult)),
-			});
+		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor, issuePort);
+		await (scheduler as unknown as TickFn).tick();
 
-			const scheduler = new ConsolidationScheduler(
-				consolidator,
-				logger,
-				metrics,
-				auditor,
-				issuePort,
-			);
-			await (scheduler as unknown as TickFn).tick();
+		// findRecentIssues は呼ばれるが、同タイトルが見つかるので createIssue はスキップ
+		expect(issuePort.findRecentIssues).toHaveBeenCalledTimes(1);
+		expect(issuePort.createIssue).not.toHaveBeenCalled();
+		// スキップログが出力される
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("skip"));
+	});
 
-			// findRecentIssues は呼ばれるが、同タイトルが見つかるので createIssue はスキップ
-			expect(issuePort.findRecentIssues).toHaveBeenCalledTimes(1);
-			expect(issuePort.createIssue).not.toHaveBeenCalled();
-			// スキップログが出力される
-			expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("skip"));
+	test("severity 'major' + issueTitle なし → Issue 起票しない", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const issuePort = createMockGitHubIssuePort();
+		const auditor = createMockCriticAuditor({
+			audit: mock(() =>
+				Promise.resolve({
+					severity: "major",
+					summary: "drift detected but no issue info",
+					// issueTitle, issueBody を省略
+				}),
+			),
+		});
+		const consolidator = createMockConsolidator({
+			getActiveNamespaces: mock(() => [discordGuildNamespace("333")]),
+			consolidate: mock(() => Promise.resolve(successResult)),
 		});
 
-		test("severity 'major' + issueTitle なし → Issue 起票しない", async () => {
-			const logger = createMockLogger();
-			const metrics = createMockMetrics();
-			const issuePort = createMockGitHubIssuePort();
-			const auditor = createMockCriticAuditor({
-				audit: mock(() =>
-					Promise.resolve({
-						severity: "major",
-						summary: "drift detected but no issue info",
-						// issueTitle, issueBody を省略
-					}),
-				),
-			});
-			const consolidator = createMockConsolidator({
-				getActiveNamespaces: mock(() => [discordGuildNamespace("333")]),
-				consolidate: mock(() => Promise.resolve(successResult)),
-			});
+		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor, issuePort);
+		await (scheduler as unknown as TickFn).tick();
 
-			const scheduler = new ConsolidationScheduler(
-				consolidator,
-				logger,
-				metrics,
-				auditor,
-				issuePort,
-			);
-			await (scheduler as unknown as TickFn).tick();
+		// issueTitle がないので Issue 関連の呼び出しは一切行われない
+		expect(issuePort.findRecentIssues).not.toHaveBeenCalled();
+		expect(issuePort.createIssue).not.toHaveBeenCalled();
+	});
 
-			// issueTitle がないので Issue 関連の呼び出しは一切行われない
-			expect(issuePort.findRecentIssues).not.toHaveBeenCalled();
-			expect(issuePort.createIssue).not.toHaveBeenCalled();
+	test("GitHubIssuePort 未提供 → 既存動作のまま（Issue 起票しない）", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const auditor = createMockCriticAuditor({
+			audit: mock(() =>
+				Promise.resolve({
+					severity: "major",
+					summary: "drift detected",
+					issueTitle: "[character-drift] guild 444: drift",
+					issueBody: "body",
+				}),
+			),
+		});
+		const consolidator = createMockConsolidator({
+			getActiveNamespaces: mock(() => [discordGuildNamespace("444")]),
+			consolidate: mock(() => Promise.resolve(successResult)),
 		});
 
-		test("GitHubIssuePort 未提供 → 既存動作のまま（Issue 起票しない）", async () => {
-			const logger = createMockLogger();
-			const metrics = createMockMetrics();
-			const auditor = createMockCriticAuditor({
-				audit: mock(() =>
-					Promise.resolve({
-						severity: "major",
-						summary: "drift detected",
-						issueTitle: "[character-drift] guild 444: drift",
-						issueBody: "body",
-					}),
-				),
-			});
-			const consolidator = createMockConsolidator({
-				getActiveNamespaces: mock(() => [discordGuildNamespace("444")]),
-				consolidate: mock(() => Promise.resolve(successResult)),
-			});
+		// 第5引数（issueReporter）を省略
+		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
+		await (scheduler as unknown as TickFn).tick();
 
-			// 第5引数（issueReporter）を省略
-			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
-			await (scheduler as unknown as TickFn).tick();
+		// warn ログは出る（既存動作）がクラッシュしない
+		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("MAJOR drift detected"));
+		// Issue 関連の呼び出しが行われていないことを間接的に確認（エラーなし）
+	});
 
-			// warn ログは出る（既存動作）がクラッシュしない
-			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("MAJOR drift detected"));
-			// Issue 関連の呼び出しが行われていないことを間接的に確認（エラーなし）
+	test("GitHubIssuePort.createIssue がエラー → エラーログのみ、クラッシュしない", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const createIssueError = new Error("GitHub API rate limit");
+		const issuePort = createMockGitHubIssuePort({
+			createIssue: mock(() => Promise.reject(createIssueError)),
+		});
+		const auditor = createMockCriticAuditor({
+			audit: mock(() =>
+				Promise.resolve({
+					severity: "major",
+					summary: "drift detected",
+					issueTitle: "[character-drift] guild 555: drift",
+					issueBody: "body",
+				}),
+			),
+		});
+		const consolidator = createMockConsolidator({
+			getActiveNamespaces: mock(() => [discordGuildNamespace("555")]),
+			consolidate: mock(() => Promise.resolve(successResult)),
 		});
 
-		test("GitHubIssuePort.createIssue がエラー → エラーログのみ、クラッシュしない", async () => {
-			const logger = createMockLogger();
-			const metrics = createMockMetrics();
-			const createIssueError = new Error("GitHub API rate limit");
-			const issuePort = createMockGitHubIssuePort({
-				createIssue: mock(() => Promise.reject(createIssueError)),
-			});
-			const auditor = createMockCriticAuditor({
-				audit: mock(() =>
-					Promise.resolve({
-						severity: "major",
-						summary: "drift detected",
-						issueTitle: "[character-drift] guild 555: drift",
-						issueBody: "body",
-					}),
-				),
-			});
-			const consolidator = createMockConsolidator({
-				getActiveNamespaces: mock(() => [discordGuildNamespace("555")]),
-				consolidate: mock(() => Promise.resolve(successResult)),
-			});
+		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor, issuePort);
 
-			const scheduler = new ConsolidationScheduler(
-				consolidator,
-				logger,
-				metrics,
-				auditor,
-				issuePort,
-			);
+		// クラッシュせずに完了する
+		await (scheduler as unknown as TickFn).tick();
 
-			// クラッシュせずに完了する
-			await (scheduler as unknown as TickFn).tick();
-
-			// createIssue が呼ばれた（試みた）
-			expect(issuePort.createIssue).toHaveBeenCalledTimes(1);
-			// エラーログが出力される
-			expect(logger.error).toHaveBeenCalledWith(
-				expect.stringContaining("issue"),
-				expect.any(Error),
-			);
-		});
+		// createIssue が呼ばれた（試みた）
+		expect(issuePort.createIssue).toHaveBeenCalledTimes(1);
+		// エラーログが出力される
+		expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("issue"), expect.any(Error));
 	});
 });


### PR DESCRIPTION
## Summary
- `drift_score` gauge と `drift_audits_total` counter を PrometheusCollector に登録
- `CriticAuditorPort` / `CriticResult` に `driftScore?: number` フィールドを追加し、`CriticAuditor.audit()` がスコアを返すように変更
- `ConsolidationScheduler.runCriticAudit()` で `namespace` / `severity` ラベル付きメトリクスを発行し、`drift_score` gauge を設定
- Grafana ダッシュボードに "Character Drift" row を追加（3パネル: Drift Score Trend, Drift Audits by Severity, Drift Audits by Namespace）
- Drift Score パネルに閾値設定（0.3 = warning, 0.5 = critical）

Closes #818

## Test plan
- [x] `nr test:spec` — 1629 pass, 0 fail
- [x] `nr test:unit` — 596 pass, 0 fail
- [x] `nr validate` — fmt OK, lint 0 errors, check は既存の apps/web エラーのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)