### PR TITLE
fix(shell): open network に pasta を使う

### DIFF
--- a/docs/agent-capabilities-and-shell-sandbox.md
+++ b/docs/agent-capabilities-and-shell-sandbox.md
@@ -36,7 +36,7 @@ OpenCode 組み込み `bash` は使わない。shell 実行は `shell-workspace`
 既定 policy:
 
 - rootless Podman で prebuilt image を実行する。
-- network は `open` を既定にし、rootless Podman の `slirp4netns` でインターネットアクセスを許可する。必要なら `SHELL_WORKSPACE_NETWORK_PROFILE=none` で無効化できる。
+- network は `open` を既定にし、rootless Podman の `pasta` でインターネットアクセスを許可する。必要なら `SHELL_WORKSPACE_NETWORK_PROFILE=none` で無効化できる。
 - root filesystem は read-only。
 - session workspace だけを `/workspace` に read-write mount する。
 - sandbox 内の `HOME`、XDG cache/config、`TMPDIR` は `/workspace` 配下に向け、session ごとに作成する。

--- a/packages/mcp/src/shell-workspace.ts
+++ b/packages/mcp/src/shell-workspace.ts
@@ -128,7 +128,7 @@ export function buildShellPodmanCmd(options: {
 		"podman",
 		"run",
 		"--rm",
-		`--network=${networkProfile === "open" ? "slirp4netns" : "none"}`,
+		`--network=${networkProfile === "open" ? "pasta" : "none"}`,
 		"--read-only",
 		"--tmpfs",
 		"/tmp:size=64M",

--- a/spec/mcp/shell-workspace.spec.ts
+++ b/spec/mcp/shell-workspace.spec.ts
@@ -55,7 +55,7 @@ describe("buildShellPodmanCmd", () => {
 			timeoutSeconds: 10,
 		});
 
-		expect(cmd).toContain("--network=slirp4netns");
+		expect(cmd).toContain("--network=pasta");
 		expect(cmd).toContain("--read-only");
 		expect(cmd).toContain("HOME=/workspace/.home");
 		expect(cmd).toContain("XDG_CACHE_HOME=/workspace/.cache");


### PR DESCRIPTION
## 概要
- shell-workspace の open network を slirp4netns から pasta に変更
- bot から host Podman socket 経由で pasta network が使えることを確認済み
- sandbox policy の説明とテストを更新

## 検証
- podman exec vicissitude sh -lc "podman run --rm --network=pasta vicissitude-code-exec bash -lc 'printf bot-podman-pasta-ok'"
- nr test spec/mcp/shell-workspace.spec.ts
- nr validate
- nr test