### PR TITLE
chore(container): 開発用ユーティリティを追加する

### DIFF
--- a/containers/bot/Containerfile
+++ b/containers/bot/Containerfile
@@ -5,13 +5,26 @@ RUN mise use -g bun@1 node@24 python@3.11
 
 # システム依存パッケージ
 RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
+    bash wget git gh openssh-client \
+    jq ripgrep fd-find less file tree vim-tiny \
+    unzip zip tar gzip xz-utils zstd rsync sqlite3 \
+    procps psmisc lsof iproute2 iputils-ping dnsutils netcat-openbsd \
     podman \
     slirp4netns \
     # canvas v3 (N-API) native build deps
     build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
     # headless-gl (Mesa + Xvfb + ANGLE build) deps
     xvfb xauth libgl1-mesa-dri libgl1-mesa-dev libglapi-mesa libosmesa6 libxi-dev \
+    && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/containers/code-exec/Containerfile
+++ b/containers/code-exec/Containerfile
@@ -1,8 +1,21 @@
 FROM docker.io/oven/bun:1-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 bash && \
-    apt-get clean && \
+RUN mkdir -p /etc/apt/keyrings && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    python3 bash git gh openssh-client \
+    wget jq ripgrep fd-find less file tree vim-tiny \
+    unzip zip tar gzip xz-utils zstd rsync sqlite3 \
+    procps psmisc lsof iproute2 iputils-ping dnsutils netcat-openbsd \
+    && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
+    && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /bin/bash sandbox


### PR DESCRIPTION
## Summary
- bot image に gh / git / rg / fd / jq / curl など開発・調査用ユーティリティを追加
- code-exec image にも同じ基本ユーティリティを追加
- GitHub CLI は公式 apt repo からインストールする

## Tests
- podman build -f containers/bot/Containerfile -t vicissitude-base .
- podman build -f containers/code-exec/Containerfile -t vicissitude-code-exec .
- podman run --rm vicissitude-base sh -lc 'gh --version | head -1; git --version; rg --version | head -1; fd --version; jq --version; curl --version | head -1'
- podman run --rm vicissitude-code-exec sh -lc 'gh --version | head -1; git --version; rg --version | head -1; fd --version; jq --version; curl --version | head -1'
- nr validate