### PR TITLE
chore(opencode): opencode を 1.14.41 に更新する

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "vicissitude",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@opencode-ai/sdk": "^1.4.6",
+        "@opencode-ai/sdk": "^1.14.41",
         "canvas": "^3.2.1",
         "discord.js": "^14.25.1",
         "drizzle-orm": "^0.45.1",
@@ -139,7 +139,7 @@
     "packages/opencode": {
       "name": "@vicissitude/opencode",
       "dependencies": {
-        "@opencode-ai/sdk": "^1.4.6",
+        "@opencode-ai/sdk": "^1.14.41",
       },
     },
     "packages/scheduling": {
@@ -305,7 +305,7 @@
 
     "@monogrid/gainmap-js": ["@monogrid/gainmap-js@3.4.0", "", { "dependencies": { "promise-worker-transferable": "^1.0.4" }, "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.4.6", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-sQaVfEfQW3m3DeCVlurSTUjgIYdIk+gIfOys51MVFYzJHw+FyjjuAt7EKKA+LeZU5AiWGlpkIRa1rJo5KWMXCw=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.41", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-RYb2dCUv0TWIvBNnnO6ANbAPYri6rKuWizSoVFw/Pw+SCDj9ASHM5gAZ+jkskp8gYMfLLHe/Fpkun/9mr8m0IQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/containers/bot/Containerfile
+++ b/containers/bot/Containerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN bun install -g opencode-ai@1.4.3 && \
+RUN bun install -g opencode-ai@1.14.41 && \
     cp /root/.bun/install/global/node_modules/opencode-ai/bin/.opencode /usr/local/bin/opencode && \
     chmod 755 /usr/local/bin/opencode && \
     rm -rf /root/.bun && \

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.1",
-		"@opencode-ai/sdk": "^1.4.6",
+		"@opencode-ai/sdk": "^1.14.41",
 		"canvas": "^3.2.1",
 		"discord.js": "^14.25.1",
 		"drizzle-orm": "^0.45.1",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -8,6 +8,6 @@
 		"./stream-helpers": "./src/stream-helpers.ts"
 	},
 	"dependencies": {
-		"@opencode-ai/sdk": "^1.4.6"
+		"@opencode-ai/sdk": "^1.14.41"
 	}
 }

--- a/packages/opencode/src/stream-helpers.test.ts
+++ b/packages/opencode/src/stream-helpers.test.ts
@@ -29,22 +29,8 @@ describe("classifyEvent — workspace イベント", () => {
 		});
 	});
 
-	// 3. workspace.status status="error" + error="custom msg"
-	test("workspace.status (status='error', error='custom msg') で message が 'custom msg'", () => {
-		const event = {
-			type: "workspace.status",
-			properties: { status: "error", error: "custom msg" },
-		} as unknown as Event;
-
-		const result = classifyEvent(event, SESSION_ID, new Map());
-
-		expect(result).not.toBeNull();
-		if (result?.type !== "error") throw new Error("unreachable");
-		expect(result.message).toBe("custom msg");
-	});
-
-	// 4. workspace.status status="error" + error undefined → フォールバック
-	test("workspace.status (status='error') で error が undefined の場合、'workspace error' にフォールバック", () => {
+	// 3. workspace.status status="error" → 固定メッセージ
+	test("workspace.status (status='error') は 'workspace error' を返す", () => {
 		const event = {
 			type: "workspace.status",
 			properties: { status: "error" },
@@ -60,7 +46,7 @@ describe("classifyEvent — workspace イベント", () => {
 		});
 	});
 
-	// 5. workspace.status status="disconnected" 戻り値厳密一致
+	// 4. workspace.status status="disconnected" 戻り値厳密一致
 	test("workspace.status (status='disconnected') の戻り値が厳密に一致する", () => {
 		const event = {
 			type: "workspace.status",
@@ -77,7 +63,7 @@ describe("classifyEvent — workspace イベント", () => {
 		});
 	});
 
-	// 6. workspace.status status="connected" → null
+	// 5. workspace.status status="connected" → null
 	test("workspace.status (status='connected') は null を返す", () => {
 		const event = {
 			type: "workspace.status",
@@ -89,7 +75,7 @@ describe("classifyEvent — workspace イベント", () => {
 		expect(result).toBeNull();
 	});
 
-	// 7. workspace.status status="connecting" → null
+	// 6. workspace.status status="connecting" → null
 	test("workspace.status (status='connecting') は null を返す", () => {
 		const event = {
 			type: "workspace.status",
@@ -101,7 +87,7 @@ describe("classifyEvent — workspace イベント", () => {
 		expect(result).toBeNull();
 	});
 
-	// 8. workspace.ready → null
+	// 7. workspace.ready → null
 	test("workspace.ready は null を返す", () => {
 		const event = {
 			type: "workspace.ready",
@@ -122,7 +108,7 @@ describe("classifyEvent — workspace イベント", () => {
 
 		const events = [
 			{ type: "workspace.failed", properties: { message: "fail" } },
-			{ type: "workspace.status", properties: { status: "error", error: "err" } },
+			{ type: "workspace.status", properties: { status: "error" } },
 			{ type: "workspace.status", properties: { status: "disconnected" } },
 			{ type: "workspace.status", properties: { status: "connected" } },
 			{ type: "workspace.ready", properties: {} },

--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -157,7 +157,7 @@ export function classifyEvent(
 		if (typed.properties.status === "error") {
 			return {
 				type: "error",
-				message: typed.properties.error ?? "workspace error",
+				message: "workspace error",
 				retryable: true,
 				errorClass: "WorkspaceError",
 			};

--- a/spec/opencode/stream-helpers.spec.ts
+++ b/spec/opencode/stream-helpers.spec.ts
@@ -408,28 +408,13 @@ describe("classifyEvent", () => {
 	test("workspace.status (status='error') が error として classify される", () => {
 		const event = {
 			type: "workspace.status",
-			properties: { workspaceID: "ws-1", status: "error", error: "connection reset" },
-		} as unknown as Event;
-
-		const result = classifyEvent(event, sessionId, new Map());
-
-		expect(result).not.toBeNull();
-		expect(result?.type).toBe("error");
-		if (result?.type !== "error") throw new Error("unreachable");
-		expect(result.message).toContain("connection reset");
-		expect(result.retryable).toBe(true);
-		expect(result.errorClass).toBe("WorkspaceError");
-	});
-
-	test("workspace.status (status='error') で error フィールドが未設定の場合はデフォルトメッセージ", () => {
-		const event = {
-			type: "workspace.status",
 			properties: { workspaceID: "ws-1", status: "error" },
 		} as unknown as Event;
 
 		const result = classifyEvent(event, sessionId, new Map());
 
 		expect(result).not.toBeNull();
+		expect(result?.type).toBe("error");
 		if (result?.type !== "error") throw new Error("unreachable");
 		expect(result.message).toContain("workspace error");
 		expect(result.retryable).toBe(true);


### PR DESCRIPTION
## Summary
- Update @opencode-ai/sdk from 1.4.6 to 1.14.41 in root and @vicissitude/opencode workspace
- Update bot container opencode-ai CLI to 1.14.41
- Adjust workspace.status error handling to match SDK 1.14.41 event shape

## Validation
- nr validate
- nr test
- bun test packages/opencode spec/opencode
- podman build -f containers/bot/Containerfile -t vicissitude-bot:opencode-1.14.41 .

Closes #928