### PR TITLE
Minecraft brainの温度を設定化

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ OpenCode SDK 組み込み: `webfetch`
 - `OPENCODE_TEMPERATURE`: Discord エージェント（通常 + heartbeat）の生成温度（デフォルト: `1.0`、範囲: `0`〜`2`）
 - `MC_PROVIDER_ID`: Minecraft エージェント用プロバイダ ID（省略時は `OPENCODE_PROVIDER_ID` にフォールバック）
 - `MC_MODEL_ID`: Minecraft エージェント用モデル ID（省略時は `OPENCODE_MODEL_ID` にフォールバック）
+- `MC_TEMPERATURE`: Minecraft エージェント用生成温度（デフォルト: `0.7`、範囲: `0`〜`2`）
 - `GENIUS_ACCESS_TOKEN`: Genius API アクセストークン（歌詞取得用、任意。未設定時は歌詞取得をスキップ）
 
 ## 6. 受け入れ条件

--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -26,6 +26,7 @@ function createTestConfig(overrides?: Partial<AppConfig>): AppConfig {
 		mcBrain: {
 			providerId: "test-provider",
 			modelId: "test-model",
+			temperature: 0.7,
 		},
 		dataDir: "/tmp/vicissitude-bootstrap-test",
 		contextDir: "/tmp/test-context",

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -681,6 +681,7 @@ export async function bootstrap(): Promise<void> {
 			opencodePort: ports.minecraft(),
 			providerId: config.mcBrain.providerId,
 			modelId: config.mcBrain.modelId,
+			temperature: config.mcBrain.temperature,
 			sessionMaxAgeMs: config.opencode.sessionMaxAgeHours * 3_600_000,
 			mcHost: config.minecraft.host,
 			mcMcpPort: String(config.minecraft.mcpPort),

--- a/apps/discord/src/config.ts
+++ b/apps/discord/src/config.ts
@@ -64,6 +64,7 @@ const appConfigSchema = z.object({
 	mcBrain: z.object({
 		providerId: z.string(),
 		modelId: z.string(),
+		temperature: safeNumber.min(0).max(2),
 	}),
 	spotify: spotifySchema.optional(),
 	genius: geniusSchema.optional(),
@@ -114,6 +115,7 @@ export function loadConfig(
 		mcBrain: {
 			providerId: env.MC_PROVIDER_ID ?? openCodeProviderId,
 			modelId: env.MC_MODEL_ID ?? env.OPENCODE_MODEL_ID ?? "big-pickle",
+			temperature: Number(env.MC_TEMPERATURE ?? "0.7"),
 		},
 		spotify: env.SPOTIFY_CLIENT_ID
 			? {

--- a/packages/agent/src/minecraft/brain-manager.test.ts
+++ b/packages/agent/src/minecraft/brain-manager.test.ts
@@ -22,6 +22,7 @@ function createTestDeps(overrides?: Partial<McBrainManagerDeps>): McBrainManager
 		opencodePort: 9999,
 		providerId: "test-provider",
 		modelId: "test-model",
+		temperature: 0.7,
 		sessionMaxAgeMs: 3_600_000,
 		lifecyclePollMs: TEST_POLL_MS,
 		...overrides,

--- a/packages/agent/src/minecraft/brain-manager.ts
+++ b/packages/agent/src/minecraft/brain-manager.ts
@@ -22,6 +22,7 @@ export interface McBrainManagerDeps {
 	opencodePort: number;
 	providerId: string;
 	modelId: string;
+	temperature: number;
 	sessionMaxAgeMs: number;
 	/** ライフサイクルポーリング間隔（ms）。デフォルト 10_000 */
 	lifecyclePollMs?: number;
@@ -105,7 +106,7 @@ export class McBrainManager {
 			port: deps.opencodePort,
 			mcpServers: profile.mcpServers,
 			builtinTools: profile.builtinTools,
-			temperature: 0.7,
+			temperature: deps.temperature,
 			logger: deps.logger,
 		});
 		const overlayDir: string = resolve(deps.root, "data/context/minecraft");

--- a/spec/core/config.spec.ts
+++ b/spec/core/config.spec.ts
@@ -21,6 +21,9 @@ describe("loadConfig", () => {
 		expect(config.opencode.basePort).toBe(4096);
 		expect(config.opencode.sessionMaxAgeHours).toBe(48);
 		expect(config.opencode.temperature).toBe(1.0);
+		expect(config.mcBrain.providerId).toBe("github-copilot");
+		expect(config.mcBrain.modelId).toBe("big-pickle");
+		expect(config.mcBrain.temperature).toBe(0.7);
 		expect(config.memory.providerId).toBe("github-copilot");
 		expect(config.memory.modelId).toBe("gpt-4o");
 		expect(config.memory.ollamaBaseUrl).toBe("http://ollama:11434");
@@ -46,6 +49,9 @@ describe("loadConfig", () => {
 				OPENCODE_BASE_PORT: "5000",
 				SESSION_MAX_AGE_HOURS: "24",
 				OPENCODE_TEMPERATURE: "0.5",
+				MC_PROVIDER_ID: "mc-provider",
+				MC_MODEL_ID: "mc-model",
+				MC_TEMPERATURE: "0.3",
 				MEMORY_PROVIDER_ID: "memory-provider",
 				MEMORY_MODEL_ID: "memory-model",
 				OLLAMA_BASE_URL: "http://localhost:11434",
@@ -59,6 +65,9 @@ describe("loadConfig", () => {
 		expect(config.opencode.basePort).toBe(5000);
 		expect(config.opencode.sessionMaxAgeHours).toBe(24);
 		expect(config.opencode.temperature).toBe(0.5);
+		expect(config.mcBrain.providerId).toBe("mc-provider");
+		expect(config.mcBrain.modelId).toBe("mc-model");
+		expect(config.mcBrain.temperature).toBe(0.3);
 		expect(config.memory.providerId).toBe("memory-provider");
 		expect(config.memory.modelId).toBe("memory-model");
 		expect(config.memory.ollamaBaseUrl).toBe("http://localhost:11434");
@@ -74,6 +83,10 @@ describe("loadConfig", () => {
 		);
 
 		expect(config.memory.providerId).toBe("my-provider");
+	});
+
+	it("MC_TEMPERATURE が範囲外なら ZodError が throw される", () => {
+		expect(() => loadConfig(baseEnv({ MC_TEMPERATURE: "2.1" }), root)).toThrow();
 	});
 
 	describe("Minecraft", () => {

--- a/spec/discord/bootstrap-memory.spec.ts
+++ b/spec/discord/bootstrap-memory.spec.ts
@@ -54,6 +54,7 @@ function makeConfig(dataDir: string): AppConfig {
 		mcBrain: {
 			providerId: "mc-provider",
 			modelId: "mc-model",
+			temperature: 0.7,
 		},
 		dataDir,
 		contextDir: "/tmp/test-context",

--- a/spec/discord/bootstrap.spec.ts
+++ b/spec/discord/bootstrap.spec.ts
@@ -30,6 +30,7 @@ function makeConfig(
 		mcBrain: {
 			providerId: "mc-provider",
 			modelId: "mc-model",
+			temperature: 0.7,
 		},
 		dataDir: "/tmp/test-data",
 		contextDir: "/tmp/test-context",


### PR DESCRIPTION
## 概要
- MC_TEMPERATURE を追加し、Minecraft brain の生成温度を設定化
- mcBrain 設定から OpencodeSessionAdapter へ temperature を渡す
- README と設定テストを更新

Closes #871

## 検証
- bun test spec/core/config.spec.ts packages/agent/src/minecraft/brain-manager.test.ts
- nr validate
- nr test