### PR TITLE
fix(shell): Podman の workspace bind path を修正する

### DIFF
--- a/apps/discord/src/config-schema.ts
+++ b/apps/discord/src/config-schema.ts
@@ -51,6 +51,7 @@ export const shellWorkspaceSchema = z
 		enabled: z.literal(true),
 		image: z.string().min(1, "SHELL_WORKSPACE_IMAGE is required"),
 		dataDir: z.string(),
+		hostDataDir: z.string().optional(),
 		auditLogPath: z.string(),
 		defaultTtlMinutes: safeInt.min(1),
 		maxTtlMinutes: safeInt.min(1),

--- a/apps/discord/src/config.ts
+++ b/apps/discord/src/config.ts
@@ -26,6 +26,9 @@ function buildShellWorkspaceConfig(env: Record<string, string | undefined>, data
 		enabled: true,
 		image: env.SHELL_WORKSPACE_IMAGE ?? "vicissitude-code-exec",
 		dataDir: resolve(dataDir, "shell-workspaces"),
+		...(env.SHELL_WORKSPACE_HOST_DATA_DIR
+			? { hostDataDir: env.SHELL_WORKSPACE_HOST_DATA_DIR }
+			: {}),
 		auditLogPath: resolve(dataDir, "shell-workspace-audit.jsonl"),
 		defaultTtlMinutes: Number(env.SHELL_WORKSPACE_DEFAULT_TTL_MINUTES ?? "60"),
 		maxTtlMinutes: Number(env.SHELL_WORKSPACE_MAX_TTL_MINUTES ?? "120"),

--- a/apps/discord/src/profile-config.ts
+++ b/apps/discord/src/profile-config.ts
@@ -67,6 +67,7 @@ export type ProfileConfig = z.infer<typeof profileConfigSchema>;
 
 function buildProfileShellWorkspaceConfig(
 	profile: ProfileConfig,
+	env: Record<string, string | undefined>,
 	dataDir: string,
 ): AppConfig["shellWorkspace"] {
 	const shellWorkspace = profile.features.shellWorkspace;
@@ -75,6 +76,9 @@ function buildProfileShellWorkspaceConfig(
 		enabled: true,
 		image: shellWorkspace.image,
 		dataDir: resolve(dataDir, "shell-workspaces"),
+		...(env.SHELL_WORKSPACE_HOST_DATA_DIR
+			? { hostDataDir: env.SHELL_WORKSPACE_HOST_DATA_DIR }
+			: {}),
 		auditLogPath: resolve(dataDir, "shell-workspace-audit.jsonl"),
 		defaultTtlMinutes: shellWorkspace.defaultTtlMinutes,
 		maxTtlMinutes: shellWorkspace.maxTtlMinutes,
@@ -157,7 +161,7 @@ export function loadConfigFromProfile(
 					modelId: profile.features.imageRecognition.modelId,
 				}
 			: undefined,
-		shellWorkspace: buildProfileShellWorkspaceConfig(profile, dataDir),
+		shellWorkspace: buildProfileShellWorkspaceConfig(profile, env, dataDir),
 		dataDir,
 		contextDir: resolve(resolvedRoot, "context"),
 	};

--- a/compose.yaml
+++ b/compose.yaml
@@ -70,6 +70,7 @@ services:
     init: true
     environment:
       APP_ROOT: /app
+      SHELL_WORKSPACE_HOST_DATA_DIR: ${PWD}/data/shell-workspaces
     env_file:
       - .env
     ports:

--- a/docs/agent-capabilities-and-shell-sandbox.md
+++ b/docs/agent-capabilities-and-shell-sandbox.md
@@ -48,17 +48,20 @@ MVP の既定 policy:
 
 ## 設定
 
-| 環境変数                                  | 既定                    | 説明                            |
-| ----------------------------------------- | ----------------------- | ------------------------------- |
-| `SHELL_WORKSPACE_ENABLED`                 | `false`                 | `true`/`1`/`yes`/`on` で有効化  |
-| `SHELL_WORKSPACE_IMAGE`                   | `vicissitude-code-exec` | Podman で起動する sandbox image |
-| `SHELL_WORKSPACE_DEFAULT_TTL_MINUTES`     | `60`                    | session の既定 TTL              |
-| `SHELL_WORKSPACE_MAX_TTL_MINUTES`         | `120`                   | session TTL 上限                |
-| `SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS` | `30`                    | `shell_exec` の既定 timeout     |
-| `SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS`     | `120`                   | `shell_exec` timeout 上限       |
-| `SHELL_WORKSPACE_MAX_OUTPUT_CHARS`        | `50000`                 | stdout + stderr の返却上限      |
+| 環境変数                                  | 既定                    | 説明                                                                  |
+| ----------------------------------------- | ----------------------- | --------------------------------------------------------------------- |
+| `SHELL_WORKSPACE_ENABLED`                 | `false`                 | `true`/`1`/`yes`/`on` で有効化                                        |
+| `SHELL_WORKSPACE_IMAGE`                   | `vicissitude-code-exec` | Podman で起動する sandbox image                                       |
+| `SHELL_WORKSPACE_DEFAULT_TTL_MINUTES`     | `60`                    | session の既定 TTL                                                    |
+| `SHELL_WORKSPACE_MAX_TTL_MINUTES`         | `120`                   | session TTL 上限                                                      |
+| `SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS` | `30`                    | `shell_exec` の既定 timeout                                           |
+| `SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS`     | `120`                   | `shell_exec` timeout 上限                                             |
+| `SHELL_WORKSPACE_MAX_OUTPUT_CHARS`        | `50000`                 | stdout + stderr の返却上限                                            |
+| `SHELL_WORKSPACE_HOST_DATA_DIR`           | unset                   | ホスト Podman socket 経由で実行する場合のホスト側 workspace directory |
 
 `shell-workspace` 有効時、core MCP には `DISCORD_ATTACHMENT_ALLOWED_DIRS` として shell workspace directory を渡す。これにより `shell_export_file` が返したパスを `core_send_message(..., file_path)` で添付できる。
+
+bot コンテナからホスト Podman socket を使う deploy では、sandbox の bind mount source はホスト側 path である必要がある。この場合は `SHELL_WORKSPACE_HOST_DATA_DIR` にホスト側の `data/shell-workspaces` を指定し、MCP プロセスが管理・添付に使う `SHELL_WORKSPACE_DATA_DIR` とは分ける。
 
 ## 監査ログ
 

--- a/packages/agent/src/mcp-config.ts
+++ b/packages/agent/src/mcp-config.ts
@@ -15,6 +15,7 @@ export type AgentCapability = "shell-workspace";
 export interface ShellWorkspaceMcpConfigOptions {
 	image: string;
 	dataDir: string;
+	hostDataDir?: string;
 	auditLogPath: string;
 	defaultTtlMinutes: number;
 	maxTtlMinutes: number;
@@ -75,6 +76,7 @@ function buildShellWorkspaceEnvironment(
 		SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS: String(config.maxTimeoutSeconds),
 		SHELL_WORKSPACE_MAX_OUTPUT_CHARS: String(config.maxOutputChars),
 	};
+	if (config.hostDataDir) env.SHELL_WORKSPACE_HOST_DATA_DIR = config.hostDataDir;
 	if (process.env.XDG_RUNTIME_DIR) env.XDG_RUNTIME_DIR = process.env.XDG_RUNTIME_DIR;
 	if (process.env.TMPDIR) env.TMPDIR = process.env.TMPDIR;
 	return env;

--- a/packages/mcp/src/shell-workspace-server.ts
+++ b/packages/mcp/src/shell-workspace-server.ts
@@ -47,6 +47,7 @@ function loadShellWorkspaceConfig(): ShellWorkspaceConfig {
 		agentId: process.env.SHELL_WORKSPACE_AGENT_ID ?? "unknown",
 		image: process.env.SHELL_WORKSPACE_IMAGE ?? SHELL_WORKSPACE_DEFAULT_IMAGE,
 		dataDir: process.env.SHELL_WORKSPACE_DATA_DIR ?? DEFAULT_DATA_DIR,
+		hostDataDir: process.env.SHELL_WORKSPACE_HOST_DATA_DIR,
 		auditLogPath: process.env.SHELL_WORKSPACE_AUDIT_LOG ?? DEFAULT_AUDIT_LOG,
 		defaultTtlMinutes,
 		maxTtlMinutes,

--- a/packages/mcp/src/shell-workspace.ts
+++ b/packages/mcp/src/shell-workspace.ts
@@ -15,6 +15,7 @@ export interface ShellWorkspaceConfig {
 	agentId: string;
 	image: string;
 	dataDir: string;
+	hostDataDir?: string;
 	auditLogPath: string;
 	defaultTtlMinutes: number;
 	maxTtlMinutes: number;
@@ -38,6 +39,7 @@ interface ShellSession {
 	id: string;
 	label: string | null;
 	dir: string;
+	hostDir: string;
 	createdAt: number;
 	expiresAt: number;
 	lastUsedAt: number;
@@ -164,12 +166,14 @@ export class ShellWorkspaceManager {
 
 		const id = crypto.randomUUID();
 		const dir = resolve(this.config.dataDir, id);
+		const hostDir = this.config.hostDataDir ? resolve(this.config.hostDataDir, id) : dir;
 		mkdirSync(dir, { recursive: false });
 
 		const session: ShellSession = {
 			id,
 			label: normalizeLabel(input.label),
 			dir,
+			hostDir,
 			createdAt: now,
 			expiresAt: now + ttlMinutes * 60_000,
 			lastUsedAt: now,
@@ -194,7 +198,7 @@ export class ShellWorkspaceManager {
 		session.lastUsedAt = this.now();
 		const cmd = buildShellPodmanCmd({
 			image: this.config.image,
-			workspaceDir: session.dir,
+			workspaceDir: session.hostDir,
 			cwd,
 			command: input.command,
 			timeoutSeconds,

--- a/spec/agent/mcp-config.spec.ts
+++ b/spec/agent/mcp-config.spec.ts
@@ -62,7 +62,10 @@ describe("mcpServerConfigs", () => {
 		const configs = mcpServerConfigs("discord:123", {
 			...defaultOpts,
 			capabilities: ["shell-workspace"],
-			shellWorkspace,
+			shellWorkspace: {
+				...shellWorkspace,
+				hostDataDir: "/host/data/shell-workspaces",
+			},
 		});
 		const shell = configs["shell-workspace"];
 
@@ -71,6 +74,7 @@ describe("mcpServerConfigs", () => {
 			expect(shell.environment?.SHELL_WORKSPACE_AGENT_ID).toBe("discord:123");
 			expect(shell.environment?.SHELL_WORKSPACE_IMAGE).toBe("sandbox-image");
 			expect(shell.environment?.SHELL_WORKSPACE_DATA_DIR).toBe("/data/shell-workspaces");
+			expect(shell.environment?.SHELL_WORKSPACE_HOST_DATA_DIR).toBe("/host/data/shell-workspaces");
 			expect(shell.environment?.DISCORD_TOKEN).toBeUndefined();
 		}
 	});

--- a/spec/mcp/shell-workspace.spec.ts
+++ b/spec/mcp/shell-workspace.spec.ts
@@ -100,6 +100,35 @@ describe("ShellWorkspaceManager", () => {
 		manager.close();
 	});
 
+	it("hostDataDir 指定時は Podman mount source だけホスト側 path を使う", async () => {
+		const seenCommands: string[][] = [];
+		const runner: ProcessRunner = (cmd) => {
+			seenCommands.push([...cmd]);
+			return Promise.resolve({
+				exitCode: 0,
+				output: "ok",
+				timedOut: false,
+				outputTruncated: false,
+			});
+		};
+		const root = mkdtempSync(join(os.tmpdir(), "shell-workspace-paths-"));
+		const dataDir = join(root, "container", "shell-workspaces");
+		const hostDataDir = "/host/project/data/shell-workspaces";
+		const config = createConfig({
+			dataDir,
+			hostDataDir,
+			runProcess: runner,
+		});
+		const manager = new ShellWorkspaceManager(config);
+		const session = manager.startSession({});
+
+		await manager.exec({ sessionId: session.sessionId, command: "pwd" });
+
+		expect(session.workspaceDir).toBe(join(dataDir, session.sessionId));
+		expect(seenCommands[0]).toContain(`${hostDataDir}/${session.sessionId}:/workspace:rw`);
+		manager.close();
+	});
+
 	it("期限切れ session を削除する", () => {
 		let now = Date.parse("2026-05-07T00:00:00.000Z");
 		const config = createConfig({ now: () => now });


### PR DESCRIPTION
## Summary
- bot コンテナからホスト Podman socket を使う場合の workspace bind source を host path に分離
- deploy compose で SHELL_WORKSPACE_HOST_DATA_DIR を設定
- shell workspace の hostDataDir 伝播と Podman mount source をテスト

## Tests
- bun test spec/mcp/shell-workspace.spec.ts spec/agent/mcp-config.spec.ts spec/core/profile-config.spec.ts spec/core/config.spec.ts
- nr validate
- nr test