### PR TITLE
refactor: hasColumn ヘルパーを @vicissitude/shared/sqlite に集約 (#850)

### DIFF
--- a/packages/memory/src/storage-schema.ts
+++ b/packages/memory/src/storage-schema.ts
@@ -1,10 +1,6 @@
 import type { Database } from "bun:sqlite";
 
-/** テーブル内に指定カラムが存在するかチェック（PRAGMA はパラメータバインド非対応のため文字列補間を使用。呼び出し元はリテラルのみ） */
-function hasColumn(db: Database, tableName: string, columnName: string): boolean {
-	const columns = db.prepare(`PRAGMA table_info(${tableName})`).all() as { name: string }[];
-	return columns.some((c) => c.name === columnName);
-}
+import { hasColumn } from "@vicissitude/shared/sqlite";
 
 export function createEpisodeTables(db: Database): void {
 	db.exec(`CREATE TABLE IF NOT EXISTS episodes (

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
 		"./ws-protocol": "./src/ws-protocol.ts",
 		"./ports": "./src/ports.ts",
 		"./tts": "./src/tts.ts",
-		"./test-helpers": "./src/test-helpers.ts"
+		"./test-helpers": "./src/test-helpers.ts",
+		"./sqlite": "./src/sqlite.ts"
 	}
 }

--- a/packages/shared/src/sqlite.ts
+++ b/packages/shared/src/sqlite.ts
@@ -1,0 +1,7 @@
+import type { Database } from "bun:sqlite";
+
+/** テーブル内に指定カラムが存在するかチェック（PRAGMA はパラメータバインド非対応のため文字列補間を使用。呼び出し元はリテラルのみ） */
+export function hasColumn(db: Database, tableName: string, columnName: string): boolean {
+	const columns = db.prepare(`PRAGMA table_info(${tableName})`).all() as { name: string }[];
+	return columns.some((c) => c.name === columnName);
+}

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { mkdirSync } from "fs";
 import { join } from "path";
 
+import { hasColumn } from "@vicissitude/shared/sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import * as schema from "./schema.ts";
@@ -82,12 +83,6 @@ function hasTable(sqlite: Database, tableName: string): boolean {
 	return !!sqlite
 		.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
 		.get(tableName);
-}
-
-/** テーブル内に指定カラムが存在するかチェック（PRAGMA はパラメータバインド非対応のため文字列補間を使用。呼び出し元はリテラルのみ） */
-function hasColumn(sqlite: Database, tableName: string, columnName: string): boolean {
-	const columns = sqlite.prepare(`PRAGMA table_info(${tableName})`).all() as { name: string }[];
-	return columns.some((c) => c.name === columnName);
 }
 
 /** 既存 DB のマイグレーション（CREATE_TABLES_SQL の前に実行） */


### PR DESCRIPTION
## Summary
- `packages/store/src/db.ts` と `packages/memory/src/storage-schema.ts` で重複していた `hasColumn` ヘルパーを `packages/shared/src/sqlite.ts` に集約
- 両パッケージから `@vicissitude/shared/sqlite` 経由で import するよう変更

Closes #850

## Test plan
- [x] `bun test packages/memory packages/store packages/shared` → 181 pass / 0 fail
- [x] `nr fmt:check` → 通過
- [x] 型チェック: 変更パッケージ（store/memory/shared）にエラーなし（既存の minecraft/web 関連エラーは pre-existing）

🤖 Generated with [Claude Code](https://claude.com/claude-code)