### PR TITLE
fix(agent): compaction後の待機詰まりを解消する

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ TypeScript + Bun で動作し、OpenCode を推論エンジンとして使用す
   - 発火条件: idle 遷移時に以下のいずれかを満たす場合（クールダウン 30 分）。
     - トークン蓄積量（input + output）が閾値以上。
     - 深夜帯（2:00–5:00 JST）かつセッション経過がセッション寿命の半分以上かつトークン蓄積が閾値の半分以上。
-  - フロー: `summarizeSession` → compacted イベント → rewatch（イベントストリーム再購読）。セッションは維持される。
+  - 明示的に `summarizeSession` を呼ぶ経路では、API の正常終了を compaction 完了として扱う。OpenCode は `session.compacted` / `session.idle` を HTTP 応答前に発火しうるため、応答後に rewatch してそれらのイベントを待たない。
+  - compaction 成功後はセッションを維持し、次回プロンプトで system prompt を再注入する。
   - 失敗時はスキップし、通常のメッセージ待機ループを継続する。
-- リカバリ（ローテーション不要）: compacted（proactive compaction 含む）/ streamDisconnected はセッション存続中のため、イベントストリームの再購読のみ行う。
+- リカバリ（ローテーション不要）: 監視中イベントストリームから受け取った compacted / streamDisconnected はセッション存続中のため、イベントストリームの再購読のみ行う。
 
 ### 3.4 ツール構成
 

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -228,10 +228,7 @@ export class AgentRunner implements AiAgent {
 
 				// proactive compaction: idle イベント後にトークン閾値 or 深夜帯判定
 				// eslint-disable-next-line no-await-in-loop -- best-effort compaction before rotation
-				if (event.type === "idle" && (await this.tryProactiveCompact(event, signal))) {
-					resetBackoffState();
-					continue;
-				}
+				if (event.type === "idle") await this.tryProactiveCompact(event);
 
 				// eslint-disable-next-line no-await-in-loop -- rotation only happens after session end
 				await this.rotateSessionIfExpired();
@@ -366,7 +363,8 @@ export class AgentRunner implements AiAgent {
 
 		if (this.pendingCompaction) {
 			this.pendingCompaction = false;
-			if (await this.triggerCompaction(signal)) return;
+			await this.triggerCompaction();
+			if (signal.aborted) return;
 		}
 
 		let text: string;
@@ -573,48 +571,41 @@ export class AgentRunner implements AiAgent {
 	}
 
 	/** 会話ブレイクによる compaction を試行する */
-	protected async triggerCompaction(signal: AbortSignal): Promise<boolean> {
+	protected async triggerCompaction(): Promise<void> {
 		const now = this.nowProvider();
 		if (this.lastCompactionAt !== null && now - this.lastCompactionAt < this.compactionCooldownMs) {
-			return false;
+			return;
 		}
 		const sessionId = this.sessionStore.get(this.profile.name, this.sessionKey);
-		if (!sessionId) return false;
+		if (!sessionId) return;
 		try {
 			await this.sessionPort.summarizeSession(sessionId, this.profile.model);
 			this.lastCompactionAt = now;
 			this.pendingSystemReinject = true;
-			this.logger.info(`[${this.profile.name}:${this.agentId}] break-triggered compaction`);
-			this.rewatchSession(signal);
-			return true;
+			this.logger.info(
+				`[${this.profile.name}:${this.agentId}] break-triggered compaction completed`,
+			);
 		} catch (err) {
 			this.logger.warn(
 				`[${this.profile.name}:${this.agentId}] break-triggered compaction failed: ${formatErrorMessage(err)}`,
 			);
-			return false;
 		}
 	}
 
-	/** proactive compaction を試行し、成功して rewatch を開始した場合に true を返す */
-	private async tryProactiveCompact(
-		event: OpencodeSessionEvent & { type: "idle" },
-		signal: AbortSignal,
-	): Promise<boolean> {
-		if (!this.shouldProactiveCompact(event)) return false;
+	/** proactive compaction を試行し、成功した場合は次回プロンプトで system prompt を再注入する */
+	private async tryProactiveCompact(event: OpencodeSessionEvent & { type: "idle" }): Promise<void> {
+		if (!this.shouldProactiveCompact(event)) return;
 		const sessionId = this.sessionStore.get(this.profile.name, this.sessionKey);
-		if (!sessionId) return false;
+		if (!sessionId) return;
 		try {
 			await this.sessionPort.summarizeSession(sessionId, this.profile.model);
 			this.lastCompactionAt = this.nowProvider();
 			this.pendingSystemReinject = true;
-			this.logger.info(`[${this.profile.name}:${this.agentId}] proactive compaction triggered`);
-			this.rewatchSession(signal);
-			return true;
+			this.logger.info(`[${this.profile.name}:${this.agentId}] proactive compaction completed`);
 		} catch (err) {
 			this.logger.warn(
 				`[${this.profile.name}:${this.agentId}] proactive compaction failed, continuing normally: ${formatErrorMessage(err)}`,
 			);
-			return false;
 		}
 	}
 

--- a/spec/agent/runner-break-compaction.spec.ts
+++ b/spec/agent/runner-break-compaction.spec.ts
@@ -3,7 +3,7 @@
  *
  * 期待仕様:
  * 1. pendingCompaction = true のとき ensureSessionStarted が triggerCompaction を呼び summarizeSession が実行される
- * 2. triggerCompaction 成功後、promptAsyncAndWatchSession は呼ばれず waitForSessionIdle（rewatchSession 経由）が呼ばれる
+ * 2. triggerCompaction 成功後、waitForSessionIdle は呼ばず、保留中メッセージの通常プロンプト処理に進む
  * 3. クールダウン期間中は triggerCompaction がスキップされ通常のメッセージ処理に進む
  * 4. セッション未存在時は triggerCompaction がスキップされ通常のメッセージ処理に進む
  * 5. summarizeSession が reject しても polling loop はクラッシュせず通常のメッセージ処理に進む
@@ -72,10 +72,9 @@ afterEach(() => {
 
 describe("pendingCompaction フラグ消費による break-triggered compaction", () => {
 	test("pendingCompaction = true のとき ensureSessionStarted が summarizeSession を実行する", async () => {
-		const rewatchDone = deferred<OpencodeSessionEvent>();
-
+		const sessionDone = deferred<OpencodeSessionEvent>();
 		const sessionPort = createSessionPortWithSummarize({
-			waitForSessionIdle: mock(() => rewatchDone.promise),
+			promptAsyncAndWatchSession: mock(() => sessionDone.promise),
 		});
 		// 既存セッションが存在する状態にする
 		(sessionPort.sessionExists as ReturnType<typeof mock>).mockImplementation(() =>
@@ -109,14 +108,14 @@ describe("pendingCompaction フラグ消費による break-triggered compaction"
 		});
 
 		runner.stop();
-		rewatchDone.resolve({ type: "cancelled" });
+		sessionDone.resolve({ type: "cancelled" });
 	});
 
-	test("triggerCompaction 成功後、promptAsyncAndWatchSession は呼ばれず waitForSessionIdle が呼ばれる", async () => {
-		const rewatchDone = deferred<OpencodeSessionEvent>();
+	test("triggerCompaction 成功後、waitForSessionIdle は呼ばず通常プロンプト処理に進む", async () => {
+		const sessionDone = deferred<OpencodeSessionEvent>();
 
-		const promptAsyncAndWatchSessionMock = mock(() => Promise.resolve({ type: "idle" as const }));
-		const waitForSessionIdleMock = mock(() => rewatchDone.promise);
+		const promptAsyncAndWatchSessionMock = mock(() => sessionDone.promise);
+		const waitForSessionIdleMock = mock(() => Promise.resolve({ type: "idle" as const }));
 
 		const sessionPort = createSessionPortWithSummarize({
 			promptAsyncAndWatchSession: promptAsyncAndWatchSessionMock,
@@ -145,14 +144,13 @@ describe("pendingCompaction フラグ消費による break-triggered compaction"
 		await Bun.sleep(0);
 		await Bun.sleep(0);
 
-		// compaction 成功 → rewatchSession 経由で waitForSessionIdle が呼ばれる
+		// compaction 成功 → SSE rewatch ではなく、保留中メッセージの prompt へ進む
 		expect(sessionPort.summarizeSession).toHaveBeenCalledTimes(1);
-		expect(waitForSessionIdleMock).toHaveBeenCalled();
-		// promptAsyncAndWatchSession は呼ばれない（ensureSessionStarted が早期 return）
-		expect(promptAsyncAndWatchSessionMock).not.toHaveBeenCalled();
+		expect(waitForSessionIdleMock).not.toHaveBeenCalled();
+		expect(promptAsyncAndWatchSessionMock).toHaveBeenCalled();
 
 		runner.stop();
-		rewatchDone.resolve({ type: "cancelled" });
+		sessionDone.resolve({ type: "cancelled" });
 	});
 });
 
@@ -161,11 +159,15 @@ describe("pendingCompaction フラグ消費による break-triggered compaction"
 describe("クールダウン中の triggerCompaction スキップ", () => {
 	test("クールダウン期間中は triggerCompaction がスキップされ通常のメッセージ処理に進む", async () => {
 		// まず1回 compaction を成功させてクールダウンに入る
-		const firstRewatchDone = deferred<OpencodeSessionEvent>();
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
 		const secondSessionDone = deferred<OpencodeSessionEvent>();
 
-		const promptAsyncAndWatchSessionMock = mock(() => secondSessionDone.promise);
-		const waitForSessionIdleMock = mock(() => firstRewatchDone.promise);
+		let promptCallCount = 0;
+		const promptAsyncAndWatchSessionMock = mock(() => {
+			promptCallCount++;
+			return promptCallCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+		});
+		const waitForSessionIdleMock = mock(() => Promise.resolve({ type: "idle" as const }));
 
 		const sessionPort = createSessionPortWithSummarize({
 			promptAsyncAndWatchSession: promptAsyncAndWatchSessionMock,
@@ -198,9 +200,10 @@ describe("クールダウン中の triggerCompaction スキップ", () => {
 		await Bun.sleep(0);
 
 		expect(sessionPort.summarizeSession).toHaveBeenCalledTimes(1);
+		expect(waitForSessionIdleMock).not.toHaveBeenCalled();
 
-		// rewatch 完了 → polling loop が次のイテレーションへ
-		firstRewatchDone.resolve({ type: "idle" });
+		// 1回目の通常プロンプト完了 → polling loop が次のイテレーションへ
+		firstSessionDone.resolve({ type: "idle" });
 		await Bun.sleep(0);
 		await Bun.sleep(0);
 		await Bun.sleep(0);

--- a/spec/agent/runner-compaction.spec.ts
+++ b/spec/agent/runner-compaction.spec.ts
@@ -4,7 +4,7 @@
  * 期待仕様:
  * 1. トークン蓄積量が閾値を超えた場合に summarizeSession が呼ばれる
  * 2. 深夜帯（2:00-5:00 JST）にセッションが一定時間アクティブだった場合に summarizeSession が呼ばれる
- * 3. summarizeSession 呼び出し後、compacted イベントで既存の rewatch ロジックがそのまま動く
+ * 3. summarizeSession 呼び出しの正常終了を compaction 完了として扱い、rewatch で compacted イベントを待たない
  * 4. summarizeSession が失敗しても polling loop はクラッシュしない
  * 5. compaction は同一セッション内で連続発火しない（クールダウンあり）
  */
@@ -65,11 +65,11 @@ afterEach(() => {
 describe("トークン閾値による proactive compaction", () => {
 	test("蓄積トークンが閾値を超えた session.idle イベントで summarizeSession が呼ばれる", async () => {
 		const sessionDone = deferred<OpencodeSessionEvent>();
-		const rewatchDone = deferred<OpencodeSessionEvent>();
+		const waitForSessionIdleMock = mock(() => Promise.resolve({ type: "idle" as const }));
 
 		const sessionPort = createSessionPortWithSummarize({
 			promptAsyncAndWatchSession: mock(() => sessionDone.promise),
-			waitForSessionIdle: mock(() => rewatchDone.promise),
+			waitForSessionIdle: waitForSessionIdleMock,
 		});
 
 		const runner = new TestAgent({
@@ -104,9 +104,9 @@ describe("トークン閾値による proactive compaction", () => {
 			providerId: "test-provider",
 			modelId: "test-model",
 		});
+		expect(waitForSessionIdleMock).not.toHaveBeenCalled();
 
 		runner.stop();
-		rewatchDone.resolve({ type: "cancelled" });
 	});
 
 	test("蓄積トークンが閾値未満なら summarizeSession は呼ばれない", async () => {
@@ -159,11 +159,11 @@ describe("トークン閾値による proactive compaction", () => {
 describe("深夜帯（2:00-5:00 JST）proactive compaction", () => {
 	test("深夜帯 + セッション経過半分以上 + トークン閾値半分以上なら summarizeSession が呼ばれる", async () => {
 		const sessionDone = deferred<OpencodeSessionEvent>();
-		const rewatchDone = deferred<OpencodeSessionEvent>();
+		const waitForSessionIdleMock = mock(() => Promise.resolve({ type: "idle" as const }));
 
 		const sessionPort = createSessionPortWithSummarize({
 			promptAsyncAndWatchSession: mock(() => sessionDone.promise),
-			waitForSessionIdle: mock(() => rewatchDone.promise),
+			waitForSessionIdle: waitForSessionIdleMock,
 		});
 
 		const sessionMaxAgeMs = 3_600_000;
@@ -207,9 +207,9 @@ describe("深夜帯（2:00-5:00 JST）proactive compaction", () => {
 		await Bun.sleep(0);
 
 		expect(sessionPort.summarizeSession).toHaveBeenCalledTimes(1);
+		expect(waitForSessionIdleMock).not.toHaveBeenCalled();
 
 		runner.stop();
-		rewatchDone.resolve({ type: "cancelled" });
 	});
 });
 
@@ -279,7 +279,6 @@ describe("proactive compaction のクールダウン", () => {
 	test("直前に compaction を実行した場合、クールダウン中は再発火しない", async () => {
 		const firstDone = deferred<OpencodeSessionEvent>();
 		const secondDone = deferred<OpencodeSessionEvent>();
-		const thirdDone = deferred<OpencodeSessionEvent>();
 
 		let sessionCallCount = 0;
 
@@ -287,10 +286,8 @@ describe("proactive compaction のクールダウン", () => {
 			promptAsyncAndWatchSession: mock(() => {
 				sessionCallCount++;
 				if (sessionCallCount === 1) return firstDone.promise;
-				if (sessionCallCount === 2) return secondDone.promise;
-				return thirdDone.promise;
+				return secondDone.promise;
 			}),
-			waitForSessionIdle: mock(() => secondDone.promise),
 		});
 
 		const runner = new TestAgent({
@@ -321,7 +318,11 @@ describe("proactive compaction のクールダウン", () => {
 		await Bun.sleep(0);
 		await Bun.sleep(0);
 
-		// compacted イベントで rewatch → 再度 idle（再度閾値超え）
+		// 2回目の通常プロンプトで再度閾値超え
+		await runner.send({ sessionKey: "k", message: "second" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
 		secondDone.resolve({
 			type: "idle",
 			tokens: { input: 200, output: 100, cacheRead: 50 },
@@ -334,7 +335,6 @@ describe("proactive compaction のクールダウン", () => {
 		expect(sessionPort.summarizeSession).toHaveBeenCalledTimes(1);
 
 		runner.stop();
-		thirdDone.resolve({ type: "cancelled" });
 	});
 });
 
@@ -408,9 +408,8 @@ describe("compaction 後のシステムプロンプト再注入 (pendingSystemRe
 	});
 
 	test("proactive compaction 成功後の次回プロンプトで contextBuilder.build が呼ばれる", async () => {
-		// tryProactiveCompact 成功 → summarizeSession → compacted → rewatch → idle → 新メッセージで build
+		// tryProactiveCompact 成功 → summarizeSession 正常終了 → 新メッセージで build
 		const firstSessionDone = deferred<OpencodeSessionEvent>();
-		const rewatchDone = deferred<OpencodeSessionEvent>();
 		const secondSessionDone = deferred<OpencodeSessionEvent>();
 
 		const contextBuilder = createContextBuilder();
@@ -420,9 +419,12 @@ describe("compaction 後のシステムプロンプト再注入 (pendingSystemRe
 			return Promise.resolve("system prompt");
 		});
 
+		let watchCallCount = 0;
 		const sessionPort = createSessionPortWithSummarize({
-			promptAsyncAndWatchSession: mock(() => firstSessionDone.promise),
-			waitForSessionIdle: mock(() => rewatchDone.promise),
+			promptAsyncAndWatchSession: mock(() => {
+				watchCallCount++;
+				return watchCallCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+			}),
 		});
 
 		const runner = new TestAgent({
@@ -446,7 +448,7 @@ describe("compaction 後のシステムプロンプト再注入 (pendingSystemRe
 
 		expect(buildCallCount).toBe(1);
 
-		// ステップ2: 閾値超えの idle → summarizeSession 発火 → rewatchSession
+		// ステップ2: 閾値超えの idle → summarizeSession 発火。rewatch はしない
 		firstSessionDone.resolve({
 			type: "idle",
 			tokens: { input: 200, output: 100, cacheRead: 50 },
@@ -457,17 +459,7 @@ describe("compaction 後のシステムプロンプト再注入 (pendingSystemRe
 
 		expect(sessionPort.summarizeSession).toHaveBeenCalledTimes(1);
 
-		// ステップ3: rewatch が idle で解決 → ループが waitForMessages に入る
-		// promptAsyncAndWatchSession を次回用に差し替え
-		(
-			sessionPort as unknown as { promptAsyncAndWatchSession: ReturnType<typeof mock> }
-		).promptAsyncAndWatchSession = mock(() => secondSessionDone.promise);
-		rewatchDone.resolve({ type: "idle" });
-		await Bun.sleep(0);
-		await Bun.sleep(0);
-		await Bun.sleep(0);
-
-		// ステップ4: 2回目のメッセージ → pendingSystemReinject により build が呼ばれる
+		// ステップ3: 2回目のメッセージ → pendingSystemReinject により build が呼ばれる
 		await runner.send({ sessionKey: "k", message: "second" });
 		await Bun.sleep(0);
 		await Bun.sleep(0);


### PR DESCRIPTION
## 概要
- 明示的な summarizeSession 呼び出し経路では API 正常終了を compaction 完了として扱うように変更
- break-triggered / proactive compaction 後に waitForSessionIdle で compacted/idle イベントを待たないように修正
- README と関連 spec を更新

## 検証
- bun test spec/agent/runner-break-compaction.spec.ts spec/agent/runner-compaction.spec.ts packages/agent/src/runner.test.ts
- nr validate
- nr test