### PR TITLE
fix: ConsolidationPipeline がディスク上の namespace を発見できない問題を修正

### DIFF
--- a/packages/memory/src/conversation-recorder.ts
+++ b/packages/memory/src/conversation-recorder.ts
@@ -13,6 +13,7 @@ import { EpisodicMemory } from "./episodic.ts";
 import type { MemoryLlmPort } from "./llm-port.ts";
 import {
 	defaultSubject,
+	discoverNamespacesFromDisk,
 	type MemoryNamespace,
 	namespaceKey,
 	resolveMemoryDbDir,
@@ -77,24 +78,24 @@ export class MemoryConversationRecorder implements ConversationRecorder, MemoryC
 	}
 
 	getActiveNamespaces(): MemoryNamespace[] {
-		return [...this.instances.values()].map((v) => v.ns);
+		const seen = new Map<string, MemoryNamespace>();
+		for (const { ns } of this.instances.values()) {
+			seen.set(namespaceKey(ns), ns);
+		}
+		for (const ns of discoverNamespacesFromDisk(this.dataDir)) {
+			const key = namespaceKey(ns);
+			if (!seen.has(key)) {
+				seen.set(key, ns);
+			}
+		}
+		return [...seen.values()];
 	}
 
 	consolidate(namespace: MemoryNamespace): Promise<ConsolidationResult> {
 		// record() のロックとは独立: SQLite WAL モードで読み書き直列化は DB 側が保証するため、
 		// consolidation が record() をブロックする必要はない
-		const key = namespaceKey(namespace);
-		const entry = this.instances.get(key);
-		if (!entry) {
-			return Promise.resolve({
-				processedEpisodes: 0,
-				newFacts: 0,
-				reinforced: 0,
-				updated: 0,
-				invalidated: 0,
-			});
-		}
-		return entry.inst.consolidation.consolidate(defaultSubject(namespace));
+		const { consolidation } = this.getOrCreate(namespace);
+		return consolidation.consolidate(defaultSubject(namespace));
 	}
 
 	async close(): Promise<void> {

--- a/packages/memory/src/namespace.ts
+++ b/packages/memory/src/namespace.ts
@@ -12,6 +12,7 @@
 export {
 	defaultSubject,
 	discordGuildNamespace,
+	discoverNamespacesFromDisk,
 	GUILD_ID_RE,
 	HUA_SELF_SUBJECT,
 	INTERNAL_NAMESPACE,

--- a/packages/shared/src/namespace.ts
+++ b/packages/shared/src/namespace.ts
@@ -9,6 +9,7 @@
  * 詳細な仕様契約は spec/memory/namespace.spec.ts を参照。
  */
 
+import { existsSync, readdirSync } from "fs";
 import { resolve } from "path";
 
 /** Memory のパーティショニング単位 */
@@ -119,4 +120,33 @@ export function defaultSubject(namespace: MemoryNamespace): string {
 		case "internal":
 			return HUA_SELF_SUBJECT;
 	}
+}
+
+/**
+ * ディスク上の既存 DB ファイルから namespace を発見する。
+ * consolidation スケジューラが 30 分に 1 回呼ぶ想定なので同期 I/O で問題なし。
+ */
+export function discoverNamespacesFromDisk(dataDir: string): MemoryNamespace[] {
+	const result: MemoryNamespace[] = [];
+
+	// internal/memory.db
+	if (existsSync(resolve(dataDir, "internal", "memory.db"))) {
+		result.push(INTERNAL_NAMESPACE);
+	}
+
+	// guilds/{guildId}/memory.db
+	const guildsDir = resolve(dataDir, "guilds");
+	let entries: string[];
+	try {
+		entries = readdirSync(guildsDir);
+	} catch {
+		return result;
+	}
+	for (const name of entries) {
+		if (GUILD_ID_RE.test(name) && existsSync(resolve(guildsDir, name, "memory.db"))) {
+			result.push(discordGuildNamespace(name));
+		}
+	}
+
+	return result;
 }

--- a/spec/memory/conversation-recorder.spec.ts
+++ b/spec/memory/conversation-recorder.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { existsSync, rmSync } from "fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { resolve as resolvePath } from "path";
 
 import type {
 	GuildInstance,
@@ -168,17 +169,14 @@ describe("MemoryConversationRecorder (namespace API)", () => {
 		expect(namespaces[0]).toEqual(INTERNAL_NAMESPACE);
 	});
 
-	test("consolidate() で未初期化 namespace → 0 initialized result", async () => {
+	test("consolidate() で未初期化 namespace → getOrCreate で instance 生成して実行", async () => {
+		mockConsolidate.mockClear();
 		const recorder = createRecorder();
 
 		const result = await recorder.consolidate(discordGuildNamespace("99999"));
-		expect(result).toEqual({
-			processedEpisodes: 0,
-			newFacts: 0,
-			reinforced: 0,
-			updated: 0,
-			invalidated: 0,
-		});
+		// #811: consolidate() は未初期化でも getOrCreate() で instance を生成する
+		expect(mockConsolidate).toHaveBeenCalledWith("99999");
+		expect(result.processedEpisodes).toBe(3);
 	});
 
 	test("consolidate() で初期化済み namespace → pipeline.consolidate 呼び出し（subject 渡し）", async () => {
@@ -219,5 +217,59 @@ describe("MemoryConversationRecorder (namespace API)", () => {
 
 		expect(mockStorageClose).toHaveBeenCalled();
 		expect(recorder.getActiveNamespaces()).toEqual([]);
+	});
+
+	test("getActiveNamespaces() → ディスク上の既存 DB も発見する（record() なし）", () => {
+		// Arrange: TEMP_DIR 配下に guilds/12345/memory.db を事前作成
+		const guildDir = resolvePath(TEMP_DIR, "guilds", "12345");
+		mkdirSync(guildDir, { recursive: true });
+		writeFileSync(resolvePath(guildDir, "memory.db"), "");
+
+		const recorder = createRecorder();
+
+		// Act: record() を呼ばない
+		const namespaces = recorder.getActiveNamespaces();
+
+		// Assert: ディスク上の DB が発見される
+		expect(namespaces).toHaveLength(1);
+		expect(namespaces[0]).toEqual(discordGuildNamespace("12345"));
+	});
+
+	test("getActiveNamespaces() → インメモリとディスクの重複は排除される", async () => {
+		// Arrange: ディスクに guilds/100/memory.db を作成し、同じ namespace で record() も呼ぶ
+		const guildDir = resolvePath(TEMP_DIR, "guilds", "100");
+		mkdirSync(guildDir, { recursive: true });
+		writeFileSync(resolvePath(guildDir, "memory.db"), "");
+
+		mockAddMessage.mockClear();
+		mockAddMessage.mockImplementation(() => Promise.resolve([]));
+		const recorder = createRecorder();
+		await recorder.record(discordGuildNamespace("100"), sampleMessage);
+
+		// Act
+		const namespaces = recorder.getActiveNamespaces();
+
+		// Assert: 重複なしで 1 つだけ返る
+		expect(namespaces).toHaveLength(1);
+		expect(namespaces[0]).toEqual(discordGuildNamespace("100"));
+	});
+
+	test("consolidate() → ディスク上のみの namespace でも動作する", async () => {
+		// Arrange: record() なしでディスク DB のみ存在
+		const guildDir = resolvePath(TEMP_DIR, "guilds", "42");
+		mkdirSync(guildDir, { recursive: true });
+		writeFileSync(resolvePath(guildDir, "memory.db"), "");
+
+		mockConsolidate.mockClear();
+		const recorder = createRecorder();
+
+		// Act: record() を呼ばずに consolidate()
+		const ns = discordGuildNamespace("42");
+		const result = await recorder.consolidate(ns);
+
+		// Assert: getOrCreate() で GuildInstance が生成され、pipeline.consolidate が呼ばれる
+		expect(mockConsolidate).toHaveBeenCalledTimes(1);
+		expect(mockConsolidate).toHaveBeenCalledWith("42");
+		expect(result.processedEpisodes).toBe(3);
 	});
 });

--- a/spec/memory/namespace.spec.ts
+++ b/spec/memory/namespace.spec.ts
@@ -57,11 +57,13 @@
  *   export function defaultSubject(namespace: MemoryNamespace): string;
  */
 
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { resolve } from "path";
 
 import {
 	discordGuildNamespace,
+	discoverNamespacesFromDisk,
 	INTERNAL_NAMESPACE,
 	HUA_SELF_SUBJECT,
 	defaultSubject,
@@ -73,6 +75,13 @@ import {
 } from "@vicissitude/memory/namespace";
 
 const DATA_DIR = "/data/memory";
+const TEMP_DIR = `/tmp/vicissitude-namespace-spec-${process.pid}`;
+
+afterEach(() => {
+	if (existsSync(TEMP_DIR)) {
+		rmSync(TEMP_DIR, { recursive: true, force: true });
+	}
+});
 
 describe("MemoryNamespace: factory / constant", () => {
 	it("discordGuildNamespace は guildId を持つ discord-guild namespace を返す", () => {
@@ -279,6 +288,64 @@ describe("recorder subject 導出契約（defaultSubject）", () => {
 		// HUA_SELF_SUBJECT は validateUserId の制約を満たす
 		expect(HUA_SELF_SUBJECT.length).toBeGreaterThan(0);
 		expect(HUA_SELF_SUBJECT.length).toBeLessThanOrEqual(256);
+	});
+});
+
+describe("discoverNamespacesFromDisk", () => {
+	it("空ディレクトリ → 空配列を返す", () => {
+		mkdirSync(TEMP_DIR, { recursive: true });
+		const result = discoverNamespacesFromDisk(TEMP_DIR);
+		expect(result).toEqual([]);
+	});
+
+	it("guilds/{numericId}/memory.db が存在 → discord-guild namespace を返す", () => {
+		const guildDir = resolve(TEMP_DIR, "guilds", "123456789");
+		mkdirSync(guildDir, { recursive: true });
+		writeFileSync(resolve(guildDir, "memory.db"), "");
+
+		const result = discoverNamespacesFromDisk(TEMP_DIR);
+		expect(result).toEqual([discordGuildNamespace("123456789")]);
+	});
+
+	it("internal/memory.db が存在 → internal namespace を返す", () => {
+		const internalDir = resolve(TEMP_DIR, "internal");
+		mkdirSync(internalDir, { recursive: true });
+		writeFileSync(resolve(internalDir, "memory.db"), "");
+
+		const result = discoverNamespacesFromDisk(TEMP_DIR);
+		expect(result).toEqual([INTERNAL_NAMESPACE]);
+	});
+
+	it("非数値ディレクトリ名 → スキップする", () => {
+		const badDir = resolve(TEMP_DIR, "guilds", "not-a-number");
+		mkdirSync(badDir, { recursive: true });
+		writeFileSync(resolve(badDir, "memory.db"), "");
+
+		const result = discoverNamespacesFromDisk(TEMP_DIR);
+		expect(result).toEqual([]);
+	});
+
+	it("memory.db がないディレクトリ → スキップする", () => {
+		const guildDir = resolve(TEMP_DIR, "guilds", "999");
+		mkdirSync(guildDir, { recursive: true });
+
+		const result = discoverNamespacesFromDisk(TEMP_DIR);
+		expect(result).toEqual([]);
+	});
+
+	it("guilds + internal 両方存在 → 両方返す", () => {
+		const guildDir = resolve(TEMP_DIR, "guilds", "111");
+		mkdirSync(guildDir, { recursive: true });
+		writeFileSync(resolve(guildDir, "memory.db"), "");
+
+		const internalDir = resolve(TEMP_DIR, "internal");
+		mkdirSync(internalDir, { recursive: true });
+		writeFileSync(resolve(internalDir, "memory.db"), "");
+
+		const result = discoverNamespacesFromDisk(TEMP_DIR);
+		expect(result).toHaveLength(2);
+		expect(result.some((ns) => ns.surface === "discord-guild" && ns.guildId === "111")).toBe(true);
+		expect(result.some((ns) => ns.surface === "internal")).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Summary
- `getActiveNamespaces()` がインメモリの instances Map のみを参照していたため、Bot 再起動後に `record()` が呼ばれるまで既存 namespace が発見されず consolidation がスキップされていた
- `discoverNamespacesFromDisk()` を追加し、ディスク上の `guilds/{guildId}/memory.db` と `internal/memory.db` を走査して namespace を発見するようにした
- `consolidate()` を未初期化 namespace でも `getOrCreate()` で GuildInstance を生成して実行するよう修正

Closes #811

## Test plan
- [x] `discoverNamespacesFromDisk` の仕様テスト 6 件追加 (spec/memory/namespace.spec.ts)
- [x] `getActiveNamespaces` ディスク発見テスト 3 件追加 (spec/memory/conversation-recorder.spec.ts)
- [x] 既存テスト 2234 件全通過
- [x] `nr validate` (fmt:check + lint + check) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)