### PR TITLE
デプロイ元の古いcheckoutを検出する

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ AIキャラクター「ふあ」
 
 TypeScript + Bun で動作し、OpenCode を推論エンジンとして使用する。
 
+## デプロイ
+
+`nr deploy` は本番 checkout の stale deploy を防ぐため、実行前に `git fetch origin main` を行い、現在のブランチが `main` で、`HEAD` が `origin/main` と一致していることを検証する。一致しない場合は deploy を中止する。
+
 ## コンセプト
 
 そこで生きているかような自然な存在、AITuber もどきを作る。ただし、特段バーチャルにこだわらない。当面はDiscordが本拠地。

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"test:quality": "bun scripts/test-quality.ts",
 		"test:quality:flake": "bun scripts/test-quality-flake.ts",
 		"validate": "bun run fmt:check && bun run lint && bun run check",
-		"deploy": "podman-compose down installer builder bot 2>/dev/null; podman-compose up -d && echo 'Deployed: podman-compose logs -f to follow logs'",
+		"deploy": "bun scripts/check-deploy-source.ts && (podman-compose down installer builder bot 2>/dev/null || true) && podman-compose up -d && echo 'Deployed: podman-compose logs -f to follow logs'",
 		"auto-triage:claude": "bun scripts/auto-triage-claude.ts",
 		"auto-triage:claude:once": "bun scripts/auto-triage-claude.ts --once",
 		"auto-triage:codex": "bun scripts/auto-triage-codex.ts",

--- a/scripts/check-deploy-source.test.ts
+++ b/scripts/check-deploy-source.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	type CommandResult,
+	getDeploySourceStatus,
+	validateDeploySource,
+} from "./check-deploy-source.ts";
+
+function ok(stdout = ""): CommandResult {
+	return { status: 0, stdout, stderr: "" };
+}
+
+function fail(stderr: string): CommandResult {
+	return { status: 1, stdout: "", stderr };
+}
+
+describe("check-deploy-source", () => {
+	test("main が origin/main と一致していれば問題なし", () => {
+		const status = {
+			branch: "main",
+			head: "0123456789abcdef",
+			remoteHead: "0123456789abcdef",
+		};
+
+		expect(validateDeploySource(status)).toEqual([]);
+	});
+
+	test("main 以外からの deploy を拒否する", () => {
+		const problems = validateDeploySource({
+			branch: "feature/example",
+			head: "0123456789abcdef",
+			remoteHead: "0123456789abcdef",
+		});
+
+		expect(problems.join("\n")).toContain("main ブランチ");
+	});
+
+	test("origin/main より古い checkout を拒否する", () => {
+		const problems = validateDeploySource({
+			branch: "main",
+			head: "aaaaaaaaaaaaaaaa",
+			remoteHead: "bbbbbbbbbbbbbbbb",
+		});
+
+		expect(problems.join("\n")).toContain("origin/main と一致していません");
+		expect(problems.join("\n")).toContain("HEAD=aaaaaaa");
+		expect(problems.join("\n")).toContain("origin/main=bbbbbbb");
+	});
+
+	test("git コマンド失敗は例外にする", () => {
+		expect(() =>
+			getDeploySourceStatus((command, args) => {
+				if (command === "git" && args[0] === "fetch") return fail("network down");
+				return ok("");
+			}),
+		).toThrow("network down");
+	});
+
+	test("git から deploy 元の状態を読み取る", () => {
+		const outputs = new Map<string, CommandResult>([
+			["git fetch origin main", ok("")],
+			["git branch --show-current", ok("main\n")],
+			["git rev-parse HEAD", ok("0123456789abcdef\n")],
+			["git rev-parse origin/main", ok("0123456789abcdef\n")],
+		]);
+
+		const status = getDeploySourceStatus((command, args) => {
+			const key = [command, ...args].join(" ");
+			const result = outputs.get(key);
+			if (!result) return fail(`unexpected command: ${key}`);
+			return result;
+		});
+
+		expect(status).toEqual({
+			branch: "main",
+			head: "0123456789abcdef",
+			remoteHead: "0123456789abcdef",
+		});
+	});
+});

--- a/scripts/check-deploy-source.ts
+++ b/scripts/check-deploy-source.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from "node:child_process";
+
+export interface CommandResult {
+	status: number;
+	stdout: string;
+	stderr: string;
+}
+
+export type CommandRunner = (command: string, args: string[]) => CommandResult;
+
+export interface DeploySourceStatus {
+	branch: string;
+	head: string;
+	remoteHead: string;
+}
+
+const DEPLOY_BRANCH = "main";
+const DEPLOY_REMOTE_REF = "origin/main";
+
+export function runCommand(command: string, args: string[]): CommandResult {
+	const result = spawnSync(command, args, { encoding: "utf8" });
+	return {
+		status: result.status ?? 1,
+		stdout: result.stdout,
+		stderr: result.stderr,
+	};
+}
+
+export function getDeploySourceStatus(runner: CommandRunner = runCommand): DeploySourceStatus {
+	requireCommand(runner, "git", ["fetch", "origin", DEPLOY_BRANCH]);
+
+	return {
+		branch: requireCommand(runner, "git", ["branch", "--show-current"]),
+		head: requireCommand(runner, "git", ["rev-parse", "HEAD"]),
+		remoteHead: requireCommand(runner, "git", ["rev-parse", DEPLOY_REMOTE_REF]),
+	};
+}
+
+export function validateDeploySource(status: DeploySourceStatus): string[] {
+	const problems: string[] = [];
+
+	if (status.branch !== DEPLOY_BRANCH) {
+		problems.push(
+			`deploy は ${DEPLOY_BRANCH} ブランチから実行してください: current=${status.branch}`,
+		);
+	}
+
+	if (status.head !== status.remoteHead) {
+		problems.push(
+			`deploy 元が ${DEPLOY_REMOTE_REF} と一致していません: HEAD=${shortSha(status.head)} ${DEPLOY_REMOTE_REF}=${shortSha(status.remoteHead)}`,
+		);
+	}
+
+	return problems;
+}
+
+function requireCommand(runner: CommandRunner, command: string, args: string[]): string {
+	const result = runner(command, args);
+	if (result.status !== 0) {
+		const output = [result.stderr.trim(), result.stdout.trim()].filter(Boolean).join("\n");
+		throw new Error(`${[command, ...args].join(" ")} failed: ${output}`);
+	}
+	return result.stdout.trim();
+}
+
+function shortSha(sha: string): string {
+	return sha.length > 7 ? sha.slice(0, 7) : sha;
+}
+
+if (import.meta.main) {
+	try {
+		const status = getDeploySourceStatus();
+		const problems = validateDeploySource(status);
+		if (problems.length > 0) {
+			for (const problem of problems) console.error(`[deploy] ${problem}`);
+			process.exit(1);
+		}
+		console.log(`[deploy] source verified: ${DEPLOY_BRANCH}@${shortSha(status.head)}`);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`[deploy] source check failed: ${message}`);
+		process.exit(1);
+	}
+}


### PR DESCRIPTION
## 概要
- #892 の調査で、本番 compose の bind mount 元 checkout が origin/main より 7 commits 古く、compaction 修正済みコードがコンテナへ反映されていないことを確認
- nr deploy の前段に main と origin/main の一致チェックを追加
- README に deploy 前チェック仕様を追記

## 検証
- bun test scripts/check-deploy-source.test.ts
- nr validate
- nr test

Closes #892