### PR TITLE
docs: 画像認識モデル設定例を追加する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@ OPENCODE_BASE_PORT=4096
 SESSION_MAX_AGE_HOURS=48
 OPENCODE_TEMPERATURE=1.0
 
+# Discord image recognition helper (optional)
+# Enable this when OPENCODE_MODEL_ID cannot read images directly.
+# DISCORD_IMAGE_RECOGNITION_ENABLED=true
+# DISCORD_IMAGE_RECOGNITION_PROVIDER_ID=github-copilot
+# DISCORD_IMAGE_RECOGNITION_MODEL_ID=gpt-4o
+
 # Memory settings
 MEMORY_PROVIDER_ID=github-copilot
 MEMORY_MODEL_ID=gpt-4o


### PR DESCRIPTION
## 概要
- `.env.example` に Discord 画像認識補助の設定例を追加
- 画像認識用モデルは `DISCORD_IMAGE_RECOGNITION_MODEL_ID`、プロバイダは `DISCORD_IMAGE_RECOGNITION_PROVIDER_ID` で指定することをサンプルで明示

## 検証
- `nr validate`
- `nr test`