### PR TITLE
Add per-turn identity prompt prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ OpenCode SDK 組み込み: `webfetch`
 
 - オーバーレイ方式: `context/`（git 管理・ベース）と `data/context/`（gitignore・オーバーレイ）の二層構成。読み込みは `data/context/` → `context/` のフォールバック、書き込みは常に `data/context/`。
 - 静的ファイル: `IDENTITY.md`, `SOUL.md`, `DISCORD.md`, `HEARTBEAT.md`, `TOOLS-CORE.md`, `TOOLS-CODE.md`, `TOOLS-MINECRAFT.md`
+- 毎ターンの自己認識補助: Discord 会話プロンプトの先頭に `あなたは{name}です。` を注入する。`VICISSITUDE_IDENTITY_NAME` を優先し、未設定時は `data/context/IDENTITY.md` → `context/IDENTITY.md` の順に `name:` / `full_name:` から抽出する。
 - Memory ファクト注入: 起動時に長期記憶から蓄積済みファクトをシステムプロンプトに注入。
 - サイズ制約: ファイル毎最大 20,000 文字、合計最大 150,000 文字。
 

--- a/packages/agent/src/discord/context-builder.ts
+++ b/packages/agent/src/discord/context-builder.ts
@@ -32,6 +32,7 @@ const GUILD_CONTEXT_AFTER: ContextFileName = "HEARTBEAT.md";
 
 const PER_FILE_MAX = 20_000;
 const TOTAL_MAX = 150_000;
+const IDENTITY_NAME_ENV = "VICISSITUDE_IDENTITY_NAME";
 
 export class ContextBuilder implements ContextBuilderPort {
 	constructor(
@@ -84,6 +85,12 @@ export class ContextBuilder implements ContextBuilderPort {
 		}
 
 		return sections.join("\n\n");
+	}
+
+	async buildTurnPromptPrefix(): Promise<string | null> {
+		const name = await this.resolveIdentityName();
+		if (!name) return null;
+		return `あなたは${name}です。`;
 	}
 
 	/** Maximum facts to inject into system prompt */
@@ -145,6 +152,18 @@ export class ContextBuilder implements ContextBuilderPort {
 		return this.readContextFile(basePath);
 	}
 
+	private async resolveIdentityName(): Promise<string | null> {
+		const envName = process.env[IDENTITY_NAME_ENV];
+		if (typeof envName === "string") {
+			const trimmed = envName.trim();
+			if (trimmed) return trimmed;
+		}
+
+		const identity = await this.readOverlaid("IDENTITY.md");
+		if (!identity) return null;
+		return extractIdentityName(identity);
+	}
+
 	private async readContextFile(filepath: string): Promise<string | null> {
 		try {
 			const content = await Bun.file(filepath).text();
@@ -159,4 +178,25 @@ export class ContextBuilder implements ContextBuilderPort {
 			return null;
 		}
 	}
+}
+
+export function extractIdentityName(identity: string): string | null {
+	const lines = identity.split(/\r?\n/);
+	for (const key of ["name", "full_name"]) {
+		const prefix = `${key}:`;
+		const line = lines.find((candidate) => candidate.trimStart().startsWith(prefix));
+		const value = line?.slice(line.indexOf(":") + 1).trim();
+		if (value) return stripYamlScalarQuotes(value);
+	}
+	return null;
+}
+
+function stripYamlScalarQuotes(value: string): string {
+	if (value.length < 2) return value;
+	const first = value.at(0);
+	const last = value.at(-1);
+	if ((first === `"` && last === `"`) || (first === `'` && last === `'`)) {
+		return value.slice(1, -1).trim();
+	}
+	return value;
 }

--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -75,6 +75,35 @@ describe("AgentRunner", () => {
 		sessionDone.resolve({ type: "cancelled" });
 	});
 
+	test("毎ターンのプロンプト先頭に自己認識接頭辞を注入する", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPort(() => sessionDone.promise);
+		const contextBuilder: ContextBuilderPort = {
+			build: mock(() => Promise.resolve("system prompt")),
+			buildTurnPromptPrefix: mock(() => Promise.resolve("あなたはふあです。")),
+		};
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder,
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		activeRunners.add(runner);
+
+		await runner.send({ sessionKey: "k", message: "test" });
+		await Bun.sleep(0);
+
+		const params = sessionPort.promptAsyncAndWatchSession.mock.calls[0]?.[0];
+		expect(params?.text.startsWith("あなたはふあです。\n\nloop forever\n\ntest")).toBe(true);
+		expect(contextBuilder.buildTurnPromptPrefix).toHaveBeenCalledTimes(1);
+
+		runner.stop();
+		sessionDone.resolve({ type: "cancelled" });
+	});
+
 	test("session が idle になったら新規メッセージ待ちで再起動する", async () => {
 		const firstSessionDone = deferred<OpencodeSessionEvent>();
 		const secondSessionDone = deferred<OpencodeSessionEvent>();

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -384,9 +384,11 @@ export class AgentRunner implements AiAgent {
 		this.lastPromptText = text;
 		this.lastPromptAttachments = attachments;
 
-		const promptText = this.profile.pollingPrompt
-			? `${this.profile.pollingPrompt}\n\n${text}`
-			: text;
+		const turnPromptPrefix = await this.contextBuilder.buildTurnPromptPrefix?.();
+		if (signal.aborted) return;
+		const promptText = [turnPromptPrefix, this.profile.pollingPrompt, text]
+			.filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+			.join("\n\n");
 
 		const sessionId = await this.resolveSessionId();
 		if (signal.aborted) return;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -200,6 +200,7 @@ export interface SessionStorePort {
 
 export interface ContextBuilderPort {
 	build(guildId?: string): Promise<string>;
+	buildTurnPromptPrefix?(): Promise<string | null>;
 }
 
 // ─── Memory Fact Reader ──────────────────────────────────────────

--- a/spec/agent/discord/context-builder.spec.ts
+++ b/spec/agent/discord/context-builder.spec.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from "bun:test";
+/* oxlint-disable max-lines-per-function -- ContextBuilder の既存網羅 spec に回帰テストを追加するため許容 */
+import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
 import os from "os";
 import { join } from "path";
 
-import { ContextBuilder, type ContextFileName } from "@vicissitude/agent/discord/context-builder";
+import {
+	ContextBuilder,
+	extractIdentityName,
+	type ContextFileName,
+} from "@vicissitude/agent/discord/context-builder";
 import type { MemoryFact, MemoryFactReader } from "@vicissitude/shared/types";
 
 // ─── ヘルパー ────────────────────────────────────────────────────
@@ -32,6 +37,16 @@ function createMockFactReader(facts: MemoryFact[]): MemoryFactReader {
 // ─── ContextBuilder ──────────────────────────────────────────────
 
 describe("ContextBuilder", () => {
+	const savedIdentityName = process.env.VICISSITUDE_IDENTITY_NAME;
+
+	afterEach(() => {
+		if (savedIdentityName === undefined) {
+			delete process.env.VICISSITUDE_IDENTITY_NAME;
+		} else {
+			process.env.VICISSITUDE_IDENTITY_NAME = savedIdentityName;
+		}
+	});
+
 	describe("base/overlay のファイル優先順位", () => {
 		it("overlay が base を上書きする", async () => {
 			const { baseDir, overlayDir } = createTmpDirs();
@@ -53,6 +68,59 @@ describe("ContextBuilder", () => {
 			const result = await builder.build();
 
 			expect(result).toContain("base identity");
+		});
+	});
+
+	describe("毎ターン自己認識補助", () => {
+		it("環境変数の名前を最優先で使う", async () => {
+			const { baseDir, overlayDir } = createTmpDirs();
+			process.env.VICISSITUDE_IDENTITY_NAME = "環境名";
+			writeFile(overlayDir, "IDENTITY.md", "name: overlay name");
+
+			const builder = new ContextBuilder(overlayDir, baseDir);
+			const result = await builder.buildTurnPromptPrefix();
+
+			expect(result).toBe("あなたは環境名です。");
+		});
+
+		it("環境変数がなければ overlay の IDENTITY.md から name を抽出する", async () => {
+			const { baseDir, overlayDir } = createTmpDirs();
+			delete process.env.VICISSITUDE_IDENTITY_NAME;
+			writeFile(baseDir, "IDENTITY.md", "name: base name");
+			writeFile(overlayDir, "IDENTITY.md", "name: overlay name");
+
+			const builder = new ContextBuilder(overlayDir, baseDir);
+			const result = await builder.buildTurnPromptPrefix();
+
+			expect(result).toBe("あなたはoverlay nameです。");
+		});
+
+		it("overlay がなければ base の IDENTITY.md から full_name を抽出する", async () => {
+			const { baseDir, overlayDir } = createTmpDirs();
+			delete process.env.VICISSITUDE_IDENTITY_NAME;
+			writeFile(baseDir, "IDENTITY.md", 'full_name: "base full name"');
+
+			const builder = new ContextBuilder(overlayDir, baseDir);
+			const result = await builder.buildTurnPromptPrefix();
+
+			expect(result).toBe("あなたはbase full nameです。");
+		});
+
+		it("名前を抽出できない場合は null を返す", async () => {
+			const { baseDir, overlayDir } = createTmpDirs();
+			delete process.env.VICISSITUDE_IDENTITY_NAME;
+			writeFile(baseDir, "IDENTITY.md", "role: no name");
+
+			const builder = new ContextBuilder(overlayDir, baseDir);
+			const result = await builder.buildTurnPromptPrefix();
+
+			expect(result).toBeNull();
+		});
+
+		it("extractIdentityName は name を full_name より優先する", () => {
+			const result = extractIdentityName("full_name: フル\nname: 名前");
+
+			expect(result).toBe("名前");
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Inject a short per-turn identity prefix before the Discord polling prompt
- Resolve the identity name from VICISSITUDE_IDENTITY_NAME, then data/context/IDENTITY.md, then context/IDENTITY.md
- Document the behavior and cover it with tests

## Tests
- bun test spec/agent/discord/context-builder.spec.ts packages/agent/src/runner.test.ts
- nr check
- nr lint
- nr fmt:check