### PR TITLE
Fix compaction summarize model params

### DIFF
--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -25,6 +25,16 @@ const MESSAGE_DEBOUNCE_MS = 500;
 const MAX_DEBOUNCE_MS = 10_000;
 const BOT_MAX_DEBOUNCE_MS = 30_000;
 
+function formatErrorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === "string") return error;
+	try {
+		return JSON.stringify(error) ?? String(error);
+	} catch {
+		return String(error);
+	}
+}
+
 export interface RunnerDeps {
 	profile: AgentProfile;
 	agentId: string;
@@ -559,7 +569,7 @@ export class AgentRunner implements AiAgent {
 		const sessionId = this.sessionStore.get(this.profile.name, this.sessionKey);
 		if (!sessionId) return false;
 		try {
-			await this.sessionPort.summarizeSession(sessionId);
+			await this.sessionPort.summarizeSession(sessionId, this.profile.model);
 			this.lastCompactionAt = now;
 			this.pendingSystemReinject = true;
 			this.logger.info(`[${this.profile.name}:${this.agentId}] break-triggered compaction`);
@@ -567,8 +577,7 @@ export class AgentRunner implements AiAgent {
 			return true;
 		} catch (err) {
 			this.logger.warn(
-				`[${this.profile.name}:${this.agentId}] break-triggered compaction failed`,
-				err,
+				`[${this.profile.name}:${this.agentId}] break-triggered compaction failed: ${formatErrorMessage(err)}`,
 			);
 			return false;
 		}
@@ -583,7 +592,7 @@ export class AgentRunner implements AiAgent {
 		const sessionId = this.sessionStore.get(this.profile.name, this.sessionKey);
 		if (!sessionId) return false;
 		try {
-			await this.sessionPort.summarizeSession(sessionId);
+			await this.sessionPort.summarizeSession(sessionId, this.profile.model);
 			this.lastCompactionAt = this.nowProvider();
 			this.pendingSystemReinject = true;
 			this.logger.info(`[${this.profile.name}:${this.agentId}] proactive compaction triggered`);
@@ -591,8 +600,7 @@ export class AgentRunner implements AiAgent {
 			return true;
 		} catch (err) {
 			this.logger.warn(
-				`[${this.profile.name}:${this.agentId}] proactive compaction failed, continuing normally`,
-				err,
+				`[${this.profile.name}:${this.agentId}] proactive compaction failed, continuing normally: ${formatErrorMessage(err)}`,
 			);
 			return false;
 		}

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -9,6 +9,7 @@ import type {
 	Logger,
 	OpencodePromptParams,
 	OpencodeSessionEvent,
+	OpencodeModel,
 	OpencodeSessionPort,
 	PromptResult,
 	TokenUsage,
@@ -272,10 +273,14 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		}
 		return { type: "idle" };
 	}
-	async summarizeSession(sessionId: string): Promise<void> {
+	async summarizeSession(sessionId: string, model: OpencodeModel): Promise<void> {
 		this.logger?.info(`[opencode] summarizing session: ${sessionId}`);
 		const oc = await this.getClient();
-		const result = await oc.session.summarize({ sessionID: sessionId });
+		const result = await oc.session.summarize({
+			sessionID: sessionId,
+			providerID: model.providerId,
+			modelID: model.modelId,
+		});
 		if (result.error) {
 			throw new Error(`summarizeSession failed: ${JSON.stringify(result.error)}`);
 		}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -217,10 +217,15 @@ export interface MemoryFactReader {
 
 // ─── OpenCode Session Port ──────────────────────────────────────
 
+export interface OpencodeModel {
+	providerId: string;
+	modelId: string;
+}
+
 export interface OpencodePromptParams {
 	sessionId: string;
 	text: string;
-	model: { providerId: string; modelId: string };
+	model: OpencodeModel;
 	system?: string;
 	tools?: Record<string, boolean>;
 	attachments?: Attachment[];
@@ -253,7 +258,7 @@ export interface OpencodeSessionPort {
 		signal?: AbortSignal,
 	): Promise<OpencodeSessionEvent>;
 	waitForSessionIdle(sessionId: string, signal?: AbortSignal): Promise<OpencodeSessionEvent>;
-	summarizeSession(sessionId: string): Promise<void>;
+	summarizeSession(sessionId: string, model: OpencodeModel): Promise<void>;
 	deleteSession(sessionId: string): Promise<void>;
 	close(): void;
 }

--- a/spec/agent/runner-break-compaction.spec.ts
+++ b/spec/agent/runner-break-compaction.spec.ts
@@ -103,7 +103,10 @@ describe("pendingCompaction フラグ消費による break-triggered compaction"
 		await Bun.sleep(0);
 
 		expect(sessionPort.summarizeSession).toHaveBeenCalledTimes(1);
-		expect(sessionPort.summarizeSession).toHaveBeenCalledWith("session-1");
+		expect(sessionPort.summarizeSession).toHaveBeenCalledWith("session-1", {
+			providerId: "test-provider",
+			modelId: "test-model",
+		});
 
 		runner.stop();
 		rewatchDone.resolve({ type: "cancelled" });
@@ -282,12 +285,13 @@ describe("triggerCompaction 失敗時の継続", () => {
 			Promise.reject(new Error("summarize failed")),
 		);
 
+		const logger = createMockLogger();
 		const runner = new BreakTestAgent({
 			profile: createProfile(),
 			agentId: "agent-1",
 			sessionStore: createSessionStore("session-1") as never,
 			contextBuilder: createContextBuilder(),
-			logger: createMockLogger(),
+			logger,
 			sessionPort: sessionPort as unknown as OpencodeSessionPort,
 			sessionMaxAgeMs: 3_600_000,
 		});
@@ -303,6 +307,9 @@ describe("triggerCompaction 失敗時の継続", () => {
 
 		// summarizeSession は呼ばれたが失敗した
 		expect(sessionPort.summarizeSession).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("break-triggered compaction failed: summarize failed"),
+		);
 		// 失敗後、通常のメッセージ処理に fall through する
 		expect(promptAsyncAndWatchSessionMock).toHaveBeenCalled();
 

--- a/spec/agent/runner-compaction.spec.ts
+++ b/spec/agent/runner-compaction.spec.ts
@@ -100,7 +100,10 @@ describe("トークン閾値による proactive compaction", () => {
 		await Bun.sleep(0);
 
 		expect(sessionPort.summarizeSession).toHaveBeenCalledTimes(1);
-		expect(sessionPort.summarizeSession).toHaveBeenCalledWith("session-1");
+		expect(sessionPort.summarizeSession).toHaveBeenCalledWith("session-1", {
+			providerId: "test-provider",
+			modelId: "test-model",
+		});
 
 		runner.stop();
 		rewatchDone.resolve({ type: "cancelled" });
@@ -230,12 +233,13 @@ describe("proactive compaction のエラー耐性", () => {
 			Promise.reject(new Error("summarize failed")),
 		);
 
+		const logger = createMockLogger();
 		const runner = new TestAgent({
 			profile: createProfile(),
 			agentId: "agent-1",
 			sessionStore: createSessionStore() as never,
 			contextBuilder: createContextBuilder(),
-			logger: createMockLogger(),
+			logger,
 			sessionPort: sessionPort as unknown as OpencodeSessionPort,
 			sessionMaxAgeMs: 3_600_000,
 			compactionTokenThreshold: 100,
@@ -259,6 +263,9 @@ describe("proactive compaction のエラー耐性", () => {
 
 		// summarizeSession が呼ばれたが例外がスローされた
 		expect(sessionPort.summarizeSession).toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("proactive compaction failed, continuing normally: summarize failed"),
+		);
 		// polling loop は継続している（クラッシュしない）
 
 		runner.stop();

--- a/spec/opencode/session-summarize.spec.ts
+++ b/spec/opencode/session-summarize.spec.ts
@@ -2,8 +2,8 @@
  * Issue #615: OpencodeSessionPort に summarizeSession() を追加
  *
  * 期待仕様:
- * 1. OpencodeSessionPort に summarizeSession(sessionId: string): Promise<void> が存在する
- * 2. OpencodeSessionAdapter.summarizeSession は oc.session.summarize({ sessionID }) を呼ぶ
+ * 1. OpencodeSessionPort に summarizeSession(sessionId, model): Promise<void> が存在する
+ * 2. OpencodeSessionAdapter.summarizeSession は oc.session.summarize({ sessionID, providerID, modelID }) を呼ぶ
  * 3. SDK がエラーを返した場合は例外をスローする
  * 4. summarizeSession は非同期で compaction を開始するだけ（完了は session.compacted イベントで検知）
  */
@@ -16,10 +16,15 @@ import type { OpencodeSessionPort } from "@vicissitude/shared/types";
 // ─── 型レベルテスト ──────────────────────────────────────────────
 
 describe("OpencodeSessionPort 型", () => {
-	test("summarizeSession(sessionId: string): Promise<void> が存在する", () => {
+	test("summarizeSession(sessionId, model): Promise<void> が存在する", () => {
 		// コンパイルが通ること自体が型レベルの検証（ランタイム assertion なし）
 		type HasSummarize = OpencodeSessionPort["summarizeSession"];
-		type _Assert = HasSummarize extends (sessionId: string) => Promise<void> ? true : never;
+		type _Assert = HasSummarize extends (
+			sessionId: string,
+			model: { providerId: string; modelId: string },
+		) => Promise<void>
+			? true
+			: never;
 		expect(true).toBe(true);
 	});
 });
@@ -61,15 +66,20 @@ function createAdapter(client: OpencodeClient): OpencodeSessionAdapter {
 // ─── 振る舞いテスト ──────────────────────────────────────────────
 
 describe("OpencodeSessionAdapter.summarizeSession", () => {
-	test("oc.session.summarize を sessionID 付きで呼び出す", async () => {
+	test("oc.session.summarize を sessionID/providerID/modelID 付きで呼び出す", async () => {
 		const client = createClient();
 		const adapter = createAdapter(client);
 
-		await adapter.summarizeSession("session-abc");
+		await adapter.summarizeSession("session-abc", {
+			providerId: "test-provider",
+			modelId: "test-model",
+		});
 
 		expect(client.session.summarize).toHaveBeenCalledTimes(1);
 		expect(client.session.summarize).toHaveBeenCalledWith({
 			sessionID: "session-abc",
+			providerID: "test-provider",
+			modelID: "test-model",
 		});
 	});
 
@@ -77,7 +87,10 @@ describe("OpencodeSessionAdapter.summarizeSession", () => {
 		const client = createClient();
 		const adapter = createAdapter(client);
 
-		const result = await adapter.summarizeSession("session-abc");
+		const result = await adapter.summarizeSession("session-abc", {
+			providerId: "test-provider",
+			modelId: "test-model",
+		});
 
 		expect(result).toBeUndefined();
 	});
@@ -90,6 +103,36 @@ describe("OpencodeSessionAdapter.summarizeSession", () => {
 		const adapter = createAdapter(client);
 
 		// oxlint-disable-next-line await-thenable -- Bun の expect().rejects.toThrow() は実行時 Promise
-		await expect(adapter.summarizeSession("session-xyz")).rejects.toThrow();
+		await expect(
+			adapter.summarizeSession("session-xyz", {
+				providerId: "test-provider",
+				modelId: "test-model",
+			}),
+		).rejects.toThrow();
+	});
+
+	test("SDK の 400 エラー原因を例外メッセージに残す", async () => {
+		const client = createClient({
+			error: [
+				{
+					path: ["providerID"],
+					message: "Invalid input: expected string, received undefined",
+				},
+				{
+					path: ["modelID"],
+					message: "Invalid input: expected string, received undefined",
+				},
+			],
+			data: null,
+		});
+		const adapter = createAdapter(client);
+
+		// oxlint-disable-next-line await-thenable -- Bun の expect().rejects.toThrow() は実行時 Promise
+		await expect(
+			adapter.summarizeSession("session-xyz", {
+				providerId: "test-provider",
+				modelId: "test-model",
+			}),
+		).rejects.toThrow("providerID");
 	});
 });


### PR DESCRIPTION
## Summary
- Pass profile provider/model IDs into OpenCode summarize requests
- Update summarizeSession port contract and adapter call shape
- Preserve compaction failure causes in warn log messages

Closes #886

## Verification
- bun test spec/opencode/session-summarize.spec.ts spec/agent/runner-compaction.spec.ts spec/agent/runner-break-compaction.spec.ts packages/opencode/src/session-adapter.test.ts
- nr validate
- nr test