### PR TITLE
デプロイ元検証を強化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TypeScript + Bun で動作し、OpenCode を推論エンジンとして使用す
 
 ## デプロイ
 
-`nr deploy` は本番 checkout の stale deploy を防ぐため、実行前に `git fetch origin main` を行い、現在のブランチが `main` で、`HEAD` が `origin/main` と一致していることを検証する。一致しない場合は deploy を中止する。
+`nr deploy` は本番 checkout の stale deploy を防ぐため、実行前に `origin/main` を更新し、現在のブランチが `main` で、`HEAD` が `origin/main` と一致しており、作業ツリーが clean であることを検証する。一致しない場合や未コミット変更がある場合は deploy を中止する。
 
 ## コンセプト
 

--- a/scripts/check-deploy-source.test.ts
+++ b/scripts/check-deploy-source.test.ts
@@ -20,6 +20,7 @@ describe("check-deploy-source", () => {
 			branch: "main",
 			head: "0123456789abcdef",
 			remoteHead: "0123456789abcdef",
+			worktreeStatus: "",
 		};
 
 		expect(validateDeploySource(status)).toEqual([]);
@@ -30,6 +31,7 @@ describe("check-deploy-source", () => {
 			branch: "feature/example",
 			head: "0123456789abcdef",
 			remoteHead: "0123456789abcdef",
+			worktreeStatus: "",
 		});
 
 		expect(problems.join("\n")).toContain("main ブランチ");
@@ -40,11 +42,23 @@ describe("check-deploy-source", () => {
 			branch: "main",
 			head: "aaaaaaaaaaaaaaaa",
 			remoteHead: "bbbbbbbbbbbbbbbb",
+			worktreeStatus: "",
 		});
 
 		expect(problems.join("\n")).toContain("origin/main と一致していません");
 		expect(problems.join("\n")).toContain("HEAD=aaaaaaa");
 		expect(problems.join("\n")).toContain("origin/main=bbbbbbb");
+	});
+
+	test("未コミット変更がある checkout を拒否する", () => {
+		const problems = validateDeploySource({
+			branch: "main",
+			head: "0123456789abcdef",
+			remoteHead: "0123456789abcdef",
+			worktreeStatus: " M packages/example.ts\n?? scripts/tmp.ts",
+		});
+
+		expect(problems.join("\n")).toContain("未コミット変更");
 	});
 
 	test("git コマンド失敗は例外にする", () => {
@@ -58,14 +72,17 @@ describe("check-deploy-source", () => {
 
 	test("git から deploy 元の状態を読み取る", () => {
 		const outputs = new Map<string, CommandResult>([
-			["git fetch origin main", ok("")],
+			["git fetch origin refs/heads/main:refs/remotes/origin/main", ok("")],
 			["git branch --show-current", ok("main\n")],
 			["git rev-parse HEAD", ok("0123456789abcdef\n")],
 			["git rev-parse origin/main", ok("0123456789abcdef\n")],
+			["git status --porcelain", ok("")],
 		]);
+		const calls: string[] = [];
 
 		const status = getDeploySourceStatus((command, args) => {
 			const key = [command, ...args].join(" ");
+			calls.push(key);
 			const result = outputs.get(key);
 			if (!result) return fail(`unexpected command: ${key}`);
 			return result;
@@ -75,6 +92,14 @@ describe("check-deploy-source", () => {
 			branch: "main",
 			head: "0123456789abcdef",
 			remoteHead: "0123456789abcdef",
+			worktreeStatus: "",
 		});
+		expect(calls).toEqual([
+			"git fetch origin refs/heads/main:refs/remotes/origin/main",
+			"git branch --show-current",
+			"git rev-parse HEAD",
+			"git rev-parse origin/main",
+			"git status --porcelain",
+		]);
 	});
 });

--- a/scripts/check-deploy-source.ts
+++ b/scripts/check-deploy-source.ts
@@ -12,10 +12,12 @@ export interface DeploySourceStatus {
 	branch: string;
 	head: string;
 	remoteHead: string;
+	worktreeStatus: string;
 }
 
 const DEPLOY_BRANCH = "main";
 const DEPLOY_REMOTE_REF = "origin/main";
+const DEPLOY_FETCH_REFSPEC = "refs/heads/main:refs/remotes/origin/main";
 
 export function runCommand(command: string, args: string[]): CommandResult {
 	const result = spawnSync(command, args, { encoding: "utf8" });
@@ -27,12 +29,13 @@ export function runCommand(command: string, args: string[]): CommandResult {
 }
 
 export function getDeploySourceStatus(runner: CommandRunner = runCommand): DeploySourceStatus {
-	requireCommand(runner, "git", ["fetch", "origin", DEPLOY_BRANCH]);
+	requireCommand(runner, "git", ["fetch", "origin", DEPLOY_FETCH_REFSPEC]);
 
 	return {
 		branch: requireCommand(runner, "git", ["branch", "--show-current"]),
 		head: requireCommand(runner, "git", ["rev-parse", "HEAD"]),
 		remoteHead: requireCommand(runner, "git", ["rev-parse", DEPLOY_REMOTE_REF]),
+		worktreeStatus: requireCommand(runner, "git", ["status", "--porcelain"]),
 	};
 }
 
@@ -49,6 +52,10 @@ export function validateDeploySource(status: DeploySourceStatus): string[] {
 		problems.push(
 			`deploy 元が ${DEPLOY_REMOTE_REF} と一致していません: HEAD=${shortSha(status.head)} ${DEPLOY_REMOTE_REF}=${shortSha(status.remoteHead)}`,
 		);
+	}
+
+	if (status.worktreeStatus !== "") {
+		problems.push("deploy 元に未コミット変更があります。作業ツリーを clean にしてください。");
 	}
 
 	return problems;


### PR DESCRIPTION
## 概要
- PR #898 の review で見つかった deploy ガードの抜けを修正
- `origin/main` を確実に更新する refspec で fetch
- dirty worktree の deploy を拒否
- コマンド実行順と dirty 拒否をテストで固定

## 検証
- `bun test scripts/check-deploy-source.test.ts`
- `nr validate`
- `nr test`

Refs #892