### PR TITLE
fix: spec のインラインコメントを別行に移動して CI lint エラーを解消

### DIFF
--- a/spec/memory/critic-auditor.spec.ts
+++ b/spec/memory/critic-auditor.spec.ts
@@ -71,8 +71,10 @@ describe("CriticAuditor", () => {
 		const episode = makeEpisode({
 			messages: [
 				{ role: "user", content: "hello", name: "user-1" },
-				{ role: "assistant", content: "I am another bot" }, // name 欠損
-				{ role: "assistant", content: "I am different", name: "other-bot" }, // 別 bot
+				// name 欠損
+				{ role: "assistant", content: "I am another bot" },
+				// 別 bot
+				{ role: "assistant", content: "I am different", name: "other-bot" },
 			],
 			endAt: new Date(),
 		});


### PR DESCRIPTION
## Summary
- `spec/memory/critic-auditor.spec.ts` のインラインコメントを別行に移動し、`no-inline-comments` lint ルール違反を解消
- main ブランチの CI (#844 マージ後) が失敗していた問題の修正

## Test plan
- [x] `nr lint` でインラインコメントエラーが 0 件であることを確認
- [x] `bun test --filter "critic-auditor" spec/` でテストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)