### PR TITLE
[codex] Add project doc fallback for Claude instructions

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,1 @@
+project_doc_fallback_filenames = [".claude/CLAUDE.md"]


### PR DESCRIPTION
## Summary

- Add repo-local `.codex/config.toml`.
- Configure `project_doc_fallback_filenames` to load `.claude/CLAUDE.md` as the project document.

## Validation

- Ran `codex debug prompt-input '確認'` and confirmed the generated prompt includes the `.claude/CLAUDE.md` content under `--- project-doc ---`.
- Commit hook `deps-graph` passed during commit.