### PR TITLE
feat(agents): shell-worker を OpenCode bash に切り替える

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -8,7 +8,7 @@ import { ImageAttachmentDescriber } from "@vicissitude/agent/discord/image-attac
 import { formatDiscordMessage } from "@vicissitude/agent/discord/message-formatter";
 import { createConversationProfile } from "@vicissitude/agent/discord/profile";
 import { GuildRouter } from "@vicissitude/agent/discord/router";
-import { type AgentCapability, mcpServerConfigs } from "@vicissitude/agent/mcp-config";
+import { mcpServerConfigs } from "@vicissitude/agent/mcp-config";
 import { McBrainManager } from "@vicissitude/agent/minecraft/brain-manager";
 import { SessionStore } from "@vicissitude/agent/session-store";
 import { HeartbeatService } from "@vicissitude/application/heartbeat-service";
@@ -147,6 +147,15 @@ export function buildCoreEnvironment(config: AppConfig, root: string): Record<st
 	return env;
 }
 
+function buildOpencodeShellWorkspaceDirectory(
+	config: AppConfig,
+	agentId: string,
+): string | undefined {
+	if (!config.shellWorkspace) return;
+	const safeAgentId = agentId.replaceAll(/[^A-Za-z0-9._-]/g, "_");
+	return resolve(config.shellWorkspace.dataDir, "opencode", safeAgentId);
+}
+
 export function createGuildAgents(
 	config: AppConfig,
 	guildIds: string[],
@@ -175,14 +184,11 @@ export function createGuildAgents(
 	for (const [index, guildId] of guildIds.entries()) {
 		const agentIdPrefix = deps.agentIdPrefix ?? "discord";
 		const agentId = `${agentIdPrefix}:${guildId}`;
-		const capabilities: AgentCapability[] = config.shellWorkspace ? ["shell-workspace"] : [];
 		const profile = createConversationProfile({
 			...config.opencode,
 			mcpServers: mcpServerConfigs(agentId, {
 				appRoot: deps.appRoot,
 				coreEnvironment: deps.coreEnvironment,
-				capabilities,
-				shellWorkspace: config.shellWorkspace,
 			}),
 			minecraftEnabled: !!config.minecraft,
 			imageRecognitionEnabled: !!config.imageRecognition,
@@ -196,6 +202,7 @@ export function createGuildAgents(
 			defaultAgent: profile.defaultAgent,
 			primaryTools: profile.primaryTools,
 			temperature: config.opencode.temperature,
+			directory: buildOpencodeShellWorkspaceDirectory(config, agentId),
 			logger: deps.logger,
 		});
 		const attachmentProcessor = config.imageRecognition

--- a/context/TOOLS-CODE.md
+++ b/context/TOOLS-CODE.md
@@ -1,18 +1,16 @@
-## MCP ツール一覧（shell workspace）
+## Shell workspace
 
-> `SHELL_WORKSPACE_ENABLED=true` のインスタンスでのみ利用可能。メイン会話 agent は `task` で `shell-worker` サブエージェントに委譲し、OpenCode 組み込み `bash` ではなく、隔離された Podman sandbox 内で実行する。
+> `SHELL_WORKSPACE_ENABLED=true` のインスタンスでのみ利用可能。メイン会話 agent は `task` で `shell-worker` サブエージェントに委譲し、`shell-worker` だけが OpenCode 組み込み `bash` を使う。
 
-### shell-workspace サーバー
+### 実行方針
 
-- `shell_start_session(label?, ttl_minutes?)` - TTL 付き workspace session を開始
-- `shell_exec(session_id, command, cwd?, timeout_seconds?)` - `/workspace` 配下で shell command を実行
-- `shell_status(session_id?)` - session 状態を確認
-- `shell_export_file(session_id, path)` - workspace 内ファイルを Discord 添付に使えるローカルパスとして返す
-- `shell_stop_session(session_id)` - session を停止し workspace を削除
+- コード実行、ビルド、コンパイル、package install、ファイル生成、長めの調査は `task` で `shell-worker` に委譲する
+- `shell-worker` の作業ディレクトリは専用 workspace に固定されている
+- 作成したファイルを Discord に添付する必要がある場合、`shell-worker` に workspace 内へ保存させ、返却された絶対 path を `core_send_message(..., file_path)` に指定する
 
 制約:
 
-- network profile が `open` の場合はインターネットアクセス可能
-- root filesystem は writable で、sandbox 内の package install を許可する
-- host HOME、OpenCode auth、`.env`、SSH/Git 認証情報、Podman socket は sandbox に渡されない
-- CPU、メモリ、PID、timeout、出力サイズに上限あり
+- メイン会話 agent は builtin `bash` を使わない
+- `shell-worker` は workspace 外の読み書き、host secrets、auth files、環境変数 dump、権限昇格を試みない
+- OpenCode の `external_directory` permission は deny
+- ネットワークは OpenCode 実行環境の範囲で利用可能

--- a/docs/agent-capabilities-and-shell-sandbox.md
+++ b/docs/agent-capabilities-and-shell-sandbox.md
@@ -1,92 +1,69 @@
-# Agent Capabilities and Shell Sandbox
+# Agent Capabilities and Shell Workspace
 
 ## 目的
 
-Vicissitude の会話エージェントを、必要な能力だけを持つ profile として組み立てる。Discord で会話するだけのインスタンスには shell 権限を渡さず、作業用インスタンスだけに隔離された shell workspace を MCP 経由で接続する。
+Vicissitude の会話エージェントを、必要な能力だけを持つ profile として組み立てる。Discord で会話するだけのインスタンスには shell 権限を渡さず、作業用インスタンスだけに OpenCode の shell 実行能力を持つサブエージェントを追加する。
 
-OpenCode 組み込み `bash` は使わない。shell 実行は `shell-workspace` MCP サーバーに集約し、timeout、cwd、ネットワーク profile、quota、監査ログ、TTL をアプリケーション側で強制する。
+shell 実行はメイン会話 agent に直接渡さない。メイン会話 agent は OpenCode `task` ツールだけを使って `shell-worker` サブエージェントへ委譲し、`shell-worker` だけが OpenCode 組み込み `bash` を使う。
 
 ## Capability
-
-初期実装の capability は次の通り。
 
 | Capability         | 内容                                                 | 既定                                    |
 | ------------------ | ---------------------------------------------------- | --------------------------------------- |
 | `core`             | Discord 送信、返信、リアクション、記憶、リマインダー | 有効                                    |
 | `webfetch`         | OpenCode 組み込み `webfetch`                         | 有効                                    |
 | `minecraft-bridge` | Discord から Minecraft エージェントへの委譲          | `MC_HOST` 設定時のみ                    |
-| `shell-workspace`  | Podman sandbox 内の shell workspace                  | `SHELL_WORKSPACE_ENABLED=true` の時のみ |
+| `shell-workspace`  | OpenCode `bash` を使う `shell-worker` subagent       | `SHELL_WORKSPACE_ENABLED=true` の時のみ |
 
-`shell-workspace` が無効な profile では、MCP サーバーもツール説明コンテキストも注入しない。有効な profile では、メイン会話 agent は OpenCode `task` ツールだけを使って `shell-worker` サブエージェントへ shell 作業を委譲する。`shell-worker` だけが `shell_*` MCP ツールを使う。
+`shell-workspace` が無効な profile では、`task`、`bash`、ツール説明コンテキストを注入しない。有効な profile では、メイン会話 agent は `task` のみを primary tool として持ち、`build` primary agent の permission は `bash: deny` にする。
 
 ## Shell Workspace
 
-`shell-workspace` は、短いコード片実行ではなく、TTL 付きの workspace session を提供する。MVP では exec ごとに sandbox コンテナを起動し、session ごとの workspace directory を bind mount して状態を保持する。
+`shell-worker` は OpenCode builtin `bash` で作業する。OpenCode session operation には専用 `directory` を渡し、作業ディレクトリを `data/shell-workspaces/opencode/<agent-id>/` に固定する。
 
-提供ツール:
+作業ディレクトリは永続化対象の `data/shell-workspaces` 配下なので、bot restart 後もファイルは残る。作成ファイルを Discord に添付する場合は、`shell-worker` が workspace 配下に保存した絶対 path を返し、メイン会話 agent が `core_send_message(..., file_path)` に指定する。
 
-- `shell_start_session(label?, ttl_minutes?)`
-- `shell_exec(session_id, command, cwd?, timeout_seconds?)`
-- `shell_status(session_id?)`
-- `shell_export_file(session_id, path)`
-- `shell_stop_session(session_id)`
-
-## Sandbox Policy
+## Permission Policy
 
 既定 policy:
 
-- rootless Podman で prebuilt image を実行する。
-- network は `open` を既定にし、rootless Podman の `pasta` でインターネットアクセスを許可する。必要なら `SHELL_WORKSPACE_NETWORK_PROFILE=none` で無効化できる。
-- root filesystem は writable にし、`apt-get update` や package install など sandbox 内の管理操作を許可する。container root は rootless Podman の user namespace 内に閉じる。
-- session workspace だけを `/workspace` に read-write mount する。
-- sandbox 内の `HOME`、XDG cache/config、`TMPDIR` は `/workspace` 配下に向け、session ごとに作成する。
-- host HOME、OpenCode auth、`.env`、SSH/Git credential、Podman socket は sandbox に渡さない。
-- 環境変数は shell MCP プロセス、sandbox 実行の両方で allowlist 方式にする。
-- sandbox 内では root user で実行する。
-- CPU、memory、PID、timeout、output size を制限する。
-- session TTL と明示停止で workspace を削除する。
+- メイン会話 agent:
+  - `task: allow`
+  - `bash: deny`
+  - `external_directory: deny`
+- `shell-worker` subagent:
+  - `bash: allow`
+  - `task: deny`
+  - `external_directory: deny`
+- OpenCode の global builtin tool は `webfetch`、`task`、shell workspace 有効時の `bash` だけを開く。
+- `primary_tools` は `["task"]` にし、メイン会話 agent の入口を委譲に限定する。
+- `shell-worker` prompt では workspace 外の読み書き、host secrets、auth files、環境変数 dump、権限昇格を禁止する。
+
+これは OpenCode permission と作業ディレクトリによる制御であり、Podman sandbox のような OS-level isolation ではない。OpenCode `bash` を使う以上、実行プロセスは bot コンテナのユーザー権限と network の範囲で動く。
 
 ## 設定
 
-| 環境変数                                  | 既定                    | 説明                                                                  |
-| ----------------------------------------- | ----------------------- | --------------------------------------------------------------------- |
-| `SHELL_WORKSPACE_ENABLED`                 | `false`                 | `true`/`1`/`yes`/`on` で有効化                                        |
-| `SHELL_WORKSPACE_IMAGE`                   | `vicissitude-code-exec` | Podman で起動する sandbox image                                       |
-| `SHELL_WORKSPACE_NETWORK_PROFILE`         | `open`                  | `open` はインターネット許可、`none` はネットワーク無効                |
-| `SHELL_WORKSPACE_DEFAULT_TTL_MINUTES`     | `60`                    | session の既定 TTL                                                    |
-| `SHELL_WORKSPACE_MAX_TTL_MINUTES`         | `120`                   | session TTL 上限                                                      |
-| `SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS` | `30`                    | `shell_exec` の既定 timeout                                           |
-| `SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS`     | `120`                   | `shell_exec` timeout 上限                                             |
-| `SHELL_WORKSPACE_MAX_OUTPUT_CHARS`        | `50000`                 | stdout + stderr の返却上限                                            |
-| `SHELL_WORKSPACE_AGENT_PROVIDER_ID`       | `OPENCODE_PROVIDER_ID`  | `shell-worker` サブエージェントの provider                            |
-| `SHELL_WORKSPACE_AGENT_MODEL_ID`          | `OPENCODE_MODEL_ID`     | `shell-worker` サブエージェントの model                               |
-| `SHELL_WORKSPACE_AGENT_TEMPERATURE`       | `0.7`                   | `shell-worker` サブエージェントの temperature                         |
-| `SHELL_WORKSPACE_AGENT_STEPS`             | `24`                    | `shell-worker` サブエージェントの最大 agentic step 数                 |
-| `SHELL_WORKSPACE_HOST_DATA_DIR`           | unset                   | ホスト Podman socket 経由で実行する場合のホスト側 workspace directory |
+| 環境変数                                  | 既定                    | 説明                                                            |
+| ----------------------------------------- | ----------------------- | --------------------------------------------------------------- |
+| `SHELL_WORKSPACE_ENABLED`                 | `false`                 | `true`/`1`/`yes`/`on` で有効化                                  |
+| `SHELL_WORKSPACE_IMAGE`                   | `vicissitude-code-exec` | 互換設定。OpenCode shell 経路では使用しない                     |
+| `SHELL_WORKSPACE_NETWORK_PROFILE`         | `open`                  | 互換設定。OpenCode shell 経路では bot コンテナ側 network に従う |
+| `SHELL_WORKSPACE_DEFAULT_TTL_MINUTES`     | `60`                    | 互換設定。OpenCode shell 経路では使用しない                     |
+| `SHELL_WORKSPACE_MAX_TTL_MINUTES`         | `120`                   | 互換設定。OpenCode shell 経路では使用しない                     |
+| `SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS` | `30`                    | 互換設定。OpenCode shell 経路では使用しない                     |
+| `SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS`     | `120`                   | 互換設定。OpenCode shell 経路では使用しない                     |
+| `SHELL_WORKSPACE_MAX_OUTPUT_CHARS`        | `50000`                 | 互換設定。OpenCode shell 経路では使用しない                     |
+| `SHELL_WORKSPACE_AGENT_PROVIDER_ID`       | `OPENCODE_PROVIDER_ID`  | `shell-worker` サブエージェントの provider                      |
+| `SHELL_WORKSPACE_AGENT_MODEL_ID`          | `OPENCODE_MODEL_ID`     | `shell-worker` サブエージェントの model                         |
+| `SHELL_WORKSPACE_AGENT_TEMPERATURE`       | `0.7`                   | `shell-worker` サブエージェントの temperature                   |
+| `SHELL_WORKSPACE_AGENT_STEPS`             | `24`                    | `shell-worker` サブエージェントの最大 agentic step 数           |
+| `SHELL_WORKSPACE_HOST_DATA_DIR`           | unset                   | 互換設定。OpenCode shell 経路では使用しない                     |
 
-`shell-workspace` 有効時、core MCP には `DISCORD_ATTACHMENT_ALLOWED_DIRS` として shell workspace directory を渡す。これにより `shell_export_file` が返したパスを `core_send_message(..., file_path)` で添付できる。
-
-bot コンテナからホスト Podman socket を使う deploy では、sandbox の bind mount source はホスト側 path である必要がある。この場合は `SHELL_WORKSPACE_HOST_DATA_DIR` にホスト側の `data/shell-workspaces` を指定し、MCP プロセスが管理・添付に使う `SHELL_WORKSPACE_DATA_DIR` とは分ける。
-
-## 監査ログ
-
-`shell_exec` ごとに JSON Lines で監査ログを保存する。
-
-記録項目:
-
-- `timestamp`
-- `agent_id`
-- `session_id`
-- `command`
-- `cwd`
-- `exit_code`
-- `duration_ms`
-- `timed_out`
-- `output_truncated`
+`shell-workspace` 有効時、core MCP には `DISCORD_ATTACHMENT_ALLOWED_DIRS` として `data/shell-workspaces` を渡す。これにより workspace 配下の生成ファイルを Discord に添付できる。
 
 ## 非目標
 
-- OpenCode 組み込み `bash` の有効化。
-- host checkout や host HOME の直接編集。
+- メイン会話 agent への builtin `bash` 直接許可。
+- host HOME や auth files の調査、編集、添付。
 - ユーザー本人の認証情報を使った GitHub、Spotify、SSH 操作。
-- host network、privileged container、Podman socket の sandbox への直接 mount。
+- OpenCode `bash` を Podman sandbox 相当の隔離境界として扱うこと。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,8 +56,8 @@ disabled feature は key ごと省略する。`enabled: false`、`null`、空文
 		"shellWorkspace": {
 			"image": "vicissitude-code-exec",
 			"agent": {
-				"providerId": "github-copilot",
-				"modelId": "gpt5-mini",
+				"providerId": "openai",
+				"modelId": "gpt-5.4",
 				"temperature": 0.4,
 				"steps": 24
 			},

--- a/packages/agent/src/discord/profile.test.ts
+++ b/packages/agent/src/discord/profile.test.ts
@@ -41,9 +41,11 @@ describe("createConversationProfile shell workspace subagent", () => {
 		});
 
 		expect(profile.builtinTools.task).toBe(true);
+		expect(profile.builtinTools.bash).toBe(true);
 		expect(profile.defaultAgent).toBe("build");
 		expect(profile.primaryTools).toEqual(["task"]);
 		expect(profile.pollingPrompt).toContain(SHELL_WORKSPACE_AGENT_NAME);
+		expect(profile.pollingPrompt).toContain("OpenCode 組み込み bash");
 
 		const worker = profile.opencodeAgents?.[SHELL_WORKSPACE_AGENT_NAME];
 		expect(worker?.mode).toBe("subagent");
@@ -51,8 +53,13 @@ describe("createConversationProfile shell workspace subagent", () => {
 		expect(worker?.temperature).toBe(0.4);
 		expect(worker?.steps).toBe(12);
 		const workerTools = (worker as { tools?: Record<string, boolean> } | undefined)?.tools;
-		expect(workerTools?.shell_exec).toBe(true);
-		expect(workerTools?.bash).toBe(false);
+		expect(workerTools?.bash).toBe(true);
+		expect(workerTools?.task).toBe(false);
+		const workerPermission = (worker as { permission?: Record<string, string> } | undefined)
+			?.permission;
+		expect(workerPermission?.bash).toBe("allow");
+		expect(workerPermission?.task).toBe("deny");
+		expect(workerPermission?.external_directory).toBe("deny");
 	});
 
 	test("shell workspace 無効時は task と subagent 設定を追加しない", () => {
@@ -63,6 +70,7 @@ describe("createConversationProfile shell workspace subagent", () => {
 		});
 
 		expect(profile.builtinTools.task).toBe(false);
+		expect(profile.builtinTools.bash).toBe(false);
 		expect(profile.opencodeAgents).toBeUndefined();
 		expect(profile.defaultAgent).toBeUndefined();
 		expect(profile.primaryTools).toBeUndefined();

--- a/packages/agent/src/discord/profile.ts
+++ b/packages/agent/src/discord/profile.ts
@@ -3,13 +3,6 @@ import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
 import { SECURITY_PROMPT_LINES, type AgentProfile, type McpServerConfig } from "../profile.ts";
 
 export const SHELL_WORKSPACE_AGENT_NAME = "shell-worker";
-export const SHELL_WORKSPACE_TOOL_IDS = [
-	"shell_start_session",
-	"shell_exec",
-	"shell_status",
-	"shell_export_file",
-	"shell_stop_session",
-] as const;
 
 const MESSAGE_PROMPT_INSTRUCTIONS = `あなたはこの会話空間にいる存在です。
 名前・自己認識・人格・口調・会話規則は、このセッション冒頭に埋め込まれたシステム文脈の定義に従ってください。
@@ -43,9 +36,10 @@ const IMAGE_RECOGNITION_PROMPT_SECTION = `
 const SHELL_WORKSPACE_PROMPT_SECTION = `
 
 Shell workspace:
-- コード実行、ビルド、コンパイル、package install、ファイル生成、長めの調査が必要な依頼は、直接 shell_* ツールを使わず task ツールで ${SHELL_WORKSPACE_AGENT_NAME} サブエージェントに委譲する
+- コード実行、ビルド、コンパイル、package install、ファイル生成、長めの調査が必要な依頼は、直接実行せず task ツールで ${SHELL_WORKSPACE_AGENT_NAME} サブエージェントに委譲する
+- ${SHELL_WORKSPACE_AGENT_NAME} は OpenCode 組み込み bash を専用 workspace directory 内で使う
 - ${SHELL_WORKSPACE_AGENT_NAME} から返った結果を確認し、必要な要約や添付だけを core_send_message で Discord に送る
-- shell workspace 内で作ったファイルを添付する必要がある場合は、${SHELL_WORKSPACE_AGENT_NAME} に shell_export_file まで実行させ、その返却 path を core_send_message の file_path に指定する`;
+- shell workspace 内で作ったファイルを添付する必要がある場合は、${SHELL_WORKSPACE_AGENT_NAME} に workspace 内へ保存させ、返却された絶対 path を core_send_message の file_path に指定する`;
 
 export interface ShellWorkspaceSubagentConfig {
 	providerId: string;
@@ -58,43 +52,37 @@ function buildShellWorkspaceAgents(
 	shellWorkspaceSubagent: ShellWorkspaceSubagentConfig | undefined,
 ) {
 	if (!shellWorkspaceSubagent) return;
-	const shellToolAccess = Object.fromEntries(
-		SHELL_WORKSPACE_TOOL_IDS.map((toolId) => [toolId, true]),
-	);
-	const shellToolDeny = Object.fromEntries(
-		SHELL_WORKSPACE_TOOL_IDS.map((toolId) => [toolId, false]),
-	);
 	return {
 		build: {
 			mode: "primary" as const,
-			tools: shellToolDeny,
 			permission: {
 				task: "allow" as const,
 				bash: "deny" as const,
-				...Object.fromEntries(SHELL_WORKSPACE_TOOL_IDS.map((toolId) => [toolId, "deny"])),
+				external_directory: "deny" as const,
 			},
 		},
 		[SHELL_WORKSPACE_AGENT_NAME]: {
 			mode: "subagent" as const,
 			description:
-				"Run commands, compile code, install packages, and prepare files in the isolated shell workspace.",
+				"Run commands, compile code, install packages, and prepare files in the OpenCode shell workspace.",
 			model: `${shellWorkspaceSubagent.providerId}/${shellWorkspaceSubagent.modelId}`,
 			temperature: shellWorkspaceSubagent.temperature,
 			steps: shellWorkspaceSubagent.steps,
 			tools: {
 				task: false,
-				bash: false,
-				...shellToolAccess,
+				bash: true,
 			},
 			permission: {
 				task: "deny" as const,
-				bash: "deny" as const,
-				...Object.fromEntries(SHELL_WORKSPACE_TOOL_IDS.map((toolId) => [toolId, "allow"])),
+				bash: "allow" as const,
+				external_directory: "deny" as const,
 			},
 			prompt: `You are ${SHELL_WORKSPACE_AGENT_NAME}, a subagent dedicated to shell workspace work.
-Use only the shell_* MCP tools for command execution. Do not use builtin bash.
-Start a shell session before running commands, keep work inside /workspace, and report concise results to the primary agent.
-When a generated file must be sent to Discord, call shell_export_file and include the returned host-local path in your final response.`,
+Use the OpenCode builtin bash tool for command execution.
+Keep all work inside the current workspace directory. Do not read or write outside the workspace, do not inspect host secrets, auth files, or environment dumps, and do not attempt privilege escalation.
+Network access is allowed when needed for package install, builds, and research.
+When a generated file must be sent to Discord, save it under the workspace directory and include its absolute path in your final response.
+Report concise command results, relevant file paths, and any remaining failure cause to the primary agent.`,
 		},
 	};
 }
@@ -121,6 +109,7 @@ export function createConversationProfile(options: {
 		builtinTools: {
 			...OPENCODE_ALL_TOOLS_DISABLED,
 			webfetch: true,
+			bash: !!options.shellWorkspaceSubagent,
 			task: !!options.shellWorkspaceSubagent,
 		},
 		opencodeAgents,

--- a/packages/opencode/src/session-adapter.test.ts
+++ b/packages/opencode/src/session-adapter.test.ts
@@ -140,6 +140,63 @@ describe("OpencodeSessionAdapter", () => {
 		expect(options.config.agent?.["shell-worker"]?.mode).toBe("subagent");
 	});
 
+	test("session 操作に OpenCode directory を渡す", async () => {
+		const streamState = createStream();
+		const client = createClient(streamState.stream);
+		const adapter = new OpencodeSessionAdapter({
+			port: 4096,
+			mcpServers: {},
+			builtinTools: {},
+			directory: "/tmp/vicissitude-opencode-workspace",
+			clientFactory: mock(() =>
+				Promise.resolve({
+					client,
+					server: { url: "http://localhost", close: mock(() => {}) },
+				}),
+			),
+		});
+
+		await adapter.createSession("test session");
+		await adapter.sessionExists("session-1");
+		await adapter.prompt({
+			sessionId: "session-1",
+			text: "prompt",
+			model: { providerId: "provider", modelId: "model" },
+		});
+		await adapter.promptAsync({
+			sessionId: "session-1",
+			text: "prompt async",
+			model: { providerId: "provider", modelId: "model" },
+		});
+		await adapter.deleteSession("session-1");
+
+		expect(client.session.create).toHaveBeenCalledWith({
+			title: "test session",
+			directory: "/tmp/vicissitude-opencode-workspace",
+		});
+		expect(client.session.get).toHaveBeenCalledWith({
+			sessionID: "session-1",
+			directory: "/tmp/vicissitude-opencode-workspace",
+		});
+		expect(client.session.prompt).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionID: "session-1",
+				directory: "/tmp/vicissitude-opencode-workspace",
+			}),
+			expect.anything(),
+		);
+		expect(client.session.promptAsync).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionID: "session-1",
+				directory: "/tmp/vicissitude-opencode-workspace",
+			}),
+		);
+		expect(client.session.delete).toHaveBeenCalledWith({
+			sessionID: "session-1",
+			directory: "/tmp/vicissitude-opencode-workspace",
+		});
+	});
+
 	test("promptAsyncAndWatchSession は abort 時に次イベントを待たず cancelled を返す", async () => {
 		const streamState = createStream();
 		const client = createClient(streamState.stream);

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -1,4 +1,6 @@
 /* oxlint-disable max-lines -- OpenCode SDK adapter keeps session operations and stream handling in one cohesive boundary */
+import { mkdirSync } from "fs";
+
 import {
 	createOpencode,
 	type AgentConfig,
@@ -41,6 +43,8 @@ export interface OpencodeSessionAdapterConfig {
 	defaultAgent?: string;
 	primaryTools?: string[];
 	temperature?: number;
+	/** OpenCode の session / tool 実行に使う project directory */
+	directory?: string;
 	clientFactory?: typeof createOpencode;
 	logger?: Logger;
 }
@@ -57,7 +61,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 	async createSession(title: string): Promise<string> {
 		this.logger?.info(`[opencode] creating session: ${title}`);
 		const oc = await this.getClient();
-		const result = await oc.session.create({ title });
+		const result = await oc.session.create({ title, ...this.directoryQuery() });
 		if (result.error || !result.data) {
 			throw new Error(
 				`Failed to create session: ${result.error ? JSON.stringify(result.error) : "no data returned"}`,
@@ -69,7 +73,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 
 	async sessionExists(sessionId: string): Promise<boolean> {
 		const oc = await this.getClient();
-		const result = await oc.session.get({ sessionID: sessionId });
+		const result = await oc.session.get({ sessionID: sessionId, ...this.directoryQuery() });
 		return !result.error && !!result.data;
 	}
 
@@ -108,6 +112,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		const result = await oc.session.prompt(
 			{
 				sessionID: params.sessionId,
+				...this.directoryQuery(),
 				parts: this.buildParts(params),
 				model: { providerID: params.model.providerId, modelID: params.model.modelId },
 				system: params.system,
@@ -132,6 +137,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		const oc = await this.getClient();
 		const result = await oc.session.promptAsync({
 			sessionID: params.sessionId,
+			...this.directoryQuery(),
 			parts: this.buildParts(params),
 			model: { providerID: params.model.providerId, modelID: params.model.modelId },
 			system: params.system,
@@ -160,6 +166,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		try {
 			const result = await oc.session.promptAsync({
 				sessionID: params.sessionId,
+				...this.directoryQuery(),
 				parts: this.buildParts(params),
 				model: { providerID: params.model.providerId, modelID: params.model.modelId },
 				system: params.system,
@@ -173,7 +180,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 			while (true) {
 				// eslint-disable-next-line no-await-in-loop -- event stream must be consumed sequentially
 				const event = await nextStreamEvent(stream, signal, () =>
-					abortSession(oc, params.sessionId),
+					abortSession(oc, params.sessionId, this.config.directory),
 				);
 				if (event.type === "aborted") {
 					this.logger?.info("[opencode] event stream aborted");
@@ -236,7 +243,9 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		try {
 			while (true) {
 				// eslint-disable-next-line no-await-in-loop -- event stream must be consumed sequentially
-				const event = await nextStreamEvent(stream, signal, () => abortSession(oc, sessionId));
+				const event = await nextStreamEvent(stream, signal, () =>
+					abortSession(oc, sessionId, this.config.directory),
+				);
 				if (event.type === "aborted") return { type: "cancelled" };
 				if (event.type === "done") return { type: "idle", tokens: sumTokens(tokensByMessage) };
 				if (event.type === "streamTimeout") {
@@ -286,6 +295,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		const oc = await this.getClient();
 		const result = await oc.session.summarize({
 			sessionID: sessionId,
+			...this.directoryQuery(),
 			providerID: model.providerId,
 			modelID: model.modelId,
 		});
@@ -297,7 +307,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 
 	async deleteSession(sessionId: string): Promise<void> {
 		const oc = await this.getClient();
-		await oc.session.delete({ sessionID: sessionId });
+		await oc.session.delete({ sessionID: sessionId, ...this.directoryQuery() });
 	}
 
 	close(): void {
@@ -317,9 +327,16 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		return Object.keys(agent).length > 0 ? agent : undefined;
 	}
 
+	private directoryQuery(): { directory?: string } {
+		return this.config.directory ? { directory: this.config.directory } : {};
+	}
+
 	private async getClient(): Promise<OpencodeClient> {
 		if (this.client) return this.client;
 		this.logger?.info(`[opencode] initializing client (port=${this.config.port})`);
+		if (this.config.directory) {
+			mkdirSync(this.config.directory, { recursive: true });
+		}
 		const agent = this.buildAgentConfig();
 		const result = await (this.config.clientFactory ?? createOpencode)({
 			port: this.config.port,

--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -96,9 +96,15 @@ export function returnStreamOnce(stream: AbortableAsyncStream<unknown>): Promise
 	managed[STREAM_RETURN_PROMISE] = managed.return ? managed.return() : Promise.resolve();
 	return managed[STREAM_RETURN_PROMISE] as Promise<void>;
 }
-export async function abortSession(oc: OpencodeClient, sessionId: string): Promise<void> {
+export async function abortSession(
+	oc: OpencodeClient,
+	sessionId: string,
+	directory?: string,
+): Promise<void> {
 	try {
-		await oc.session.abort({ sessionID: sessionId });
+		await oc.session.abort(
+			directory ? { sessionID: sessionId, directory } : { sessionID: sessionId },
+		);
 	} catch {
 		// 停止経路ではベストエフォート。unhandled rejection にはしない。
 	}


### PR DESCRIPTION
## Summary
- route Discord shell work through the OpenCode bash-enabled shell-worker subagent instead of the shell-workspace MCP server
- pass a dedicated OpenCode directory under data/shell-workspaces/opencode/<agent-id> to session operations
- update shell workspace docs/context and tests for the OpenCode bash policy

## Tests
- nr validate
- nr test