### PR TITLE
feat(shell): sandbox のインターネット利用を有効化する

### DIFF
--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -87,6 +87,7 @@ describe("createContextLayer", () => {
 					image: "sandbox",
 					dataDir: "/tmp/shell-workspaces",
 					auditLogPath: "/tmp/shell-audit.jsonl",
+					networkProfile: "open",
 					defaultTtlMinutes: 60,
 					maxTtlMinutes: 120,
 					defaultTimeoutSeconds: 30,

--- a/apps/discord/src/config-schema.ts
+++ b/apps/discord/src/config-schema.ts
@@ -46,6 +46,8 @@ export const imageRecognitionSchema = z.object({
 	modelId: z.string().min(1, "DISCORD_IMAGE_RECOGNITION_MODEL_ID is required"),
 });
 
+export const shellWorkspaceNetworkProfileSchema = z.enum(["open", "none"]);
+
 export const shellWorkspaceSchema = z
 	.object({
 		enabled: z.literal(true),
@@ -53,6 +55,7 @@ export const shellWorkspaceSchema = z
 		dataDir: z.string(),
 		hostDataDir: z.string().optional(),
 		auditLogPath: z.string(),
+		networkProfile: shellWorkspaceNetworkProfileSchema,
 		defaultTtlMinutes: safeInt.min(1),
 		maxTtlMinutes: safeInt.min(1),
 		defaultTimeoutSeconds: safeInt.min(1),

--- a/apps/discord/src/config.ts
+++ b/apps/discord/src/config.ts
@@ -30,6 +30,7 @@ function buildShellWorkspaceConfig(env: Record<string, string | undefined>, data
 			? { hostDataDir: env.SHELL_WORKSPACE_HOST_DATA_DIR }
 			: {}),
 		auditLogPath: resolve(dataDir, "shell-workspace-audit.jsonl"),
+		networkProfile: env.SHELL_WORKSPACE_NETWORK_PROFILE ?? "open",
 		defaultTtlMinutes: Number(env.SHELL_WORKSPACE_DEFAULT_TTL_MINUTES ?? "60"),
 		maxTtlMinutes: Number(env.SHELL_WORKSPACE_MAX_TTL_MINUTES ?? "120"),
 		defaultTimeoutSeconds: Number(env.SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS ?? "30"),

--- a/apps/discord/src/profile-config.ts
+++ b/apps/discord/src/profile-config.ts
@@ -8,6 +8,7 @@ import {
 	minecraftSchema,
 	safeInt,
 	safeNumber,
+	shellWorkspaceNetworkProfileSchema,
 	ttsSchema,
 	type AppConfig,
 } from "./config-schema.ts";
@@ -44,6 +45,7 @@ export const profileConfigSchema = z.strictObject({
 		shellWorkspace: z
 			.strictObject({
 				image: z.string().min(1),
+				networkProfile: shellWorkspaceNetworkProfileSchema.optional(),
 				defaultTtlMinutes: safeInt.min(1),
 				maxTtlMinutes: safeInt.min(1),
 				defaultTimeoutSeconds: safeInt.min(1),
@@ -80,6 +82,7 @@ function buildProfileShellWorkspaceConfig(
 			? { hostDataDir: env.SHELL_WORKSPACE_HOST_DATA_DIR }
 			: {}),
 		auditLogPath: resolve(dataDir, "shell-workspace-audit.jsonl"),
+		networkProfile: shellWorkspace.networkProfile ?? "open",
 		defaultTtlMinutes: shellWorkspace.defaultTtlMinutes,
 		maxTtlMinutes: shellWorkspace.maxTtlMinutes,
 		defaultTimeoutSeconds: shellWorkspace.defaultTimeoutSeconds,

--- a/config/profile.schema.json
+++ b/config/profile.schema.json
@@ -134,6 +134,10 @@
 							"type": "string",
 							"minLength": 1
 						},
+						"networkProfile": {
+							"type": "string",
+							"enum": ["open", "none"]
+						},
 						"defaultTtlMinutes": {
 							"type": "integer",
 							"minimum": 1,

--- a/docs/agent-capabilities-and-shell-sandbox.md
+++ b/docs/agent-capabilities-and-shell-sandbox.md
@@ -4,7 +4,7 @@
 
 Vicissitude の会話エージェントを、必要な能力だけを持つ profile として組み立てる。Discord で会話するだけのインスタンスには shell 権限を渡さず、作業用インスタンスだけに隔離された shell workspace を MCP 経由で接続する。
 
-OpenCode 組み込み `bash` は使わない。shell 実行は `shell-workspace` MCP サーバーに集約し、timeout、cwd、ネットワーク、quota、監査ログ、TTL をアプリケーション側で強制する。
+OpenCode 組み込み `bash` は使わない。shell 実行は `shell-workspace` MCP サーバーに集約し、timeout、cwd、ネットワーク profile、quota、監査ログ、TTL をアプリケーション側で強制する。
 
 ## Capability
 
@@ -33,12 +33,13 @@ OpenCode 組み込み `bash` は使わない。shell 実行は `shell-workspace`
 
 ## Sandbox Policy
 
-MVP の既定 policy:
+既定 policy:
 
 - rootless Podman で prebuilt image を実行する。
-- network は `none` のみ。
+- network は `open` を既定にし、rootless Podman の `slirp4netns` でインターネットアクセスを許可する。必要なら `SHELL_WORKSPACE_NETWORK_PROFILE=none` で無効化できる。
 - root filesystem は read-only。
 - session workspace だけを `/workspace` に read-write mount する。
+- sandbox 内の `HOME`、XDG cache/config、`TMPDIR` は `/workspace` 配下に向け、session ごとに作成する。
 - host HOME、OpenCode auth、`.env`、SSH/Git credential、Podman socket は sandbox に渡さない。
 - 環境変数は shell MCP プロセス、sandbox 実行の両方で allowlist 方式にする。
 - non-root user で実行する。
@@ -52,6 +53,7 @@ MVP の既定 policy:
 | ----------------------------------------- | ----------------------- | --------------------------------------------------------------------- |
 | `SHELL_WORKSPACE_ENABLED`                 | `false`                 | `true`/`1`/`yes`/`on` で有効化                                        |
 | `SHELL_WORKSPACE_IMAGE`                   | `vicissitude-code-exec` | Podman で起動する sandbox image                                       |
+| `SHELL_WORKSPACE_NETWORK_PROFILE`         | `open`                  | `open` はインターネット許可、`none` はネットワーク無効                |
 | `SHELL_WORKSPACE_DEFAULT_TTL_MINUTES`     | `60`                    | session の既定 TTL                                                    |
 | `SHELL_WORKSPACE_MAX_TTL_MINUTES`         | `120`                   | session TTL 上限                                                      |
 | `SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS` | `30`                    | `shell_exec` の既定 timeout                                           |
@@ -84,4 +86,4 @@ bot コンテナからホスト Podman socket を使う deploy では、sandbox 
 - OpenCode 組み込み `bash` の有効化。
 - host checkout や host HOME の直接編集。
 - ユーザー本人の認証情報を使った GitHub、Spotify、SSH 操作。
-- network enabled profile。必要になった時点で、宛先制限と別途 policy を設計する。
+- host network、privileged container、Podman socket の sandbox への直接 mount。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,7 @@ disabled feature は key ごと省略する。`enabled: false`、`null`、空文
 		},
 		"shellWorkspace": {
 			"image": "vicissitude-code-exec",
+			"networkProfile": "open",
 			"defaultTtlMinutes": 60,
 			"maxTtlMinutes": 120,
 			"defaultTimeoutSeconds": 30,

--- a/packages/agent/src/mcp-config.ts
+++ b/packages/agent/src/mcp-config.ts
@@ -17,6 +17,7 @@ export interface ShellWorkspaceMcpConfigOptions {
 	dataDir: string;
 	hostDataDir?: string;
 	auditLogPath: string;
+	networkProfile: "open" | "none";
 	defaultTtlMinutes: number;
 	maxTtlMinutes: number;
 	defaultTimeoutSeconds: number;
@@ -70,6 +71,7 @@ function buildShellWorkspaceEnvironment(
 		SHELL_WORKSPACE_IMAGE: config.image,
 		SHELL_WORKSPACE_DATA_DIR: config.dataDir,
 		SHELL_WORKSPACE_AUDIT_LOG: config.auditLogPath,
+		SHELL_WORKSPACE_NETWORK_PROFILE: config.networkProfile,
 		SHELL_WORKSPACE_DEFAULT_TTL_MINUTES: String(config.defaultTtlMinutes),
 		SHELL_WORKSPACE_MAX_TTL_MINUTES: String(config.maxTtlMinutes),
 		SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS: String(config.defaultTimeoutSeconds),

--- a/packages/mcp/src/shell-workspace-server.ts
+++ b/packages/mcp/src/shell-workspace-server.ts
@@ -5,8 +5,10 @@ import { z } from "zod";
 
 import {
 	SHELL_WORKSPACE_DEFAULT_IMAGE,
+	SHELL_WORKSPACE_NETWORK_PROFILES,
 	ShellWorkspaceManager,
 	type ShellWorkspaceConfig,
+	type ShellWorkspaceNetworkProfile,
 } from "./shell-workspace.ts";
 
 const DEFAULT_DATA_DIR = "data/shell-workspaces";
@@ -24,6 +26,17 @@ function readIntEnv(name: string, fallback: number): number {
 		throw new Error(`${name} must be a positive integer`);
 	}
 	return parsed;
+}
+
+function readNetworkProfileEnv(value: string | undefined): ShellWorkspaceNetworkProfile {
+	const trimmed = value?.trim() ?? "";
+	const raw = trimmed === "" ? "open" : trimmed;
+	if (SHELL_WORKSPACE_NETWORK_PROFILES.includes(raw as ShellWorkspaceNetworkProfile)) {
+		return raw as ShellWorkspaceNetworkProfile;
+	}
+	throw new Error(
+		`SHELL_WORKSPACE_NETWORK_PROFILE must be one of: ${SHELL_WORKSPACE_NETWORK_PROFILES.join(", ")}`,
+	);
 }
 
 function loadShellWorkspaceConfig(): ShellWorkspaceConfig {
@@ -54,6 +67,7 @@ function loadShellWorkspaceConfig(): ShellWorkspaceConfig {
 		defaultTimeoutSeconds,
 		maxTimeoutSeconds,
 		maxOutputChars: readIntEnv("SHELL_WORKSPACE_MAX_OUTPUT_CHARS", 50_000),
+		networkProfile: readNetworkProfileEnv(process.env.SHELL_WORKSPACE_NETWORK_PROFILE),
 	};
 }
 

--- a/packages/mcp/src/shell-workspace.ts
+++ b/packages/mcp/src/shell-workspace.ts
@@ -11,11 +11,11 @@ import {
 import { dirname, resolve, sep } from "path";
 
 const PODMAN_TIMEOUT_EXIT = 255;
-const DEFAULT_NETWORK_PROFILE = "none";
+const DEFAULT_NETWORK_PROFILE = "open";
 const SHELL_WORKSPACE_CONTAINER_WORKDIR = "/workspace";
 
 export const SHELL_WORKSPACE_DEFAULT_IMAGE = "vicissitude-code-exec";
-export const SHELL_WORKSPACE_NETWORK_PROFILES = [DEFAULT_NETWORK_PROFILE] as const;
+export const SHELL_WORKSPACE_NETWORK_PROFILES = ["open", "none"] as const;
 
 export type ShellWorkspaceNetworkProfile = (typeof SHELL_WORKSPACE_NETWORK_PROFILES)[number];
 
@@ -30,6 +30,7 @@ export interface ShellWorkspaceConfig {
 	defaultTimeoutSeconds: number;
 	maxTimeoutSeconds: number;
 	maxOutputChars: number;
+	networkProfile: ShellWorkspaceNetworkProfile;
 	now?: () => number;
 	runProcess?: ProcessRunner;
 }
@@ -119,9 +120,6 @@ export function buildShellPodmanCmd(options: {
 	networkProfile?: ShellWorkspaceNetworkProfile;
 }): string[] {
 	const networkProfile = options.networkProfile ?? DEFAULT_NETWORK_PROFILE;
-	if (networkProfile !== "none") {
-		throw new Error("unsupported network profile");
-	}
 	const workdir =
 		options.cwd === "."
 			? SHELL_WORKSPACE_CONTAINER_WORKDIR
@@ -130,10 +128,18 @@ export function buildShellPodmanCmd(options: {
 		"podman",
 		"run",
 		"--rm",
-		"--network=none",
+		`--network=${networkProfile === "open" ? "slirp4netns" : "none"}`,
 		"--read-only",
 		"--tmpfs",
 		"/tmp:size=64M",
+		"--env",
+		`HOME=${SHELL_WORKSPACE_CONTAINER_WORKDIR}/.home`,
+		"--env",
+		`XDG_CACHE_HOME=${SHELL_WORKSPACE_CONTAINER_WORKDIR}/.cache`,
+		"--env",
+		`XDG_CONFIG_HOME=${SHELL_WORKSPACE_CONTAINER_WORKDIR}/.config`,
+		"--env",
+		`TMPDIR=${SHELL_WORKSPACE_CONTAINER_WORKDIR}/.tmp`,
 		"--memory=512m",
 		"--cpus=1",
 		"--pids-limit=128",
@@ -177,6 +183,11 @@ export class ShellWorkspaceManager {
 		const hostDir = this.config.hostDataDir ? resolve(this.config.hostDataDir, id) : dir;
 		mkdirSync(dir, { recursive: false });
 		chmodSync(dir, 0o777);
+		for (const name of [".home", ".cache", ".config", ".tmp"]) {
+			const sandboxDir = resolve(dir, name);
+			mkdirSync(sandboxDir, { recursive: false });
+			chmodSync(sandboxDir, 0o777);
+		}
 
 		const session: ShellSession = {
 			id,
@@ -211,6 +222,7 @@ export class ShellWorkspaceManager {
 			cwd,
 			command: input.command,
 			timeoutSeconds,
+			networkProfile: this.config.networkProfile,
 		});
 
 		const startedAt = this.now();

--- a/spec/agent/mcp-config.spec.ts
+++ b/spec/agent/mcp-config.spec.ts
@@ -13,6 +13,7 @@ describe("mcpServerConfigs", () => {
 		image: "sandbox-image",
 		dataDir: "/data/shell-workspaces",
 		auditLogPath: "/data/shell-workspace-audit.jsonl",
+		networkProfile: "open" as const,
 		defaultTtlMinutes: 60,
 		maxTtlMinutes: 120,
 		defaultTimeoutSeconds: 30,
@@ -75,6 +76,7 @@ describe("mcpServerConfigs", () => {
 			expect(shell.environment?.SHELL_WORKSPACE_IMAGE).toBe("sandbox-image");
 			expect(shell.environment?.SHELL_WORKSPACE_DATA_DIR).toBe("/data/shell-workspaces");
 			expect(shell.environment?.SHELL_WORKSPACE_HOST_DATA_DIR).toBe("/host/data/shell-workspaces");
+			expect(shell.environment?.SHELL_WORKSPACE_NETWORK_PROFILE).toBe("open");
 			expect(shell.environment?.DISCORD_TOKEN).toBeUndefined();
 		}
 	});

--- a/spec/core/config.spec.ts
+++ b/spec/core/config.spec.ts
@@ -154,6 +154,7 @@ describe("loadConfig", () => {
 				image: "vicissitude-code-exec",
 				dataDir: "/tmp/test-vicissitude/data/shell-workspaces",
 				auditLogPath: "/tmp/test-vicissitude/data/shell-workspace-audit.jsonl",
+				networkProfile: "open",
 				defaultTtlMinutes: 60,
 				maxTtlMinutes: 120,
 				defaultTimeoutSeconds: 30,
@@ -172,11 +173,13 @@ describe("loadConfig", () => {
 					SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS: "5",
 					SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS: "9",
 					SHELL_WORKSPACE_MAX_OUTPUT_CHARS: "12345",
+					SHELL_WORKSPACE_NETWORK_PROFILE: "none",
 				}),
 				root,
 			);
 
 			expect(config.shellWorkspace?.image).toBe("custom-shell-image");
+			expect(config.shellWorkspace?.networkProfile).toBe("none");
 			expect(config.shellWorkspace?.defaultTtlMinutes).toBe(10);
 			expect(config.shellWorkspace?.maxTtlMinutes).toBe(20);
 			expect(config.shellWorkspace?.defaultTimeoutSeconds).toBe(5);

--- a/spec/core/profile-config.spec.ts
+++ b/spec/core/profile-config.spec.ts
@@ -160,6 +160,7 @@ describe("JSON profile config", () => {
 			image: "shell-image",
 			dataDir: "/tmp/test-vicissitude/data/shell-workspaces",
 			auditLogPath: "/tmp/test-vicissitude/data/shell-workspace-audit.jsonl",
+			networkProfile: "open",
 			defaultTtlMinutes: 15,
 			maxTtlMinutes: 30,
 			defaultTimeoutSeconds: 5,

--- a/spec/discord/bootstrap.spec.ts
+++ b/spec/discord/bootstrap.spec.ts
@@ -185,6 +185,7 @@ describe("buildCoreEnvironment", () => {
 					image: "sandbox",
 					dataDir: "/tmp/shell-workspaces",
 					auditLogPath: "/tmp/shell-audit.jsonl",
+					networkProfile: "open",
 					defaultTtlMinutes: 60,
 					maxTtlMinutes: 120,
 					defaultTimeoutSeconds: 30,

--- a/spec/mcp/shell-workspace.spec.ts
+++ b/spec/mcp/shell-workspace.spec.ts
@@ -19,6 +19,7 @@ function createConfig(
 		image: "sandbox-image",
 		dataDir: join(root, "workspaces"),
 		auditLogPath: join(root, "audit.jsonl"),
+		networkProfile: "open" as const,
 		defaultTtlMinutes: 60,
 		maxTtlMinutes: 120,
 		defaultTimeoutSeconds: 30,
@@ -45,7 +46,7 @@ describe("normalizeWorkspaceRelativePath", () => {
 });
 
 describe("buildShellPodmanCmd", () => {
-	it("network none と sandbox 制約を含む Podman command を組み立てる", () => {
+	it("open network と sandbox 制約を含む Podman command を組み立てる", () => {
 		const cmd = buildShellPodmanCmd({
 			image: "sandbox-image",
 			workspaceDir: "/tmp/workspace",
@@ -54,13 +55,30 @@ describe("buildShellPodmanCmd", () => {
 			timeoutSeconds: 10,
 		});
 
-		expect(cmd).toContain("--network=none");
+		expect(cmd).toContain("--network=slirp4netns");
 		expect(cmd).toContain("--read-only");
+		expect(cmd).toContain("HOME=/workspace/.home");
+		expect(cmd).toContain("XDG_CACHE_HOME=/workspace/.cache");
+		expect(cmd).toContain("XDG_CONFIG_HOME=/workspace/.config");
+		expect(cmd).toContain("TMPDIR=/workspace/.tmp");
 		expect(cmd).toContain("--cap-drop=ALL");
 		expect(cmd).toContain("--security-opt=no-new-privileges");
 		expect(cmd).toContain("/tmp/workspace:/workspace:rw");
 		expect(cmd).toContain("/workspace/project");
 		expect(cmd.slice(-3)).toEqual(["bash", "-lc", "pwd"]);
+	});
+
+	it("network profile none ではネットワークを無効化する", () => {
+		const cmd = buildShellPodmanCmd({
+			image: "sandbox-image",
+			workspaceDir: "/tmp/workspace",
+			cwd: ".",
+			command: "true",
+			timeoutSeconds: 10,
+			networkProfile: "none",
+		});
+
+		expect(cmd).toContain("--network=none");
 	});
 });
 
@@ -83,6 +101,10 @@ describe("ShellWorkspaceManager", () => {
 		const session = manager.startSession({ label: "test", ttlMinutes: 10 });
 
 		expect(statSync(session.workspaceDir).mode & 0o777).toBe(0o777);
+		expect(existsSync(join(session.workspaceDir, ".home"))).toBe(true);
+		expect(existsSync(join(session.workspaceDir, ".cache"))).toBe(true);
+		expect(existsSync(join(session.workspaceDir, ".config"))).toBe(true);
+		expect(existsSync(join(session.workspaceDir, ".tmp"))).toBe(true);
 
 		const result = await manager.exec({
 			sessionId: session.sessionId,


### PR DESCRIPTION
## 概要
- shell-workspace の network profile に open/none を追加し、既定を open に変更
- sandbox 内 HOME/cache/config/tmp を workspace 配下に作成して、ネット利用を伴う作業をしやすくする
- profile/env/schema/docs/tests を更新

## 検証
- nr validate
- nr test