### PR TITLE
refactor(memory): consolidation の責務境界を分離する

### DIFF
--- a/docs/memory-consolidation-architecture.md
+++ b/docs/memory-consolidation-architecture.md
@@ -10,6 +10,11 @@
 - `ConsolidationPipeline`
   - ユースケースの流れだけを制御する。
   - 対象エピソードの取得、抽出戦略の選択、ファクト適用、エピソード統合済みマークを順に実行する。
+- `ConsolidationExtractor`
+  - LLM 呼び出しによるファクト抽出だけを担当する。
+  - 既存ファクトがある場合は Predict-Calibrate、ない場合は直接抽出を使う。
+- `ConsolidationEpisodeFinalizer`
+  - FSRS review とエピソード統合済みマークを担当する。
 - 契約
   - LLM から受け取る structured output の検証を担当する。
   - action、category、fact、keywords、existingFactId の前提条件をここで確定する。
@@ -24,7 +29,8 @@
 
 - `consolidate(userId)` は空でない userId のみ受け付ける。
 - LLM structured output は `facts` 配列のみを入口とし、1 episode あたり最大 30 件までとする。
-- `reinforce` / `update` / `invalidate` は `existingFactId` を必須にする。
+- `new` は `existingFactId` を持たない。
+- `reinforce` / `update` / `invalidate` は `existingFactId` を必須にし、処理時点の active existing fact を参照しなければならない。
 - fact は空文字を禁止し、最大 1000 文字とする。
 - keywords は配列で、最大 10 件、各 keyword は最大 100 文字とする。
 - ファクト重複は embedding 類似度 0.95 以上を同一内容として扱う。
@@ -33,5 +39,5 @@
 
 - LLM 呼び出しは抽出フェーズに限定する。
 - LLM embedding と storage write はファクト適用境界に限定する。
-- 時刻はファクト適用コンテキストで 1 回だけ確定し、invalidate と FSRS review に同じ時刻を渡す。
+- 時刻は episode 処理コンテキストで 1 回だけ確定し、ファクト適用、invalidate、FSRS review、統合済みマークに同じ時刻を渡す。
 - エピソードはファクト適用と FSRS review が終わった後に統合済みにする。

--- a/packages/memory/src/consolidation-action-applier.ts
+++ b/packages/memory/src/consolidation-action-applier.ts
@@ -13,6 +13,10 @@ export interface FactApplicationContext {
 	now: Date;
 }
 
+interface ResolvedFactApplicationContext extends FactApplicationContext {
+	existingFactsById: ReadonlyMap<string, SemanticFact>;
+}
+
 export interface FactApplicationResult {
 	newFacts: number;
 	reinforced: number;
@@ -47,46 +51,51 @@ export class ConsolidationFactApplier {
 		ctx: FactApplicationContext,
 		output: ConsolidationOutput,
 	): Promise<FactApplicationResult> {
+		const resolvedCtx = {
+			...ctx,
+			existingFactsById: new Map(ctx.existingFacts.map((fact) => [fact.id, fact])),
+		};
 		const result = emptyFactApplicationResult();
 		for (const extracted of output.facts) {
 			// eslint-disable-next-line no-await-in-loop -- sequential writes preserve action order
-			const actualAction = await this.dispatchAction(ctx, extracted);
-			if (actualAction) {
-				incrementResult(result, actualAction);
-			}
+			const actualAction = await this.dispatchAction(resolvedCtx, extracted);
+			incrementResult(result, actualAction);
 		}
 		return result;
 	}
 
 	private async dispatchAction(
-		ctx: FactApplicationContext,
+		ctx: ResolvedFactApplicationContext,
 		extracted: ExtractedFact,
-	): Promise<ConsolidationAction | null> {
+	): Promise<ConsolidationAction> {
 		switch (extracted.action) {
 			case "new": {
 				return this.applyNew(ctx, extracted);
 			}
 			case "reinforce": {
-				return (await this.applyReinforce(ctx, extracted)) ? "reinforce" : null;
+				await this.applyReinforce(ctx, extracted);
+				return "reinforce";
 			}
 			case "update": {
-				return (await this.applyUpdate(ctx, extracted)) ? "update" : null;
+				await this.applyUpdate(ctx, extracted);
+				return "update";
 			}
 			case "invalidate": {
-				return (await this.applyInvalidate(ctx, extracted)) ? "invalidate" : null;
+				await this.applyInvalidate(ctx, extracted);
+				return "invalidate";
 			}
 		}
 	}
 
 	private async applyNew(
-		ctx: FactApplicationContext,
+		ctx: ResolvedFactApplicationContext,
 		extracted: ExtractedFact,
 	): Promise<ConsolidationAction> {
 		const embedding = await this.llm.embed(extracted.fact);
 		const duplicate = await this.findDuplicate(ctx.userId, embedding);
 		if (duplicate) {
 			await this.storage.updateFact(ctx.userId, duplicate.id, {
-				sourceEpisodicIds: [...duplicate.sourceEpisodicIds, ctx.episodeId],
+				sourceEpisodicIds: appendSourceEpisode(duplicate, ctx.episodeId),
 			});
 			return "reinforce";
 		}
@@ -118,50 +127,42 @@ export class ConsolidationFactApplier {
 	}
 
 	private async applyReinforce(
-		ctx: FactApplicationContext,
-		extracted: ExtractedFact,
-	): Promise<boolean> {
-		if (!extracted.existingFactId) {
-			return false;
-		}
-		const existing = ctx.existingFacts.find((f) => f.id === extracted.existingFactId);
-		if (!existing) {
-			return false;
-		}
+		ctx: ResolvedFactApplicationContext,
+		extracted: ExtractedFact & { action: "reinforce" },
+	): Promise<void> {
+		const existing = this.requireExistingFact(ctx, extracted.existingFactId, extracted.action);
 		await this.storage.updateFact(ctx.userId, extracted.existingFactId, {
-			sourceEpisodicIds: [...existing.sourceEpisodicIds, ctx.episodeId],
+			sourceEpisodicIds: appendSourceEpisode(existing, ctx.episodeId),
 		});
-		return true;
 	}
 
 	private async applyUpdate(
-		ctx: FactApplicationContext,
-		extracted: ExtractedFact,
-	): Promise<boolean> {
-		if (extracted.existingFactId) {
-			const existing = ctx.existingFacts.find((f) => f.id === extracted.existingFactId);
-			if (!existing) {
-				return false;
-			}
-			await this.storage.invalidateFact(ctx.userId, extracted.existingFactId, ctx.now);
-		}
+		ctx: ResolvedFactApplicationContext,
+		extracted: ExtractedFact & { action: "update" },
+	): Promise<void> {
+		this.requireExistingFact(ctx, extracted.existingFactId, extracted.action);
+		await this.storage.invalidateFact(ctx.userId, extracted.existingFactId, ctx.now);
 		await this.applyNew(ctx, extracted);
-		return true;
 	}
 
 	private async applyInvalidate(
-		ctx: FactApplicationContext,
-		extracted: ExtractedFact,
-	): Promise<boolean> {
-		if (!extracted.existingFactId) {
-			return false;
-		}
-		const existing = ctx.existingFacts.find((f) => f.id === extracted.existingFactId);
-		if (!existing) {
-			return false;
-		}
+		ctx: ResolvedFactApplicationContext,
+		extracted: ExtractedFact & { action: "invalidate" },
+	): Promise<void> {
+		this.requireExistingFact(ctx, extracted.existingFactId, extracted.action);
 		await this.storage.invalidateFact(ctx.userId, extracted.existingFactId, ctx.now);
-		return true;
+	}
+
+	private requireExistingFact(
+		ctx: ResolvedFactApplicationContext,
+		factId: string,
+		action: ConsolidationAction,
+	): SemanticFact {
+		const existing = ctx.existingFactsById.get(factId);
+		if (!existing) {
+			throw new Error(`consolidation action "${action}" references unknown fact: ${factId}`);
+		}
+		return existing;
 	}
 }
 
@@ -174,4 +175,10 @@ const ACTION_TO_RESULT_KEY: Record<ConsolidationAction, keyof FactApplicationRes
 
 function incrementResult(result: FactApplicationResult, action: ConsolidationAction): void {
 	result[ACTION_TO_RESULT_KEY[action]]++;
+}
+
+function appendSourceEpisode(fact: SemanticFact, episodeId: string): string[] {
+	return fact.sourceEpisodicIds.includes(episodeId)
+		? fact.sourceEpisodicIds
+		: [...fact.sourceEpisodicIds, episodeId];
 }

--- a/packages/memory/src/consolidation-action-applier.ts
+++ b/packages/memory/src/consolidation-action-applier.ts
@@ -14,7 +14,7 @@ export interface FactApplicationContext {
 }
 
 interface ResolvedFactApplicationContext extends FactApplicationContext {
-	existingFactsById: ReadonlyMap<string, SemanticFact>;
+	activeFactsById: Map<string, SemanticFact>;
 }
 
 export interface FactApplicationResult {
@@ -53,7 +53,7 @@ export class ConsolidationFactApplier {
 	): Promise<FactApplicationResult> {
 		const resolvedCtx = {
 			...ctx,
-			existingFactsById: new Map(ctx.existingFacts.map((fact) => [fact.id, fact])),
+			activeFactsById: new Map(ctx.existingFacts.map((fact) => [fact.id, fact])),
 		};
 		const result = emptyFactApplicationResult();
 		for (const extracted of output.facts) {
@@ -94,9 +94,12 @@ export class ConsolidationFactApplier {
 		const embedding = await this.llm.embed(extracted.fact);
 		const duplicate = await this.findDuplicate(ctx.userId, embedding);
 		if (duplicate) {
-			await this.storage.updateFact(ctx.userId, duplicate.id, {
+			const reinforced = {
+				...duplicate,
 				sourceEpisodicIds: appendSourceEpisode(duplicate, ctx.episodeId),
-			});
+			};
+			await this.storage.updateFact(ctx.userId, duplicate.id, reinforced);
+			ctx.activeFactsById.set(duplicate.id, reinforced);
 			return "reinforce";
 		}
 		const fact = createFact({
@@ -109,6 +112,7 @@ export class ConsolidationFactApplier {
 			now: ctx.now,
 		});
 		await this.storage.saveFact(ctx.userId, fact);
+		ctx.activeFactsById.set(fact.id, fact);
 		return "new";
 	}
 
@@ -131,9 +135,12 @@ export class ConsolidationFactApplier {
 		extracted: ExtractedFact & { action: "reinforce" },
 	): Promise<void> {
 		const existing = this.requireExistingFact(ctx, extracted.existingFactId, extracted.action);
-		await this.storage.updateFact(ctx.userId, extracted.existingFactId, {
+		const reinforced = {
+			...existing,
 			sourceEpisodicIds: appendSourceEpisode(existing, ctx.episodeId),
-		});
+		};
+		await this.storage.updateFact(ctx.userId, extracted.existingFactId, reinforced);
+		ctx.activeFactsById.set(extracted.existingFactId, reinforced);
 	}
 
 	private async applyUpdate(
@@ -142,6 +149,7 @@ export class ConsolidationFactApplier {
 	): Promise<void> {
 		this.requireExistingFact(ctx, extracted.existingFactId, extracted.action);
 		await this.storage.invalidateFact(ctx.userId, extracted.existingFactId, ctx.now);
+		ctx.activeFactsById.delete(extracted.existingFactId);
 		await this.applyNew(ctx, extracted);
 	}
 
@@ -151,6 +159,7 @@ export class ConsolidationFactApplier {
 	): Promise<void> {
 		this.requireExistingFact(ctx, extracted.existingFactId, extracted.action);
 		await this.storage.invalidateFact(ctx.userId, extracted.existingFactId, ctx.now);
+		ctx.activeFactsById.delete(extracted.existingFactId);
 	}
 
 	private requireExistingFact(
@@ -158,9 +167,11 @@ export class ConsolidationFactApplier {
 		factId: string,
 		action: ConsolidationAction,
 	): SemanticFact {
-		const existing = ctx.existingFactsById.get(factId);
+		const existing = ctx.activeFactsById.get(factId);
 		if (!existing) {
-			throw new Error(`consolidation action "${action}" references unknown fact: ${factId}`);
+			throw new Error(
+				`consolidation action "${action}" references inactive or unknown fact: ${factId}`,
+			);
 		}
 		return existing;
 	}

--- a/packages/memory/src/consolidation-contract.ts
+++ b/packages/memory/src/consolidation-contract.ts
@@ -2,7 +2,40 @@ import type { Schema } from "./llm-port.ts";
 import type { ConsolidationAction, FactCategory } from "./types.ts";
 import { CONSOLIDATION_ACTIONS, FACT_CATEGORIES } from "./types.ts";
 
-export interface ExtractedFact {
+export interface BaseExtractedFact {
+	category: FactCategory;
+	fact: string;
+	keywords: string[];
+}
+
+export interface NewExtractedFact extends BaseExtractedFact {
+	action: "new";
+	existingFactId?: never;
+}
+
+export interface ReinforceExtractedFact extends BaseExtractedFact {
+	action: "reinforce";
+	existingFactId: string;
+}
+
+export interface UpdateExtractedFact extends BaseExtractedFact {
+	action: "update";
+	existingFactId: string;
+}
+
+export interface InvalidateExtractedFact extends BaseExtractedFact {
+	action: "invalidate";
+	existingFactId: string;
+}
+
+export type ExistingExtractedFact =
+	| ReinforceExtractedFact
+	| UpdateExtractedFact
+	| InvalidateExtractedFact;
+
+export type ExtractedFact = NewExtractedFact | ExistingExtractedFact;
+
+export interface RawExtractedFact {
 	action: ConsolidationAction;
 	category: FactCategory;
 	fact: string;
@@ -20,6 +53,11 @@ const MAX_FACT_LENGTH = 1000;
 const MAX_KEYWORD_LENGTH = 100;
 const VALID_ACTIONS = new Set<string>(CONSOLIDATION_ACTIONS);
 const VALID_CATEGORIES = new Set<string>(FACT_CATEGORIES);
+const ACTIONS_REQUIRING_EXISTING_FACT_ID: ReadonlySet<ConsolidationAction> = new Set([
+	"reinforce",
+	"update",
+	"invalidate",
+]);
 
 function validateFactFields(obj: Record<string, unknown>, i: number): void {
 	if (typeof obj["action"] !== "string" || !VALID_ACTIONS.has(obj["action"])) {
@@ -62,8 +100,10 @@ function validateKeywords(obj: Record<string, unknown>, i: number): void {
 
 function validateExistingFactId(obj: Record<string, unknown>, i: number): void {
 	const action = obj["action"] as ConsolidationAction;
-	const needsExistingId = action === "reinforce" || action === "update" || action === "invalidate";
-	if (needsExistingId && typeof obj["existingFactId"] !== "string") {
+	if (action === "new" && obj["existingFactId"] !== undefined) {
+		throw new TypeError(`facts[${i}].existingFactId: not allowed for action "new"`);
+	}
+	if (ACTIONS_REQUIRING_EXISTING_FACT_ID.has(action) && typeof obj["existingFactId"] !== "string") {
 		throw new TypeError(`facts[${i}].existingFactId: required for action "${action}"`);
 	}
 }
@@ -76,13 +116,37 @@ function validateExtractedFact(f: unknown, i: number): ExtractedFact {
 	validateFactFields(obj, i);
 	validateKeywords(obj, i);
 	validateExistingFactId(obj, i);
-	return {
+	return toExtractedFact({
 		action: obj["action"] as ConsolidationAction,
 		category: obj["category"] as FactCategory,
 		fact: obj["fact"] as string,
 		keywords: obj["keywords"] as string[],
 		existingFactId: typeof obj["existingFactId"] === "string" ? obj["existingFactId"] : undefined,
-	};
+	});
+}
+
+function toExtractedFact(fact: RawExtractedFact): ExtractedFact {
+	switch (fact.action) {
+		case "new": {
+			return {
+				action: fact.action,
+				category: fact.category,
+				fact: fact.fact,
+				keywords: fact.keywords,
+			};
+		}
+		case "reinforce":
+		case "update":
+		case "invalidate": {
+			return {
+				action: fact.action,
+				category: fact.category,
+				fact: fact.fact,
+				keywords: fact.keywords,
+				existingFactId: fact.existingFactId as string,
+			};
+		}
+	}
 }
 
 export const consolidationSchema: Schema<ConsolidationOutput> = {

--- a/packages/memory/src/consolidation-episode-finalizer.ts
+++ b/packages/memory/src/consolidation-episode-finalizer.ts
@@ -1,0 +1,23 @@
+import type { EpisodicMemory } from "./episodic.ts";
+import type { MemoryStorage } from "./storage.ts";
+
+export interface EpisodeFinalizationContext {
+	userId: string;
+	episodeId: string;
+	now: Date;
+}
+
+/** Side-effect boundary for completing an episode after fact application. */
+export class ConsolidationEpisodeFinalizer {
+	constructor(
+		private readonly storage: MemoryStorage,
+		private readonly episodic: EpisodicMemory | null,
+	) {}
+
+	async finalize(ctx: EpisodeFinalizationContext): Promise<void> {
+		if (this.episodic) {
+			await this.episodic.review(ctx.userId, ctx.episodeId, { rating: "good", now: ctx.now });
+		}
+		await this.storage.markEpisodeConsolidated(ctx.userId, ctx.episodeId, ctx.now);
+	}
+}

--- a/packages/memory/src/consolidation-extractor.ts
+++ b/packages/memory/src/consolidation-extractor.ts
@@ -1,0 +1,50 @@
+import { consolidationSchema, type ConsolidationOutput } from "./consolidation-contract.ts";
+import {
+	buildCalibrationMessages,
+	buildExtractionMessages,
+	buildPredictionMessages,
+} from "./consolidation-prompts.ts";
+import type { Episode } from "./episode.ts";
+import type { MemoryLlmPort } from "./llm-port.ts";
+import type { SemanticFact } from "./semantic-fact.ts";
+
+export type ConsolidationExtractionStrategy = "direct" | "predict-calibrate";
+
+/** LLM-backed extraction boundary for consolidation. */
+export class ConsolidationExtractor {
+	constructor(private readonly llm: MemoryLlmPort) {}
+
+	extract(episode: Episode, existingFacts: SemanticFact[]): Promise<ConsolidationOutput> {
+		const strategy = selectExtractionStrategy(existingFacts);
+		return strategy === "predict-calibrate"
+			? this.predictThenCalibrate(episode, existingFacts)
+			: this.extractDirect(episode, existingFacts);
+	}
+
+	private extractDirect(
+		episode: Episode,
+		existingFacts: SemanticFact[],
+	): Promise<ConsolidationOutput> {
+		return this.llm.chatStructured<ConsolidationOutput>(
+			buildExtractionMessages(episode, existingFacts),
+			consolidationSchema,
+		);
+	}
+
+	private async predictThenCalibrate(
+		episode: Episode,
+		existingFacts: SemanticFact[],
+	): Promise<ConsolidationOutput> {
+		const prediction = await this.llm.chat(buildPredictionMessages(episode, existingFacts));
+		return this.llm.chatStructured<ConsolidationOutput>(
+			buildCalibrationMessages(episode, prediction, existingFacts),
+			consolidationSchema,
+		);
+	}
+}
+
+export function selectExtractionStrategy(
+	existingFacts: SemanticFact[],
+): ConsolidationExtractionStrategy {
+	return existingFacts.length > 0 ? "predict-calibrate" : "direct";
+}

--- a/packages/memory/src/consolidation-prompts.ts
+++ b/packages/memory/src/consolidation-prompts.ts
@@ -79,7 +79,7 @@ Each fact must have:
   - "guideline": How the assistant should behave — rules, tone preferences, conditional instructions given by the user. NOT general advice or knowledge shared in conversation.
 - fact: A concise statement of the fact
 - keywords: 1-5 relevant keywords
-- existingFactId: Required for "reinforce", "update", "invalidate" actions`;
+- existingFactId: Required for "reinforce", "update", "invalidate" actions; omit for "new"`;
 }
 
 function buildExistingFactsSection(existingFacts: SemanticFact[]): string {

--- a/packages/memory/src/consolidation.test.ts
+++ b/packages/memory/src/consolidation.test.ts
@@ -134,23 +134,25 @@ describe("ConsolidationPipeline PCL", () => {
 		});
 	});
 
-	describe("predictCalibrate fallback", () => {
-		test("predict failure -> falls back to extractFacts", async () => {
+	describe("predictCalibrate contract", () => {
+		test("predict failure rejects without direct extraction fallback", async () => {
 			const llm = createSpyLLM({ chatThrows: true, structuredResponse: validOutput() });
 			const pipeline = new ConsolidationPipeline(llm, storage);
 
 			await makeFact(storage);
 			await makeEpisode(storage);
 
-			// Should not throw
-			const result = await pipeline.consolidate(userId);
+			let error: unknown;
+			try {
+				await pipeline.consolidate(userId);
+			} catch (err) {
+				error = err;
+			}
+			expect(error).toBeInstanceOf(Error);
+			expect((error as Error).message).toContain("predict failed");
 
-			// predict threw -> extractFacts called via chatStructured
-			// predict was attempted
 			expect(llm.chatCalls).toHaveLength(1);
-			// extractFacts fallback
-			expect(llm.chatStructuredCalls).toHaveLength(1);
-			expect(result.processedEpisodes).toBe(1);
+			expect(llm.chatStructuredCalls).toHaveLength(0);
 		});
 
 		test("predict success -> calibrate is called", async () => {

--- a/packages/memory/src/consolidation.ts
+++ b/packages/memory/src/consolidation.ts
@@ -4,36 +4,39 @@ import {
 	emptyFactApplicationResult,
 	type FactApplicationResult,
 } from "./consolidation-action-applier.ts";
-import { consolidationSchema, type ConsolidationOutput } from "./consolidation-contract.ts";
-import {
-	buildCalibrationMessages,
-	buildExtractionMessages,
-	buildPredictionMessages,
-} from "./consolidation-prompts.ts";
+import { ConsolidationEpisodeFinalizer } from "./consolidation-episode-finalizer.ts";
+import { ConsolidationExtractor } from "./consolidation-extractor.ts";
 import type { Episode } from "./episode.ts";
 import type { EpisodicMemory } from "./episodic.ts";
 import type { MemoryLlmPort } from "./llm-port.ts";
-import type { SemanticFact } from "./semantic-fact.ts";
 import type { MemoryStorage } from "./storage.ts";
 import { validateUserId } from "./utils.ts";
 
 export type { ConsolidationOutput, ExtractedFact } from "./consolidation-contract.ts";
+export { ConsolidationExtractor, selectExtractionStrategy } from "./consolidation-extractor.ts";
 
 /** Result of a consolidation run */
 export interface ConsolidationResult extends FactApplicationResult {
 	processedEpisodes: number;
 }
 
+export type ConsolidationClock = () => Date;
+
 /** Consolidation pipeline — converts episodes into semantic facts */
 export class ConsolidationPipeline {
+	private readonly extractor: ConsolidationExtractor;
 	private readonly factApplier: ConsolidationFactApplier;
+	private readonly episodeFinalizer: ConsolidationEpisodeFinalizer;
 
 	constructor(
-		protected llm: MemoryLlmPort,
-		protected storage: MemoryStorage,
-		private episodic: EpisodicMemory | null = null,
+		llm: MemoryLlmPort,
+		private readonly storage: MemoryStorage,
+		episodic: EpisodicMemory | null = null,
+		private readonly clock: ConsolidationClock = () => new Date(),
 	) {
+		this.extractor = new ConsolidationExtractor(llm);
 		this.factApplier = new ConsolidationFactApplier(llm, storage);
+		this.episodeFinalizer = new ConsolidationEpisodeFinalizer(storage, episodic);
 	}
 
 	/** Run consolidation for a user: extract facts from unconsolidated episodes */
@@ -55,69 +58,15 @@ export class ConsolidationPipeline {
 		result: ConsolidationResult,
 	): Promise<void> {
 		const existingFacts = await this.storage.getFacts(userId);
-		const extracted = await this.extractForEpisode(episode, existingFacts);
-		const now = new Date();
+		const extracted = await this.extractor.extract(episode, existingFacts);
+		const now = this.clock();
 		const actionResult = await this.factApplier.apply(
 			{ userId, episodeId: episode.id, existingFacts, now },
 			extracted,
 		);
 		addFactApplicationResult(result, actionResult);
-		if (this.episodic) {
-			await this.episodic.review(userId, episode.id, { rating: "good", now });
-		}
-		await this.storage.markEpisodeConsolidated(userId, episode.id);
+		await this.episodeFinalizer.finalize({ userId, episodeId: episode.id, now });
 		result.processedEpisodes++;
-	}
-
-	private extractForEpisode(
-		episode: Episode,
-		existingFacts: SemanticFact[],
-	): Promise<ConsolidationOutput> {
-		return existingFacts.length > 0
-			? this.predictCalibrate(episode, existingFacts)
-			: this.extractFacts(episode, existingFacts);
-	}
-
-	/** Use LLM to extract facts from a single episode */
-	private extractFacts(
-		episode: Episode,
-		existingFacts: SemanticFact[],
-	): Promise<ConsolidationOutput> {
-		return this.llm.chatStructured<ConsolidationOutput>(
-			buildExtractionMessages(episode, existingFacts),
-			consolidationSchema,
-		);
-	}
-
-	/** PCL: predict then calibrate, with fallback to direct extraction */
-	private async predictCalibrate(
-		episode: Episode,
-		existingFacts: SemanticFact[],
-	): Promise<ConsolidationOutput> {
-		let prediction: string;
-		try {
-			prediction = await this.predict(episode, existingFacts);
-		} catch {
-			return this.extractFacts(episode, existingFacts);
-		}
-		return this.calibrate(episode, prediction, existingFacts);
-	}
-
-	/** PREDICT phase: generate prediction text from existing facts + episode title + summary */
-	private predict(episode: Episode, existingFacts: SemanticFact[]): Promise<string> {
-		return this.llm.chat(buildPredictionMessages(episode, existingFacts));
-	}
-
-	/** CALIBRATE phase: extract facts by comparing prediction with actual episode */
-	private calibrate(
-		episode: Episode,
-		prediction: string,
-		existingFacts: SemanticFact[],
-	): Promise<ConsolidationOutput> {
-		return this.llm.chatStructured<ConsolidationOutput>(
-			buildCalibrationMessages(episode, prediction, existingFacts),
-			consolidationSchema,
-		);
 	}
 }
 

--- a/packages/memory/src/episodic.ts
+++ b/packages/memory/src/episodic.ts
@@ -68,9 +68,9 @@ export class EpisodicMemory {
 	}
 
 	/** Mark an episode as consolidated into semantic memory */
-	async markConsolidated(userId: string, episodeId: string): Promise<void> {
+	async markConsolidated(userId: string, episodeId: string, consolidatedAt: Date): Promise<void> {
 		validateUserId(userId);
-		return this.storage.markEpisodeConsolidated(userId, episodeId);
+		return this.storage.markEpisodeConsolidated(userId, episodeId, consolidatedAt);
 	}
 
 	/** Calculate the current retrievability of an episode */

--- a/packages/memory/src/storage.ts
+++ b/packages/memory/src/storage.ts
@@ -242,10 +242,14 @@ export class MemoryStorage {
 			);
 	}
 
-	async markEpisodeConsolidated(userId: string, episodeId: string): Promise<void> {
+	async markEpisodeConsolidated(
+		userId: string,
+		episodeId: string,
+		consolidatedAt: Date,
+	): Promise<void> {
 		this.db
 			.prepare("UPDATE episodes SET consolidated_at = ? WHERE id = ? AND user_id = ?")
-			.run(Date.now(), episodeId, userId);
+			.run(consolidatedAt.getTime(), episodeId, userId);
 	}
 
 	async saveFact(userId: string, fact: SemanticFact): Promise<void> {

--- a/spec/memory/consolidation.spec.ts
+++ b/spec/memory/consolidation.spec.ts
@@ -230,6 +230,53 @@ describe("ConsolidationPipeline — reinforce", () => {
 		const facts = await storage.getFacts(userId);
 		expect(facts).toHaveLength(0);
 	});
+
+	test("rejects reinforce after the same output invalidates that fact", async () => {
+		const existingFact = createFact({
+			userId,
+			category: "preference",
+			fact: "User likes TypeScript",
+			keywords: ["typescript"],
+			sourceEpisodicIds: ["ep-old"],
+			embedding: [0.1, 0.2, 0.3],
+		});
+		await storage.saveFact(userId, existingFact);
+
+		const episode = makeEpisode();
+		await storage.saveEpisode(userId, episode);
+
+		const llmResponse: ConsolidationOutput = {
+			facts: [
+				{
+					action: "invalidate",
+					category: "preference",
+					fact: "User no longer likes TypeScript",
+					keywords: ["typescript"],
+					existingFactId: existingFact.id,
+				},
+				{
+					action: "reinforce",
+					category: "preference",
+					fact: "User likes TypeScript",
+					keywords: ["typescript"],
+					existingFactId: existingFact.id,
+				},
+			],
+		};
+
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
+		let error: unknown;
+		try {
+			await pipeline.consolidate(userId);
+		} catch (err) {
+			error = err;
+		}
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain("unknown fact");
+
+		const facts = await storage.getFacts(userId);
+		expect(facts).toHaveLength(0);
+	});
 });
 
 describe("ConsolidationPipeline — update", () => {
@@ -278,6 +325,54 @@ describe("ConsolidationPipeline — update", () => {
 		expect(facts).toHaveLength(1);
 		expect(facts[0]!.fact).toBe("User now prefers TypeScript over JavaScript");
 		expect(facts[0]!.sourceEpisodicIds).toEqual([episode.id]);
+	});
+
+	test("rejects reinforce after the same output updates that fact", async () => {
+		const existingFact = createFact({
+			userId,
+			category: "preference",
+			fact: "User likes JavaScript",
+			keywords: ["javascript"],
+			sourceEpisodicIds: ["ep-old"],
+			embedding: [0.1, 0.2, 0.3],
+		});
+		await storage.saveFact(userId, existingFact);
+
+		const episode = makeEpisode();
+		await storage.saveEpisode(userId, episode);
+
+		const llmResponse: ConsolidationOutput = {
+			facts: [
+				{
+					action: "update",
+					category: "preference",
+					fact: "User now prefers TypeScript",
+					keywords: ["typescript"],
+					existingFactId: existingFact.id,
+				},
+				{
+					action: "reinforce",
+					category: "preference",
+					fact: "User likes JavaScript",
+					keywords: ["javascript"],
+					existingFactId: existingFact.id,
+				},
+			],
+		};
+
+		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
+		let error: unknown;
+		try {
+			await pipeline.consolidate(userId);
+		} catch (err) {
+			error = err;
+		}
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain("unknown fact");
+
+		const facts = await storage.getFacts(userId);
+		expect(facts).toHaveLength(1);
+		expect(facts[0]!.fact).toBe("User now prefers TypeScript");
 	});
 });
 

--- a/spec/memory/consolidation.spec.ts
+++ b/spec/memory/consolidation.spec.ts
@@ -63,7 +63,7 @@ describe("ConsolidationPipeline — no episodes", () => {
 	test("skips already consolidated episodes", async () => {
 		const episode = makeEpisode();
 		await storage.saveEpisode(userId, episode);
-		await storage.markEpisodeConsolidated(userId, episode.id);
+		await storage.markEpisodeConsolidated(userId, episode.id, new Date("2026-01-01T00:00:00Z"));
 
 		const pipeline = new ConsolidationPipeline(createConsolidationLLM(), storage);
 		const result = await pipeline.consolidate(userId);
@@ -201,7 +201,7 @@ describe("ConsolidationPipeline — reinforce", () => {
 		expect(facts[0]!.sourceEpisodicIds).toHaveLength(2);
 	});
 
-	test("skips reinforce when existingFactId not found", async () => {
+	test("rejects reinforce when existingFactId is not active", async () => {
 		const episode = makeEpisode();
 		await storage.saveEpisode(userId, episode);
 
@@ -218,9 +218,15 @@ describe("ConsolidationPipeline — reinforce", () => {
 		};
 
 		const pipeline = new ConsolidationPipeline(createConsolidationLLM(llmResponse), storage);
-		const result = await pipeline.consolidate(userId);
+		let error: unknown;
+		try {
+			await pipeline.consolidate(userId);
+		} catch (err) {
+			error = err;
+		}
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain("unknown fact");
 
-		expect(result.reinforced).toBe(0);
 		const facts = await storage.getFacts(userId);
 		expect(facts).toHaveLength(0);
 	});
@@ -321,7 +327,7 @@ describe("ConsolidationPipeline — invalidate", () => {
 		expect(facts).toHaveLength(0);
 	});
 
-	test("skips invalidate when existingFactId is missing", async () => {
+	test("does not invalidate when no facts are extracted", async () => {
 		const episode = makeEpisode();
 		await storage.saveEpisode(userId, episode);
 
@@ -714,6 +720,27 @@ describe("ConsolidationPipeline — schema validation", () => {
 		expect(pipeline.consolidate(userId)).rejects.toThrow("existingFactId");
 	});
 
+	test("rejects new action with existingFactId", async () => {
+		const episode = makeEpisode();
+		await storage.saveEpisode(userId, episode);
+
+		const pipeline = new ConsolidationPipeline(
+			createInvalidLLM({
+				facts: [
+					{
+						action: "new",
+						category: "preference",
+						fact: "Some fact",
+						keywords: ["test"],
+						existingFactId: "fact-1",
+					},
+				],
+			}),
+			storage,
+		);
+		expect(pipeline.consolidate(userId)).rejects.toThrow("not allowed");
+	});
+
 	test("rejects fact with non-array keywords", async () => {
 		const episode = makeEpisode();
 		await storage.saveEpisode(userId, episode);
@@ -1004,7 +1031,7 @@ describe("ConsolidationPipeline — Predict-Calibrate Learning", () => {
 		expect(systemMsg!.content).toContain(predictionText);
 	});
 
-	test("falls back to direct extraction when chat() throws", async () => {
+	test("rejects when predict step throws", async () => {
 		const existingFact = createFact({
 			userId,
 			category: "preference",
@@ -1018,31 +1045,22 @@ describe("ConsolidationPipeline — Predict-Calibrate Learning", () => {
 		const episode = makeEpisode();
 		await storage.saveEpisode(userId, episode);
 
-		const calibrateResponse: ConsolidationOutput = {
-			facts: [
-				{
-					action: "new",
-					category: "interest",
-					fact: "User is exploring Deno",
-					keywords: ["deno"],
-				},
-			],
-		};
 		const { llm, calls } = createPCLMockLLM({
 			predictError: new Error("LLM predict failed"),
-			calibrateResponse,
 		});
 
 		const pipeline = new ConsolidationPipeline(llm, storage);
-		const result = await pipeline.consolidate(userId);
+		let error: unknown;
+		try {
+			await pipeline.consolidate(userId);
+		} catch (err) {
+			error = err;
+		}
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain("LLM predict failed");
 
-		// chat() was attempted, then chatStructured() ran as fallback
 		expect(calls.some((c) => c.method === "chat")).toBe(true);
-		expect(calls.some((c) => c.method === "chatStructured")).toBe(true);
-
-		// Result is valid despite predict failure
-		expect(result.processedEpisodes).toBe(1);
-		expect(result.newFacts).toBe(1);
+		expect(calls.some((c) => c.method === "chatStructured")).toBe(false);
 	});
 
 	test("PCL mode produces correct ConsolidationResult counts", async () => {

--- a/spec/memory/episodic.spec.ts
+++ b/spec/memory/episodic.spec.ts
@@ -51,7 +51,7 @@ describe("EpisodicMemory — retrieval", () => {
 		const ep2 = makeEpisode();
 		await storage.saveEpisode(userId, ep1);
 		await storage.saveEpisode(userId, ep2);
-		await storage.markEpisodeConsolidated(userId, ep1.id);
+		await storage.markEpisodeConsolidated(userId, ep1.id, new Date("2026-01-01T00:00:00Z"));
 
 		const unconsolidated = await episodic.getUnconsolidated(userId);
 		expect(unconsolidated).toHaveLength(1);
@@ -194,10 +194,12 @@ describe("EpisodicMemory — consolidation", () => {
 		const ep = makeEpisode();
 		await storage.saveEpisode(userId, ep);
 
-		await episodic.markConsolidated(userId, ep.id);
+		const consolidatedAt = new Date("2026-01-02T00:00:00Z");
+		await episodic.markConsolidated(userId, ep.id, consolidatedAt);
 
 		const updated = await storage.getEpisodeById(userId, ep.id);
 		expect(updated!.consolidatedAt).not.toBeNull();
+		expect(updated!.consolidatedAt!.getTime()).toBe(consolidatedAt.getTime());
 		expect(updated!.consolidatedAt).toBeInstanceOf(Date);
 	});
 });

--- a/spec/memory/segmenter-integration.spec.ts
+++ b/spec/memory/segmenter-integration.spec.ts
@@ -218,7 +218,7 @@ describe("Integration: Segmenter + MemoryStorage + EpisodicMemory", () => {
 		await addMessagesSequentially(segmenter, 5);
 
 		const episodes = await episodic.getEpisodes(userId);
-		await episodic.markConsolidated(userId, episodes[0]!.id);
+		await episodic.markConsolidated(userId, episodes[0]!.id, new Date("2026-01-01T00:00:00Z"));
 
 		const unconsolidated = await episodic.getUnconsolidated(userId);
 		expect(unconsolidated).toHaveLength(0);

--- a/spec/memory/storage.spec.ts
+++ b/spec/memory/storage.spec.ts
@@ -56,7 +56,7 @@ describe("MemoryStorage — episodic memory", () => {
 		const ep2 = makeEpisode();
 		await storage.saveEpisode(userId, ep1);
 		await storage.saveEpisode(userId, ep2);
-		await storage.markEpisodeConsolidated(userId, ep1.id);
+		await storage.markEpisodeConsolidated(userId, ep1.id, new Date("2026-01-01T00:00:00Z"));
 
 		const unconsolidated = await storage.getUnconsolidatedEpisodes(userId);
 		expect(unconsolidated).toHaveLength(1);
@@ -85,10 +85,12 @@ describe("MemoryStorage — episodic memory", () => {
 		await storage.saveEpisode(userId, ep);
 		expect(ep.consolidatedAt).toBeNull();
 
-		await storage.markEpisodeConsolidated(userId, ep.id);
+		const consolidatedAt = new Date("2026-01-02T00:00:00Z");
+		await storage.markEpisodeConsolidated(userId, ep.id, consolidatedAt);
 		const updated = await storage.getEpisodeById(userId, ep.id);
 		expect(updated!.consolidatedAt).not.toBeNull();
 		expect(updated!.consolidatedAt).toBeInstanceOf(Date);
+		expect(updated!.consolidatedAt!.getTime()).toBe(consolidatedAt.getTime());
 	});
 
 	test("preserves messages JSON", async () => {
@@ -217,7 +219,7 @@ describe("MemoryStorage — tenant isolation (episodes)", () => {
 	test("markEpisodeConsolidated does not affect other user's episode", async () => {
 		const ep = makeEpisode({ userId: "user-1" });
 		await storage.saveEpisode("user-1", ep);
-		await storage.markEpisodeConsolidated("user-2", ep.id);
+		await storage.markEpisodeConsolidated("user-2", ep.id, new Date("2026-01-01T00:00:00Z"));
 		const found = await storage.getEpisodeById("user-1", ep.id);
 		expect(found!.consolidatedAt).toBeNull();
 	});


### PR DESCRIPTION
## 概要
- consolidation の LLM 抽出を ConsolidationExtractor に分離
- FSRS review と統合済みマークを ConsolidationEpisodeFinalizer に分離
- ExtractedFact を action ごとの判別共用体にし、existingFactId 契約を厳格化
- episode 処理時刻を pipeline で 1 回だけ確定し、storage へ明示的に渡す

## 検証
- bun test packages/memory/src/consolidation.test.ts spec/memory/consolidation.spec.ts spec/memory/storage.spec.ts spec/memory/episodic.spec.ts spec/memory/segmenter-integration.spec.ts
- nr validate
- nr test