### PR TITLE
fix: CriticAuditor が botName で assistant メッセージをフィルタ (#798)

### DIFF
--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -7,6 +7,7 @@ import type { AppConfig } from "./config.ts";
 
 function createTestConfig(overrides?: Partial<AppConfig>): AppConfig {
 	return {
+		botName: "ふあ",
 		discordToken: "test-token",
 		webPort: 4000,
 		gatewayPort: 4001,

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -310,7 +310,13 @@ export async function setupMemoryRecording(
 						storage = new MemoryStorage(resolveMemoryDbPath(dataDir, namespace));
 						storageCache.set(userId, storage);
 					}
-					const auditor = new CriticAuditor({ llm, storage, driftCalculator, characterDefinition });
+					const auditor = new CriticAuditor({
+						llm,
+						storage,
+						driftCalculator,
+						characterDefinition,
+						botName: config.botName,
+					});
 					return auditor.audit(userId);
 				},
 			};

--- a/apps/discord/src/config.ts
+++ b/apps/discord/src/config.ts
@@ -45,6 +45,7 @@ const githubSchema = z.object({
 });
 
 const appConfigSchema = z.object({
+	botName: z.string().min(1, "BOT_NAME is required"),
 	discordToken: z.string().min(1, "DISCORD_TOKEN is required"),
 	webPort: safeInt,
 	gatewayPort: safeInt,
@@ -94,6 +95,7 @@ export function loadConfig(
 	const basePort = Number(env.OPENCODE_BASE_PORT ?? "4096");
 
 	const raw = {
+		botName: env.BOT_NAME ?? "ふあ",
 		discordToken: env.DISCORD_TOKEN ?? "",
 		webPort: Number(env.WEB_PORT ?? "4000"),
 		gatewayPort: Number(env.GATEWAY_PORT ?? "4001"),

--- a/packages/memory/src/critic-auditor.ts
+++ b/packages/memory/src/critic-auditor.ts
@@ -36,6 +36,7 @@ export interface CriticAuditorDeps {
 	storage: MemoryStorage;
 	driftCalculator: DriftScoreCalculator;
 	characterDefinition: string;
+	botName: string;
 	nowProvider?: () => number;
 }
 
@@ -44,6 +45,7 @@ export class CriticAuditor {
 	private readonly storage: MemoryStorage;
 	private readonly driftCalculator: DriftScoreCalculator;
 	private readonly characterDefinition: string;
+	private readonly botName: string;
 	private readonly nowProvider: () => number;
 
 	constructor(deps: CriticAuditorDeps) {
@@ -51,6 +53,7 @@ export class CriticAuditor {
 		this.storage = deps.storage;
 		this.driftCalculator = deps.driftCalculator;
 		this.characterDefinition = deps.characterDefinition;
+		this.botName = deps.botName;
 		this.nowProvider = deps.nowProvider ?? Date.now;
 	}
 
@@ -59,9 +62,9 @@ export class CriticAuditor {
 		const sinceMs = this.nowProvider() - NINETY_MINUTES_MS;
 		const episodes = await this.storage.getRecentEpisodes(userId, sinceMs, RECENT_EPISODE_LIMIT);
 
-		// assistant メッセージを抽出
+		// bot の assistant メッセージのみ抽出（name 欠損メッセージはスキップ）
 		const assistantMessages: ChatMessage[] = episodes.flatMap((ep) =>
-			ep.messages.filter((m) => m.role === "assistant"),
+			ep.messages.filter((m) => m.role === "assistant" && m.name === this.botName),
 		);
 		if (assistantMessages.length === 0) return null;
 

--- a/spec/discord/bootstrap-memory.spec.ts
+++ b/spec/discord/bootstrap-memory.spec.ts
@@ -22,6 +22,7 @@ import { createMockLogger } from "../test-helpers.ts";
 
 function makeConfig(dataDir: string): AppConfig {
 	return {
+		botName: "ふあ",
 		discordToken: "test-token",
 		webPort: 3000,
 		gatewayPort: 3001,

--- a/spec/discord/bootstrap.spec.ts
+++ b/spec/discord/bootstrap.spec.ts
@@ -11,6 +11,7 @@ function makeConfig(
 	} = {},
 ): AppConfig {
 	return {
+		botName: "ふあ",
 		discordToken: "test-discord-token",
 		webPort: 3000,
 		gatewayPort: 3001,

--- a/spec/memory/critic-auditor.spec.ts
+++ b/spec/memory/critic-auditor.spec.ts
@@ -11,6 +11,7 @@ import type { ChatMessage } from "@vicissitude/memory/types";
 import { createMockLLM, makeEpisode } from "./test-helpers.ts";
 
 const userId = "user-1";
+const botName = "ふあ";
 const characterDefinition = "You are hua, a casual and snarky girl.";
 
 /** LLM that records chatStructured calls for inspection */
@@ -59,18 +60,19 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
+			botName,
 		});
 		const result = await auditor.audit(userId);
 
 		expect(result).toBeNull();
 	});
 
-	test("ドリフトスコアが低く(< 0.03)エピソード数が少ない(< 3)場合はスキップして null", async () => {
-		// 低ドリフトの assistant メッセージ 1 件のみ
+	test("name が欠損または別 bot の assistant メッセージはスキップされる", async () => {
 		const episode = makeEpisode({
 			messages: [
-				{ role: "user", content: "hello" },
-				{ role: "assistant", content: "うん" },
+				{ role: "user", content: "hello", name: "user-1" },
+				{ role: "assistant", content: "I am another bot" }, // name 欠損
+				{ role: "assistant", content: "I am different", name: "other-bot" }, // 別 bot
 			],
 			endAt: new Date(),
 		});
@@ -82,6 +84,32 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
+			botName,
+		});
+		const result = await auditor.audit(userId);
+
+		// botName にマッチする assistant メッセージがないので null
+		expect(result).toBeNull();
+	});
+
+	test("ドリフトスコアが低く(< 0.03)エピソード数が少ない(< 3)場合はスキップして null", async () => {
+		// 低ドリフトの assistant メッセージ 1 件のみ
+		const episode = makeEpisode({
+			messages: [
+				{ role: "user", content: "hello", name: "user-1" },
+				{ role: "assistant", content: "うん", name: botName },
+			],
+			endAt: new Date(),
+		});
+		await storage.saveEpisode(userId, episode);
+
+		const llm = createMockLLM({ structuredResponse: { severity: "none", summary: "ok" } });
+		const auditor = new CriticAuditor({
+			llm,
+			storage,
+			driftCalculator: drift,
+			characterDefinition,
+			botName,
 		});
 		const result = await auditor.audit(userId);
 
@@ -92,11 +120,12 @@ describe("CriticAuditor", () => {
 		// 高ドリフトの assistant メッセージ
 		const episode = makeEpisode({
 			messages: [
-				{ role: "user", content: "hello" },
+				{ role: "user", content: "hello", name: "user-1" },
 				{
 					role: "assistant",
 					content:
 						"お手伝いします。素晴らしいご質問ですね。了解しました。もちろんです。確認してみますね。",
+					name: botName,
 				},
 			],
 			endAt: new Date(),
@@ -113,6 +142,7 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
+			botName,
 		});
 		const result = await auditor.audit(userId);
 
@@ -127,8 +157,8 @@ describe("CriticAuditor", () => {
 		for (let i = 0; i < 3; i++) {
 			const ep = makeEpisode({
 				messages: [
-					{ role: "user", content: `question ${i}` },
-					{ role: "assistant", content: `answer ${i}` },
+					{ role: "user", content: `question ${i}`, name: "user-1" },
+					{ role: "assistant", content: `answer ${i}`, name: botName },
 				],
 				endAt: new Date(),
 			});
@@ -148,6 +178,7 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
+			botName,
 		});
 		const result = await auditor.audit(userId);
 
@@ -165,8 +196,8 @@ describe("CriticAuditor", () => {
 		for (let i = 0; i < 3; i++) {
 			const ep = makeEpisode({
 				messages: [
-					{ role: "user", content: `question ${i}` },
-					{ role: "assistant", content: `answer ${i}` },
+					{ role: "user", content: `question ${i}`, name: "user-1" },
+					{ role: "assistant", content: `answer ${i}`, name: botName },
 				],
 				endAt: new Date(),
 			});
@@ -184,6 +215,7 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
+			botName,
 		});
 		const result = await auditor.audit(userId);
 


### PR DESCRIPTION
## Summary

- `CriticAuditor` に `botName` パラメータを追加し、assistant メッセージを `name === botName` でフィルタするよう修正
- `name` フィールドが欠損しているメッセージはフォールバックせずスキップ（他 bot の発話を誤評価しない）
- `AppConfig` に `botName` フィールドを追加（環境変数 `BOT_NAME`、デフォルト `"ふあ"`）

## Test plan

- [x] 新規テスト: name 欠損・別 bot 名のメッセージがスキップされることを検証
- [x] 既存テスト: 全 spec/unit テスト通過確認済み
- [x] `nr validate` (fmt + lint + typecheck) 通過確認済み

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)