### PR TITLE
fix(shell): workspace session の権限を修正する

### DIFF
--- a/packages/mcp/src/shell-workspace.ts
+++ b/packages/mcp/src/shell-workspace.ts
@@ -1,5 +1,13 @@
 /* oxlint-disable max-lines -- shell workspace policy, session lifecycle, and audit helpers stay together */
-import { appendFileSync, existsSync, mkdirSync, realpathSync, rmSync, statSync } from "fs";
+import {
+	appendFileSync,
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	realpathSync,
+	rmSync,
+	statSync,
+} from "fs";
 import { dirname, resolve, sep } from "path";
 
 const PODMAN_TIMEOUT_EXIT = 255;
@@ -168,6 +176,7 @@ export class ShellWorkspaceManager {
 		const dir = resolve(this.config.dataDir, id);
 		const hostDir = this.config.hostDataDir ? resolve(this.config.hostDataDir, id) : dir;
 		mkdirSync(dir, { recursive: false });
+		chmodSync(dir, 0o777);
 
 		const session: ShellSession = {
 			id,

--- a/spec/mcp/shell-workspace.spec.ts
+++ b/spec/mcp/shell-workspace.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, statSync, symlinkSync, writeFileSync } from "fs";
 import os from "os";
 import { join } from "path";
 
@@ -81,6 +81,8 @@ describe("ShellWorkspaceManager", () => {
 		const config = createConfig({ now: () => now, runProcess: runner });
 		const manager = new ShellWorkspaceManager(config);
 		const session = manager.startSession({ label: "test", ttlMinutes: 10 });
+
+		expect(statSync(session.workspaceDir).mode & 0o777).toBe(0o777);
 
 		const result = await manager.exec({
 			sessionId: session.sessionId,


### PR DESCRIPTION
## Summary
- shell workspace session ディレクトリを sandbox ユーザーが書き込める mode にする
- session ディレクトリの mode を回帰テストで確認

## Tests
- bun test spec/mcp/shell-workspace.spec.ts
- nr validate
- nr test