### PR TITLE
fix(deploy): config ディレクトリを bot に mount する

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -81,6 +81,7 @@ services:
       - bot-dist:/app/dist:ro
       - ./packages:/app/packages:ro
       - ./apps:/app/apps:ro
+      - ./config:/app/config:ro
       - ./data:/app/data:rw
       - ./context:/app/context:ro
       - ${XDG_RUNTIME_DIR:-/run/user/1000}/podman/podman.sock:/run/podman/podman.sock:ro


### PR DESCRIPTION
## Summary
- bot コンテナに `./config:/app/config:ro` を mount
- `.env` の `VICISSITUDE_CONFIG_PATH=config/local.json` が deploy 後も解決できるようにする

## Tests
- `podman-compose config`
- `nr validate`
