### PR TITLE
fix(memory): validateAuthorId が制御文字 strip 後の空文字を undefined として扱う (#856)

### DIFF
--- a/packages/memory/src/parse-helpers.test.ts
+++ b/packages/memory/src/parse-helpers.test.ts
@@ -223,6 +223,12 @@ describe("validateMessages", () => {
 			expect(result[0]!.authorId).toBe("user456");
 		});
 
+		test("treats control-only authorId as undefined after stripping", () => {
+			const result = validateMessages([{ role: "user", content: "hi", authorId: "\n\t\r" }]);
+			expect(result[0]!.authorId).toBeUndefined();
+			expect("authorId" in result[0]!).toBe(false);
+		});
+
 		test("authorId length check uses raw length (before strip)", () => {
 			// 65 chars total but all but one are control chars; still rejected because
 			// length check happens before stripping

--- a/packages/memory/src/parse-helpers.ts
+++ b/packages/memory/src/parse-helpers.ts
@@ -79,7 +79,8 @@ function validateAuthorId(value: unknown, index: number): string | undefined {
 	}
 	// Strip control characters defensively (authorId should never contain them)
 	// eslint-disable-next-line no-control-regex -- intentional control character stripping
-	return value.replaceAll(/[\u0000-\u001F\u007F]/g, "");
+	const stripped = value.replaceAll(/[\u0000-\u001F\u007F]/g, "");
+	return stripped.length === 0 ? undefined : stripped;
 }
 
 function validateTimestampAsObject(


### PR DESCRIPTION
## Summary

- `validateAuthorId` で制御文字を strip した後に空文字となるケース（例: `"\n\n\n"`）でも `undefined` を返すよう修正
- 入力時点で空文字の場合の既存挙動と統一し、空文字 `authorId` が `ChatMessage` に混入しないことを保証

Closes #856

## Test plan

- [x] `parse-helpers.test.ts` に再現テスト「treats control-only authorId as undefined after stripping」を追加
- [x] `nr test:spec` 全 1648 件パス
- [x] `nr test` で `parse-helpers.test.ts` 全 58 件パス

## Note

Issue で言及されていた `validateName` 側の対称化はスコープ外（`name` は表示用のため空文字も意味を持ち得る）。今回は authorId 側のみ統一する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)