### PR TITLE
refactor(memory): migrateMemoryDb() パターンへ集約

### DIFF
--- a/packages/memory/src/storage-schema.test.ts
+++ b/packages/memory/src/storage-schema.test.ts
@@ -7,6 +7,7 @@ import {
 	createEpisodeTables,
 	createFactTables,
 	createMessageQueue,
+	migrateMemoryDb,
 } from "./storage-schema.ts";
 
 interface SqliteMasterRow {
@@ -124,20 +125,44 @@ describe("sqlite-schema", () => {
 			);
 		});
 
-		test("adds author_id via ALTER when running on legacy schema (without author_id)", () => {
-			// 旧 DB スキーマをシミュレート: author_id カラムなしで CREATE
+		test("is idempotent: running twice does not throw", () => {
+			expect(() => {
+				createMessageQueue(db);
+				createMessageQueue(db);
+			}).not.toThrow();
+			const columns = getColumnNames(db, "message_queue");
+			const authorIdCount = columns.filter((c) => c === "author_id").length;
+			expect(authorIdCount).toBe(1);
+		});
+	});
+
+	describe("migrateMemoryDb", () => {
+		interface ColumnInfo {
+			name: string;
+		}
+
+		function getColumnNames(database: Database, table: string): string[] {
+			const cols = database.prepare(`PRAGMA table_info(${table})`).all() as ColumnInfo[];
+			return cols.map((c) => c.name);
+		}
+
+		test("is no-op when message_queue table does not exist", () => {
+			expect(() => migrateMemoryDb(db)).not.toThrow();
+		});
+
+		test("adds author_id when running on legacy schema (without author_id)", () => {
+			// 旧 DB スキーマをシミュレート
 			db.exec(`CREATE TABLE message_queue (
 				id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL,
 				role TEXT NOT NULL, content TEXT NOT NULL, name TEXT, timestamp INTEGER)`);
 			expect(getColumnNames(db, "message_queue")).not.toContain("author_id");
 
-			createMessageQueue(db);
+			migrateMemoryDb(db);
 
 			expect(getColumnNames(db, "message_queue")).toContain("author_id");
 		});
 
-		test("preserves existing data when adding author_id via ALTER", () => {
-			// 旧 DB に author_id なしでデータが入っている状態をシミュレート
+		test("preserves existing data when adding author_id", () => {
 			db.exec(`CREATE TABLE message_queue (
 				id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL,
 				role TEXT NOT NULL, content TEXT NOT NULL, name TEXT, timestamp INTEGER)`);
@@ -145,46 +170,34 @@ describe("sqlite-schema", () => {
 				"INSERT INTO message_queue (user_id, role, content, name, timestamp) VALUES ('u1', 'user', 'hi', 'Alice', 1000)",
 			);
 
-			createMessageQueue(db);
+			migrateMemoryDb(db);
 
 			const row = db
 				.prepare("SELECT user_id, content, author_id FROM message_queue WHERE user_id = 'u1'")
 				.get() as { user_id: string; content: string; author_id: string | null };
 			expect(row.user_id).toBe("u1");
 			expect(row.content).toBe("hi");
-			// 既存行の author_id は NULL（ALTER ADD COLUMN のデフォルト）
 			expect(row.author_id).toBeNull();
 		});
 
-		test("is idempotent: running twice does not throw duplicate column error", () => {
-			expect(() => {
-				createMessageQueue(db);
-				createMessageQueue(db);
-			}).not.toThrow();
-			// author_id は依然として 1 つだけ存在
-			const columns = getColumnNames(db, "message_queue");
-			const authorIdCount = columns.filter((c) => c === "author_id").length;
-			expect(authorIdCount).toBe(1);
-		});
-
-		test("is idempotent: running three times still safe", () => {
-			expect(() => {
-				createMessageQueue(db);
-				createMessageQueue(db);
-				createMessageQueue(db);
-			}).not.toThrow();
-		});
-
-		test("ALTER path is idempotent against legacy schema", () => {
-			// legacy → migrate → re-run all idempotent
+		test("is idempotent against legacy schema", () => {
 			db.exec(`CREATE TABLE message_queue (
 				id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL,
 				role TEXT NOT NULL, content TEXT NOT NULL, name TEXT, timestamp INTEGER)`);
 			expect(() => {
-				createMessageQueue(db);
-				createMessageQueue(db);
+				migrateMemoryDb(db);
+				migrateMemoryDb(db);
+				migrateMemoryDb(db);
 			}).not.toThrow();
-			expect(getColumnNames(db, "message_queue")).toContain("author_id");
+			const columns = getColumnNames(db, "message_queue");
+			expect(columns.filter((c) => c === "author_id").length).toBe(1);
+		});
+
+		test("is no-op on fresh DB created by createMessageQueue", () => {
+			createMessageQueue(db);
+			expect(() => migrateMemoryDb(db)).not.toThrow();
+			const columns = getColumnNames(db, "message_queue");
+			expect(columns.filter((c) => c === "author_id").length).toBe(1);
 		});
 	});
 
@@ -212,6 +225,21 @@ describe("sqlite-schema", () => {
 				createAllTables(db);
 				createAllTables(db);
 			}).not.toThrow();
+		});
+
+		test("migrates legacy message_queue schema (author_id added)", () => {
+			interface ColumnInfo {
+				name: string;
+			}
+			// 旧 DB に message_queue が author_id なしで存在する状態
+			db.exec(`CREATE TABLE message_queue (
+				id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL,
+				role TEXT NOT NULL, content TEXT NOT NULL, name TEXT, timestamp INTEGER)`);
+
+			createAllTables(db);
+
+			const cols = db.prepare("PRAGMA table_info(message_queue)").all() as ColumnInfo[];
+			expect(cols.map((c) => c.name)).toContain("author_id");
 		});
 	});
 });

--- a/packages/memory/src/storage-schema.ts
+++ b/packages/memory/src/storage-schema.ts
@@ -2,6 +2,20 @@ import type { Database } from "bun:sqlite";
 
 import { hasColumn } from "@vicissitude/shared/sqlite";
 
+function hasTable(db: Database, tableName: string): boolean {
+	return !!db
+		.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+		.get(tableName);
+}
+
+/** 既存 DB のマイグレーション（CREATE 系より前に実行する） */
+export function migrateMemoryDb(db: Database): void {
+	// message_queue: author_id カラム追加（#847）
+	if (hasTable(db, "message_queue") && !hasColumn(db, "message_queue", "author_id")) {
+		db.exec("ALTER TABLE message_queue ADD COLUMN author_id TEXT");
+	}
+}
+
 export function createEpisodeTables(db: Database): void {
 	db.exec(`CREATE TABLE IF NOT EXISTS episodes (
 		id TEXT PRIMARY KEY, user_id TEXT NOT NULL, title TEXT NOT NULL, summary TEXT NOT NULL,
@@ -39,10 +53,6 @@ export function createMessageQueue(db: Database): void {
 		id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL,
 		role TEXT NOT NULL, content TEXT NOT NULL, name TEXT, author_id TEXT, timestamp INTEGER)`);
 	db.exec("CREATE INDEX IF NOT EXISTS idx_mq_user_id ON message_queue(user_id)");
-	// idempotent migration: 旧 DB に author_id カラムがなければ追加（#847）
-	if (!hasColumn(db, "message_queue", "author_id")) {
-		db.exec("ALTER TABLE message_queue ADD COLUMN author_id TEXT");
-	}
 }
 
 export function createEmbeddingMeta(db: Database): void {
@@ -51,6 +61,7 @@ export function createEmbeddingMeta(db: Database): void {
 }
 
 export function createAllTables(db: Database): void {
+	migrateMemoryDb(db);
 	createEpisodeTables(db);
 	createFactTables(db);
 	createMessageQueue(db);


### PR DESCRIPTION
## Summary

- closes #851
- `packages/store/src/db.ts` と同じパターンで CREATE と ALTER を分離
- `createMessageQueue()` に混在していた `author_id` ALTER ロジックを `migrateMemoryDb()` に切り出し
- `createAllTables()` 冒頭で `migrateMemoryDb()` を実行する順序に変更

## Test plan

- [x] `bun test packages/memory/` (180 pass)
- [x] `bun test spec/memory/ spec/discord/bootstrap-memory.spec.ts` (383 pass)
- [x] `nr lint:fix` / `oxfmt --check` (0 warnings)
- [x] legacy schema (author_id 無し) → migrate → CREATE が正しく動作することを test で担保

🤖 Generated with [Claude Code](https://claude.com/claude-code)