### PR TITLE
refactor(config): AppConfig.botName / BOT_NAME を削除 (#849)

### DIFF
--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -7,7 +7,6 @@ import type { AppConfig } from "./config.ts";
 
 function createTestConfig(overrides?: Partial<AppConfig>): AppConfig {
 	return {
-		botName: "ふあ",
 		discordToken: "test-token",
 		webPort: 4000,
 		gatewayPort: 4001,

--- a/apps/discord/src/config.ts
+++ b/apps/discord/src/config.ts
@@ -45,7 +45,6 @@ const githubSchema = z.object({
 });
 
 const appConfigSchema = z.object({
-	botName: z.string().min(1, "BOT_NAME is required"),
 	discordToken: z.string().min(1, "DISCORD_TOKEN is required"),
 	webPort: safeInt,
 	gatewayPort: safeInt,
@@ -95,7 +94,6 @@ export function loadConfig(
 	const basePort = Number(env.OPENCODE_BASE_PORT ?? "4096");
 
 	const raw = {
-		botName: env.BOT_NAME ?? "ふあ",
 		discordToken: env.DISCORD_TOKEN ?? "",
 		webPort: Number(env.WEB_PORT ?? "4000"),
 		gatewayPort: Number(env.GATEWAY_PORT ?? "4001"),

--- a/spec/discord/bootstrap-memory.spec.ts
+++ b/spec/discord/bootstrap-memory.spec.ts
@@ -21,7 +21,6 @@ import { createMockLogger } from "../test-helpers.ts";
 
 function makeConfig(dataDir: string): AppConfig {
 	return {
-		botName: "ふあ",
 		discordToken: "test-token",
 		webPort: 3000,
 		gatewayPort: 3001,

--- a/spec/discord/bootstrap.spec.ts
+++ b/spec/discord/bootstrap.spec.ts
@@ -11,7 +11,6 @@ function makeConfig(
 	} = {},
 ): AppConfig {
 	return {
-		botName: "ふあ",
 		discordToken: "test-discord-token",
 		webPort: 3000,
 		gatewayPort: 3001,


### PR DESCRIPTION
## Summary

- #847 / #848 で `CriticAuditor` のフィルタが `botName` から `authorId` ベースに変わったため dead config 化していた `AppConfig.botName` フィールドと `BOT_NAME` 環境変数を削除
- Zod schema / loader / 3 つのテスト fixture から `botName` を一括除去（合計 5 行削除）
- `scripts/extract-audit-data.ts` および `.claude/skills/character-audit/SKILL.md` の `botName` は `IDENTITY.md` ベースの独立解決のため触っていない

## Breaking change

- `BOT_NAME` 環境変数は schema 検証から外れるので、運用ホストの `.env` から `BOT_NAME=…` 行を**マージと同時に削除**すること

Closes #849

## Test plan

- [x] `nr validate` (fmt:check + lint + check) PASS
- [x] `nr test` 2267 passed / 0 failed (ベースライン一致)
- [x] `apps/discord/` 配下に `botName` / `BOT_NAME` 残存参照なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)