### PR TITLE
feat(shell): worker env secret forwardingを追加する

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -203,6 +203,7 @@ export function createGuildAgents(
 			primaryTools: profile.primaryTools,
 			temperature: config.opencode.temperature,
 			directory: buildOpencodeShellWorkspaceDirectory(config, agentId),
+			environment: config.shellWorkspace?.environment,
 			logger: deps.logger,
 		});
 		const attachmentProcessor = config.imageRecognition

--- a/apps/discord/src/config-schema.ts
+++ b/apps/discord/src/config-schema.ts
@@ -55,11 +55,14 @@ export const shellWorkspaceAgentSchema = z.object({
 	steps: safeInt.min(1),
 });
 
+export const shellWorkspaceEnvironmentSchema = z.record(z.string().min(1), z.string().min(1));
+
 export const shellWorkspaceSchema = z
 	.object({
 		enabled: z.literal(true),
 		image: z.string().min(1, "SHELL_WORKSPACE_IMAGE is required"),
 		agent: shellWorkspaceAgentSchema,
+		environment: shellWorkspaceEnvironmentSchema.optional(),
 		dataDir: z.string(),
 		hostDataDir: z.string().optional(),
 		auditLogPath: z.string(),

--- a/apps/discord/src/profile-config.ts
+++ b/apps/discord/src/profile-config.ts
@@ -8,6 +8,7 @@ import {
 	minecraftSchema,
 	safeInt,
 	safeNumber,
+	shellWorkspaceEnvironmentSchema,
 	shellWorkspaceNetworkProfileSchema,
 	ttsSchema,
 	type AppConfig,
@@ -17,6 +18,12 @@ const modelSelectionSchema = z.strictObject({
 	providerId: z.string().min(1),
 	modelId: z.string().min(1),
 });
+
+const environmentSourceSchema = z.strictObject({
+	fromEnv: z.string().min(1),
+});
+
+const shellWorkspaceProfileEnvironmentSchema = z.record(z.string().min(1), environmentSourceSchema);
 
 export const profileConfigSchema = z.strictObject({
 	$schema: z.string().min(1).optional(),
@@ -49,6 +56,7 @@ export const profileConfigSchema = z.strictObject({
 					temperature: safeNumber.min(0).max(2),
 					steps: safeInt.min(1),
 				}),
+				environment: shellWorkspaceProfileEnvironmentSchema.optional(),
 				networkProfile: shellWorkspaceNetworkProfileSchema.optional(),
 				defaultTtlMinutes: safeInt.min(1),
 				maxTtlMinutes: safeInt.min(1),
@@ -82,6 +90,7 @@ function buildProfileShellWorkspaceConfig(
 		enabled: true,
 		image: shellWorkspace.image,
 		agent: shellWorkspace.agent,
+		environment: resolveShellWorkspaceEnvironment(shellWorkspace.environment, env),
 		dataDir: resolve(dataDir, "shell-workspaces"),
 		...(env.SHELL_WORKSPACE_HOST_DATA_DIR
 			? { hostDataDir: env.SHELL_WORKSPACE_HOST_DATA_DIR }
@@ -94,6 +103,20 @@ function buildProfileShellWorkspaceConfig(
 		maxTimeoutSeconds: shellWorkspace.maxTimeoutSeconds,
 		maxOutputChars: shellWorkspace.maxOutputChars,
 	};
+}
+
+function resolveShellWorkspaceEnvironment(
+	sources: Record<string, { fromEnv: string }> | undefined,
+	env: Record<string, string | undefined>,
+): Record<string, string> | undefined {
+	if (!sources) return;
+	const resolved = Object.fromEntries(
+		Object.entries(sources).map(([name, source]) => [
+			name,
+			requireSecret(env, source.fromEnv, `features.shellWorkspace.environment.${name}`),
+		]),
+	);
+	return shellWorkspaceEnvironmentSchema.parse(resolved);
 }
 
 function requireSecret(

--- a/config/profile.schema.json
+++ b/config/profile.schema.json
@@ -159,6 +159,24 @@
 							"required": ["providerId", "modelId", "temperature", "steps"],
 							"additionalProperties": false
 						},
+						"environment": {
+							"type": "object",
+							"propertyNames": {
+								"type": "string",
+								"minLength": 1
+							},
+							"additionalProperties": {
+								"type": "object",
+								"properties": {
+									"fromEnv": {
+										"type": "string",
+										"minLength": 1
+									}
+								},
+								"required": ["fromEnv"],
+								"additionalProperties": false
+							}
+						},
 						"networkProfile": {
 							"type": "string",
 							"enum": ["open", "none"]

--- a/docs/agent-capabilities-and-shell-sandbox.md
+++ b/docs/agent-capabilities-and-shell-sandbox.md
@@ -61,6 +61,8 @@ shell 実行はメイン会話 agent に直接渡さない。メイン会話 age
 
 `shell-workspace` 有効時、core MCP には `DISCORD_ATTACHMENT_ALLOWED_DIRS` として `data/shell-workspaces` を渡す。これにより workspace 配下の生成ファイルを Discord に添付できる。
 
+JSON profile の `features.shellWorkspace.environment` には shell-worker へ渡す env 名を宣言できる。secret の実値は profile に書かず、`{ "fromEnv": "HUA_GITHUB_TOKEN" }` のように bot コンテナの環境変数を参照する。参照元 env が未設定の場合は起動時にエラーにする。
+
 ## 非目標
 
 - メイン会話 agent への builtin `bash` 直接許可。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,10 @@ disabled feature は key ごと省略する。`enabled: false`、`null`、空文
 				"temperature": 0.4,
 				"steps": 24
 			},
+			"environment": {
+				"GH_TOKEN": { "fromEnv": "HUA_GITHUB_TOKEN" },
+				"GITHUB_TOKEN": { "fromEnv": "HUA_GITHUB_TOKEN" }
+			},
 			"networkProfile": "open",
 			"defaultTtlMinutes": 60,
 			"maxTtlMinutes": 120,
@@ -86,6 +90,8 @@ disabled feature は key ごと省略する。`enabled: false`、`null`、空文
 feature section が存在する場合だけ、その feature の secret env を必須にする。
 
 Spotify の推薦プレイリストは secret ではないため `features.spotify.recommendPlaylistId` に書ける。移行中の環境では既存の `SPOTIFY_RECOMMEND_PLAYLIST_ID` も引き続き読み込む。
+
+`features.shellWorkspace.environment` は shell-worker の OpenCode server process に渡す env 名を明示する。値は profile に書かず、`fromEnv` で実行環境の secret env を参照する。たとえば `HUA_GITHUB_TOKEN` を `GH_TOKEN` / `GITHUB_TOKEN` として渡すと、`gh` と GitHub SDK の両方が同じ bot token を利用できる。
 
 ## パースと検証
 

--- a/packages/agent/src/mcp-config.ts
+++ b/packages/agent/src/mcp-config.ts
@@ -18,6 +18,7 @@ export interface ShellWorkspaceMcpConfigOptions {
 	hostDataDir?: string;
 	auditLogPath: string;
 	networkProfile: "open" | "none";
+	environment?: Record<string, string>;
 	defaultTtlMinutes: number;
 	maxTtlMinutes: number;
 	defaultTimeoutSeconds: number;
@@ -65,6 +66,7 @@ function buildShellWorkspaceEnvironment(
 	config: ShellWorkspaceMcpConfigOptions,
 ): Record<string, string> {
 	const env: Record<string, string> = {
+		...config.environment,
 		PATH: process.env.PATH ?? "",
 		HOME: process.env.HOME ?? "",
 		SHELL_WORKSPACE_AGENT_ID: agentId,

--- a/packages/opencode/src/session-adapter.test.ts
+++ b/packages/opencode/src/session-adapter.test.ts
@@ -197,6 +197,43 @@ describe("OpencodeSessionAdapter", () => {
 		});
 	});
 
+	test("OpenCode 起動時だけ追加 environment を process env に反映する", async () => {
+		const saved = process.env.VICISSITUDE_OPENCODE_TEST_TOKEN;
+		delete process.env.VICISSITUDE_OPENCODE_TEST_TOKEN;
+		let valueDuringLaunch: string | undefined;
+		const streamState = createStream();
+		const client = createClient(streamState.stream);
+		const clientFactory = mock(() => {
+			valueDuringLaunch = process.env.VICISSITUDE_OPENCODE_TEST_TOKEN;
+			return Promise.resolve({
+				client,
+				server: { url: "http://localhost", close: mock(() => {}) },
+			});
+		});
+		const adapter = new OpencodeSessionAdapter({
+			port: 4096,
+			mcpServers: {},
+			builtinTools: {},
+			environment: {
+				VICISSITUDE_OPENCODE_TEST_TOKEN: "secret-value",
+			},
+			clientFactory,
+		});
+
+		try {
+			await adapter.createSession("test session");
+
+			expect(valueDuringLaunch).toBe("secret-value");
+			expect(process.env.VICISSITUDE_OPENCODE_TEST_TOKEN).toBeUndefined();
+		} finally {
+			if (saved === undefined) {
+				delete process.env.VICISSITUDE_OPENCODE_TEST_TOKEN;
+			} else {
+				process.env.VICISSITUDE_OPENCODE_TEST_TOKEN = saved;
+			}
+		}
+	});
+
 	test("promptAsyncAndWatchSession は abort 時に次イベントを待たず cancelled を返す", async () => {
 		const streamState = createStream();
 		const client = createClient(streamState.stream);

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -45,6 +45,8 @@ export interface OpencodeSessionAdapterConfig {
 	temperature?: number;
 	/** OpenCode の session / tool 実行に使う project directory */
 	directory?: string;
+	/** OpenCode server process に追加で渡す環境変数 */
+	environment?: Record<string, string>;
 	clientFactory?: typeof createOpencode;
 	logger?: Logger;
 }
@@ -338,22 +340,48 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 			mkdirSync(this.config.directory, { recursive: true });
 		}
 		const agent = this.buildAgentConfig();
-		const result = await (this.config.clientFactory ?? createOpencode)({
-			port: this.config.port,
-			config: {
-				mcp: this.config.mcpServers,
-				tools: this.config.builtinTools,
-				default_agent: this.config.defaultAgent,
-				agent,
-				experimental: {
-					mcp_timeout: MCP_REQUEST_TIMEOUT_MS,
-					primary_tools: this.config.primaryTools,
+		const result = await withProcessEnvironment(this.config.environment, () =>
+			(this.config.clientFactory ?? createOpencode)({
+				port: this.config.port,
+				config: {
+					mcp: this.config.mcpServers,
+					tools: this.config.builtinTools,
+					default_agent: this.config.defaultAgent,
+					agent,
+					experimental: {
+						mcp_timeout: MCP_REQUEST_TIMEOUT_MS,
+						primary_tools: this.config.primaryTools,
+					},
 				},
-			},
-		});
+			}),
+		);
 		this.client = result.client;
 		this.closeServer = result.server.close.bind(result.server);
 		this.logger?.info(`[opencode] client initialized (port=${this.config.port})`);
 		return this.client;
+	}
+}
+
+function withProcessEnvironment<T>(
+	environment: Record<string, string> | undefined,
+	run: () => T,
+): T {
+	if (!environment || Object.keys(environment).length === 0) return run();
+	const previous = new Map<string, string | undefined>();
+	for (const [name, value] of Object.entries(environment)) {
+		const previousValue = process.env[name] as string | undefined;
+		previous.set(name, previousValue);
+		process.env[name] = value;
+	}
+	try {
+		return run();
+	} finally {
+		for (const [name, value] of previous) {
+			if (value === undefined) {
+				delete process.env[name];
+			} else {
+				process.env[name] = value;
+			}
+		}
 	}
 }

--- a/spec/agent/mcp-config.spec.ts
+++ b/spec/agent/mcp-config.spec.ts
@@ -66,6 +66,10 @@ describe("mcpServerConfigs", () => {
 			shellWorkspace: {
 				...shellWorkspace,
 				hostDataDir: "/host/data/shell-workspaces",
+				environment: {
+					GH_TOKEN: "github-token",
+					GITHUB_TOKEN: "github-token",
+				},
 			},
 		});
 		const shell = configs["shell-workspace"];
@@ -77,6 +81,8 @@ describe("mcpServerConfigs", () => {
 			expect(shell.environment?.SHELL_WORKSPACE_DATA_DIR).toBe("/data/shell-workspaces");
 			expect(shell.environment?.SHELL_WORKSPACE_HOST_DATA_DIR).toBe("/host/data/shell-workspaces");
 			expect(shell.environment?.SHELL_WORKSPACE_NETWORK_PROFILE).toBe("open");
+			expect(shell.environment?.GH_TOKEN).toBe("github-token");
+			expect(shell.environment?.GITHUB_TOKEN).toBe("github-token");
 			expect(shell.environment?.DISCORD_TOKEN).toBeUndefined();
 		}
 	});

--- a/spec/core/profile-config.spec.ts
+++ b/spec/core/profile-config.spec.ts
@@ -144,6 +144,10 @@ describe("JSON profile config", () => {
 							temperature: 0.3,
 							steps: 16,
 						},
+						environment: {
+							GH_TOKEN: { fromEnv: "HUA_GITHUB_TOKEN" },
+							GITHUB_TOKEN: { fromEnv: "HUA_GITHUB_TOKEN" },
+						},
 						defaultTtlMinutes: 15,
 						maxTtlMinutes: 30,
 						defaultTimeoutSeconds: 5,
@@ -152,7 +156,7 @@ describe("JSON profile config", () => {
 					},
 				},
 			},
-			baseEnv(),
+			baseEnv({ HUA_GITHUB_TOKEN: "test-github-token" }),
 			root,
 		);
 
@@ -170,6 +174,10 @@ describe("JSON profile config", () => {
 				temperature: 0.3,
 				steps: 16,
 			},
+			environment: {
+				GH_TOKEN: "test-github-token",
+				GITHUB_TOKEN: "test-github-token",
+			},
 			dataDir: "/tmp/test-vicissitude/data/shell-workspaces",
 			auditLogPath: "/tmp/test-vicissitude/data/shell-workspace-audit.jsonl",
 			networkProfile: "open",
@@ -179,6 +187,37 @@ describe("JSON profile config", () => {
 			maxTimeoutSeconds: 10,
 			maxOutputChars: 12345,
 		});
+	});
+
+	it("shellWorkspace.environment の参照元 env が未設定ならエラーにする", () => {
+		expect(() =>
+			loadConfigFromProfile(
+				{
+					...baseProfile,
+					features: {
+						shellWorkspace: {
+							image: "shell-image",
+							agent: {
+								providerId: "shell-provider",
+								modelId: "shell-model",
+								temperature: 0.3,
+								steps: 16,
+							},
+							environment: {
+								GH_TOKEN: { fromEnv: "HUA_GITHUB_TOKEN" },
+							},
+							defaultTtlMinutes: 15,
+							maxTtlMinutes: 30,
+							defaultTimeoutSeconds: 5,
+							maxTimeoutSeconds: 10,
+							maxOutputChars: 12345,
+						},
+					},
+				},
+				baseEnv(),
+				root,
+			),
+		).toThrow("HUA_GITHUB_TOKEN is required");
 	});
 
 	it("secret が必要な feature は env 未設定ならエラーにする", () => {


### PR DESCRIPTION
## Summary
- features.shellWorkspace.environment で shell-worker 用 env を fromEnv 参照から構築できるようにした
- OpenCode server 起動時に明示 env を一時的に注入し、builtin bash から GH_TOKEN / GITHUB_TOKEN を使えるようにした
- profile schema、docs、テストを更新した

## Tests
- nr validate
- nr test