### PR TITLE
fix(config): profile の schema metadata を許可する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 node_modules/
 .env
 .env.local
+/config/local.json
 /PLAN.md
 /artifacts/
 data/

--- a/apps/discord/src/profile-config.ts
+++ b/apps/discord/src/profile-config.ts
@@ -18,6 +18,7 @@ const modelSelectionSchema = z.strictObject({
 });
 
 export const profileConfigSchema = z.strictObject({
+	$schema: z.string().min(1).optional(),
 	ports: z.strictObject({
 		web: safeInt,
 		gateway: safeInt,

--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "./profile.schema.json",
 	"ports": {
 		"web": 4000,
 		"gateway": 4001,

--- a/config/profile.schema.json
+++ b/config/profile.schema.json
@@ -3,6 +3,10 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"type": "object",
 	"properties": {
+		"$schema": {
+			"type": "string",
+			"minLength": 1
+		},
 		"ports": {
 			"type": "object",
 			"properties": {

--- a/spec/core/profile-config.spec.ts
+++ b/spec/core/profile-config.spec.ts
@@ -73,6 +73,16 @@ describe("JSON profile config", () => {
 		expect(parsed.ports.web).toBe(4100);
 	});
 
+	it("$schema metadata を含む profile も読み込める", () => {
+		const parsed = profileConfigSchema.parse({
+			$schema: "./profile.schema.json",
+			...baseProfile,
+		});
+
+		expect(parsed.$schema).toBe("./profile.schema.json");
+		expect(parsed.models.conversation.modelId).toBe("conversation-model");
+	});
+
 	it("JSON Schema ファイルは Zod schema から生成される内容と一致する", () => {
 		const schemaFile = JSON.parse(readFileSync(resolve("config/profile.schema.json"), "utf8"));
 		const generatedSchema = {


### PR DESCRIPTION
## Summary
- profile JSON の `$schema` metadata を loader/schema で許可
- `config/default.json` に schema 参照を追加
- ローカル profile 用の `config/local.json` を ignore

## Local migration
- `.env` を secret と `VICISSITUDE_CONFIG_PATH=config/local.json` 中心に整理
- 既存 `.env` の非 secret 設定を `config/local.json` に変換済み

## Tests
- `nr test spec/core/profile-config.spec.ts spec/core/config.spec.ts apps/discord/src/config.test.ts`
- `nr validate`
- `nr test`
