### PR TITLE
feat(agent): shell workspace MCP を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,37 +77,38 @@ TypeScript + Bun で動作し、OpenCode を推論エンジンとして使用す
 
 MCP サーバー経由で各種操作を提供する。OpenCode は MCP ツールに `{サーバー名}_{ツール名}` のプレフィックスを付けるため、実際の呼び出し名は下表の通り。
 
-| カテゴリ     | MCP サーバー | 主要ツール                                                                                                                                                        |
-| ------------ | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| チャット     | core         | core_send_message, core_reply, core_add_reaction, core_read_messages, core_list_channels                                                                          |
-| コード実行   | code-exec    | code-exec_execute_code                                                                                                                                            |
-| スケジュール | core         | core_list_reminders, core_add_reminder, core_update_reminder, core_remove_reminder                                                                                |
-| 記憶         | core         | core_memory_retrieve, core_memory_get_facts                                                                                                                       |
-| ゲーム委譲   | core         | core_minecraft_delegate, core_minecraft_status, core_minecraft_start_session, core_minecraft_stop_session                                                         |
-| ゲーム操作   | minecraft    | minecraft_observe_state, minecraft_follow_player, minecraft_go_to, minecraft_collect_block, minecraft_attack_entity, minecraft_craft_item 等                      |
-| ゲーム通信   | mc-bridge    | mc-bridge_mc_report, mc-bridge_check_commands                                                                                                                     |
-| ゲーム記憶   | mc-bridge    | mc-bridge_mc_read_goals, mc-bridge_mc_update_goals, mc-bridge_mc_read_progress, mc-bridge_mc_update_progress, mc-bridge_mc_read_skills, mc-bridge_mc_record_skill |
-| 選曲         | core         | core_spotify_pick_track                                                                                                                                           |
-| 楽曲検索     | core         | core_spotify_search                                                                                                                                               |
-| お気に入り   | core         | core_spotify_saved_tracks                                                                                                                                         |
-| 楽曲詳細     | core         | core_spotify_track_detail                                                                                                                                         |
-| 歌詞取得     | core         | core_fetch_lyrics                                                                                                                                                 |
-| 聴取記録     | core         | core_save_listening_fact                                                                                                                                          |
-| メタ         | core         | core_list_tools                                                                                                                                                   |
+| カテゴリ     | MCP サーバー    | 主要ツール                                                                                                                                                           |
+| ------------ | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| チャット     | core            | core_send_message, core_reply, core_add_reaction, core_read_messages, core_list_channels                                                                             |
+| Shell 作業   | shell-workspace | shell-workspace_shell_start_session, shell-workspace_shell_exec, shell-workspace_shell_status, shell-workspace_shell_export_file, shell-workspace_shell_stop_session |
+| スケジュール | core            | core_list_reminders, core_add_reminder, core_update_reminder, core_remove_reminder                                                                                   |
+| 記憶         | core            | core_memory_retrieve, core_memory_get_facts                                                                                                                          |
+| ゲーム委譲   | core            | core_minecraft_delegate, core_minecraft_status, core_minecraft_start_session, core_minecraft_stop_session                                                            |
+| ゲーム操作   | minecraft       | minecraft_observe_state, minecraft_follow_player, minecraft_go_to, minecraft_collect_block, minecraft_attack_entity, minecraft_craft_item 等                         |
+| ゲーム通信   | mc-bridge       | mc-bridge_mc_report, mc-bridge_check_commands                                                                                                                        |
+| ゲーム記憶   | mc-bridge       | mc-bridge_mc_read_goals, mc-bridge_mc_update_goals, mc-bridge_mc_read_progress, mc-bridge_mc_update_progress, mc-bridge_mc_read_skills, mc-bridge_mc_record_skill    |
+| 選曲         | core            | core_spotify_pick_track                                                                                                                                              |
+| 楽曲検索     | core            | core_spotify_search                                                                                                                                                  |
+| お気に入り   | core            | core_spotify_saved_tracks                                                                                                                                            |
+| 楽曲詳細     | core            | core_spotify_track_detail                                                                                                                                            |
+| 歌詞取得     | core            | core_fetch_lyrics                                                                                                                                                    |
+| 聴取記録     | core            | core_save_listening_fact                                                                                                                                             |
+| メタ         | core            | core_list_tools                                                                                                                                                      |
 
 OpenCode SDK 組み込み: `webfetch`
 
 ### 3.5 コンテキスト管理
 
 - オーバーレイ方式: `context/`（git 管理・ベース）と `data/context/`（gitignore・オーバーレイ）の二層構成。読み込みは `data/context/` → `context/` のフォールバック、書き込みは常に `data/context/`。
-- 静的ファイル: `IDENTITY.md`, `SOUL.md`, `DISCORD.md`, `HEARTBEAT.md`, `TOOLS-CORE.md`, `TOOLS-CODE.md`, `TOOLS-MINECRAFT.md`
+- 静的ファイル: `IDENTITY.md`, `SOUL.md`, `DISCORD.md`, `HEARTBEAT.md`, `TOOLS-CORE.md`
+- capability 連動ファイル: `TOOLS-CODE.md` は `SHELL_WORKSPACE_ENABLED=true` 時のみ、`TOOLS-MINECRAFT.md` は `MC_HOST` 設定時のみ注入する。
 - 毎ターンの自己認識補助: Discord 会話プロンプトの先頭に `あなたは{name}です。` を注入する。`VICISSITUDE_IDENTITY_NAME` を優先し、未設定時は `data/context/IDENTITY.md` → `context/IDENTITY.md` の順に `name:` / `full_name:` から抽出する。
 - Memory ファクト注入: 起動時に長期記憶から蓄積済みファクトをシステムプロンプトに注入。
 - サイズ制約: ファイル毎最大 20,000 文字、合計最大 150,000 文字。
 
 ### 3.6 マルチテナント分離
 
-- 人格共通: `IDENTITY.md`, `SOUL.md`, `DISCORD.md`, `HEARTBEAT.md`, `TOOLS-CORE.md`, `TOOLS-CODE.md`, `TOOLS-MINECRAFT.md` は全テナントで共有。
+- 人格共通: `IDENTITY.md`, `SOUL.md`, `DISCORD.md`, `HEARTBEAT.md`, `TOOLS-CORE.md` は全テナントで共有。`TOOLS-CODE.md`, `TOOLS-MINECRAFT.md` は capability 有効時のみ共有コンテキストとして注入する。
 - 記憶分離: `MEMORY.md`, `LESSONS.md` はテナントごとに分離（オーバーレイ方式）。
 - Memory 分離: `MemoryNamespace` により namespace 単位で独立した DB を持つ。
   - `discord-guild`: Discord ギルドごとの記憶。DB パス: `guilds/{guildId}/memory.db`
@@ -193,7 +194,7 @@ OpenCode SDK 組み込み: `webfetch`
 2. Bot 自身のメッセージには反応しない。
 3. セッション管理が永続化され、再起動後も継続できる。
 4. ブートストラップコンテキストが毎回 system prompt として注入される。
-5. MCP サーバー経由で Discord 操作・コード実行が可能。
+5. MCP サーバー経由で Discord 操作が可能。`SHELL_WORKSPACE_ENABLED=true` のインスタンスでは隔離 shell workspace 操作も可能。
 6. AI がメッセージ駆動プロンプトにより、自律的に応答を判断・送信する。
 7. `minecraft` MCP サーバー経由で、接続・状態取得・追従/移動・基本採集の最小フローが動作する。
 8. AI が Minecraft 状況を簡潔に要約して Discord 上で説明できる。

--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import os from "os";
+import { join } from "path";
 
 import { createMockLogger } from "@vicissitude/shared/test-helpers";
 
-import { createStoreLayer, createMetrics } from "./bootstrap.ts";
+import { createContextLayer, createStoreLayer, createMetrics } from "./bootstrap.ts";
 import type { AppConfig } from "./config.ts";
 
 function createTestConfig(overrides?: Partial<AppConfig>): AppConfig {
@@ -34,6 +37,16 @@ function createTestConfig(overrides?: Partial<AppConfig>): AppConfig {
 	};
 }
 
+function createContextRoot(): string {
+	const root = mkdtempSync(join(os.tmpdir(), "vicissitude-context-root-"));
+	const contextDir = join(root, "context");
+	mkdirSync(contextDir, { recursive: true });
+	writeFileSync(join(contextDir, "TOOLS-CORE.md"), "core tools");
+	writeFileSync(join(contextDir, "TOOLS-CODE.md"), "shell tools");
+	writeFileSync(join(contextDir, "TOOLS-MINECRAFT.md"), "minecraft tools");
+	return root;
+}
+
 describe("createStoreLayer", () => {
 	test("DB と SessionStore を返す", () => {
 		const config = createTestConfig();
@@ -51,5 +64,42 @@ describe("createMetrics", () => {
 
 		expect(collector).toBeDefined();
 		expect(server).toBeDefined();
+	});
+});
+
+describe("createContextLayer", () => {
+	test("デフォルトでは capability 連動ツール説明を除外する", async () => {
+		const root = createContextRoot();
+		const { contextBuilder } = createContextLayer(createTestConfig(), root);
+		const context = await contextBuilder.build();
+
+		expect(context).toContain("core tools");
+		expect(context).not.toContain("shell tools");
+		expect(context).not.toContain("minecraft tools");
+	});
+
+	test("shellWorkspace 有効時は TOOLS-CODE を注入する", async () => {
+		const root = createContextRoot();
+		const { contextBuilder } = createContextLayer(
+			createTestConfig({
+				shellWorkspace: {
+					enabled: true,
+					image: "sandbox",
+					dataDir: "/tmp/shell-workspaces",
+					auditLogPath: "/tmp/shell-audit.jsonl",
+					defaultTtlMinutes: 60,
+					maxTtlMinutes: 120,
+					defaultTimeoutSeconds: 30,
+					maxTimeoutSeconds: 120,
+					maxOutputChars: 50_000,
+				},
+			}),
+			root,
+		);
+		const context = await contextBuilder.build();
+
+		expect(context).toContain("core tools");
+		expect(context).toContain("shell tools");
+		expect(context).not.toContain("minecraft tools");
 	});
 });

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -8,7 +8,7 @@ import { ImageAttachmentDescriber } from "@vicissitude/agent/discord/image-attac
 import { formatDiscordMessage } from "@vicissitude/agent/discord/message-formatter";
 import { createConversationProfile } from "@vicissitude/agent/discord/profile";
 import { GuildRouter } from "@vicissitude/agent/discord/router";
-import { mcpServerConfigs } from "@vicissitude/agent/mcp-config";
+import { type AgentCapability, mcpServerConfigs } from "@vicissitude/agent/mcp-config";
 import { McBrainManager } from "@vicissitude/agent/minecraft/brain-manager";
 import { SessionStore } from "@vicissitude/agent/session-store";
 import { HeartbeatService } from "@vicissitude/application/heartbeat-service";
@@ -85,14 +85,14 @@ export function createStoreLayer(config: AppConfig) {
 // ─── Context Layer ──────────────────────────────────────────────
 
 export function createContextLayer(config: AppConfig, root: string, factReader?: MemoryFactReader) {
-	const excludeFiles: ReadonlySet<ContextFileName> | undefined = config.minecraft
-		? undefined
-		: new Set<ContextFileName>(["TOOLS-MINECRAFT.md"]);
+	const excludeFiles = new Set<ContextFileName>();
+	if (!config.minecraft) excludeFiles.add("TOOLS-MINECRAFT.md");
+	if (!config.shellWorkspace) excludeFiles.add("TOOLS-CODE.md");
 	const contextBuilder = new ContextBuilder(
 		resolve(root, "data/context"),
 		resolve(root, "context"),
 		factReader,
-		excludeFiles,
+		excludeFiles.size > 0 ? excludeFiles : undefined,
 	);
 	return { contextBuilder };
 }
@@ -140,6 +140,10 @@ export function buildCoreEnvironment(config: AppConfig, root: string): Record<st
 		env.MC_HOST = config.minecraft.host;
 	}
 
+	if (config.shellWorkspace) {
+		env.DISCORD_ATTACHMENT_ALLOWED_DIRS = config.shellWorkspace.dataDir;
+	}
+
 	return env;
 }
 
@@ -171,11 +175,14 @@ export function createGuildAgents(
 	for (const [index, guildId] of guildIds.entries()) {
 		const agentIdPrefix = deps.agentIdPrefix ?? "discord";
 		const agentId = `${agentIdPrefix}:${guildId}`;
+		const capabilities: AgentCapability[] = config.shellWorkspace ? ["shell-workspace"] : [];
 		const profile = createConversationProfile({
 			...config.opencode,
 			mcpServers: mcpServerConfigs(agentId, {
 				appRoot: deps.appRoot,
 				coreEnvironment: deps.coreEnvironment,
+				capabilities,
+				shellWorkspace: config.shellWorkspace,
 			}),
 			minecraftEnabled: !!config.minecraft,
 			imageRecognitionEnabled: !!config.imageRecognition,

--- a/apps/discord/src/config.ts
+++ b/apps/discord/src/config.ts
@@ -50,6 +50,28 @@ const imageRecognitionSchema = z.object({
 	modelId: z.string().min(1, "DISCORD_IMAGE_RECOGNITION_MODEL_ID is required"),
 });
 
+const shellWorkspaceSchema = z
+	.object({
+		enabled: z.literal(true),
+		image: z.string().min(1, "SHELL_WORKSPACE_IMAGE is required"),
+		dataDir: z.string(),
+		auditLogPath: z.string(),
+		defaultTtlMinutes: safeInt.min(1),
+		maxTtlMinutes: safeInt.min(1),
+		defaultTimeoutSeconds: safeInt.min(1),
+		maxTimeoutSeconds: safeInt.min(1),
+		maxOutputChars: safeInt.min(1),
+	})
+	.refine((v) => v.defaultTtlMinutes <= v.maxTtlMinutes, {
+		message: "SHELL_WORKSPACE_DEFAULT_TTL_MINUTES must be <= SHELL_WORKSPACE_MAX_TTL_MINUTES",
+		path: ["defaultTtlMinutes"],
+	})
+	.refine((v) => v.defaultTimeoutSeconds <= v.maxTimeoutSeconds, {
+		message:
+			"SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS must be <= SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS",
+		path: ["defaultTimeoutSeconds"],
+	});
+
 const appConfigSchema = z.object({
 	discordToken: z.string().min(1, "DISCORD_TOKEN is required"),
 	webPort: safeInt,
@@ -78,6 +100,7 @@ const appConfigSchema = z.object({
 	minecraft: minecraftSchema.optional(),
 	github: githubSchema.optional(),
 	imageRecognition: imageRecognitionSchema.optional(),
+	shellWorkspace: shellWorkspaceSchema.optional(),
 	dataDir: z.string(),
 	contextDir: z.string(),
 });
@@ -98,11 +121,27 @@ function parseBooleanEnv(value: string | undefined): boolean {
 	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
+function buildShellWorkspaceConfig(env: Record<string, string | undefined>, dataDir: string) {
+	if (!parseBooleanEnv(env.SHELL_WORKSPACE_ENABLED)) return;
+	return {
+		enabled: true,
+		image: env.SHELL_WORKSPACE_IMAGE ?? "vicissitude-code-exec",
+		dataDir: resolve(dataDir, "shell-workspaces"),
+		auditLogPath: resolve(dataDir, "shell-workspace-audit.jsonl"),
+		defaultTtlMinutes: Number(env.SHELL_WORKSPACE_DEFAULT_TTL_MINUTES ?? "60"),
+		maxTtlMinutes: Number(env.SHELL_WORKSPACE_MAX_TTL_MINUTES ?? "120"),
+		defaultTimeoutSeconds: Number(env.SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS ?? "30"),
+		maxTimeoutSeconds: Number(env.SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS ?? "120"),
+		maxOutputChars: Number(env.SHELL_WORKSPACE_MAX_OUTPUT_CHARS ?? "50000"),
+	};
+}
+
 export function loadConfig(
 	env: Record<string, string | undefined> = process.env,
 	root?: string,
 ): AppConfig {
 	const resolvedRoot = root ?? process.env.APP_ROOT ?? resolve(process.cwd());
+	const dataDir = resolve(resolvedRoot, "data");
 
 	const openCodeProviderId = env.OPENCODE_PROVIDER_ID ?? "github-copilot";
 
@@ -172,7 +211,8 @@ export function loadConfig(
 					modelId: env.DISCORD_IMAGE_RECOGNITION_MODEL_ID ?? "",
 				}
 			: undefined,
-		dataDir: resolve(resolvedRoot, "data"),
+		shellWorkspace: buildShellWorkspaceConfig(env, dataDir),
+		dataDir,
 		contextDir: resolve(resolvedRoot, "context"),
 	};
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -55,6 +55,7 @@ services:
         bun build apps/discord/src/index.ts --outdir dist --target bun --packages external &&
         bun build packages/mcp/src/core-server.ts --outfile dist/core-server.js --target bun --packages external &&
         bun build packages/mcp/src/code-exec-server.ts --outfile dist/code-exec-server.js --target bun --packages external &&
+        bun build packages/mcp/src/shell-workspace-server.ts --outfile dist/shell-workspace-server.js --target bun --packages external &&
         bun build packages/minecraft/src/server.ts --outfile dist/minecraft-server.js --target bun --packages external &&
         bun build packages/minecraft/src/mc-bridge-server.ts --outfile dist/mc-bridge-server.js --target bun --packages external
     depends_on:

--- a/context/TOOLS-CODE.md
+++ b/context/TOOLS-CODE.md
@@ -1,9 +1,18 @@
-## MCP ツール一覧（コード実行）
+## MCP ツール一覧（shell workspace）
 
-### code-exec サーバー
+> `SHELL_WORKSPACE_ENABLED=true` のインスタンスでのみ利用可能。OpenCode 組み込み `bash` ではなく、隔離された Podman sandbox 内で実行する。
 
-- `execute_code(language, code)` - サンドボックスコンテナ内でコード実行
-  - language: "javascript" | "typescript" | "python" | "shell"
-  - コード長上限: 10,000 文字
-  - タイムアウト: 15秒（コンテナ起動含む）
-  - ネットワークアクセス不可、ファイルシステム読み取り専用（/tmp のみ書き込み可、10MB 上限）
+### shell-workspace サーバー
+
+- `shell_start_session(label?, ttl_minutes?)` - TTL 付き workspace session を開始
+- `shell_exec(session_id, command, cwd?, timeout_seconds?)` - `/workspace` 配下で shell command を実行
+- `shell_status(session_id?)` - session 状態を確認
+- `shell_export_file(session_id, path)` - workspace 内ファイルを Discord 添付に使えるローカルパスとして返す
+- `shell_stop_session(session_id)` - session を停止し workspace を削除
+
+制約:
+
+- ネットワークアクセス不可
+- workspace 以外のファイルシステムは読み取り専用
+- host HOME、OpenCode auth、`.env`、SSH/Git 認証情報、Podman socket は sandbox に渡されない
+- CPU、メモリ、PID、timeout、出力サイズに上限あり

--- a/docs/agent-capabilities-and-shell-sandbox.md
+++ b/docs/agent-capabilities-and-shell-sandbox.md
@@ -1,0 +1,84 @@
+# Agent Capabilities and Shell Sandbox
+
+## 目的
+
+Vicissitude の会話エージェントを、必要な能力だけを持つ profile として組み立てる。Discord で会話するだけのインスタンスには shell 権限を渡さず、作業用インスタンスだけに隔離された shell workspace を MCP 経由で接続する。
+
+OpenCode 組み込み `bash` は使わない。shell 実行は `shell-workspace` MCP サーバーに集約し、timeout、cwd、ネットワーク、quota、監査ログ、TTL をアプリケーション側で強制する。
+
+## Capability
+
+初期実装の capability は次の通り。
+
+| Capability         | 内容                                                 | 既定                                    |
+| ------------------ | ---------------------------------------------------- | --------------------------------------- |
+| `core`             | Discord 送信、返信、リアクション、記憶、リマインダー | 有効                                    |
+| `webfetch`         | OpenCode 組み込み `webfetch`                         | 有効                                    |
+| `minecraft-bridge` | Discord から Minecraft エージェントへの委譲          | `MC_HOST` 設定時のみ                    |
+| `shell-workspace`  | Podman sandbox 内の shell workspace                  | `SHELL_WORKSPACE_ENABLED=true` の時のみ |
+
+`shell-workspace` が無効な profile では、MCP サーバーもツール説明コンテキストも注入しない。
+
+## Shell Workspace
+
+`shell-workspace` は、短いコード片実行ではなく、TTL 付きの workspace session を提供する。MVP では exec ごとに sandbox コンテナを起動し、session ごとの workspace directory を bind mount して状態を保持する。
+
+提供ツール:
+
+- `shell_start_session(label?, ttl_minutes?)`
+- `shell_exec(session_id, command, cwd?, timeout_seconds?)`
+- `shell_status(session_id?)`
+- `shell_export_file(session_id, path)`
+- `shell_stop_session(session_id)`
+
+## Sandbox Policy
+
+MVP の既定 policy:
+
+- rootless Podman で prebuilt image を実行する。
+- network は `none` のみ。
+- root filesystem は read-only。
+- session workspace だけを `/workspace` に read-write mount する。
+- host HOME、OpenCode auth、`.env`、SSH/Git credential、Podman socket は sandbox に渡さない。
+- 環境変数は shell MCP プロセス、sandbox 実行の両方で allowlist 方式にする。
+- non-root user で実行する。
+- `--cap-drop=ALL` と `--security-opt=no-new-privileges` を設定する。
+- CPU、memory、PID、timeout、output size を制限する。
+- session TTL と明示停止で workspace を削除する。
+
+## 設定
+
+| 環境変数                                  | 既定                    | 説明                            |
+| ----------------------------------------- | ----------------------- | ------------------------------- |
+| `SHELL_WORKSPACE_ENABLED`                 | `false`                 | `true`/`1`/`yes`/`on` で有効化  |
+| `SHELL_WORKSPACE_IMAGE`                   | `vicissitude-code-exec` | Podman で起動する sandbox image |
+| `SHELL_WORKSPACE_DEFAULT_TTL_MINUTES`     | `60`                    | session の既定 TTL              |
+| `SHELL_WORKSPACE_MAX_TTL_MINUTES`         | `120`                   | session TTL 上限                |
+| `SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS` | `30`                    | `shell_exec` の既定 timeout     |
+| `SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS`     | `120`                   | `shell_exec` timeout 上限       |
+| `SHELL_WORKSPACE_MAX_OUTPUT_CHARS`        | `50000`                 | stdout + stderr の返却上限      |
+
+`shell-workspace` 有効時、core MCP には `DISCORD_ATTACHMENT_ALLOWED_DIRS` として shell workspace directory を渡す。これにより `shell_export_file` が返したパスを `core_send_message(..., file_path)` で添付できる。
+
+## 監査ログ
+
+`shell_exec` ごとに JSON Lines で監査ログを保存する。
+
+記録項目:
+
+- `timestamp`
+- `agent_id`
+- `session_id`
+- `command`
+- `cwd`
+- `exit_code`
+- `duration_ms`
+- `timed_out`
+- `output_truncated`
+
+## 非目標
+
+- OpenCode 組み込み `bash` の有効化。
+- host checkout や host HOME の直接編集。
+- ユーザー本人の認証情報を使った GitHub、Spotify、SSH 操作。
+- network enabled profile。必要になった時点で、宛先制限と別途 policy を設計する。

--- a/packages/agent/src/mcp-config.ts
+++ b/packages/agent/src/mcp-config.ts
@@ -6,6 +6,21 @@ export interface McpConfigOptions {
 	appRoot: string;
 	/** core MCP プロセスに渡す環境変数 */
 	coreEnvironment: Record<string, string>;
+	capabilities?: readonly AgentCapability[];
+	shellWorkspace?: ShellWorkspaceMcpConfigOptions;
+}
+
+export type AgentCapability = "shell-workspace";
+
+export interface ShellWorkspaceMcpConfigOptions {
+	image: string;
+	dataDir: string;
+	auditLogPath: string;
+	defaultTtlMinutes: number;
+	maxTtlMinutes: number;
+	defaultTimeoutSeconds: number;
+	maxTimeoutSeconds: number;
+	maxOutputChars: number;
 }
 
 /**
@@ -16,6 +31,7 @@ export interface McpConfigOptions {
  */
 export function mcpServerConfigs(agentId: string, opts: McpConfigOptions) {
 	const { appRoot, coreEnvironment } = opts;
+	const capabilities = new Set(opts.capabilities ?? []);
 
 	const configs: Record<string, McpServerConfig> = {
 		core: {
@@ -26,13 +42,42 @@ export function mcpServerConfigs(agentId: string, opts: McpConfigOptions) {
 				AGENT_ID: agentId,
 			},
 		},
-		"code-exec": {
-			type: "local",
-			command: ["bun", "run", resolve(appRoot, "dist/code-exec-server.js")],
-		},
 	};
 
+	if (capabilities.has("shell-workspace")) {
+		if (!opts.shellWorkspace) {
+			throw new Error("shellWorkspace config is required when shell-workspace is enabled");
+		}
+		configs["shell-workspace"] = {
+			type: "local",
+			command: ["bun", "run", resolve(appRoot, "dist/shell-workspace-server.js")],
+			environment: buildShellWorkspaceEnvironment(agentId, opts.shellWorkspace),
+		};
+	}
+
 	return configs;
+}
+
+function buildShellWorkspaceEnvironment(
+	agentId: string,
+	config: ShellWorkspaceMcpConfigOptions,
+): Record<string, string> {
+	const env: Record<string, string> = {
+		PATH: process.env.PATH ?? "",
+		HOME: process.env.HOME ?? "",
+		SHELL_WORKSPACE_AGENT_ID: agentId,
+		SHELL_WORKSPACE_IMAGE: config.image,
+		SHELL_WORKSPACE_DATA_DIR: config.dataDir,
+		SHELL_WORKSPACE_AUDIT_LOG: config.auditLogPath,
+		SHELL_WORKSPACE_DEFAULT_TTL_MINUTES: String(config.defaultTtlMinutes),
+		SHELL_WORKSPACE_MAX_TTL_MINUTES: String(config.maxTtlMinutes),
+		SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS: String(config.defaultTimeoutSeconds),
+		SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS: String(config.maxTimeoutSeconds),
+		SHELL_WORKSPACE_MAX_OUTPUT_CHARS: String(config.maxOutputChars),
+	};
+	if (process.env.XDG_RUNTIME_DIR) env.XDG_RUNTIME_DIR = process.env.XDG_RUNTIME_DIR;
+	if (process.env.TMPDIR) env.TMPDIR = process.env.TMPDIR;
+	return env;
 }
 
 export interface McpMinecraftConfigOptions {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -4,6 +4,8 @@
 	"exports": {
 		"./core-server": "./src/core-server.ts",
 		"./code-exec-server": "./src/code-exec-server.ts",
+		"./shell-workspace": "./src/shell-workspace.ts",
+		"./shell-workspace-server": "./src/shell-workspace-server.ts",
 		"./http-server": "./src/http-server.ts",
 		"./memory-cache": "./src/memory-cache.ts",
 		"./lru-cache": "./src/lru-cache.ts",

--- a/packages/mcp/src/shell-workspace-server.ts
+++ b/packages/mcp/src/shell-workspace-server.ts
@@ -1,0 +1,202 @@
+/* oxlint-disable max-lines-per-function -- MCP tool registration is declarative and easier to audit in one entry point */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+import {
+	SHELL_WORKSPACE_DEFAULT_IMAGE,
+	ShellWorkspaceManager,
+	type ShellWorkspaceConfig,
+} from "./shell-workspace.ts";
+
+const DEFAULT_DATA_DIR = "data/shell-workspaces";
+const DEFAULT_AUDIT_LOG = "data/shell-workspace-audit.jsonl";
+const CLEANUP_INTERVAL_MS = 5 * 60_000;
+const MAX_COMMAND_LENGTH = 8_000;
+const MAX_LABEL_LENGTH = 80;
+const MAX_CWD_LENGTH = 240;
+
+function readIntEnv(name: string, fallback: number): number {
+	const value = process.env[name];
+	if (value === undefined || value.trim() === "") return fallback;
+	const parsed = Number(value);
+	if (!Number.isInteger(parsed) || parsed < 1) {
+		throw new Error(`${name} must be a positive integer`);
+	}
+	return parsed;
+}
+
+function loadShellWorkspaceConfig(): ShellWorkspaceConfig {
+	const defaultTtlMinutes = readIntEnv("SHELL_WORKSPACE_DEFAULT_TTL_MINUTES", 60);
+	const maxTtlMinutes = readIntEnv("SHELL_WORKSPACE_MAX_TTL_MINUTES", 120);
+	const defaultTimeoutSeconds = readIntEnv("SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS", 30);
+	const maxTimeoutSeconds = readIntEnv("SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS", 120);
+
+	if (defaultTtlMinutes > maxTtlMinutes) {
+		throw new Error(
+			"SHELL_WORKSPACE_DEFAULT_TTL_MINUTES must be <= SHELL_WORKSPACE_MAX_TTL_MINUTES",
+		);
+	}
+	if (defaultTimeoutSeconds > maxTimeoutSeconds) {
+		throw new Error(
+			"SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS must be <= SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS",
+		);
+	}
+
+	return {
+		agentId: process.env.SHELL_WORKSPACE_AGENT_ID ?? "unknown",
+		image: process.env.SHELL_WORKSPACE_IMAGE ?? SHELL_WORKSPACE_DEFAULT_IMAGE,
+		dataDir: process.env.SHELL_WORKSPACE_DATA_DIR ?? DEFAULT_DATA_DIR,
+		auditLogPath: process.env.SHELL_WORKSPACE_AUDIT_LOG ?? DEFAULT_AUDIT_LOG,
+		defaultTtlMinutes,
+		maxTtlMinutes,
+		defaultTimeoutSeconds,
+		maxTimeoutSeconds,
+		maxOutputChars: readIntEnv("SHELL_WORKSPACE_MAX_OUTPUT_CHARS", 50_000),
+	};
+}
+
+async function checkPodmanSetup(image: string): Promise<void> {
+	const podmanCheck = Bun.spawn(["podman", "--version"], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	await podmanCheck.exited;
+	if (podmanCheck.exitCode !== 0) {
+		throw new Error("podman is not available. Install podman and try again.");
+	}
+
+	const imageCheck = Bun.spawn(["podman", "image", "exists", image], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	await imageCheck.exited;
+	if (imageCheck.exitCode !== 0) {
+		throw new Error(`Container image '${image}' not found.`);
+	}
+}
+
+function formatJson(value: unknown): string {
+	return JSON.stringify(value, null, 2);
+}
+
+function formatExecResult(result: Awaited<ReturnType<ShellWorkspaceManager["exec"]>>): string {
+	return [
+		`session_id: ${result.sessionId}`,
+		`exit_code: ${result.exitCode ?? "null"}`,
+		`duration_ms: ${result.durationMs}`,
+		`timed_out: ${result.timedOut}`,
+		`output_truncated: ${result.outputTruncated}`,
+		"",
+		"output:",
+		result.output,
+	].join("\n");
+}
+
+async function main(): Promise<void> {
+	const config = loadShellWorkspaceConfig();
+	await checkPodmanSetup(config.image);
+
+	const manager = new ShellWorkspaceManager(config);
+	const cleanupTimer = setInterval(() => manager.cleanupExpired(), CLEANUP_INTERVAL_MS);
+	cleanupTimer.unref?.();
+
+	const server = new McpServer({
+		name: "shell-workspace",
+		version: "0.1.0",
+	});
+
+	server.registerTool(
+		"shell_start_session",
+		{
+			description: "Start an isolated shell workspace session",
+			inputSchema: {
+				label: z.string().max(MAX_LABEL_LENGTH).optional(),
+				ttl_minutes: z.number().int().min(1).max(config.maxTtlMinutes).optional(),
+			},
+		},
+		({ label, ttl_minutes }) => {
+			const info = manager.startSession({ label, ttlMinutes: ttl_minutes });
+			return { content: [{ type: "text", text: formatJson(info) }] };
+		},
+	);
+
+	server.registerTool(
+		"shell_exec",
+		{
+			description: "Execute a shell command inside an isolated /workspace sandbox",
+			inputSchema: {
+				session_id: z.uuid(),
+				command: z.string().min(1).max(MAX_COMMAND_LENGTH),
+				cwd: z.string().max(MAX_CWD_LENGTH).optional(),
+				timeout_seconds: z.number().int().min(1).max(config.maxTimeoutSeconds).optional(),
+			},
+		},
+		async ({ session_id, command, cwd, timeout_seconds }) => {
+			const result = await manager.exec({
+				sessionId: session_id,
+				command,
+				cwd,
+				timeoutSeconds: timeout_seconds,
+			});
+			return { content: [{ type: "text", text: formatExecResult(result) }] };
+		},
+	);
+
+	server.registerTool(
+		"shell_status",
+		{
+			description: "List shell workspace sessions or inspect one session",
+			inputSchema: {
+				session_id: z.uuid().optional(),
+			},
+		},
+		({ session_id }) => {
+			return { content: [{ type: "text", text: formatJson(manager.status(session_id)) }] };
+		},
+	);
+
+	server.registerTool(
+		"shell_export_file",
+		{
+			description: "Return a host-local file path for a file inside the shell workspace",
+			inputSchema: {
+				session_id: z.uuid(),
+				path: z.string().min(1).max(MAX_CWD_LENGTH),
+			},
+		},
+		({ session_id, path }) => {
+			const filePath = manager.exportFile(session_id, path);
+			return { content: [{ type: "text", text: filePath }] };
+		},
+	);
+
+	server.registerTool(
+		"shell_stop_session",
+		{
+			description: "Stop a shell workspace session and delete its workspace",
+			inputSchema: {
+				session_id: z.uuid(),
+			},
+		},
+		({ session_id }) => {
+			const info = manager.stopSession(session_id);
+			return { content: [{ type: "text", text: formatJson(info) }] };
+		},
+	);
+
+	async function shutdown() {
+		clearInterval(cleanupTimer);
+		manager.close();
+		await server.close();
+		process.exit(0);
+	}
+
+	process.on("SIGINT", () => void shutdown());
+	process.on("SIGTERM", () => void shutdown());
+
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+}
+
+void main();

--- a/packages/mcp/src/shell-workspace.ts
+++ b/packages/mcp/src/shell-workspace.ts
@@ -1,0 +1,370 @@
+/* oxlint-disable max-lines -- shell workspace policy, session lifecycle, and audit helpers stay together */
+import { appendFileSync, existsSync, mkdirSync, realpathSync, rmSync, statSync } from "fs";
+import { dirname, resolve, sep } from "path";
+
+const PODMAN_TIMEOUT_EXIT = 255;
+const DEFAULT_NETWORK_PROFILE = "none";
+const SHELL_WORKSPACE_CONTAINER_WORKDIR = "/workspace";
+
+export const SHELL_WORKSPACE_DEFAULT_IMAGE = "vicissitude-code-exec";
+export const SHELL_WORKSPACE_NETWORK_PROFILES = [DEFAULT_NETWORK_PROFILE] as const;
+
+export type ShellWorkspaceNetworkProfile = (typeof SHELL_WORKSPACE_NETWORK_PROFILES)[number];
+
+export interface ShellWorkspaceConfig {
+	agentId: string;
+	image: string;
+	dataDir: string;
+	auditLogPath: string;
+	defaultTtlMinutes: number;
+	maxTtlMinutes: number;
+	defaultTimeoutSeconds: number;
+	maxTimeoutSeconds: number;
+	maxOutputChars: number;
+	now?: () => number;
+	runProcess?: ProcessRunner;
+}
+
+export interface ShellSessionInfo {
+	sessionId: string;
+	label: string | null;
+	createdAt: string;
+	expiresAt: string;
+	lastUsedAt: string;
+	workspaceDir: string;
+}
+
+interface ShellSession {
+	id: string;
+	label: string | null;
+	dir: string;
+	createdAt: number;
+	expiresAt: number;
+	lastUsedAt: number;
+}
+
+export interface ShellExecResult {
+	sessionId: string;
+	exitCode: number | null;
+	durationMs: number;
+	timedOut: boolean;
+	output: string;
+	outputTruncated: boolean;
+}
+
+export interface ProcessResult {
+	exitCode: number | null;
+	output: string;
+	timedOut: boolean;
+	outputTruncated: boolean;
+}
+
+export type ProcessRunner = (
+	cmd: readonly string[],
+	options: { timeoutMs: number; maxOutputChars: number },
+) => Promise<ProcessResult>;
+
+export interface ShellAuditRecord {
+	timestamp: string;
+	agent_id: string;
+	session_id: string;
+	command: string;
+	cwd: string;
+	exit_code: number | null;
+	duration_ms: number;
+	timed_out: boolean;
+	output_truncated: boolean;
+}
+
+export function normalizeWorkspaceRelativePath(
+	input: string | undefined,
+	fieldName: string,
+): string {
+	const raw = (input ?? ".").trim();
+	if (raw === "" || raw === ".") return ".";
+	if (raw.includes("\0")) throw new Error(`${fieldName} must not contain NUL bytes`);
+	if (raw.startsWith("/") || /^[A-Za-z]:/.test(raw)) {
+		throw new Error(`${fieldName} must be a relative path inside /workspace`);
+	}
+
+	const parts = raw.split(/[\\/]+/).filter((part) => part !== "" && part !== ".");
+	if (parts.length === 0) return ".";
+	if (parts.some((part) => part === "..")) {
+		throw new Error(`${fieldName} must not contain '..'`);
+	}
+	return parts.join("/");
+}
+
+function normalizeLabel(input: string | undefined): string | null {
+	const label = input?.trim();
+	return label && label.length > 0 ? label : null;
+}
+
+export function buildShellPodmanCmd(options: {
+	image: string;
+	workspaceDir: string;
+	cwd: string;
+	command: string;
+	timeoutSeconds: number;
+	networkProfile?: ShellWorkspaceNetworkProfile;
+}): string[] {
+	const networkProfile = options.networkProfile ?? DEFAULT_NETWORK_PROFILE;
+	if (networkProfile !== "none") {
+		throw new Error("unsupported network profile");
+	}
+	const workdir =
+		options.cwd === "."
+			? SHELL_WORKSPACE_CONTAINER_WORKDIR
+			: `${SHELL_WORKSPACE_CONTAINER_WORKDIR}/${options.cwd}`;
+	return [
+		"podman",
+		"run",
+		"--rm",
+		"--network=none",
+		"--read-only",
+		"--tmpfs",
+		"/tmp:size=64M",
+		"--memory=512m",
+		"--cpus=1",
+		"--pids-limit=128",
+		"--cap-drop=ALL",
+		"--security-opt=no-new-privileges",
+		"--timeout",
+		String(options.timeoutSeconds + 5),
+		"--user=sandbox",
+		"--volume",
+		`${options.workspaceDir}:${SHELL_WORKSPACE_CONTAINER_WORKDIR}:rw`,
+		"--workdir",
+		workdir,
+		options.image,
+		"bash",
+		"-lc",
+		options.command,
+	];
+}
+
+export class ShellWorkspaceManager {
+	private readonly sessions = new Map<string, ShellSession>();
+	private readonly now: () => number;
+	private readonly runProcess: ProcessRunner;
+
+	constructor(private readonly config: ShellWorkspaceConfig) {
+		this.now = config.now ?? Date.now;
+		this.runProcess = config.runProcess ?? runLimitedProcess;
+		mkdirSync(config.dataDir, { recursive: true });
+		mkdirSync(dirname(config.auditLogPath), { recursive: true });
+	}
+
+	startSession(input: { label?: string; ttlMinutes?: number }): ShellSessionInfo {
+		const now = this.now();
+		const ttlMinutes = input.ttlMinutes ?? this.config.defaultTtlMinutes;
+		if (ttlMinutes < 1 || ttlMinutes > this.config.maxTtlMinutes) {
+			throw new Error(`ttl_minutes must be between 1 and ${this.config.maxTtlMinutes}`);
+		}
+
+		const id = crypto.randomUUID();
+		const dir = resolve(this.config.dataDir, id);
+		mkdirSync(dir, { recursive: false });
+
+		const session: ShellSession = {
+			id,
+			label: normalizeLabel(input.label),
+			dir,
+			createdAt: now,
+			expiresAt: now + ttlMinutes * 60_000,
+			lastUsedAt: now,
+		};
+		this.sessions.set(id, session);
+		return this.toInfo(session);
+	}
+
+	async exec(input: {
+		sessionId: string;
+		command: string;
+		cwd?: string;
+		timeoutSeconds?: number;
+	}): Promise<ShellExecResult> {
+		const session = this.requireSession(input.sessionId);
+		const cwd = normalizeWorkspaceRelativePath(input.cwd, "cwd");
+		const timeoutSeconds = input.timeoutSeconds ?? this.config.defaultTimeoutSeconds;
+		if (timeoutSeconds < 1 || timeoutSeconds > this.config.maxTimeoutSeconds) {
+			throw new Error(`timeout_seconds must be between 1 and ${this.config.maxTimeoutSeconds}`);
+		}
+
+		session.lastUsedAt = this.now();
+		const cmd = buildShellPodmanCmd({
+			image: this.config.image,
+			workspaceDir: session.dir,
+			cwd,
+			command: input.command,
+			timeoutSeconds,
+		});
+
+		const startedAt = this.now();
+		const result = await this.runProcess(cmd, {
+			timeoutMs: (timeoutSeconds + 5) * 1_000,
+			maxOutputChars: this.config.maxOutputChars,
+		});
+		const durationMs = this.now() - startedAt;
+		const execResult: ShellExecResult = {
+			sessionId: session.id,
+			exitCode: result.exitCode,
+			durationMs,
+			timedOut: result.timedOut,
+			output: result.output,
+			outputTruncated: result.outputTruncated,
+		};
+		this.writeAudit({
+			timestamp: new Date(this.now()).toISOString(),
+			agent_id: this.config.agentId,
+			session_id: session.id,
+			command: input.command,
+			cwd,
+			exit_code: result.exitCode,
+			duration_ms: durationMs,
+			timed_out: result.timedOut,
+			output_truncated: result.outputTruncated,
+		});
+		return execResult;
+	}
+
+	status(sessionId?: string): ShellSessionInfo[] {
+		this.cleanupExpired();
+		if (sessionId) return [this.toInfo(this.requireSession(sessionId))];
+		return [...this.sessions.values()].map((session) => this.toInfo(session));
+	}
+
+	exportFile(sessionId: string, path: string): string {
+		const session = this.requireSession(sessionId);
+		const relativePath = normalizeWorkspaceRelativePath(path, "path");
+		if (relativePath === ".") throw new Error("path must point to a file inside /workspace");
+
+		const workspaceRoot = realpathSync(session.dir);
+		const candidate = resolve(session.dir, relativePath);
+		if (!existsSync(candidate)) throw new Error(`file not found: ${path}`);
+		const realCandidate = realpathSync(candidate);
+		if (realCandidate !== workspaceRoot && !realCandidate.startsWith(`${workspaceRoot}${sep}`)) {
+			throw new Error("path must stay inside the workspace");
+		}
+		if (!statSync(realCandidate).isFile()) throw new Error(`path is not a file: ${path}`);
+		return realCandidate;
+	}
+
+	stopSession(sessionId: string): ShellSessionInfo {
+		const session = this.requireSession(sessionId);
+		const info = this.toInfo(session);
+		this.sessions.delete(sessionId);
+		rmSync(session.dir, { recursive: true, force: true });
+		return info;
+	}
+
+	cleanupExpired(): void {
+		const now = this.now();
+		for (const session of this.sessions.values()) {
+			if (session.expiresAt <= now) {
+				this.sessions.delete(session.id);
+				rmSync(session.dir, { recursive: true, force: true });
+			}
+		}
+	}
+
+	close(): void {
+		for (const session of this.sessions.values()) {
+			rmSync(session.dir, { recursive: true, force: true });
+		}
+		this.sessions.clear();
+	}
+
+	private requireSession(sessionId: string): ShellSession {
+		this.cleanupExpired();
+		const session = this.sessions.get(sessionId);
+		if (!session) throw new Error(`unknown or expired session_id: ${sessionId}`);
+		return session;
+	}
+
+	private toInfo(session: ShellSession): ShellSessionInfo {
+		return {
+			sessionId: session.id,
+			label: session.label,
+			createdAt: new Date(session.createdAt).toISOString(),
+			expiresAt: new Date(session.expiresAt).toISOString(),
+			lastUsedAt: new Date(session.lastUsedAt).toISOString(),
+			workspaceDir: session.dir,
+		};
+	}
+
+	private writeAudit(record: ShellAuditRecord): void {
+		appendFileSync(this.config.auditLogPath, `${JSON.stringify(record)}\n`);
+	}
+}
+
+async function runLimitedProcess(
+	cmd: readonly string[],
+	options: { timeoutMs: number; maxOutputChars: number },
+): Promise<ProcessResult> {
+	const proc = Bun.spawn([...cmd], { stdout: "pipe", stderr: "pipe" });
+
+	let timedOut = false;
+	const timeoutId = setTimeout(() => {
+		timedOut = true;
+		proc.kill();
+	}, options.timeoutMs);
+
+	const byteLimit = options.maxOutputChars * 4;
+	const [stdout, stderr] = await Promise.all([
+		collectStream(proc.stdout as ReadableStream<Uint8Array>, byteLimit),
+		collectStream(proc.stderr as ReadableStream<Uint8Array>, byteLimit),
+	]);
+
+	await proc.exited;
+	clearTimeout(timeoutId);
+
+	const raw = (stdout.text + stderr.text).trim() || "(no output)";
+	const truncated = truncateOutput(raw, options.maxOutputChars);
+	const podmanTimedOut = proc.exitCode === PODMAN_TIMEOUT_EXIT;
+
+	return {
+		exitCode: proc.exitCode,
+		output: truncated.output,
+		timedOut: timedOut || podmanTimedOut,
+		outputTruncated: stdout.truncated || stderr.truncated || truncated.truncated,
+	};
+}
+
+function truncateOutput(output: string, maxChars: number): { output: string; truncated: boolean } {
+	if (output.length <= maxChars) return { output, truncated: false };
+	const omitted = output.length - maxChars;
+	const marker = `\n\n... (truncated ${omitted} chars) ...\n\n`;
+	if (maxChars <= marker.length) return { output: output.slice(0, maxChars), truncated: true };
+	const headSize = Math.floor((maxChars - marker.length) * 0.8);
+	const tailSize = maxChars - marker.length - headSize;
+	return {
+		output: `${output.slice(0, headSize)}${marker}${output.slice(-tailSize)}`,
+		truncated: true,
+	};
+}
+
+async function collectStream(
+	stream: ReadableStream<Uint8Array>,
+	limit: number,
+): Promise<{ text: string; truncated: boolean }> {
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	let truncated = false;
+	for await (const chunk of stream) {
+		const remaining = limit - total;
+		if (remaining <= 0) {
+			truncated = true;
+			break;
+		}
+		if (remaining < chunk.length) {
+			chunks.push(chunk.slice(0, remaining));
+			total += remaining;
+			truncated = true;
+			break;
+		}
+		chunks.push(chunk);
+		total += chunk.length;
+	}
+	return { text: new TextDecoder().decode(Buffer.concat(chunks)), truncated };
+}

--- a/packages/mcp/src/tools/discord.ts
+++ b/packages/mcp/src/tools/discord.ts
@@ -7,7 +7,16 @@ import type { EmotionAnalyzer, MoodWriter } from "@vicissitude/shared/ports";
 import type { Client, TextChannel } from "discord.js";
 import { z } from "zod";
 
-const ALLOWED_FILE_DIRS = ["/tmp/vicissitude-screenshots"];
+const DEFAULT_ALLOWED_FILE_DIRS = ["/tmp/vicissitude-screenshots"];
+const ATTACHMENT_ALLOWED_DIRS_ENV = "DISCORD_ATTACHMENT_ALLOWED_DIRS";
+
+function allowedFileDirs(): string[] {
+	const extra = (process.env[ATTACHMENT_ALLOWED_DIRS_ENV] ?? "")
+		.split(path.delimiter)
+		.map((dir) => dir.trim())
+		.filter((dir) => dir.length > 0);
+	return [...DEFAULT_ALLOWED_FILE_DIRS, ...extra].map((dir) => path.resolve(dir));
+}
 
 function validateFilePath(filePath: string): void {
 	const absolute = path.resolve(filePath);
@@ -15,7 +24,9 @@ function validateFilePath(filePath: string): void {
 		throw new Error(`File not found: ${filePath}`);
 	}
 	const resolved = realpathSync(absolute);
-	const allowed = ALLOWED_FILE_DIRS.some((dir) => resolved.startsWith(dir + "/"));
+	const allowed = allowedFileDirs().some(
+		(dir) => resolved === dir || resolved.startsWith(dir + path.sep),
+	);
 	if (!allowed) {
 		throw new Error(`File path not allowed: ${filePath}`);
 	}

--- a/spec/agent/mcp-config.spec.ts
+++ b/spec/agent/mcp-config.spec.ts
@@ -9,10 +9,20 @@ describe("mcpServerConfigs", () => {
 		appRoot: "/test/root",
 		coreEnvironment: { DISCORD_TOKEN: "test", DATA_DIR: "/data" },
 	};
+	const shellWorkspace = {
+		image: "sandbox-image",
+		dataDir: "/data/shell-workspaces",
+		auditLogPath: "/data/shell-workspace-audit.jsonl",
+		defaultTtlMinutes: 60,
+		maxTtlMinutes: 120,
+		defaultTimeoutSeconds: 30,
+		maxTimeoutSeconds: 120,
+		maxOutputChars: 50_000,
+	};
 
-	it("core と code-exec のみ返す", () => {
+	it("デフォルトでは core のみ返す", () => {
 		const configs = mcpServerConfigs("discord:123", defaultOpts);
-		expect(Object.keys(configs).toSorted()).toEqual(["code-exec", "core"]);
+		expect(Object.keys(configs).toSorted()).toEqual(["core"]);
 	});
 
 	it("core は local 型", () => {
@@ -36,6 +46,42 @@ describe("mcpServerConfigs", () => {
 			expect(core.environment?.DISCORD_TOKEN).toBe("test");
 			expect(core.environment?.DATA_DIR).toBe("/data");
 		}
+	});
+
+	it("shell-workspace capability が有効な場合だけ shell-workspace を返す", () => {
+		const configs = mcpServerConfigs("discord:123", {
+			...defaultOpts,
+			capabilities: ["shell-workspace"],
+			shellWorkspace,
+		});
+
+		expect(Object.keys(configs).toSorted()).toEqual(["core", "shell-workspace"]);
+	});
+
+	it("shell-workspace の environment は専用設定のみを含む", () => {
+		const configs = mcpServerConfigs("discord:123", {
+			...defaultOpts,
+			capabilities: ["shell-workspace"],
+			shellWorkspace,
+		});
+		const shell = configs["shell-workspace"];
+
+		expect(shell?.type).toBe("local");
+		if (shell?.type === "local") {
+			expect(shell.environment?.SHELL_WORKSPACE_AGENT_ID).toBe("discord:123");
+			expect(shell.environment?.SHELL_WORKSPACE_IMAGE).toBe("sandbox-image");
+			expect(shell.environment?.SHELL_WORKSPACE_DATA_DIR).toBe("/data/shell-workspaces");
+			expect(shell.environment?.DISCORD_TOKEN).toBeUndefined();
+		}
+	});
+
+	it("shell-workspace capability 有効時に設定がなければエラーにする", () => {
+		expect(() =>
+			mcpServerConfigs("discord:123", {
+				...defaultOpts,
+				capabilities: ["shell-workspace"],
+			}),
+		).toThrow("shellWorkspace config is required");
 	});
 });
 

--- a/spec/core/config.spec.ts
+++ b/spec/core/config.spec.ts
@@ -29,6 +29,7 @@ describe("loadConfig", () => {
 		expect(config.memory.ollamaBaseUrl).toBe("http://ollama:11434");
 		expect(config.memory.embeddingModel).toBe("embeddinggemma");
 		expect(config.minecraft).toBeUndefined();
+		expect(config.shellWorkspace).toBeUndefined();
 		expect(config.dataDir).toBe("/tmp/test-vicissitude/data");
 		expect(config.contextDir).toBe("/tmp/test-vicissitude/context");
 	});
@@ -136,6 +137,64 @@ describe("loadConfig", () => {
 			expect(config.minecraft?.profilesFolder).toBe("/tmp/mc-profiles");
 			expect(config.minecraft?.mcpPort).toBe(4000);
 			expect(config.minecraft?.viewerPort).toBe(5000);
+		});
+	});
+
+	describe("Shell workspace", () => {
+		it("SHELL_WORKSPACE_ENABLED が設定されていれば shellWorkspace がセットされる", () => {
+			const config = loadConfig(
+				baseEnv({
+					SHELL_WORKSPACE_ENABLED: "true",
+				}),
+				root,
+			);
+
+			expect(config.shellWorkspace).toEqual({
+				enabled: true,
+				image: "vicissitude-code-exec",
+				dataDir: "/tmp/test-vicissitude/data/shell-workspaces",
+				auditLogPath: "/tmp/test-vicissitude/data/shell-workspace-audit.jsonl",
+				defaultTtlMinutes: 60,
+				maxTtlMinutes: 120,
+				defaultTimeoutSeconds: 30,
+				maxTimeoutSeconds: 120,
+				maxOutputChars: 50_000,
+			});
+		});
+
+		it("Shell workspace のカスタム値が反映される", () => {
+			const config = loadConfig(
+				baseEnv({
+					SHELL_WORKSPACE_ENABLED: "1",
+					SHELL_WORKSPACE_IMAGE: "custom-shell-image",
+					SHELL_WORKSPACE_DEFAULT_TTL_MINUTES: "10",
+					SHELL_WORKSPACE_MAX_TTL_MINUTES: "20",
+					SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS: "5",
+					SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS: "9",
+					SHELL_WORKSPACE_MAX_OUTPUT_CHARS: "12345",
+				}),
+				root,
+			);
+
+			expect(config.shellWorkspace?.image).toBe("custom-shell-image");
+			expect(config.shellWorkspace?.defaultTtlMinutes).toBe(10);
+			expect(config.shellWorkspace?.maxTtlMinutes).toBe(20);
+			expect(config.shellWorkspace?.defaultTimeoutSeconds).toBe(5);
+			expect(config.shellWorkspace?.maxTimeoutSeconds).toBe(9);
+			expect(config.shellWorkspace?.maxOutputChars).toBe(12_345);
+		});
+
+		it("Shell workspace の既定 TTL が上限を超える場合はエラーにする", () => {
+			expect(() =>
+				loadConfig(
+					baseEnv({
+						SHELL_WORKSPACE_ENABLED: "true",
+						SHELL_WORKSPACE_DEFAULT_TTL_MINUTES: "30",
+						SHELL_WORKSPACE_MAX_TTL_MINUTES: "10",
+					}),
+					root,
+				),
+			).toThrow("SHELL_WORKSPACE_DEFAULT_TTL_MINUTES");
 		});
 	});
 });

--- a/spec/discord/bootstrap.spec.ts
+++ b/spec/discord/bootstrap.spec.ts
@@ -8,6 +8,7 @@ function makeConfig(
 	overrides: {
 		spotify?: AppConfig["spotify"];
 		genius?: AppConfig["genius"];
+		shellWorkspace?: AppConfig["shellWorkspace"];
 	} = {},
 ): AppConfig {
 	return {
@@ -173,6 +174,33 @@ describe("buildCoreEnvironment", () => {
 		it("config.genius が存在しない場合は GENIUS_ACCESS_TOKEN を含まない", () => {
 			const result = buildCoreEnvironment(makeConfig(), ROOT);
 			expect(result).not.toHaveProperty("GENIUS_ACCESS_TOKEN");
+		});
+	});
+
+	describe("Shell workspace 環境変数", () => {
+		it("config.shellWorkspace が存在する場合は添付許可ディレクトリを含む", () => {
+			const config = makeConfig({
+				shellWorkspace: {
+					enabled: true,
+					image: "sandbox",
+					dataDir: "/tmp/shell-workspaces",
+					auditLogPath: "/tmp/shell-audit.jsonl",
+					defaultTtlMinutes: 60,
+					maxTtlMinutes: 120,
+					defaultTimeoutSeconds: 30,
+					maxTimeoutSeconds: 120,
+					maxOutputChars: 50_000,
+				},
+			});
+			const result = buildCoreEnvironment(config, ROOT);
+
+			expect(result.DISCORD_ATTACHMENT_ALLOWED_DIRS).toBe("/tmp/shell-workspaces");
+		});
+
+		it("config.shellWorkspace が存在しない場合は添付許可ディレクトリを追加しない", () => {
+			const result = buildCoreEnvironment(makeConfig(), ROOT);
+
+			expect(result).not.toHaveProperty("DISCORD_ATTACHMENT_ALLOWED_DIRS");
 		});
 	});
 });

--- a/spec/mcp/shell-workspace.spec.ts
+++ b/spec/mcp/shell-workspace.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "fs";
+import os from "os";
+import { join } from "path";
+
+import {
+	buildShellPodmanCmd,
+	normalizeWorkspaceRelativePath,
+	ShellWorkspaceManager,
+	type ProcessRunner,
+} from "@vicissitude/mcp/shell-workspace";
+
+function createConfig(
+	overrides: Partial<ConstructorParameters<typeof ShellWorkspaceManager>[0]> = {},
+) {
+	const root = mkdtempSync(join(os.tmpdir(), "shell-workspace-test-"));
+	return {
+		agentId: "discord:123",
+		image: "sandbox-image",
+		dataDir: join(root, "workspaces"),
+		auditLogPath: join(root, "audit.jsonl"),
+		defaultTtlMinutes: 60,
+		maxTtlMinutes: 120,
+		defaultTimeoutSeconds: 30,
+		maxTimeoutSeconds: 120,
+		maxOutputChars: 50_000,
+		...overrides,
+	};
+}
+
+describe("normalizeWorkspaceRelativePath", () => {
+	it("相対パスを正規化する", () => {
+		expect(normalizeWorkspaceRelativePath("./foo/bar", "cwd")).toBe("foo/bar");
+		expect(normalizeWorkspaceRelativePath("", "cwd")).toBe(".");
+		expect(normalizeWorkspaceRelativePath(undefined, "cwd")).toBe(".");
+	});
+
+	it("workspace 外に出るパスを拒否する", () => {
+		expect(() => normalizeWorkspaceRelativePath("/etc", "cwd")).toThrow("relative path");
+		expect(() => normalizeWorkspaceRelativePath("../secret", "cwd")).toThrow(
+			"must not contain '..'",
+		);
+		expect(() => normalizeWorkspaceRelativePath("C:\\Users", "cwd")).toThrow("relative path");
+	});
+});
+
+describe("buildShellPodmanCmd", () => {
+	it("network none と sandbox 制約を含む Podman command を組み立てる", () => {
+		const cmd = buildShellPodmanCmd({
+			image: "sandbox-image",
+			workspaceDir: "/tmp/workspace",
+			cwd: "project",
+			command: "pwd",
+			timeoutSeconds: 10,
+		});
+
+		expect(cmd).toContain("--network=none");
+		expect(cmd).toContain("--read-only");
+		expect(cmd).toContain("--cap-drop=ALL");
+		expect(cmd).toContain("--security-opt=no-new-privileges");
+		expect(cmd).toContain("/tmp/workspace:/workspace:rw");
+		expect(cmd).toContain("/workspace/project");
+		expect(cmd.slice(-3)).toEqual(["bash", "-lc", "pwd"]);
+	});
+});
+
+describe("ShellWorkspaceManager", () => {
+	it("session を作成し、exec 結果と監査ログを記録する", async () => {
+		let now = Date.parse("2026-05-07T00:00:00.000Z");
+		const seenCommands: string[][] = [];
+		const runner: ProcessRunner = (cmd) => {
+			seenCommands.push([...cmd]);
+			now += 123;
+			return Promise.resolve({
+				exitCode: 0,
+				output: "ok",
+				timedOut: false,
+				outputTruncated: false,
+			});
+		};
+		const config = createConfig({ now: () => now, runProcess: runner });
+		const manager = new ShellWorkspaceManager(config);
+		const session = manager.startSession({ label: "test", ttlMinutes: 10 });
+
+		const result = await manager.exec({
+			sessionId: session.sessionId,
+			command: "echo ok",
+			cwd: ".",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.durationMs).toBe(123);
+		expect(result.output).toBe("ok");
+		expect(seenCommands).toHaveLength(1);
+		const audit = JSON.parse(readFileSync(config.auditLogPath, "utf8").trim());
+		expect(audit.agent_id).toBe("discord:123");
+		expect(audit.session_id).toBe(session.sessionId);
+		expect(audit.command).toBe("echo ok");
+		expect(audit.exit_code).toBe(0);
+		manager.close();
+	});
+
+	it("期限切れ session を削除する", () => {
+		let now = Date.parse("2026-05-07T00:00:00.000Z");
+		const config = createConfig({ now: () => now });
+		const manager = new ShellWorkspaceManager(config);
+		const session = manager.startSession({ ttlMinutes: 1 });
+
+		expect(existsSync(session.workspaceDir)).toBe(true);
+		now += 61_000;
+		manager.cleanupExpired();
+
+		expect(manager.status()).toEqual([]);
+		expect(existsSync(session.workspaceDir)).toBe(false);
+	});
+
+	it("exportFile は symlink による workspace 外参照を拒否する", () => {
+		const config = createConfig();
+		const manager = new ShellWorkspaceManager(config);
+		const session = manager.startSession({});
+		const outside = join(mkdtempSync(join(os.tmpdir(), "shell-outside-")), "secret.txt");
+		writeFileSync(outside, "secret");
+		symlinkSync(outside, join(session.workspaceDir, "leak.txt"));
+
+		expect(() => manager.exportFile(session.sessionId, "leak.txt")).toThrow("inside the workspace");
+		manager.close();
+	});
+});

--- a/spec/mcp/tools/discord.spec.ts
+++ b/spec/mcp/tools/discord.spec.ts
@@ -1,5 +1,8 @@
 /* oxlint-disable no-non-null-assertion -- test assertions after length/null checks */
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "fs";
+import os from "os";
+import { join } from "path";
 
 import {
 	captureTools,
@@ -78,6 +81,32 @@ describe("send_message", () => {
 			threw = true;
 		}
 		expect(threw).toBe(true);
+	});
+
+	test("DISCORD_ATTACHMENT_ALLOWED_DIRS 配下の file_path を送信できる", async () => {
+		const saved = process.env.DISCORD_ATTACHMENT_ALLOWED_DIRS;
+		const dir = mkdtempSync(join(os.tmpdir(), "discord-attachment-"));
+		const filePath = join(dir, "result.txt");
+		writeFileSync(filePath, "result");
+		process.env.DISCORD_ATTACHMENT_ALLOWED_DIRS = dir;
+		try {
+			const { tools } = captureTools({ discordClient: createDiscordClientStub() });
+			const sendMessage = tools.get("send_message")!;
+
+			const result = (await sendMessage({
+				channel_id: "ch-1",
+				content: "テスト",
+				file_path: filePath,
+			})) as ToolResult;
+
+			expect(result.content[0]!.text).toBe("Sent message sent-msg-1");
+		} finally {
+			if (saved === undefined) {
+				delete process.env.DISCORD_ATTACHMENT_ALLOWED_DIRS;
+			} else {
+				process.env.DISCORD_ATTACHMENT_ALLOWED_DIRS = saved;
+			}
+		}
 	});
 });
 


### PR DESCRIPTION
## 概要
- shell workspace capability を追加し、会話専用インスタンスでは shell MCP と TOOLS-CODE を接続しないように変更
- OpenCode builtin bash ではなく shell-workspace MCP で Podman sandbox 実行、TTL、timeout、監査ログ、export_file を提供
- shell workspace 有効時に成果物を Discord 添付できるよう core の許可ディレクトリを capability 連動で追加

## 検証
- bun test spec/agent/mcp-config.spec.ts spec/core/config.spec.ts apps/discord/src/bootstrap.test.ts spec/mcp/shell-workspace.spec.ts
- bun test spec/discord/bootstrap.spec.ts spec/mcp/tools/discord.spec.ts spec/agent/mcp-config.spec.ts spec/core/config.spec.ts apps/discord/src/bootstrap.test.ts spec/mcp/shell-workspace.spec.ts
- nr validate
- nr test