### PR TITLE
fix: CriticAuditor のフィルタを authorId ベースに変更 (#847)

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -268,6 +268,13 @@ export async function setupMemoryRecording(
 		metricsCollector?: PrometheusCollector;
 		embeddingAdapter?: OllamaEmbeddingAdapter;
 		root: string;
+		/**
+		 * Bot の Discord user id を遅延解決するための callback。
+		 * gateway.start() より前に setupMemoryRecording が呼ばれるため、
+		 * audit 実行時に最新値を取得する必要がある。
+		 * 未解決の間 (undefined を返す) は audit が no-op (null) になる。
+		 */
+		getBotUserId?: () => string | undefined;
 	},
 ): Promise<MemoryResources | undefined> {
 	const dataDir = resolve(config.dataDir, "memory");
@@ -303,6 +310,11 @@ export async function setupMemoryRecording(
 			const adapter = {
 				characterDefinition,
 				audit(userId: string) {
+					// gateway.start() 前に audit が呼ばれた場合、bot user id 未解決のため早期 return
+					// (namespace 解決は GUILD_ID_RE バリデーションを行うため、それより前に判定する)
+					const botUserId = opts.getBotUserId?.();
+					if (!botUserId) return Promise.resolve(null);
+
 					let storage = storageCache.get(userId);
 					if (!storage) {
 						const namespace: MemoryNamespace =
@@ -315,7 +327,7 @@ export async function setupMemoryRecording(
 						storage,
 						driftCalculator,
 						characterDefinition,
-						botName: config.botName,
+						botUserId,
 					});
 					return auditor.audit(userId);
 				},
@@ -572,6 +584,9 @@ export async function bootstrap(): Promise<void> {
 		metricsCollector: metrics.collector,
 		embeddingAdapter: ollamaEmbedding,
 		root,
+		// gateway.start() より前に setupMemoryRecording が呼ばれるため、
+		// CriticAuditor が必要とする bot user id は遅延解決する (#847)
+		getBotUserId: () => gateway.getClient()?.user?.id,
 	});
 	const ingestionService = new MessageIngestionService({
 		logger,

--- a/packages/application/src/message-ingestion-service.ts
+++ b/packages/application/src/message-ingestion-service.ts
@@ -50,6 +50,7 @@ export class MessageIngestionService {
 			role,
 			content,
 			name: message.authorName,
+			authorId: message.authorId,
 			timestamp: message.timestamp,
 		};
 

--- a/packages/memory/src/conversation-recorder.ts
+++ b/packages/memory/src/conversation-recorder.ts
@@ -65,8 +65,9 @@ export class MemoryConversationRecorder implements ConversationRecorder, MemoryC
 			await segmenter.addMessage(subject, {
 				role: message.role,
 				content: message.content,
-				name: message.name,
-				timestamp: message.timestamp,
+				...(message.name === undefined ? {} : { name: message.name }),
+				...(message.authorId === undefined ? {} : { authorId: message.authorId }),
+				...(message.timestamp === undefined ? {} : { timestamp: message.timestamp }),
 			});
 		};
 		const next = doRecord();

--- a/packages/memory/src/conversation-recorder.ts
+++ b/packages/memory/src/conversation-recorder.ts
@@ -65,9 +65,9 @@ export class MemoryConversationRecorder implements ConversationRecorder, MemoryC
 			await segmenter.addMessage(subject, {
 				role: message.role,
 				content: message.content,
-				...(message.name === undefined ? {} : { name: message.name }),
-				...(message.authorId === undefined ? {} : { authorId: message.authorId }),
-				...(message.timestamp === undefined ? {} : { timestamp: message.timestamp }),
+				name: message.name,
+				authorId: message.authorId,
+				timestamp: message.timestamp,
 			});
 		};
 		const next = doRecord();

--- a/packages/memory/src/critic-auditor.ts
+++ b/packages/memory/src/critic-auditor.ts
@@ -36,7 +36,8 @@ export interface CriticAuditorDeps {
 	storage: MemoryStorage;
 	driftCalculator: DriftScoreCalculator;
 	characterDefinition: string;
-	botName: string;
+	/** Discord user id of this bot. Used to filter assistant messages by stable identifier. */
+	botUserId: string;
 	nowProvider?: () => number;
 }
 
@@ -44,8 +45,8 @@ export class CriticAuditor {
 	private readonly llm: MemoryLlmPort;
 	private readonly storage: MemoryStorage;
 	private readonly driftCalculator: DriftScoreCalculator;
-	private readonly characterDefinition: string;
-	private readonly botName: string;
+	readonly characterDefinition: string;
+	private readonly botUserId: string;
 	private readonly nowProvider: () => number;
 
 	constructor(deps: CriticAuditorDeps) {
@@ -53,7 +54,7 @@ export class CriticAuditor {
 		this.storage = deps.storage;
 		this.driftCalculator = deps.driftCalculator;
 		this.characterDefinition = deps.characterDefinition;
-		this.botName = deps.botName;
+		this.botUserId = deps.botUserId;
 		this.nowProvider = deps.nowProvider ?? Date.now;
 	}
 
@@ -62,9 +63,11 @@ export class CriticAuditor {
 		const sinceMs = this.nowProvider() - NINETY_MINUTES_MS;
 		const episodes = await this.storage.getRecentEpisodes(userId, sinceMs, RECENT_EPISODE_LIMIT);
 
-		// bot の assistant メッセージのみ抽出（name 欠損メッセージはスキップ）
+		// bot の assistant メッセージのみ抽出（authorId が一致しないメッセージはスキップ）
+		// guild ニックネームと無関係な、stable な platform user id でフィルタすることで
+		// ニックネーム衝突や同名の他 bot による誤検知を防ぐ（#847）
 		const assistantMessages: ChatMessage[] = episodes.flatMap((ep) =>
-			ep.messages.filter((m) => m.role === "assistant" && m.name === this.botName),
+			ep.messages.filter((m) => m.role === "assistant" && m.authorId === this.botUserId),
 		);
 		if (assistantMessages.length === 0) return null;
 

--- a/packages/memory/src/critic-auditor.ts
+++ b/packages/memory/src/critic-auditor.ts
@@ -45,7 +45,7 @@ export class CriticAuditor {
 	private readonly llm: MemoryLlmPort;
 	private readonly storage: MemoryStorage;
 	private readonly driftCalculator: DriftScoreCalculator;
-	readonly characterDefinition: string;
+	private readonly characterDefinition: string;
 	private readonly botUserId: string;
 	private readonly nowProvider: () => number;
 

--- a/packages/memory/src/parse-helpers.test.ts
+++ b/packages/memory/src/parse-helpers.test.ts
@@ -152,6 +152,102 @@ describe("validateMessages", () => {
 			"name: too long",
 		);
 	});
+
+	describe("authorId validation", () => {
+		test("preserves a short authorId", () => {
+			const result = validateMessages([{ role: "user", content: "hi", authorId: "user-123" }]);
+			expect(result[0]!.authorId).toBe("user-123");
+		});
+
+		test("preserves a Discord snowflake (18 digits)", () => {
+			const snowflake = "123456789012345678";
+			const result = validateMessages([{ role: "user", content: "hi", authorId: snowflake }]);
+			expect(result[0]!.authorId).toBe(snowflake);
+		});
+
+		test("preserves a Discord snowflake (20 digits)", () => {
+			const snowflake = "12345678901234567890";
+			const result = validateMessages([{ role: "user", content: "hi", authorId: snowflake }]);
+			expect(result[0]!.authorId).toBe(snowflake);
+		});
+
+		test("accepts authorId of exactly 64 characters", () => {
+			const id = "a".repeat(64);
+			const result = validateMessages([{ role: "user", content: "hi", authorId: id }]);
+			expect(result[0]!.authorId).toBe(id);
+		});
+
+		test("throws when authorId exceeds 64 characters", () => {
+			const id = "a".repeat(65);
+			expect(() => validateMessages([{ role: "user", content: "hi", authorId: id }])).toThrow(
+				"authorId: too long",
+			);
+		});
+
+		test("treats empty string authorId as undefined", () => {
+			const result = validateMessages([{ role: "user", content: "hi", authorId: "" }]);
+			expect(result[0]!.authorId).toBeUndefined();
+			expect("authorId" in result[0]!).toBe(false);
+		});
+
+		test("omits authorId when absent", () => {
+			const result = validateMessages([{ role: "user", content: "hi" }]);
+			expect(result[0]!.authorId).toBeUndefined();
+			expect("authorId" in result[0]!).toBe(false);
+		});
+
+		test("omits authorId when null", () => {
+			const result = validateMessages([{ role: "user", content: "hi", authorId: null }]);
+			expect(result[0]!.authorId).toBeUndefined();
+			expect("authorId" in result[0]!).toBe(false);
+		});
+
+		test("omits authorId when not a string (number)", () => {
+			const result = validateMessages([{ role: "user", content: "hi", authorId: 12345 }]);
+			expect(result[0]!.authorId).toBeUndefined();
+			expect("authorId" in result[0]!).toBe(false);
+		});
+
+		test("omits authorId when not a string (boolean)", () => {
+			const result = validateMessages([{ role: "user", content: "hi", authorId: true }]);
+			expect(result[0]!.authorId).toBeUndefined();
+		});
+
+		test("strips control characters from authorId", () => {
+			const result = validateMessages([{ role: "user", content: "hi", authorId: "user\n123\t\r" }]);
+			expect(result[0]!.authorId).toBe("user123");
+		});
+
+		test("strips DEL character (0x7F) from authorId", () => {
+			const result = validateMessages([{ role: "user", content: "hi", authorId: "user\u007F456" }]);
+			expect(result[0]!.authorId).toBe("user456");
+		});
+
+		test("authorId length check uses raw length (before strip)", () => {
+			// 65 chars total but all but one are control chars; still rejected because
+			// length check happens before stripping
+			// 65 chars
+			const id = `${"\n".repeat(64)}a`;
+			expect(() => validateMessages([{ role: "user", content: "hi", authorId: id }])).toThrow(
+				"authorId: too long",
+			);
+		});
+
+		test("preserves authorId alongside name and timestamp", () => {
+			const result = validateMessages([
+				{
+					role: "user",
+					content: "hi",
+					name: "Alice",
+					authorId: "discord-987",
+					timestamp: "2026-01-01T00:00:00Z",
+				},
+			]);
+			expect(result[0]!.name).toBe("Alice");
+			expect(result[0]!.authorId).toBe("discord-987");
+			expect(result[0]!.timestamp).toBeInstanceOf(Date);
+		});
+	});
 });
 
 describe("validateEmbedding", () => {

--- a/packages/memory/src/parse-helpers.ts
+++ b/packages/memory/src/parse-helpers.ts
@@ -6,6 +6,7 @@ const VALID_CATEGORIES = new Set<string>(FACT_CATEGORIES);
 
 const MAX_EMBEDDING_DIM = 4096;
 const MAX_NAME_LENGTH = 100;
+const MAX_AUTHOR_ID_LENGTH = 64;
 
 export function parseJson(raw: string, field: string): unknown {
 	try {
@@ -60,6 +61,27 @@ function validateName(value: unknown, index: number): string | undefined {
 	return value.replaceAll(/[\u0000-\u001F\u007F]/g, "");
 }
 
+function validateAuthorId(value: unknown, index: number): string | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		return undefined;
+	}
+	if (value.length === 0) {
+		// Empty string is not a valid identifier; treat as absent rather than throwing
+		return undefined;
+	}
+	if (value.length > MAX_AUTHOR_ID_LENGTH) {
+		throw new RangeError(
+			`messages[${index}].authorId: too long (${value.length}), maximum ${MAX_AUTHOR_ID_LENGTH}`,
+		);
+	}
+	// Strip control characters defensively (authorId should never contain them)
+	// eslint-disable-next-line no-control-regex -- intentional control character stripping
+	return value.replaceAll(/[\u0000-\u001F\u007F]/g, "");
+}
+
 function validateTimestampAsObject(
 	value: unknown,
 	index: number,
@@ -77,10 +99,12 @@ function validateMessage(m: unknown, i: number): ChatMessage {
 		throw new TypeError(`messages[${i}]: expected content string`);
 	}
 	const name = validateName(obj["name"], i);
+	const authorId = validateAuthorId(obj["authorId"], i);
 	return {
 		role: validateRole(obj["role"]),
 		content: obj["content"],
 		...(name === undefined ? {} : { name }),
+		...(authorId === undefined ? {} : { authorId }),
 		...validateTimestampAsObject(obj["timestamp"], i),
 	};
 }

--- a/packages/memory/src/storage-rows.ts
+++ b/packages/memory/src/storage-rows.ts
@@ -82,6 +82,7 @@ export interface MessageRow {
 	role: string;
 	content: string;
 	name: string | null;
+	author_id: string | null;
 	timestamp: number | null;
 }
 
@@ -90,6 +91,7 @@ export function rowToMessage(row: MessageRow): ChatMessage {
 		role: validateRole(row.role),
 		content: row.content,
 		...(row.name === null ? {} : { name: row.name }),
+		...(row.author_id === null ? {} : { authorId: row.author_id }),
 		...(row.timestamp === null ? {} : { timestamp: new Date(row.timestamp) }),
 	};
 }

--- a/packages/memory/src/storage-schema.test.ts
+++ b/packages/memory/src/storage-schema.test.ts
@@ -83,6 +83,15 @@ describe("sqlite-schema", () => {
 	});
 
 	describe("createMessageQueue", () => {
+		interface ColumnInfo {
+			name: string;
+		}
+
+		function getColumnNames(database: Database, table: string): string[] {
+			const cols = database.prepare(`PRAGMA table_info(${table})`).all() as ColumnInfo[];
+			return cols.map((c) => c.name);
+		}
+
 		test("creates message_queue table", () => {
 			createMessageQueue(db);
 			expect(getNames(db, "table")).toContain("message_queue");
@@ -91,6 +100,91 @@ describe("sqlite-schema", () => {
 		test("creates user_id index", () => {
 			createMessageQueue(db);
 			expect(getNames(db, "index", "message_queue")).toContain("idx_mq_user_id");
+		});
+
+		test("includes author_id column on fresh DB", () => {
+			createMessageQueue(db);
+			const columns = getColumnNames(db, "message_queue");
+			expect(columns).toContain("author_id");
+		});
+
+		test("includes all expected columns on fresh DB", () => {
+			createMessageQueue(db);
+			const columns = getColumnNames(db, "message_queue");
+			expect(columns).toEqual(
+				expect.arrayContaining([
+					"id",
+					"user_id",
+					"role",
+					"content",
+					"name",
+					"author_id",
+					"timestamp",
+				]),
+			);
+		});
+
+		test("adds author_id via ALTER when running on legacy schema (without author_id)", () => {
+			// 旧 DB スキーマをシミュレート: author_id カラムなしで CREATE
+			db.exec(`CREATE TABLE message_queue (
+				id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL,
+				role TEXT NOT NULL, content TEXT NOT NULL, name TEXT, timestamp INTEGER)`);
+			expect(getColumnNames(db, "message_queue")).not.toContain("author_id");
+
+			createMessageQueue(db);
+
+			expect(getColumnNames(db, "message_queue")).toContain("author_id");
+		});
+
+		test("preserves existing data when adding author_id via ALTER", () => {
+			// 旧 DB に author_id なしでデータが入っている状態をシミュレート
+			db.exec(`CREATE TABLE message_queue (
+				id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL,
+				role TEXT NOT NULL, content TEXT NOT NULL, name TEXT, timestamp INTEGER)`);
+			db.exec(
+				"INSERT INTO message_queue (user_id, role, content, name, timestamp) VALUES ('u1', 'user', 'hi', 'Alice', 1000)",
+			);
+
+			createMessageQueue(db);
+
+			const row = db
+				.prepare("SELECT user_id, content, author_id FROM message_queue WHERE user_id = 'u1'")
+				.get() as { user_id: string; content: string; author_id: string | null };
+			expect(row.user_id).toBe("u1");
+			expect(row.content).toBe("hi");
+			// 既存行の author_id は NULL（ALTER ADD COLUMN のデフォルト）
+			expect(row.author_id).toBeNull();
+		});
+
+		test("is idempotent: running twice does not throw duplicate column error", () => {
+			expect(() => {
+				createMessageQueue(db);
+				createMessageQueue(db);
+			}).not.toThrow();
+			// author_id は依然として 1 つだけ存在
+			const columns = getColumnNames(db, "message_queue");
+			const authorIdCount = columns.filter((c) => c === "author_id").length;
+			expect(authorIdCount).toBe(1);
+		});
+
+		test("is idempotent: running three times still safe", () => {
+			expect(() => {
+				createMessageQueue(db);
+				createMessageQueue(db);
+				createMessageQueue(db);
+			}).not.toThrow();
+		});
+
+		test("ALTER path is idempotent against legacy schema", () => {
+			// legacy → migrate → re-run all idempotent
+			db.exec(`CREATE TABLE message_queue (
+				id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL,
+				role TEXT NOT NULL, content TEXT NOT NULL, name TEXT, timestamp INTEGER)`);
+			expect(() => {
+				createMessageQueue(db);
+				createMessageQueue(db);
+			}).not.toThrow();
+			expect(getColumnNames(db, "message_queue")).toContain("author_id");
 		});
 	});
 

--- a/packages/memory/src/storage-schema.ts
+++ b/packages/memory/src/storage-schema.ts
@@ -1,5 +1,11 @@
 import type { Database } from "bun:sqlite";
 
+/** テーブル内に指定カラムが存在するかチェック（PRAGMA はパラメータバインド非対応のため文字列補間を使用。呼び出し元はリテラルのみ） */
+function hasColumn(db: Database, tableName: string, columnName: string): boolean {
+	const columns = db.prepare(`PRAGMA table_info(${tableName})`).all() as { name: string }[];
+	return columns.some((c) => c.name === columnName);
+}
+
 export function createEpisodeTables(db: Database): void {
 	db.exec(`CREATE TABLE IF NOT EXISTS episodes (
 		id TEXT PRIMARY KEY, user_id TEXT NOT NULL, title TEXT NOT NULL, summary TEXT NOT NULL,
@@ -35,8 +41,12 @@ export function createFactTables(db: Database): void {
 export function createMessageQueue(db: Database): void {
 	db.exec(`CREATE TABLE IF NOT EXISTS message_queue (
 		id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL,
-		role TEXT NOT NULL, content TEXT NOT NULL, name TEXT, timestamp INTEGER)`);
+		role TEXT NOT NULL, content TEXT NOT NULL, name TEXT, author_id TEXT, timestamp INTEGER)`);
 	db.exec("CREATE INDEX IF NOT EXISTS idx_mq_user_id ON message_queue(user_id)");
+	// idempotent migration: 旧 DB に author_id カラムがなければ追加（#847）
+	if (!hasColumn(db, "message_queue", "author_id")) {
+		db.exec("ALTER TABLE message_queue ADD COLUMN author_id TEXT");
+	}
 }
 
 export function createEmbeddingMeta(db: Database): void {

--- a/packages/memory/src/storage.ts
+++ b/packages/memory/src/storage.ts
@@ -333,13 +333,14 @@ export class MemoryStorage {
 	async pushMessage(userId: string, message: ChatMessage): Promise<void> {
 		this.db
 			.prepare(
-				"INSERT INTO message_queue (user_id, role, content, name, timestamp) VALUES (?, ?, ?, ?, ?)",
+				"INSERT INTO message_queue (user_id, role, content, name, author_id, timestamp) VALUES (?, ?, ?, ?, ?, ?)",
 			)
 			.run(
 				userId,
 				message.role,
 				message.content,
 				message.name ?? null,
+				message.authorId ?? null,
 				message.timestamp?.getTime() ?? null,
 			);
 	}
@@ -347,7 +348,7 @@ export class MemoryStorage {
 	async getMessageQueue(userId: string): Promise<ChatMessage[]> {
 		const rows = this.db
 			.prepare(
-				"SELECT role, content, name, timestamp FROM message_queue WHERE user_id = ? ORDER BY id ASC",
+				"SELECT role, content, name, author_id, timestamp FROM message_queue WHERE user_id = ? ORDER BY id ASC",
 			)
 			.all(userId) as MessageRow[];
 		return rows.map((r) => rowToMessage(r));

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -10,6 +10,11 @@ export interface ChatMessage {
 	content: string;
 	/** Display name of the speaker (e.g. participant name in multi-person conversations) */
 	name?: string;
+	/**
+	 * Stable platform-level user identifier (e.g. Discord user id).
+	 * Used by CriticAuditor for bot-message filtering. NEVER included in LLM prompts.
+	 */
+	authorId?: string;
 	timestamp?: Date;
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -95,6 +95,11 @@ export interface ConversationMessage {
 	role: ConversationRole;
 	content: string;
 	name?: string;
+	/**
+	 * Stable platform-level user identifier (e.g. Discord user id).
+	 * Used downstream by CriticAuditor to filter bot's own messages.
+	 */
+	authorId?: string;
 	timestamp?: Date;
 }
 

--- a/spec/application/message-ingestion-service.spec.ts
+++ b/spec/application/message-ingestion-service.spec.ts
@@ -65,6 +65,39 @@ describe("MessageIngestionService", () => {
 		);
 	});
 
+	test("ConversationMessage に IncomingMessage.authorId が転送される", async () => {
+		// CriticAuditor が authorId でフィルタするため、IngestionService は authorId を保持して
+		// ConversationRecorder に渡す責務がある（#847）
+		const recordMock = mock(() => Promise.resolve());
+		const recorder: ConversationRecorder = { record: recordMock };
+		const logger = createMockLogger();
+		const service = new MessageIngestionService({ logger, recorder });
+
+		service.handleIncomingMessage(
+			createMockMessage({
+				isBot: true,
+				authorId: "1100000000000000001",
+				// guild ニックネーム
+				authorName: "hua-bot",
+				content: "応答",
+			}),
+			{ recordConversation: true },
+		);
+
+		await Promise.resolve();
+
+		expect(recordMock).toHaveBeenCalledTimes(1);
+		expect(recordMock).toHaveBeenCalledWith(
+			discordGuildNamespace("1111"),
+			expect.objectContaining({
+				role: "assistant",
+				content: "応答",
+				authorId: "1100000000000000001",
+				name: "hua-bot",
+			}),
+		);
+	});
+
 	test("recordConversation 未指定なら Memory 記録しない", async () => {
 		const recorder: ConversationRecorder = {
 			record: mock(() => Promise.resolve()),

--- a/spec/discord/bootstrap-memory.spec.ts
+++ b/spec/discord/bootstrap-memory.spec.ts
@@ -1,4 +1,4 @@
-/* oxlint-disable require-await -- spec file */
+/* oxlint-disable require-await, no-non-null-assertion, unicorn/no-useless-undefined -- spec file: explicit undefined required to test getBotUserId callback shape */
 /**
  * setupMemoryRecording() の仕様テスト
  *
@@ -192,5 +192,64 @@ describe("setupMemoryRecording()", () => {
 		// 結果が返される（undefined でもエラーでなければOK）
 		// Promise が resolve することそのものが検証
 		expect(result === undefined || typeof result === "object").toBe(true);
+	});
+
+	test("opts.getBotUserId が CriticAuditor の audit() 経由で利用可能（遅延解決）", async () => {
+		// #847: gateway.start() より前に setupMemoryRecording が呼ばれるため、
+		// botUserId は遅延解決される必要がある。getBotUserId callback を opts に渡せること、
+		// および audit 呼び出しまで bot user id 解決を遅延できることを検証する。
+		const contextDir = resolve(testDir, "context");
+		mkdirSync(contextDir, { recursive: true });
+		writeFileSync(resolve(contextDir, "SOUL.md"), "# Character\nYou are hua.");
+
+		const config = makeConfig(resolve(testDir, "data"));
+		let resolved: string | undefined;
+		const getBotUserId = () => resolved;
+
+		// 1) bot user id 未解決の状態で setup
+		const result = await setupMemoryRecording(config, logger, {
+			memoryPort: 19999,
+			root: testDir,
+			getBotUserId,
+		});
+
+		expect(result).not.toBeUndefined();
+		if (!result) return;
+
+		// 2) gateway.start() 後に bot user id が判明
+		resolved = "1100000000000000001";
+
+		// 3) audit() 呼び出し時に最新の bot user id を使うこと（直接呼び出しはせず、
+		//    CriticAuditor が getBotUserId を解決済みかどうかは impl 側で内部 wiring）
+		const scheduler = result.consolidationScheduler as unknown as { criticAuditor?: unknown };
+		expect(scheduler.criticAuditor).toBeDefined();
+		const auditor = scheduler.criticAuditor as { audit?: unknown };
+		expect(typeof auditor.audit).toBe("function");
+	});
+
+	test("getBotUserId が undefined を返している間に audit() が呼ばれても throw しない", async () => {
+		// gateway.start() 前に consolidationScheduler が起動するケースは現状ないが、
+		// 防衛的に bot user id 未解決時の audit は no-op（null 返却）になることを期待する。
+		const contextDir = resolve(testDir, "context");
+		mkdirSync(contextDir, { recursive: true });
+		writeFileSync(resolve(contextDir, "SOUL.md"), "# Character");
+
+		const config = makeConfig(resolve(testDir, "data"));
+		const result = await setupMemoryRecording(config, logger, {
+			memoryPort: 19999,
+			root: testDir,
+			getBotUserId: () => undefined,
+		});
+
+		expect(result).not.toBeUndefined();
+		if (!result) return;
+		const scheduler = result.consolidationScheduler as unknown as {
+			criticAuditor?: { audit: (userId: string) => Promise<unknown> };
+		};
+		expect(scheduler.criticAuditor).toBeDefined();
+
+		// bot user id 未解決時は audit は null を返して early-return すること
+		const auditResult = await scheduler.criticAuditor!.audit("guild-1");
+		expect(auditResult).toBeNull();
 	});
 });

--- a/spec/memory/conversation-recorder.spec.ts
+++ b/spec/memory/conversation-recorder.spec.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-non-null-assertion -- test assertions after length/null checks */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { resolve as resolvePath } from "path";
@@ -14,6 +15,7 @@ import {
 	HUA_SELF_SUBJECT,
 	INTERNAL_NAMESPACE,
 } from "@vicissitude/memory/namespace";
+import type { ChatMessage } from "@vicissitude/memory/types";
 
 const TEMP_DIR = `/tmp/vicissitude-memory-test-${process.pid}`;
 
@@ -23,7 +25,9 @@ afterEach(() => {
 	}
 });
 
-const mockAddMessage = mock((): Promise<Episode[]> => Promise.resolve([]));
+const mockAddMessage = mock(
+	(_userId: string, _msg: ChatMessage): Promise<Episode[]> => Promise.resolve([]),
+);
 const mockConsolidate = mock(() =>
 	Promise.resolve({
 		processedEpisodes: 3,
@@ -49,6 +53,7 @@ function createRecorder() {
 const sampleMessage = {
 	role: "user" as const,
 	content: "hello",
+	authorId: "user-id-alice",
 	name: "alice",
 	timestamp: new Date(),
 };
@@ -70,6 +75,7 @@ describe("MemoryConversationRecorder (namespace API)", () => {
 		expect(mockAddMessage).toHaveBeenCalledWith("12345", {
 			role: "user",
 			content: "hello",
+			authorId: "user-id-alice",
 			name: "alice",
 			timestamp: sampleMessage.timestamp,
 		});
@@ -84,6 +90,7 @@ describe("MemoryConversationRecorder (namespace API)", () => {
 		expect(mockAddMessage).toHaveBeenCalledWith(HUA_SELF_SUBJECT, {
 			role: "user",
 			content: "hello",
+			authorId: "user-id-alice",
 			name: "alice",
 			timestamp: sampleMessage.timestamp,
 		});
@@ -217,6 +224,48 @@ describe("MemoryConversationRecorder (namespace API)", () => {
 
 		expect(mockStorageClose).toHaveBeenCalled();
 		expect(recorder.getActiveNamespaces()).toEqual([]);
+	});
+
+	test("record() で authorId が segmenter.addMessage に転送される", async () => {
+		// CriticAuditor が authorId でフィルタするため、ConversationRecorder は authorId を破棄せず転送する責務がある
+		mockAddMessage.mockClear();
+		mockAddMessage.mockImplementation(() => Promise.resolve([]));
+		const recorder = createRecorder();
+		const ns = discordGuildNamespace("12345");
+		await recorder.record(ns, {
+			role: "assistant",
+			content: "hi",
+			authorId: "1100000000000000001",
+			name: "ふあ",
+			timestamp: sampleMessage.timestamp,
+		});
+
+		expect(mockAddMessage).toHaveBeenCalledWith("12345", {
+			role: "assistant",
+			content: "hi",
+			authorId: "1100000000000000001",
+			name: "ふあ",
+			timestamp: sampleMessage.timestamp,
+		});
+	});
+
+	test("record() で authorId が省略されても segmenter.addMessage は呼ばれる（authorId は optional）", async () => {
+		mockAddMessage.mockClear();
+		mockAddMessage.mockImplementation(() => Promise.resolve([]));
+		const recorder = createRecorder();
+		const ns = discordGuildNamespace("12345");
+		await recorder.record(ns, {
+			role: "user",
+			content: "no authorId",
+			name: "anon",
+			timestamp: sampleMessage.timestamp,
+		});
+
+		// authorId が無い場合は addMessage に渡るペイロードでも authorId フィールドは含まれない
+		expect(mockAddMessage).toHaveBeenCalledTimes(1);
+		const [, payload] = mockAddMessage.mock.calls[0]!;
+		expect(payload.authorId).toBeUndefined();
+		expect(payload.content).toBe("no authorId");
 	});
 
 	test("getActiveNamespaces() → ディスク上の既存 DB も発見する（record() なし）", () => {

--- a/spec/memory/critic-auditor.spec.ts
+++ b/spec/memory/critic-auditor.spec.ts
@@ -11,7 +11,7 @@ import type { ChatMessage } from "@vicissitude/memory/types";
 import { createMockLLM, makeEpisode } from "./test-helpers.ts";
 
 const userId = "user-1";
-const botName = "ふあ";
+const botUserId = "1100000000000000001";
 const characterDefinition = "You are hua, a casual and snarky girl.";
 
 /** LLM that records chatStructured calls for inspection */
@@ -49,7 +49,7 @@ describe("CriticAuditor", () => {
 	test("assistant メッセージがない場合は null を返す", async () => {
 		// エピソードはあるが assistant メッセージがない
 		const episode = makeEpisode({
-			messages: [{ role: "user", content: "hello" }],
+			messages: [{ role: "user", content: "hello", authorId: "user-1" }],
 			endAt: new Date(),
 		});
 		await storage.saveEpisode(userId, episode);
@@ -60,21 +60,26 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
-			botName,
+			botUserId,
 		});
 		const result = await auditor.audit(userId);
 
 		expect(result).toBeNull();
 	});
 
-	test("name が欠損または別 bot の assistant メッセージはスキップされる", async () => {
+	test("authorId が欠損または別 bot の assistant メッセージはスキップされる", async () => {
 		const episode = makeEpisode({
 			messages: [
-				{ role: "user", content: "hello", name: "user-1" },
-				// name 欠損
-				{ role: "assistant", content: "I am another bot" },
-				// 別 bot
-				{ role: "assistant", content: "I am different", name: "other-bot" },
+				{ role: "user", content: "hello", authorId: "user-1", name: "user-1" },
+				// authorId 欠損（旧データや他経路で挿入されたデータ）
+				{ role: "assistant", content: "I am another bot", name: "ふあ" },
+				// 別 bot user
+				{
+					role: "assistant",
+					content: "I am different",
+					authorId: "9999999999999999999",
+					name: "ふあ",
+				},
 			],
 			endAt: new Date(),
 		});
@@ -86,11 +91,40 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
-			botName,
+			botUserId,
 		});
 		const result = await auditor.audit(userId);
 
-		// botName にマッチする assistant メッセージがないので null
+		// botUserId にマッチする assistant メッセージがないので null
+		expect(result).toBeNull();
+	});
+
+	test("name が一致しても authorId が一致しなければスキップされる（ニックネーム不一致対策）", async () => {
+		// 同名（ふあ）の別 bot が同一 guild にいるケース。authorId が異なれば除外される。
+		const episode = makeEpisode({
+			messages: [
+				{ role: "user", content: "hello", authorId: "user-1", name: "user-1" },
+				{
+					role: "assistant",
+					content: "別 bot の発話",
+					authorId: "8888888888888888888",
+					name: "ふあ",
+				},
+			],
+			endAt: new Date(),
+		});
+		await storage.saveEpisode(userId, episode);
+
+		const llm = createMockLLM({ structuredResponse: { severity: "none", summary: "ok" } });
+		const auditor = new CriticAuditor({
+			llm,
+			storage,
+			driftCalculator: drift,
+			characterDefinition,
+			botUserId,
+		});
+		const result = await auditor.audit(userId);
+
 		expect(result).toBeNull();
 	});
 
@@ -98,8 +132,8 @@ describe("CriticAuditor", () => {
 		// 低ドリフトの assistant メッセージ 1 件のみ
 		const episode = makeEpisode({
 			messages: [
-				{ role: "user", content: "hello", name: "user-1" },
-				{ role: "assistant", content: "うん", name: botName },
+				{ role: "user", content: "hello", authorId: "user-1", name: "user-1" },
+				{ role: "assistant", content: "うん", authorId: botUserId, name: "ふあ" },
 			],
 			endAt: new Date(),
 		});
@@ -111,23 +145,25 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
-			botName,
+			botUserId,
 		});
 		const result = await auditor.audit(userId);
 
 		expect(result).toBeNull();
 	});
 
-	test("ドリフトスコアが閾値以上の場合は LLM を呼んで CriticResult を返す", async () => {
-		// 高ドリフトの assistant メッセージ
+	test("ドリフトスコアが閾値以上の場合は LLM を呼んで CriticResult を返す（authorId でフィルタ）", async () => {
+		// 高ドリフトの assistant メッセージ。guild ニックネーム（name）は異なっても authorId が一致すれば対象。
 		const episode = makeEpisode({
 			messages: [
-				{ role: "user", content: "hello", name: "user-1" },
+				{ role: "user", content: "hello", authorId: "user-1", name: "user-1" },
 				{
 					role: "assistant",
 					content:
 						"お手伝いします。素晴らしいご質問ですね。了解しました。もちろんです。確認してみますね。",
-					name: botName,
+					// ニックネームが "hua-bot" になっていても authorId が一致すれば対象になる
+					authorId: botUserId,
+					name: "hua-bot",
 				},
 			],
 			endAt: new Date(),
@@ -144,7 +180,7 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
-			botName,
+			botUserId,
 		});
 		const result = await auditor.audit(userId);
 
@@ -159,8 +195,8 @@ describe("CriticAuditor", () => {
 		for (let i = 0; i < 3; i++) {
 			const ep = makeEpisode({
 				messages: [
-					{ role: "user", content: `question ${i}`, name: "user-1" },
-					{ role: "assistant", content: `answer ${i}`, name: botName },
+					{ role: "user", content: `question ${i}`, authorId: "user-1", name: "user-1" },
+					{ role: "assistant", content: `answer ${i}`, authorId: botUserId, name: "ふあ" },
 				],
 				endAt: new Date(),
 			});
@@ -180,7 +216,7 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
-			botName,
+			botUserId,
 		});
 		const result = await auditor.audit(userId);
 
@@ -198,8 +234,8 @@ describe("CriticAuditor", () => {
 		for (let i = 0; i < 3; i++) {
 			const ep = makeEpisode({
 				messages: [
-					{ role: "user", content: `question ${i}`, name: "user-1" },
-					{ role: "assistant", content: `answer ${i}`, name: botName },
+					{ role: "user", content: `question ${i}`, authorId: "user-1", name: "user-1" },
+					{ role: "assistant", content: `answer ${i}`, authorId: botUserId, name: "ふあ" },
 				],
 				endAt: new Date(),
 			});
@@ -217,7 +253,7 @@ describe("CriticAuditor", () => {
 			storage,
 			driftCalculator: drift,
 			characterDefinition,
-			botName,
+			botUserId,
 		});
 		const result = await auditor.audit(userId);
 

--- a/spec/memory/storage.spec.ts
+++ b/spec/memory/storage.spec.ts
@@ -409,6 +409,27 @@ describe("MemoryStorage — message queue", () => {
 		expect(queue[0]!.name).toBeUndefined();
 	});
 
+	test("preserves message authorId through round-trip", async () => {
+		await storage.pushMessage(userId, {
+			role: "user",
+			content: "hello",
+			authorId: "1100000000000000001",
+			name: "Alice",
+		});
+
+		const queue = await storage.getMessageQueue(userId);
+		expect(queue).toHaveLength(1);
+		expect(queue[0]!.authorId).toBe("1100000000000000001");
+	});
+
+	test("message without authorId round-trips correctly", async () => {
+		await storage.pushMessage(userId, { role: "user", content: "hello", name: "Alice" });
+
+		const queue = await storage.getMessageQueue(userId);
+		expect(queue).toHaveLength(1);
+		expect(queue[0]!.authorId).toBeUndefined();
+	});
+
 	test("preserves message name in episode messages JSON", async () => {
 		const messages: ChatMessage[] = [
 			{ role: "user", content: "hello", name: "Alice" },
@@ -420,6 +441,23 @@ describe("MemoryStorage — message queue", () => {
 		const found = await storage.getEpisodeById(userId, ep.id);
 		expect(found!.messages[0]!.name).toBe("Alice");
 		expect(found!.messages[1]!.name).toBeUndefined();
+	});
+
+	test("preserves message authorId in episode messages JSON", async () => {
+		// CriticAuditor が authorId でフィルタするため、エピソード内の messages に authorId が永続化される必要がある
+		const messages: ChatMessage[] = [
+			{ role: "user", content: "hello", authorId: "user-id-1", name: "Alice" },
+			{ role: "assistant", content: "hi", authorId: "1100000000000000001", name: "ふあ" },
+			// authorId が無いメッセージも許容（optional）
+			{ role: "user", content: "no id", name: "anon" },
+		];
+		const ep = makeEpisode({ messages });
+		await storage.saveEpisode(userId, ep);
+
+		const found = await storage.getEpisodeById(userId, ep.id);
+		expect(found!.messages[0]!.authorId).toBe("user-id-1");
+		expect(found!.messages[1]!.authorId).toBe("1100000000000000001");
+		expect(found!.messages[2]!.authorId).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
Closes #847

## Summary

- `CriticAuditor` の assistant メッセージフィルタを `botName` 一致から Discord user ID (`authorId`) 一致へ変更
- guild ニックネームと `config.botName` の不一致で監査が無音停止する問題を解消
- 旧データ（`authorId` 欠損）はホワイトリスト方式のフィルタで自然に除外される

## 主な変更

- `ChatMessage` / `ConversationMessage` に `authorId?: string` を追加（LLM プロンプトには出さない）
- `CriticAuditorDeps.botName` → `botUserId: string` に置換
- `bootstrap` で `getBotUserId: () => gateway.getClient()?.user?.id` を遅延注入。未解決時は audit を null 早期 return（gateway 切断中・起動前を防衛）
- `message_queue` テーブルに `author_id` カラムを追加。`hasColumn` ガード付き idempotent ALTER で既存 DB を破壊せずマイグレーション
- `parse-helpers` に `validateAuthorId` 追加（最大 64 文字、空文字 → undefined、制御文字 strip）

## Test plan

- [x] `nr validate`（fmt:check + lint + check）pass
- [x] `nr test` 全 2265 件 pass
- [x] 新規 spec: 「name 一致でも authorId 不一致なら除外」（#847 リグレッション防止）
- [x] 新規 spec: 「`getBotUserId` が undefined を返している間に audit() が throw しない」
- [x] `storage-schema.test.ts` で hasColumn ガードと migration の idempotency を検証

## Follow-up

- `AppConfig.botName` は今回 PR では保持。CriticAuditor から剥がしたことで実行時の参照が消えたため dead config 化。整理は別 Issue で追跡予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)