### PR TITLE
feat(agent): 再開コンテキストをsystem promptに注入する (refs #927)

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -13,6 +13,7 @@ import { McBrainManager } from "@vicissitude/agent/minecraft/brain-manager";
 import { SessionStore } from "@vicissitude/agent/session-store";
 import { HeartbeatService } from "@vicissitude/application/heartbeat-service";
 import { MessageIngestionService } from "@vicissitude/application/message-ingestion-service";
+import { ResumeContextService } from "@vicissitude/application/resume-context-service";
 import { createGatewayServer } from "@vicissitude/gateway/server";
 import { WsConnectionManager } from "@vicissitude/gateway/ws-handler";
 import { GitHubIssueAdapter } from "@vicissitude/infrastructure/http/github-issue-adapter";
@@ -99,13 +100,16 @@ export function createContextLayer(config: AppConfig, root: string, factReader?:
 
 // ─── Guild Agents ───────────────────────────────────────────────
 
-function createFileSessionSummaryWriter(overlayDir: string): SessionSummaryWriter {
+function createFileSessionSummaryWriter(
+	overlayDir: string,
+	onWrite?: (guildId: string) => Promise<void>,
+): SessionSummaryWriter {
 	return {
-		write(guildId: string, content: string): Promise<void> {
+		async write(guildId: string, content: string): Promise<void> {
 			const dir = resolve(overlayDir, `guilds/${guildId}`);
 			mkdirSync(dir, { recursive: true });
 			writeFileSync(resolve(dir, "SESSION-SUMMARY.md"), content);
-			return Promise.resolve();
+			await onWrite?.(guildId);
 		},
 	};
 }
@@ -609,7 +613,16 @@ export async function bootstrap(): Promise<void> {
 	const ports = createPortLayout(config.opencode.basePort, guildIds.length);
 
 	// Guild agents
-	const summaryWriter = createFileSessionSummaryWriter(resolve(root, "data/context"));
+	const contextOverlayDir = resolve(root, "data/context");
+	const resumeContextService = new ResumeContextService({
+		memoryDataDir,
+		overlayDir: contextOverlayDir,
+		logger,
+	});
+	await resumeContextService.updateGuilds(guildIds);
+	const summaryWriter = createFileSessionSummaryWriter(contextOverlayDir, (guildId) =>
+		resumeContextService.updateGuild(guildId),
+	);
 	const agents = createGuildAgents(config, guildIds, {
 		db,
 		sessionStore,
@@ -737,6 +750,7 @@ export async function bootstrap(): Promise<void> {
 		chatAdapter: memoryResources?.chatAdapter,
 		recorder: memoryResources?.recorder,
 		mcProcess,
+		resumeContextService,
 		closeDb: () => closeDb(db),
 	});
 	process.on("SIGINT", () => void shutdown());

--- a/apps/discord/src/shutdown.ts
+++ b/apps/discord/src/shutdown.ts
@@ -14,6 +14,7 @@ export interface ShutdownDeps {
 	factReader: { close(): void };
 	chatAdapter?: { close(): void };
 	recorder?: { close(): void };
+	resumeContextService?: { close(): void };
 	mcProcess?: { kill(): void } | null;
 	closeDb: () => void;
 }
@@ -51,6 +52,7 @@ export function createShutdown(deps: ShutdownDeps): () => Promise<void> {
 		// chatAdapter.close() -> MemoryChatAdapter.close() -> memorySessionPort.close()
 		await safe("chatAdapter", () => deps.chatAdapter?.close());
 		await safe("recorder", () => deps.recorder?.close());
+		await safe("resumeContextService", () => deps.resumeContextService?.close());
 		await safe("mcProcess", () => deps.mcProcess?.kill());
 		await safe("db", () => deps.closeDb());
 

--- a/packages/agent/src/discord/context-builder.ts
+++ b/packages/agent/src/discord/context-builder.ts
@@ -16,6 +16,7 @@ const CONTEXT_FILES = [
 	{ name: "LESSONS.md", scope: "guild" },
 	{ name: "MEMORY.md", scope: "guild" },
 	{ name: "SESSION-SUMMARY.md", scope: "guild" },
+	{ name: "RESUME-CONTEXT.md", scope: "guild" },
 	// Phase 2: Behavior
 	{ name: "DISCORD.md", scope: "shared" },
 	{ name: "HEARTBEAT.md", scope: "shared" },

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -4,6 +4,7 @@
 	"exports": {
 		"./heartbeat-service": "./src/heartbeat-service.ts",
 		"./message-ingestion-service": "./src/message-ingestion-service.ts",
+		"./resume-context-service": "./src/resume-context-service.ts",
 		"./split-message": "./src/split-message.ts"
 	}
 }

--- a/packages/application/src/resume-context-service.test.ts
+++ b/packages/application/src/resume-context-service.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+	defaultSubject,
+	discordGuildNamespace,
+	resolveMemoryDbDir,
+	resolveMemoryDbPath,
+} from "@vicissitude/memory/namespace";
+import type { SemanticFact } from "@vicissitude/memory/semantic-fact";
+import { MemoryStorage } from "@vicissitude/memory/storage";
+
+import { ResumeContextService } from "./resume-context-service.ts";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+function createTempRoot(): string {
+	const root: string = join(tmpdir(), `vicissitude-resume-context-${crypto.randomUUID()}`);
+	mkdirSync(root, { recursive: true });
+	tempRoots.push(root);
+	return root;
+}
+
+function createFact(overrides: Partial<SemanticFact> = {}): SemanticFact {
+	const now = new Date("2026-01-03T00:00:00Z");
+	return {
+		id: overrides.id ?? crypto.randomUUID(),
+		userId: overrides.userId ?? "123456789012345678",
+		category: overrides.category ?? "preference",
+		fact: overrides.fact ?? "TypeScript が好き",
+		keywords: overrides.keywords ?? [],
+		sourceEpisodicIds: overrides.sourceEpisodicIds ?? [],
+		embedding: overrides.embedding ?? [0.1, 0.2, 0.3],
+		validAt: overrides.validAt ?? now,
+		invalidAt: overrides.invalidAt ?? null,
+		createdAt: overrides.createdAt ?? now,
+	};
+}
+
+describe("ResumeContextService", () => {
+	test("memory DB から RESUME-CONTEXT.md を生成する", async () => {
+		const root = createTempRoot();
+		const memoryDataDir: string = join(root, "memory");
+		const overlayDir: string = join(root, "context");
+		const guildId = "123456789012345678";
+		const namespace = discordGuildNamespace(guildId);
+		const userId = defaultSubject(namespace);
+		const dbDir = resolveMemoryDbDir(memoryDataDir, namespace);
+		mkdirSync(dbDir, { recursive: true });
+
+		const storage = new MemoryStorage(resolveMemoryDbPath(memoryDataDir, namespace));
+		await storage.saveFact(
+			userId,
+			createFact({
+				userId,
+				category: "goal",
+				fact: "再開時に過去の文脈を思い出す",
+				createdAt: new Date("2026-01-04T00:00:00Z"),
+			}),
+		);
+		await storage.saveFact(
+			userId,
+			createFact({
+				userId,
+				category: "preference",
+				fact: "短い要約を好む",
+				createdAt: new Date("2026-01-02T00:00:00Z"),
+			}),
+		);
+		await storage.saveEpisode(userId, {
+			id: "episode-1",
+			userId,
+			title: "再開コンテキストの相談",
+			summary: "デプロイし直したあとも文脈を失わないように、直近の記憶を要約して渡す話をした。",
+			messages: [{ role: "user", content: "再開コンテキストがほしい" }],
+			embedding: [0.1, 0.2, 0.3],
+			surprise: 0.5,
+			stability: 1,
+			difficulty: 0.3,
+			startAt: new Date("2026-01-02T11:00:00Z"),
+			endAt: new Date("2026-01-02T12:00:00Z"),
+			createdAt: new Date("2026-01-02T12:00:00Z"),
+			lastReviewedAt: null,
+			consolidatedAt: null,
+		});
+		storage.close();
+
+		const service = new ResumeContextService({
+			memoryDataDir,
+			overlayDir,
+			lookbackMs: Number.MAX_SAFE_INTEGER,
+		});
+		await service.updateGuild(guildId);
+		service.close();
+
+		const content = readFileSync(join(overlayDir, "guilds", guildId, "RESUME-CONTEXT.md"), "utf8");
+		expect(content).toContain("## 覚えておきたいこと");
+		expect(content).toContain("- 目標: 再開時に過去の文脈を思い出す");
+		expect(content).toContain("- 好み: 短い要約を好む");
+		expect(content).toContain("## 直近の会話履歴");
+		expect(content).toContain("### 2026-01-02 会話: 再開コンテキストの相談");
+		expect(content).toContain("直近の記憶を要約して渡す話をした。");
+	});
+
+	test("memory DB がなければ古い RESUME-CONTEXT.md を削除する", async () => {
+		const root = createTempRoot();
+		const memoryDataDir: string = join(root, "memory");
+		const overlayDir: string = join(root, "context");
+		const guildId = "123456789012345678";
+		const stalePath = join(overlayDir, "guilds", guildId, "RESUME-CONTEXT.md");
+		mkdirSync(join(overlayDir, "guilds", guildId), { recursive: true });
+		writeFileSync(stalePath, "stale");
+
+		const service = new ResumeContextService({ memoryDataDir, overlayDir });
+		await service.updateGuild(guildId);
+		service.close();
+
+		expect(existsSync(stalePath)).toBe(false);
+	});
+});

--- a/packages/application/src/resume-context-service.ts
+++ b/packages/application/src/resume-context-service.ts
@@ -70,8 +70,8 @@ export class ResumeContextService {
 		const namespace = discordGuildNamespace(guildId);
 		const key = namespaceKey(namespace);
 		const dbPath = resolveMemoryDbPath(this.deps.memoryDataDir, namespace);
-		const outputDir = resolve(this.deps.overlayDir, "guilds", guildId);
-		const outputPath = resolve(outputDir, "RESUME-CONTEXT.md");
+		const outputDir: string = resolve(this.deps.overlayDir, "guilds", guildId);
+		const outputPath: string = resolve(outputDir, "RESUME-CONTEXT.md");
 
 		if (!existsSync(dbPath)) {
 			this.removeFile(outputPath);
@@ -187,11 +187,11 @@ function formatDate(date: Date): string {
 }
 
 function trimParagraph(text: string, maxLength: number): string {
-	return trimLine(text.replace(/\s+/g, " "), maxLength);
+	return trimLine(text.replaceAll(/\s+/g, " "), maxLength);
 }
 
 function normalizeInline(text: string): string {
-	return text.replace(/\s+/g, " ").trim();
+	return text.replaceAll(/\s+/g, " ").trim();
 }
 
 function trimLine(text: string, maxLength: number): string {

--- a/packages/application/src/resume-context-service.ts
+++ b/packages/application/src/resume-context-service.ts
@@ -1,0 +1,206 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+import type { Episode } from "@vicissitude/memory/episode";
+import {
+	defaultSubject,
+	discordGuildNamespace,
+	namespaceKey,
+	resolveMemoryDbPath,
+} from "@vicissitude/memory/namespace";
+import type { SemanticFact } from "@vicissitude/memory/semantic-fact";
+import { MemoryStorage } from "@vicissitude/memory/storage";
+import type { Logger } from "@vicissitude/shared/types";
+
+const DEFAULT_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+const DEFAULT_EPISODE_LIMIT = 5;
+const DEFAULT_FACT_LIMIT = 6;
+const EPISODE_SUMMARY_MAX = 280;
+const EPISODE_TITLE_MAX = 80;
+
+const FACT_CATEGORY_LABELS: Partial<Record<SemanticFact["category"], string>> = {
+	goal: "目標",
+	relationship: "関係",
+	preference: "好み",
+	interest: "関心",
+	personality: "性格",
+	identity: "人物像",
+	experience: "経験",
+};
+
+const FACT_CATEGORY_PRIORITY = new Map<SemanticFact["category"], number>([
+	["goal", 0],
+	["relationship", 1],
+	["preference", 2],
+	["interest", 3],
+	["personality", 4],
+	["identity", 5],
+	["experience", 6],
+	["guideline", 7],
+]);
+
+export interface ResumeContextServiceDeps {
+	memoryDataDir: string;
+	overlayDir: string;
+	logger?: Logger;
+	lookbackMs?: number;
+	episodeLimit?: number;
+	factLimit?: number;
+}
+
+export class ResumeContextService {
+	private readonly instances = new Map<string, MemoryStorage>();
+	private readonly logger?: Logger;
+	private readonly lookbackMs: number;
+	private readonly episodeLimit: number;
+	private readonly factLimit: number;
+
+	constructor(private readonly deps: ResumeContextServiceDeps) {
+		this.logger = deps.logger;
+		this.lookbackMs = deps.lookbackMs ?? DEFAULT_LOOKBACK_MS;
+		this.episodeLimit = deps.episodeLimit ?? DEFAULT_EPISODE_LIMIT;
+		this.factLimit = deps.factLimit ?? DEFAULT_FACT_LIMIT;
+	}
+
+	async updateGuilds(guildIds: string[]): Promise<void> {
+		await Promise.all(guildIds.map((guildId) => this.updateGuild(guildId)));
+	}
+
+	async updateGuild(guildId: string): Promise<void> {
+		const namespace = discordGuildNamespace(guildId);
+		const key = namespaceKey(namespace);
+		const dbPath = resolveMemoryDbPath(this.deps.memoryDataDir, namespace);
+		const outputDir = resolve(this.deps.overlayDir, "guilds", guildId);
+		const outputPath = resolve(outputDir, "RESUME-CONTEXT.md");
+
+		if (!existsSync(dbPath)) {
+			this.removeFile(outputPath);
+			return;
+		}
+
+		try {
+			const storage = this.getOrCreate(key, dbPath);
+			const userId = defaultSubject(namespace);
+			const sinceMs = Date.now() - this.lookbackMs;
+			const [episodes, facts] = await Promise.all([
+				storage.getRecentEpisodes(userId, sinceMs, this.episodeLimit),
+				storage.getFacts(userId),
+			]);
+			const content = renderResumeContext(episodes, facts, this.factLimit);
+			if (!content) {
+				this.removeFile(outputPath);
+				return;
+			}
+			mkdirSync(outputDir, { recursive: true });
+			writeFileSync(outputPath, content);
+		} catch (error) {
+			this.logger?.warn(
+				`[resume-context] failed to update guild ${guildId}: ${formatErrorMessage(error)}`,
+				error,
+			);
+		}
+	}
+
+	close(): void {
+		for (const storage of this.instances.values()) {
+			storage.close();
+		}
+		this.instances.clear();
+	}
+
+	private getOrCreate(key: string, dbPath: string): MemoryStorage {
+		const existing = this.instances.get(key);
+		if (existing) return existing;
+
+		const storage = new MemoryStorage(dbPath);
+		this.instances.set(key, storage);
+		return storage;
+	}
+
+	private removeFile(path: string): void {
+		rmSync(path, { force: true });
+	}
+}
+
+function renderResumeContext(
+	episodes: Episode[],
+	facts: SemanticFact[],
+	factLimit: number,
+): string | null {
+	const sections: string[] = [];
+	const selectedFacts = selectFacts(facts, factLimit);
+
+	if (selectedFacts.length > 0) {
+		sections.push("## 覚えておきたいこと");
+		sections.push(...selectedFacts.map((fact) => `- ${formatFact(fact)}`));
+	}
+
+	if (episodes.length > 0) {
+		const lines = ["## 直近の会話履歴"];
+		for (const episode of episodes) {
+			lines.push(
+				`### ${formatDate(episode.endAt)} 会話: ${trimLine(episode.title, EPISODE_TITLE_MAX)}`,
+			);
+			lines.push(trimParagraph(episode.summary, EPISODE_SUMMARY_MAX));
+			lines.push("");
+		}
+		sections.push(lines.join("\n").trimEnd());
+	}
+
+	if (sections.length === 0) return null;
+	return sections.join("\n\n").trim();
+}
+
+function selectFacts(facts: SemanticFact[], limit: number): SemanticFact[] {
+	const seen = new Set<string>();
+	return facts
+		.filter((fact) => {
+			const normalized = normalizeInline(fact.fact);
+			if (!normalized || seen.has(normalized)) return false;
+			seen.add(normalized);
+			return true;
+		})
+		.toSorted((a, b) => {
+			const priorityA = FACT_CATEGORY_PRIORITY.get(a.category) ?? Number.MAX_SAFE_INTEGER;
+			const priorityB = FACT_CATEGORY_PRIORITY.get(b.category) ?? Number.MAX_SAFE_INTEGER;
+			if (priorityA !== priorityB) return priorityA - priorityB;
+			return b.createdAt.getTime() - a.createdAt.getTime();
+		})
+		.slice(0, limit);
+}
+
+function formatFact(fact: SemanticFact): string {
+	const label = FACT_CATEGORY_LABELS[fact.category];
+	const content = normalizeInline(fact.fact);
+	return label ? `${label}: ${content}` : content;
+}
+
+function formatDate(date: Date): string {
+	return new Intl.DateTimeFormat("ja-JP", {
+		timeZone: "Asia/Tokyo",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	})
+		.format(date)
+		.replaceAll("/", "-");
+}
+
+function trimParagraph(text: string, maxLength: number): string {
+	return trimLine(text.replace(/\s+/g, " "), maxLength);
+}
+
+function normalizeInline(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
+
+function trimLine(text: string, maxLength: number): string {
+	const normalized = normalizeInline(text);
+	if (normalized.length <= maxLength) return normalized;
+	return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function formatErrorMessage(error: unknown): string {
+	if (error instanceof Error && error.message) return error.message;
+	return String(error);
+}


### PR DESCRIPTION
## Issue #927 の対応

### 変更内容
- **context-builder.ts** — RESUME-CONTEXT.md を ContextBuilder のファイルリストに追加
- **resume-context-service.ts** — 新規ファイル。起動時に直近のエピソードを取得して要約を生成するサービス
- **package.json** — 新サービスのexportを追加
- **bootstrap.ts** — ResumeContextServiceの初期化と起動時更新を統合
- **shutdown.ts** — シャットダウン時のクリーンアップ追加

### 概要
起動時に各ギルドの記憶DBから直近エピソード＋意味記憶を取得し、簡潔な再開コンテキストをマークダウンで生成。ContextBuilder.build() 内で SESSION-SUMMARY の直後に RESUME-CONTEXT.md として注入。セッションローテーション時にも更新される。