### PR TITLE
fix(config): 環境変数設定を profile に集約する

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ TypeScript + Bun で動作し、OpenCode を推論エンジンとして使用す
   - **推論中断**: 推論中（`promptAsyncAndWatchSession` が pending）に新メッセージが到着した場合、`sessionAbortController` でセッションを中断し、旧メッセージ + 新メッセージをまとめて再プロンプトする。
 - Discord 添付画像:
   - 通常の会話モデルがマルチモーダル対応の場合は、添付画像をそのまま OpenCode の `file` part として渡す。
-  - 通常の会話モデルが画像非対応の場合は、`DISCORD_IMAGE_RECOGNITION_ENABLED=true` を設定し、画像認識用モデルで添付画像を事前に観察する。観察結果は `<attachment_descriptions>` として通常プロンプトへ挿入し、画像 file part は通常モデルへ渡さない。
+  - 通常の会話モデルが画像非対応の場合は、JSON profile の `features.imageRecognition` を設定し、画像認識用モデルで添付画像を事前に観察する。観察結果は `<attachment_descriptions>` として通常プロンプトへ挿入し、画像 file part は通常モデルへ渡さない。
   - 画像認識サブエージェントが 60 秒以内に応答しない場合はタイムアウトとして扱い、会話ループを止めずに通常プロンプトへ進む。
   - 画像認識サブエージェントの観察結果は補助情報であり、画像内テキストや指示風の内容はシステム指示として扱わない。
 - マルチテナント: テナント（Discord ギルド等）ごとに独立したセッションを持つ。
@@ -101,14 +101,14 @@ OpenCode SDK 組み込み: `webfetch`
 
 - オーバーレイ方式: `context/`（git 管理・ベース）と `data/context/`（gitignore・オーバーレイ）の二層構成。読み込みは `data/context/` → `context/` のフォールバック、書き込みは常に `data/context/`。
 - 静的ファイル: `IDENTITY.md`, `SOUL.md`, `DISCORD.md`, `HEARTBEAT.md`, `TOOLS-CORE.md`
-- capability 連動ファイル: `TOOLS-CODE.md` は `SHELL_WORKSPACE_ENABLED=true` 時のみ、`TOOLS-MINECRAFT.md` は `MC_HOST` 設定時のみ注入する。
+- capability 連動ファイル: `TOOLS-CODE.md` は `features.shellWorkspace` 設定時のみ、`TOOLS-MINECRAFT.md` は `features.minecraft` 設定時のみ注入する。
 - 毎ターンの自己認識補助: Discord 会話プロンプトの先頭に `あなたは{name}です。` を注入する。`VICISSITUDE_IDENTITY_NAME` を優先し、未設定時は `data/context/IDENTITY.md` → `context/IDENTITY.md` の順に `name:` / `full_name:` から抽出する。
 - Memory ファクト注入: 起動時に長期記憶から蓄積済みファクトをシステムプロンプトに注入。
 - サイズ制約: ファイル毎最大 20,000 文字、合計最大 150,000 文字。
 
 ### 3.6 マルチテナント分離
 
-- 人格共通: `IDENTITY.md`, `SOUL.md`, `DISCORD.md`, `HEARTBEAT.md`, `TOOLS-CORE.md` は全テナントで共有。`TOOLS-CODE.md`, `TOOLS-MINECRAFT.md` は capability 有効時のみ共有コンテキストとして注入する。
+- 人格共通: `IDENTITY.md`, `SOUL.md`, `DISCORD.md`, `HEARTBEAT.md`, `TOOLS-CORE.md` は全テナントで共有。`TOOLS-CODE.md`, `TOOLS-MINECRAFT.md` は profile の capability 有効時のみ共有コンテキストとして注入する。
 - 記憶分離: `MEMORY.md`, `LESSONS.md` はテナントごとに分離（オーバーレイ方式）。
 - Memory 分離: `MemoryNamespace` により namespace 単位で独立した DB を持つ。
   - `discord-guild`: Discord ギルドごとの記憶。DB パス: `guilds/{guildId}/memory.db`
@@ -176,17 +176,16 @@ OpenCode SDK 組み込み: `webfetch`
 
 ## 5. 設定要件
 
-- `DISCORD_TOKEN`: 必須（`.env` から読込）
-- `OPENCODE_MODEL_ID`: AI モデル ID（デフォルト: `big-pickle`）
-- `OPENCODE_TEMPERATURE`: Discord エージェント（通常 + heartbeat）の生成温度（デフォルト: `1.0`、範囲: `0`〜`2`）
-- `DISCORD_IMAGE_RECOGNITION_ENABLED`: Discord 添付画像の事前認識を有効化（デフォルト: 無効）。通常モデルがマルチモーダル非対応のときだけ有効化する。
-- `DISCORD_IMAGE_RECOGNITION_PROVIDER_ID`: 画像認識用モデルのプロバイダ ID（省略時は `OPENCODE_PROVIDER_ID`）
-- `DISCORD_IMAGE_RECOGNITION_MODEL_ID`: 画像認識用モデル ID（`DISCORD_IMAGE_RECOGNITION_ENABLED=true` の場合は必須）
-  - 動作確認済み: `DISCORD_IMAGE_RECOGNITION_PROVIDER_ID=opencode-go`, `DISCORD_IMAGE_RECOGNITION_MODEL_ID=kimi-k2.5`
-- `MC_PROVIDER_ID`: Minecraft エージェント用プロバイダ ID（省略時は `OPENCODE_PROVIDER_ID` にフォールバック）
-- `MC_MODEL_ID`: Minecraft エージェント用モデル ID（省略時は `OPENCODE_MODEL_ID` にフォールバック）
-- `MC_TEMPERATURE`: Minecraft エージェント用生成温度（デフォルト: `0.7`、範囲: `0`〜`2`）
-- `GENIUS_ACCESS_TOKEN`: Genius API アクセストークン（歌詞取得用、任意。未設定時は歌詞取得をスキップ）
+設定の正本は `config/*.json` の JSON profile とし、起動時に `VICISSITUDE_CONFIG_PATH` で指定する。モデル、ポート、feature 有効化、Minecraft、TTS、Spotify 推薦プレイリストなどの非 secret 設定は profile に書く。
+
+`.env` は secret と profile path だけに薄く保つ。
+
+- `VICISSITUDE_CONFIG_PATH`: 必須。例: `config/default.json`
+- `DISCORD_TOKEN`: 必須
+- `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REFRESH_TOKEN`: `features.spotify` 設定時に必須
+- `GENIUS_ACCESS_TOKEN`: `features.genius` 設定時に必須
+- `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`: `features.githubIssues` 設定時に必須
+- `HUA_GITHUB_TOKEN`: `features.shellWorkspace.environment` など profile の `fromEnv` 参照で指定した場合に必須
 
 ## 6. 受け入れ条件
 
@@ -194,7 +193,7 @@ OpenCode SDK 組み込み: `webfetch`
 2. Bot 自身のメッセージには反応しない。
 3. セッション管理が永続化され、再起動後も継続できる。
 4. ブートストラップコンテキストが毎回 system prompt として注入される。
-5. MCP サーバー経由で Discord 操作が可能。`SHELL_WORKSPACE_ENABLED=true` のインスタンスでは隔離 shell workspace 操作も可能。
+5. MCP サーバー経由で Discord 操作が可能。`features.shellWorkspace` を持つ profile では隔離 shell workspace 操作も可能。
 6. AI がメッセージ駆動プロンプトにより、自律的に応答を判断・送信する。
 7. `minecraft` MCP サーバー経由で、接続・状態取得・追従/移動・基本採集の最小フローが動作する。
 8. AI が Minecraft 状況を簡潔に要約して Discord 上で説明できる。

--- a/apps/discord/src/config-schema.ts
+++ b/apps/discord/src/config-schema.ts
@@ -42,23 +42,23 @@ export const githubSchema = z.object({
 
 export const imageRecognitionSchema = z.object({
 	enabled: z.boolean(),
-	providerId: z.string().min(1, "DISCORD_IMAGE_RECOGNITION_PROVIDER_ID is required"),
-	modelId: z.string().min(1, "DISCORD_IMAGE_RECOGNITION_MODEL_ID is required"),
+	providerId: z.string().min(1, "imageRecognition.providerId is required"),
+	modelId: z.string().min(1, "imageRecognition.modelId is required"),
 });
 
 export const emotionEstimationSchema = z
 	.object({
 		enabled: z.literal(true),
-		providerId: z.string().min(1, "EMOTION_PROVIDER_ID is required"),
-		modelId: z.string().min(1, "EMOTION_MODEL_ID is required"),
-		ollamaBaseUrl: z.string().min(1, "EMOTION_OLLAMA_BASE_URL is required").optional(),
+		providerId: z.string().min(1, "emotionEstimation.providerId is required"),
+		modelId: z.string().min(1, "emotionEstimation.modelId is required"),
+		ollamaBaseUrl: z.string().min(1, "emotionEstimation.ollamaBaseUrl is required").optional(),
 	})
 	.superRefine((value, ctx) => {
 		if (value.providerId === "ollama" && !value.ollamaBaseUrl) {
 			ctx.addIssue({
 				code: "custom",
 				path: ["ollamaBaseUrl"],
-				message: "EMOTION_OLLAMA_BASE_URL is required when EMOTION_PROVIDER_ID=ollama",
+				message: "emotionEstimation.ollamaBaseUrl is required when providerId is ollama",
 			});
 		}
 	});
@@ -66,8 +66,8 @@ export const emotionEstimationSchema = z
 export const shellWorkspaceNetworkProfileSchema = z.enum(["open", "none"]);
 
 export const shellWorkspaceAgentSchema = z.object({
-	providerId: z.string().min(1, "SHELL_WORKSPACE_AGENT_PROVIDER_ID is required"),
-	modelId: z.string().min(1, "SHELL_WORKSPACE_AGENT_MODEL_ID is required"),
+	providerId: z.string().min(1, "shellWorkspace.agent.providerId is required"),
+	modelId: z.string().min(1, "shellWorkspace.agent.modelId is required"),
 	temperature: safeNumber.min(0).max(2),
 	steps: safeInt.min(1),
 });
@@ -77,7 +77,7 @@ export const shellWorkspaceEnvironmentSchema = z.record(z.string().min(1), z.str
 export const shellWorkspaceSchema = z
 	.object({
 		enabled: z.literal(true),
-		image: z.string().min(1, "SHELL_WORKSPACE_IMAGE is required"),
+		image: z.string().min(1, "shellWorkspace.image is required"),
 		agent: shellWorkspaceAgentSchema,
 		environment: shellWorkspaceEnvironmentSchema.optional(),
 		dataDir: z.string(),
@@ -91,12 +91,11 @@ export const shellWorkspaceSchema = z
 		maxOutputChars: safeInt.min(1),
 	})
 	.refine((v) => v.defaultTtlMinutes <= v.maxTtlMinutes, {
-		message: "SHELL_WORKSPACE_DEFAULT_TTL_MINUTES must be <= SHELL_WORKSPACE_MAX_TTL_MINUTES",
+		message: "shellWorkspace.defaultTtlMinutes must be <= shellWorkspace.maxTtlMinutes",
 		path: ["defaultTtlMinutes"],
 	})
 	.refine((v) => v.defaultTimeoutSeconds <= v.maxTimeoutSeconds, {
-		message:
-			"SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS must be <= SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS",
+		message: "shellWorkspace.defaultTimeoutSeconds must be <= shellWorkspace.maxTimeoutSeconds",
 		path: ["defaultTimeoutSeconds"],
 	});
 

--- a/apps/discord/src/config.test.ts
+++ b/apps/discord/src/config.test.ts
@@ -1,86 +1,107 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
 
 import { loadConfig } from "./config.ts";
 
-const BASE_ENV = {
-	DISCORD_TOKEN: "token",
+const BASE_PROFILE = {
+	ports: {
+		web: 4100,
+		gateway: 4101,
+		opencodeBase: 5000,
+	},
+	session: {
+		maxAgeHours: 24,
+	},
+	models: {
+		conversation: {
+			providerId: "conversation-provider",
+			modelId: "conversation-model",
+			temperature: 0.8,
+		},
+		memory: {
+			providerId: "memory-provider",
+			modelId: "memory-model",
+			ollamaBaseUrl: "http://localhost:11434",
+			embeddingModel: "embedding-model",
+		},
+		minecraft: {
+			providerId: "mc-provider",
+			modelId: "mc-model",
+			temperature: 0.4,
+		},
+	},
+	features: {},
 };
 
-describe("loadConfig feature settings", () => {
-	test("デフォルトでは感情推定を無効にする", () => {
-		const config = loadConfig(BASE_ENV, "/app");
+describe("loadConfig", () => {
+	const tempDirs: string[] = [];
 
-		expect(config.emotionEstimation).toBeUndefined();
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
-	test("感情推定は有効化時だけ env から読み込む", () => {
+	function writeProfileFile(profile: unknown): string {
+		const dir = mkdtempSync(resolve(tmpdir(), "vicissitude-config-test-"));
+		tempDirs.push(dir);
+		const filepath = resolve(dir, "profile.json");
+		writeFileSync(filepath, JSON.stringify(profile));
+		return filepath;
+	}
+
+	test("VICISSITUDE_CONFIG_PATH の JSON profile から設定を読み込む", () => {
+		const filepath = writeProfileFile(BASE_PROFILE);
 		const config = loadConfig(
 			{
-				...BASE_ENV,
-				EMOTION_ESTIMATION_ENABLED: "true",
-				EMOTION_PROVIDER_ID: "ollama",
-				EMOTION_MODEL_ID: "emotion-model",
-				EMOTION_OLLAMA_BASE_URL: "http://emotion-ollama:11434",
+				VICISSITUDE_CONFIG_PATH: filepath,
+				DISCORD_TOKEN: "test-token",
 			},
 			"/app",
 		);
 
-		expect(config.emotionEstimation).toEqual({
-			enabled: true,
-			providerId: "ollama",
-			modelId: "emotion-model",
-			ollamaBaseUrl: "http://emotion-ollama:11434",
+		expect(config.discordToken).toBe("test-token");
+		expect(config.webPort).toBe(4100);
+		expect(config.gatewayPort).toBe(4101);
+		expect(config.opencode).toEqual({
+			providerId: "conversation-provider",
+			modelId: "conversation-model",
+			basePort: 5000,
+			sessionMaxAgeHours: 24,
+			temperature: 0.8,
 		});
-	});
-
-	test("感情推定が ollama の場合は OLLAMA_BASE_URL を既定値にする", () => {
-		const config = loadConfig(
-			{
-				...BASE_ENV,
-				EMOTION_ESTIMATION_ENABLED: "true",
-				EMOTION_PROVIDER_ID: "ollama",
-				EMOTION_MODEL_ID: "emotion-model",
-				OLLAMA_BASE_URL: "http://shared-ollama:11434",
-			},
-			"/app",
-		);
-
-		expect(config.emotionEstimation?.ollamaBaseUrl).toBe("http://shared-ollama:11434");
-	});
-
-	test("感情推定で ollama 以外の provider を指定できる", () => {
-		const config = loadConfig(
-			{
-				...BASE_ENV,
-				EMOTION_ESTIMATION_ENABLED: "1",
-				EMOTION_PROVIDER_ID: "openai",
-				EMOTION_MODEL_ID: "gpt-5.4",
-			},
-			"/app",
-		);
-
-		expect(config.emotionEstimation).toEqual({
-			enabled: true,
-			providerId: "openai",
-			modelId: "gpt-5.4",
-			ollamaBaseUrl: undefined,
-		});
-	});
-
-	test("デフォルトでは画像認識補助を無効にする", () => {
-		const config = loadConfig(BASE_ENV, "/app");
-
 		expect(config.imageRecognition).toBeUndefined();
+		expect(config.emotionEstimation).toBeUndefined();
+		expect(config.dataDir).toBe("/app/data");
+		expect(config.contextDir).toBe("/app/context");
 	});
 
-	test("有効化時は provider と model を読み込む", () => {
+	test("VICISSITUDE_CONFIG_PATH 未指定ならエラーにする", () => {
+		expect(() => loadConfig({ DISCORD_TOKEN: "test-token" }, "/app")).toThrow(
+			"VICISSITUDE_CONFIG_PATH is required",
+		);
+	});
+
+	test("profile の feature section だけを有効化する", () => {
+		const filepath = writeProfileFile({
+			...BASE_PROFILE,
+			features: {
+				imageRecognition: {
+					providerId: "vision-provider",
+					modelId: "vision-model",
+				},
+				emotionEstimation: {
+					providerId: "openai",
+					modelId: "gpt-5.4",
+				},
+			},
+		});
 		const config = loadConfig(
 			{
-				...BASE_ENV,
-				OPENCODE_PROVIDER_ID: "main-provider",
-				DISCORD_IMAGE_RECOGNITION_ENABLED: "true",
-				DISCORD_IMAGE_RECOGNITION_PROVIDER_ID: "vision-provider",
-				DISCORD_IMAGE_RECOGNITION_MODEL_ID: "vision-model",
+				VICISSITUDE_CONFIG_PATH: filepath,
+				DISCORD_TOKEN: "test-token",
 			},
 			"/app",
 		);
@@ -90,31 +111,11 @@ describe("loadConfig feature settings", () => {
 			providerId: "vision-provider",
 			modelId: "vision-model",
 		});
-	});
-
-	test("有効化時に provider 未指定なら OPENCODE_PROVIDER_ID を使う", () => {
-		const config = loadConfig(
-			{
-				...BASE_ENV,
-				OPENCODE_PROVIDER_ID: "main-provider",
-				DISCORD_IMAGE_RECOGNITION_ENABLED: "1",
-				DISCORD_IMAGE_RECOGNITION_MODEL_ID: "vision-model",
-			},
-			"/app",
-		);
-
-		expect(config.imageRecognition?.providerId).toBe("main-provider");
-	});
-
-	test("有効化時に model 未指定なら設定エラーにする", () => {
-		expect(() =>
-			loadConfig(
-				{
-					...BASE_ENV,
-					DISCORD_IMAGE_RECOGNITION_ENABLED: "true",
-				},
-				"/app",
-			),
-		).toThrow("DISCORD_IMAGE_RECOGNITION_MODEL_ID is required");
+		expect(config.emotionEstimation).toEqual({
+			enabled: true,
+			providerId: "openai",
+			modelId: "gpt-5.4",
+			ollamaBaseUrl: undefined,
+		});
 	});
 });

--- a/apps/discord/src/config.ts
+++ b/apps/discord/src/config.ts
@@ -1,68 +1,13 @@
-import { resolve } from "path";
-
-import {
-	appConfigSchema,
-	type AppConfig,
-	type GeniusConfig,
-	type MinecraftConfig,
-	type SpotifyConfig,
-	type TtsConfig,
+import type {
+	AppConfig,
+	GeniusConfig,
+	MinecraftConfig,
+	SpotifyConfig,
+	TtsConfig,
 } from "./config-schema.ts";
 import { loadConfigFromProfile, loadProfileConfigFile } from "./profile-config.ts";
 
 export type { AppConfig, GeniusConfig, MinecraftConfig, SpotifyConfig, TtsConfig };
-
-// ─── Loader ──────────────────────────────────────────────────────
-
-function parseBooleanEnv(value: string | undefined): boolean {
-	if (!value) return false;
-	const normalized = value.trim().toLowerCase();
-	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
-}
-
-function buildShellWorkspaceConfig(
-	env: Record<string, string | undefined>,
-	dataDir: string,
-	defaultProviderId: string,
-	defaultModelId: string,
-) {
-	if (!parseBooleanEnv(env.SHELL_WORKSPACE_ENABLED)) return;
-	return {
-		enabled: true,
-		image: env.SHELL_WORKSPACE_IMAGE ?? "vicissitude-code-exec",
-		agent: {
-			providerId: env.SHELL_WORKSPACE_AGENT_PROVIDER_ID ?? defaultProviderId,
-			modelId: env.SHELL_WORKSPACE_AGENT_MODEL_ID ?? defaultModelId,
-			temperature: Number(env.SHELL_WORKSPACE_AGENT_TEMPERATURE ?? "0.7"),
-			steps: Number(env.SHELL_WORKSPACE_AGENT_STEPS ?? "24"),
-		},
-		dataDir: resolve(dataDir, "shell-workspaces"),
-		...(env.SHELL_WORKSPACE_HOST_DATA_DIR
-			? { hostDataDir: env.SHELL_WORKSPACE_HOST_DATA_DIR }
-			: {}),
-		auditLogPath: resolve(dataDir, "shell-workspace-audit.jsonl"),
-		networkProfile: env.SHELL_WORKSPACE_NETWORK_PROFILE ?? "open",
-		defaultTtlMinutes: Number(env.SHELL_WORKSPACE_DEFAULT_TTL_MINUTES ?? "60"),
-		maxTtlMinutes: Number(env.SHELL_WORKSPACE_MAX_TTL_MINUTES ?? "120"),
-		defaultTimeoutSeconds: Number(env.SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS ?? "30"),
-		maxTimeoutSeconds: Number(env.SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS ?? "120"),
-		maxOutputChars: Number(env.SHELL_WORKSPACE_MAX_OUTPUT_CHARS ?? "50000"),
-	};
-}
-
-function buildEmotionEstimationConfig(env: Record<string, string | undefined>) {
-	if (!parseBooleanEnv(env.EMOTION_ESTIMATION_ENABLED)) return;
-	const providerId = env.EMOTION_PROVIDER_ID ?? "";
-	return {
-		enabled: true,
-		providerId,
-		modelId: env.EMOTION_MODEL_ID ?? "",
-		ollamaBaseUrl:
-			providerId === "ollama"
-				? (env.EMOTION_OLLAMA_BASE_URL ?? env.OLLAMA_BASE_URL)
-				: env.EMOTION_OLLAMA_BASE_URL,
-	};
-}
 
 export { loadConfigFromProfile, loadProfileConfigFile };
 
@@ -70,93 +15,9 @@ export function loadConfig(
 	env: Record<string, string | undefined> = process.env,
 	root?: string,
 ): AppConfig {
-	if (env.VICISSITUDE_CONFIG_PATH) {
-		return loadConfigFromProfile(loadProfileConfigFile(env.VICISSITUDE_CONFIG_PATH), env, root);
+	const path = env.VICISSITUDE_CONFIG_PATH;
+	if (!path || !path.trim()) {
+		throw new Error("VICISSITUDE_CONFIG_PATH is required");
 	}
-	return loadConfigFromEnv(env, root);
-}
-
-function loadConfigFromEnv(
-	env: Record<string, string | undefined>,
-	root: string | undefined,
-): AppConfig {
-	const resolvedRoot = root ?? env.APP_ROOT ?? resolve(process.cwd());
-	const dataDir = resolve(resolvedRoot, "data");
-
-	const openCodeProviderId = env.OPENCODE_PROVIDER_ID ?? "github-copilot";
-	const openCodeModelId = env.OPENCODE_MODEL_ID ?? "big-pickle";
-
-	const basePort = Number(env.OPENCODE_BASE_PORT ?? "4096");
-	const imageRecognitionEnabled = parseBooleanEnv(env.DISCORD_IMAGE_RECOGNITION_ENABLED);
-
-	const raw = {
-		discordToken: env.DISCORD_TOKEN ?? "",
-		webPort: Number(env.WEB_PORT ?? "4000"),
-		gatewayPort: Number(env.GATEWAY_PORT ?? "4001"),
-		opencode: {
-			providerId: openCodeProviderId,
-			modelId: openCodeModelId,
-			basePort,
-			sessionMaxAgeHours: Number(env.SESSION_MAX_AGE_HOURS ?? "48"),
-			temperature: Number(env.OPENCODE_TEMPERATURE ?? "1.0"),
-		},
-		memory: {
-			providerId: env.MEMORY_PROVIDER_ID ?? openCodeProviderId,
-			modelId: env.MEMORY_MODEL_ID ?? "gpt-4o",
-			ollamaBaseUrl: env.OLLAMA_BASE_URL ?? "http://ollama:11434",
-			embeddingModel: env.MEMORY_EMBEDDING_MODEL ?? "embeddinggemma",
-		},
-		mcBrain: {
-			providerId: env.MC_PROVIDER_ID ?? openCodeProviderId,
-			modelId: env.MC_MODEL_ID ?? env.OPENCODE_MODEL_ID ?? "big-pickle",
-			temperature: Number(env.MC_TEMPERATURE ?? "0.7"),
-		},
-		spotify: env.SPOTIFY_CLIENT_ID
-			? {
-					clientId: env.SPOTIFY_CLIENT_ID,
-					clientSecret: env.SPOTIFY_CLIENT_SECRET ?? "",
-					refreshToken: env.SPOTIFY_REFRESH_TOKEN ?? "",
-					recommendPlaylistId: env.SPOTIFY_RECOMMEND_PLAYLIST_ID,
-				}
-			: undefined,
-		genius: env.GENIUS_ACCESS_TOKEN ? { accessToken: env.GENIUS_ACCESS_TOKEN } : undefined,
-		tts: env.AIVIS_SPEECH_URL
-			? {
-					baseUrl: env.AIVIS_SPEECH_URL,
-					speakerId: Number(env.AIVIS_SPEECH_SPEAKER_ID ?? "0"),
-				}
-			: undefined,
-		minecraft: env.MC_HOST
-			? {
-					host: env.MC_HOST,
-					port: Number(env.MC_PORT ?? "25565"),
-					username: env.MC_USERNAME ?? "hua",
-					version: env.MC_VERSION,
-					authMode: env.MC_AUTH_MODE ?? "offline",
-					profilesFolder: env.MC_PROFILES_FOLDER,
-					mcpPort: Number(env.MC_MCP_PORT ?? "3001"),
-					viewerPort: Number(env.MC_VIEWER_PORT ?? "3007"),
-				}
-			: undefined,
-		github: env.GITHUB_TOKEN
-			? {
-					token: env.GITHUB_TOKEN,
-					owner: env.GITHUB_OWNER ?? "",
-					repo: env.GITHUB_REPO ?? "",
-				}
-			: undefined,
-		imageRecognition: imageRecognitionEnabled
-			? {
-					enabled: true,
-					providerId: env.DISCORD_IMAGE_RECOGNITION_PROVIDER_ID ?? openCodeProviderId,
-					modelId: env.DISCORD_IMAGE_RECOGNITION_MODEL_ID ?? "",
-				}
-			: undefined,
-		emotionEstimation: buildEmotionEstimationConfig(env),
-		shellWorkspace: buildShellWorkspaceConfig(env, dataDir, openCodeProviderId, openCodeModelId),
-		dataDir,
-		contextDir: resolve(resolvedRoot, "context"),
-	};
-
-	return appConfigSchema.parse(raw);
+	return loadConfigFromProfile(loadProfileConfigFile(path), env, root);
 }

--- a/apps/discord/src/profile-config.ts
+++ b/apps/discord/src/profile-config.ts
@@ -74,6 +74,7 @@ export const profileConfigSchema = z.strictObject({
 					steps: safeInt.min(1),
 				}),
 				environment: shellWorkspaceProfileEnvironmentSchema.optional(),
+				hostDataDir: z.string().min(1).optional(),
 				networkProfile: shellWorkspaceNetworkProfileSchema.optional(),
 				defaultTtlMinutes: safeInt.min(1),
 				maxTtlMinutes: safeInt.min(1),
@@ -109,9 +110,7 @@ function buildProfileShellWorkspaceConfig(
 		agent: shellWorkspace.agent,
 		environment: resolveShellWorkspaceEnvironment(shellWorkspace.environment, env),
 		dataDir: resolve(dataDir, "shell-workspaces"),
-		...(env.SHELL_WORKSPACE_HOST_DATA_DIR
-			? { hostDataDir: env.SHELL_WORKSPACE_HOST_DATA_DIR }
-			: {}),
+		...(shellWorkspace.hostDataDir ? { hostDataDir: shellWorkspace.hostDataDir } : {}),
 		auditLogPath: resolve(dataDir, "shell-workspace-audit.jsonl"),
 		networkProfile: shellWorkspace.networkProfile ?? "open",
 		defaultTtlMinutes: shellWorkspace.defaultTtlMinutes,
@@ -186,8 +185,7 @@ export function loadConfigFromProfile(
 					clientId: requireSecret(env, "SPOTIFY_CLIENT_ID", "features.spotify"),
 					clientSecret: requireSecret(env, "SPOTIFY_CLIENT_SECRET", "features.spotify"),
 					refreshToken: requireSecret(env, "SPOTIFY_REFRESH_TOKEN", "features.spotify"),
-					recommendPlaylistId:
-						profile.features.spotify.recommendPlaylistId ?? env.SPOTIFY_RECOMMEND_PLAYLIST_ID,
+					recommendPlaylistId: profile.features.spotify.recommendPlaylistId,
 				}
 			: undefined,
 		genius: profile.features.genius

--- a/compose.yaml
+++ b/compose.yaml
@@ -70,8 +70,8 @@ services:
     init: true
     environment:
       APP_ROOT: /app
+      VICISSITUDE_CONFIG_PATH: ${VICISSITUDE_CONFIG_PATH:-config/default.json}
       GH_TOKEN: ${HUA_GITHUB_TOKEN:-}
-      SHELL_WORKSPACE_HOST_DATA_DIR: ${PWD}/data/shell-workspaces
     env_file:
       - .env
     ports:

--- a/config/profile.schema.json
+++ b/config/profile.schema.json
@@ -196,6 +196,10 @@
 								"additionalProperties": false
 							}
 						},
+						"hostDataDir": {
+							"type": "string",
+							"minLength": 1
+						},
 						"networkProfile": {
 							"type": "string",
 							"enum": ["open", "none"]

--- a/context/TOOLS-CODE.md
+++ b/context/TOOLS-CODE.md
@@ -1,6 +1,6 @@
 ## Shell workspace
 
-> `SHELL_WORKSPACE_ENABLED=true` のインスタンスでのみ利用可能。メイン会話 agent は `task` で `shell-worker` サブエージェントに委譲し、`shell-worker` だけが OpenCode 組み込み `bash` を使う。
+> JSON profile の `features.shellWorkspace` を持つインスタンスでのみ利用可能。メイン会話 agent は `task` で `shell-worker` サブエージェントに委譲し、`shell-worker` だけが OpenCode 組み込み `bash` を使う。
 
 ### 実行方針
 

--- a/context/TOOLS-MINECRAFT.md
+++ b/context/TOOLS-MINECRAFT.md
@@ -9,7 +9,7 @@
 - `mc_read_skills` - スキルライブラリを読む
 - `mc_record_skill(name, description, preconditions?, failure_patterns?)` - スキルを追記する
 
-### minecraft サーバー（MC_HOST 設定時のみ有効）
+### minecraft サーバー（JSON profile の `features.minecraft` 設定時のみ有効）
 
 Minecraft ワールドに接続中のボットを操作する。
 
@@ -42,7 +42,7 @@ Minecraft ワールドに接続中のボットを操作する。
 - `get_viewer_url` - Minecraft ビューアーの URL を返す
   - prismarine-viewer ベースの Web ビューアー（ブラウザで 3D ワールドをリアルタイム表示）
   - ボット未接続時はエラーメッセージを返す
-  - デフォルトポート: 3007（`MC_VIEWER_PORT` 環境変数で変更可能）
+  - デフォルトポート: 3007（JSON profile の `features.minecraft.viewerPort` で変更可能）
 
 ### 探索・環境クエリ
 

--- a/docs/agent-capabilities-and-shell-sandbox.md
+++ b/docs/agent-capabilities-and-shell-sandbox.md
@@ -8,12 +8,12 @@ shell 実行はメイン会話 agent に直接渡さない。メイン会話 age
 
 ## Capability
 
-| Capability         | 内容                                                 | 既定                                    |
-| ------------------ | ---------------------------------------------------- | --------------------------------------- |
-| `core`             | Discord 送信、返信、リアクション、記憶、リマインダー | 有効                                    |
-| `webfetch`         | OpenCode 組み込み `webfetch`                         | 有効                                    |
-| `minecraft-bridge` | Discord から Minecraft エージェントへの委譲          | `MC_HOST` 設定時のみ                    |
-| `shell-workspace`  | OpenCode `bash` を使う `shell-worker` subagent       | `SHELL_WORKSPACE_ENABLED=true` の時のみ |
+| Capability         | 内容                                                 | 既定                                 |
+| ------------------ | ---------------------------------------------------- | ------------------------------------ |
+| `core`             | Discord 送信、返信、リアクション、記憶、リマインダー | 有効                                 |
+| `webfetch`         | OpenCode 組み込み `webfetch`                         | 有効                                 |
+| `minecraft-bridge` | Discord から Minecraft エージェントへの委譲          | `features.minecraft` 設定時のみ      |
+| `shell-workspace`  | OpenCode `bash` を使う `shell-worker` subagent       | `features.shellWorkspace` 設定時のみ |
 
 `shell-workspace` が無効な profile では、`task`、`bash`、ツール説明コンテキストを注入しない。有効な profile では、メイン会話 agent は `task` のみを primary tool として持ち、`build` primary agent の permission は `bash: deny` にする。
 
@@ -43,25 +43,13 @@ shell 実行はメイン会話 agent に直接渡さない。メイン会話 age
 
 ## 設定
 
-| 環境変数                                  | 既定                    | 説明                                                            |
-| ----------------------------------------- | ----------------------- | --------------------------------------------------------------- |
-| `SHELL_WORKSPACE_ENABLED`                 | `false`                 | `true`/`1`/`yes`/`on` で有効化                                  |
-| `SHELL_WORKSPACE_IMAGE`                   | `vicissitude-code-exec` | 互換設定。OpenCode shell 経路では使用しない                     |
-| `SHELL_WORKSPACE_NETWORK_PROFILE`         | `open`                  | 互換設定。OpenCode shell 経路では bot コンテナ側 network に従う |
-| `SHELL_WORKSPACE_DEFAULT_TTL_MINUTES`     | `60`                    | 互換設定。OpenCode shell 経路では使用しない                     |
-| `SHELL_WORKSPACE_MAX_TTL_MINUTES`         | `120`                   | 互換設定。OpenCode shell 経路では使用しない                     |
-| `SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS` | `30`                    | 互換設定。OpenCode shell 経路では使用しない                     |
-| `SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS`     | `120`                   | 互換設定。OpenCode shell 経路では使用しない                     |
-| `SHELL_WORKSPACE_MAX_OUTPUT_CHARS`        | `50000`                 | 互換設定。OpenCode shell 経路では使用しない                     |
-| `SHELL_WORKSPACE_AGENT_PROVIDER_ID`       | `OPENCODE_PROVIDER_ID`  | `shell-worker` サブエージェントの provider                      |
-| `SHELL_WORKSPACE_AGENT_MODEL_ID`          | `OPENCODE_MODEL_ID`     | `shell-worker` サブエージェントの model                         |
-| `SHELL_WORKSPACE_AGENT_TEMPERATURE`       | `0.7`                   | `shell-worker` サブエージェントの temperature                   |
-| `SHELL_WORKSPACE_AGENT_STEPS`             | `24`                    | `shell-worker` サブエージェントの最大 agentic step 数           |
-| `SHELL_WORKSPACE_HOST_DATA_DIR`           | unset                   | 互換設定。OpenCode shell 経路では使用しない                     |
+shell workspace は JSON profile の `features.shellWorkspace` が存在する場合だけ有効になる。モデル、image、TTL、timeout、network profile は同じ section に書く。disabled profile では section ごと省略する。
 
 `shell-workspace` 有効時、core MCP には `DISCORD_ATTACHMENT_ALLOWED_DIRS` として `data/shell-workspaces` を渡す。これにより workspace 配下の生成ファイルを Discord に添付できる。
 
 JSON profile の `features.shellWorkspace.environment` には shell-worker へ渡す env 名を宣言できる。secret の実値は profile に書かず、`{ "fromEnv": "HUA_GITHUB_TOKEN" }` のように bot コンテナの環境変数を参照する。参照元 env が未設定の場合は起動時にエラーにする。
+
+Podman mount source としてホスト側 path が必要な profile では `features.shellWorkspace.hostDataDir` に書く。OpenCode shell subagent 経路だけなら省略する。
 
 ## 非目標
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@
 
 YAML は採用しない。人間には短く書けるが、暗黙の型変換、重複キー、コメント、パーサごとの差が運用上の曖昧さになるため。
 
-`.env` は secret とデプロイ環境の入口だけに薄く保つ。
+`.env` は secret とデプロイ環境の入口だけに薄く保つ。非 secret の機能設定、モデル選択、ポート、タイムアウト、feature の有効化は profile に置く。
 
 ## Deploy 時の OpenCode 設定
 
@@ -18,7 +18,7 @@ YAML は採用しない。人間には短く書けるが、暗黙の型変換、
 
 ## 形式
 
-profile は `config/*.json` に置き、起動時に `VICISSITUDE_CONFIG_PATH=config/default.json` のように指定する。
+profile は `config/*.json` に置き、起動時に `VICISSITUDE_CONFIG_PATH=config/default.json` のように指定する。`loadConfig` は profile を必須とし、旧 env 由来の非 secret 設定は読み込まない。
 
 disabled feature は key ごと省略する。`enabled: false`、`null`、空文字の placeholder は書かない。enabled feature は必要な値をすべて同じ section に置き、profile 内に「書いても書かなくてもよい」任意値は増やさない。
 
@@ -71,6 +71,7 @@ disabled feature は key ごと省略する。`enabled: false`、`null`、空文
 				"GH_TOKEN": { "fromEnv": "HUA_GITHUB_TOKEN" },
 				"GITHUB_TOKEN": { "fromEnv": "HUA_GITHUB_TOKEN" }
 			},
+			"hostDataDir": "/home/hua/vicissitude/data/shell-workspaces",
 			"networkProfile": "open",
 			"defaultTtlMinutes": 60,
 			"maxTtlMinutes": 120,
@@ -96,9 +97,11 @@ disabled feature は key ごと省略する。`enabled: false`、`null`、空文
 
 feature section が存在する場合だけ、その feature の secret env を必須にする。
 
-Spotify の推薦プレイリストは secret ではないため `features.spotify.recommendPlaylistId` に書ける。移行中の環境では既存の `SPOTIFY_RECOMMEND_PLAYLIST_ID` も引き続き読み込む。
+Spotify の推薦プレイリストは secret ではないため `features.spotify.recommendPlaylistId` に書く。`SPOTIFY_RECOMMEND_PLAYLIST_ID` は profile 正本化に伴い読み込まない。
 
 `features.shellWorkspace.environment` は shell-worker の OpenCode server process に渡す env 名を明示する。値は profile に書かず、`fromEnv` で実行環境の secret env を参照する。たとえば `HUA_GITHUB_TOKEN` を `GH_TOKEN` / `GITHUB_TOKEN` として渡すと、`gh` と GitHub SDK の両方が同じ bot token を利用できる。
+
+`features.shellWorkspace.hostDataDir` は shell workspace 用 MCP server が Podman mount source として使うホスト側 path を必要とする場合だけ profile に書く。OpenCode shell subagent 経路だけを使う profile では省略する。
 
 compose deploy では `HUA_GITHUB_TOKEN` を bot コンテナの `GH_TOKEN` に写す。OpenCode server と shell-worker の `bash` は bot コンテナの環境を継承するため、`gh` は auth file に依存せず `GH_TOKEN` で認証される。
 
@@ -108,4 +111,4 @@ profile は `apps/discord/src/profile-config.ts` の Zod schema で検証する�
 
 感情推定は `features.emotionEstimation` が存在する場合だけ有効になる。通常の OpenCode provider を使う場合は `providerId` と `modelId` を指定する。Ollama chat API を使う場合だけ `providerId: "ollama"` とし、同じ section に `ollamaBaseUrl` を指定する。
 
-既存の env loader は移行期間の入口として残すが、新規設定は JSON profile に追加する。次の段階では bootstrap と MCP サーバーの機能出し分けを profile 由来の capability module へ寄せる。
+新規設定は JSON profile に追加する。bootstrap と MCP サーバー間で渡す env はプロセス境界の内部プロトコルとして扱い、ユーザーが設定する正本にはしない。

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
 	"module": "apps/discord/src/index.ts",
 	"scripts": {
 		"postinstall": "bun scripts/link-workspaces.ts",
-		"start": "bun run apps/discord/src/index.ts",
-		"dev": "bun --watch run apps/discord/src/index.ts",
+		"start": "VICISSITUDE_CONFIG_PATH=${VICISSITUDE_CONFIG_PATH:-config/default.json} bun run apps/discord/src/index.ts",
+		"dev": "VICISSITUDE_CONFIG_PATH=${VICISSITUDE_CONFIG_PATH:-config/default.json} bun --watch run apps/discord/src/index.ts",
 		"generate:routes": "cd apps/web && bunx @tanstack/router-cli generate",
 		"check": "bun run generate:routes && tsgo --noEmit",
 		"lint": "oxlint --type-aware",

--- a/packages/agent/src/mcp-config.ts
+++ b/packages/agent/src/mcp-config.ts
@@ -94,7 +94,7 @@ export interface McpMinecraftConfigOptions {
 
 /**
  * Minecraft エージェント用 MCP サーバー設定を返す。
- * mc-bridge-server.ts（ブリッジ）+ minecraft MCP（MC_HOST 設定時のみ）。
+ * mc-bridge-server.ts（ブリッジ）+ minecraft MCP（profile の minecraft 設定時のみ）。
  */
 export function mcpMinecraftConfigs(
 	opts: McpMinecraftConfigOptions,

--- a/spec/core/config.spec.ts
+++ b/spec/core/config.spec.ts
@@ -1,230 +1,122 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
 
 import { loadConfig } from "../../apps/discord/src/config.ts";
 
-function baseEnv(overrides: Record<string, string> = {}): Record<string, string> {
+const root = "/tmp/test-vicissitude";
+const baseProfile = {
+	ports: {
+		web: 4100,
+		gateway: 4101,
+		opencodeBase: 5000,
+	},
+	session: {
+		maxAgeHours: 24,
+	},
+	models: {
+		conversation: {
+			providerId: "conversation-provider",
+			modelId: "conversation-model",
+			temperature: 0.8,
+		},
+		memory: {
+			providerId: "memory-provider",
+			modelId: "memory-model",
+			ollamaBaseUrl: "http://localhost:11434",
+			embeddingModel: "embedding-model",
+		},
+		minecraft: {
+			providerId: "mc-provider",
+			modelId: "mc-model",
+			temperature: 0.4,
+		},
+	},
+	features: {},
+};
+
+function env(filepath: string, overrides: Record<string, string> = {}): Record<string, string> {
 	return {
+		VICISSITUDE_CONFIG_PATH: filepath,
 		DISCORD_TOKEN: "test-token",
 		...overrides,
 	};
 }
 
 describe("loadConfig", () => {
-	const root = "/tmp/test-vicissitude";
+	const tempDirs: string[] = [];
 
-	it("全デフォルト値で設定が返る", () => {
-		const config = loadConfig(baseEnv(), root);
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	function writeProfileFile(profile: unknown): string {
+		const dir = mkdtempSync(resolve(tmpdir(), "vicissitude-config-test-"));
+		tempDirs.push(dir);
+		const filepath = resolve(dir, "profile.json");
+		writeFileSync(filepath, JSON.stringify(profile));
+		return filepath;
+	}
+
+	it("JSON profile の値で AppConfig を構築する", () => {
+		const filepath = writeProfileFile(baseProfile);
+		const config = loadConfig(env(filepath), root);
 
 		expect(config.discordToken).toBe("test-token");
-		expect(config.opencode.providerId).toBe("github-copilot");
-		expect(config.opencode.modelId).toBe("big-pickle");
-		expect(config.opencode.basePort).toBe(4096);
-		expect(config.opencode.sessionMaxAgeHours).toBe(48);
-		expect(config.opencode.temperature).toBe(1.0);
-		expect(config.mcBrain.providerId).toBe("github-copilot");
-		expect(config.mcBrain.modelId).toBe("big-pickle");
-		expect(config.mcBrain.temperature).toBe(0.7);
-		expect(config.memory.providerId).toBe("github-copilot");
-		expect(config.memory.modelId).toBe("gpt-4o");
-		expect(config.memory.ollamaBaseUrl).toBe("http://ollama:11434");
-		expect(config.memory.embeddingModel).toBe("embeddinggemma");
-		expect(config.emotionEstimation).toBeUndefined();
-		expect(config.minecraft).toBeUndefined();
-		expect(config.shellWorkspace).toBeUndefined();
+		expect(config.opencode).toEqual({
+			providerId: "conversation-provider",
+			modelId: "conversation-model",
+			basePort: 5000,
+			sessionMaxAgeHours: 24,
+			temperature: 0.8,
+		});
+		expect(config.memory).toEqual({
+			providerId: "memory-provider",
+			modelId: "memory-model",
+			ollamaBaseUrl: "http://localhost:11434",
+			embeddingModel: "embedding-model",
+		});
+		expect(config.mcBrain).toEqual({
+			providerId: "mc-provider",
+			modelId: "mc-model",
+			temperature: 0.4,
+		});
 		expect(config.dataDir).toBe("/tmp/test-vicissitude/data");
 		expect(config.contextDir).toBe("/tmp/test-vicissitude/context");
 	});
 
-	it("DISCORD_TOKEN が未設定で ZodError が throw される", () => {
-		expect(() => loadConfig({}, root)).toThrow();
+	it("DISCORD_TOKEN が未設定ならエラーにする", () => {
+		const filepath = writeProfileFile(baseProfile);
+
+		expect(() => loadConfig({ VICISSITUDE_CONFIG_PATH: filepath }, root)).toThrow(
+			"DISCORD_TOKEN is required",
+		);
 	});
 
-	it("DISCORD_TOKEN が空文字で ZodError が throw される", () => {
-		expect(() => loadConfig({ DISCORD_TOKEN: "" }, root)).toThrow();
-	});
-
-	it("環境変数のカスタム値が反映される", () => {
+	it("旧 env loader の非 secret 設定は読み込まない", () => {
+		const filepath = writeProfileFile(baseProfile);
 		const config = loadConfig(
-			baseEnv({
-				OPENCODE_PROVIDER_ID: "custom-provider",
-				OPENCODE_MODEL_ID: "custom-model",
-				OPENCODE_BASE_PORT: "5000",
-				SESSION_MAX_AGE_HOURS: "24",
-				OPENCODE_TEMPERATURE: "0.5",
-				MC_PROVIDER_ID: "mc-provider",
-				MC_MODEL_ID: "mc-model",
-				MC_TEMPERATURE: "0.3",
-				MEMORY_PROVIDER_ID: "memory-provider",
-				MEMORY_MODEL_ID: "memory-model",
-				OLLAMA_BASE_URL: "http://localhost:11434",
-				MEMORY_EMBEDDING_MODEL: "custom-embedding",
-				EMOTION_ESTIMATION_ENABLED: "true",
-				EMOTION_PROVIDER_ID: "ollama",
-				EMOTION_MODEL_ID: "emotion-model",
-				EMOTION_OLLAMA_BASE_URL: "http://emotion.local:11434",
+			env(filepath, {
+				OPENCODE_PROVIDER_ID: "env-provider",
+				MC_HOST: "mc.example.com",
+				SHELL_WORKSPACE_ENABLED: "true",
+				DISCORD_IMAGE_RECOGNITION_ENABLED: "true",
 			}),
 			root,
 		);
 
-		expect(config.opencode.providerId).toBe("custom-provider");
-		expect(config.opencode.modelId).toBe("custom-model");
-		expect(config.opencode.basePort).toBe(5000);
-		expect(config.opencode.sessionMaxAgeHours).toBe(24);
-		expect(config.opencode.temperature).toBe(0.5);
-		expect(config.mcBrain.providerId).toBe("mc-provider");
-		expect(config.mcBrain.modelId).toBe("mc-model");
-		expect(config.mcBrain.temperature).toBe(0.3);
-		expect(config.memory.providerId).toBe("memory-provider");
-		expect(config.memory.modelId).toBe("memory-model");
-		expect(config.memory.ollamaBaseUrl).toBe("http://localhost:11434");
-		expect(config.memory.embeddingModel).toBe("custom-embedding");
-		expect(config.emotionEstimation).toEqual({
-			enabled: true,
-			providerId: "ollama",
-			modelId: "emotion-model",
-			ollamaBaseUrl: "http://emotion.local:11434",
-		});
+		expect(config.opencode.providerId).toBe("conversation-provider");
+		expect(config.minecraft).toBeUndefined();
+		expect(config.shellWorkspace).toBeUndefined();
+		expect(config.imageRecognition).toBeUndefined();
 	});
 
-	it("MEMORY_PROVIDER_ID 未指定時は OPENCODE_PROVIDER_ID にフォールバック", () => {
-		const config = loadConfig(
-			baseEnv({
-				OPENCODE_PROVIDER_ID: "my-provider",
-			}),
-			root,
+	it("VICISSITUDE_CONFIG_PATH が未設定ならエラーにする", () => {
+		expect(() => loadConfig({ DISCORD_TOKEN: "test-token" }, root)).toThrow(
+			"VICISSITUDE_CONFIG_PATH is required",
 		);
-
-		expect(config.memory.providerId).toBe("my-provider");
-	});
-
-	it("MC_TEMPERATURE が範囲外なら ZodError が throw される", () => {
-		expect(() => loadConfig(baseEnv({ MC_TEMPERATURE: "2.1" }), root)).toThrow();
-	});
-
-	describe("Minecraft", () => {
-		it("MC_HOST が設定されていれば minecraft がセットされる", () => {
-			const config = loadConfig(
-				baseEnv({
-					MC_HOST: "mc.example.com",
-				}),
-				root,
-			);
-
-			expect(config.minecraft).toBeDefined();
-			expect(config.minecraft?.host).toBe("mc.example.com");
-			expect(config.minecraft?.port).toBe(25565);
-			expect(config.minecraft?.username).toBe("hua");
-			expect(config.minecraft?.version).toBeUndefined();
-			expect(config.minecraft?.mcpPort).toBe(3001);
-			expect(config.minecraft?.viewerPort).toBe(3007);
-			expect(config.minecraft?.authMode).toBe("offline");
-			expect(config.minecraft?.profilesFolder).toBeUndefined();
-		});
-
-		it("MC_HOST が未設定なら minecraft は undefined", () => {
-			const config = loadConfig(baseEnv(), root);
-			expect(config.minecraft).toBeUndefined();
-		});
-
-		it("Minecraft のカスタム値が反映される", () => {
-			const config = loadConfig(
-				baseEnv({
-					MC_HOST: "mc.example.com",
-					MC_PORT: "25000",
-					MC_USERNAME: "bot",
-					MC_VERSION: "1.20.4",
-					MC_AUTH_MODE: "microsoft",
-					MC_PROFILES_FOLDER: "/tmp/mc-profiles",
-					MC_MCP_PORT: "4000",
-					MC_VIEWER_PORT: "5000",
-				}),
-				root,
-			);
-
-			expect(config.minecraft?.port).toBe(25000);
-			expect(config.minecraft?.username).toBe("bot");
-			expect(config.minecraft?.version).toBe("1.20.4");
-			expect(config.minecraft?.authMode).toBe("microsoft");
-			expect(config.minecraft?.profilesFolder).toBe("/tmp/mc-profiles");
-			expect(config.minecraft?.mcpPort).toBe(4000);
-			expect(config.minecraft?.viewerPort).toBe(5000);
-		});
-	});
-
-	describe("Shell workspace", () => {
-		it("SHELL_WORKSPACE_ENABLED が設定されていれば shellWorkspace がセットされる", () => {
-			const config = loadConfig(
-				baseEnv({
-					SHELL_WORKSPACE_ENABLED: "true",
-				}),
-				root,
-			);
-
-			expect(config.shellWorkspace).toEqual({
-				enabled: true,
-				image: "vicissitude-code-exec",
-				agent: {
-					providerId: "github-copilot",
-					modelId: "big-pickle",
-					temperature: 0.7,
-					steps: 24,
-				},
-				dataDir: "/tmp/test-vicissitude/data/shell-workspaces",
-				auditLogPath: "/tmp/test-vicissitude/data/shell-workspace-audit.jsonl",
-				networkProfile: "open",
-				defaultTtlMinutes: 60,
-				maxTtlMinutes: 120,
-				defaultTimeoutSeconds: 30,
-				maxTimeoutSeconds: 120,
-				maxOutputChars: 50_000,
-			});
-		});
-
-		it("Shell workspace のカスタム値が反映される", () => {
-			const config = loadConfig(
-				baseEnv({
-					SHELL_WORKSPACE_ENABLED: "1",
-					SHELL_WORKSPACE_IMAGE: "custom-shell-image",
-					SHELL_WORKSPACE_DEFAULT_TTL_MINUTES: "10",
-					SHELL_WORKSPACE_MAX_TTL_MINUTES: "20",
-					SHELL_WORKSPACE_DEFAULT_TIMEOUT_SECONDS: "5",
-					SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS: "9",
-					SHELL_WORKSPACE_MAX_OUTPUT_CHARS: "12345",
-					SHELL_WORKSPACE_NETWORK_PROFILE: "none",
-					SHELL_WORKSPACE_AGENT_PROVIDER_ID: "shell-provider",
-					SHELL_WORKSPACE_AGENT_MODEL_ID: "shell-model",
-					SHELL_WORKSPACE_AGENT_TEMPERATURE: "0.2",
-					SHELL_WORKSPACE_AGENT_STEPS: "8",
-				}),
-				root,
-			);
-
-			expect(config.shellWorkspace?.image).toBe("custom-shell-image");
-			expect(config.shellWorkspace?.networkProfile).toBe("none");
-			expect(config.shellWorkspace?.defaultTtlMinutes).toBe(10);
-			expect(config.shellWorkspace?.maxTtlMinutes).toBe(20);
-			expect(config.shellWorkspace?.defaultTimeoutSeconds).toBe(5);
-			expect(config.shellWorkspace?.maxTimeoutSeconds).toBe(9);
-			expect(config.shellWorkspace?.maxOutputChars).toBe(12_345);
-			expect(config.shellWorkspace?.agent).toEqual({
-				providerId: "shell-provider",
-				modelId: "shell-model",
-				temperature: 0.2,
-				steps: 8,
-			});
-		});
-
-		it("Shell workspace の既定 TTL が上限を超える場合はエラーにする", () => {
-			expect(() =>
-				loadConfig(
-					baseEnv({
-						SHELL_WORKSPACE_ENABLED: "true",
-						SHELL_WORKSPACE_DEFAULT_TTL_MINUTES: "30",
-						SHELL_WORKSPACE_MAX_TTL_MINUTES: "10",
-					}),
-					root,
-				),
-			).toThrow("SHELL_WORKSPACE_DEFAULT_TTL_MINUTES");
-		});
 	});
 });

--- a/spec/core/profile-config.spec.ts
+++ b/spec/core/profile-config.spec.ts
@@ -153,6 +153,7 @@ describe("JSON profile config", () => {
 							GH_TOKEN: { fromEnv: "HUA_GITHUB_TOKEN" },
 							GITHUB_TOKEN: { fromEnv: "HUA_GITHUB_TOKEN" },
 						},
+						hostDataDir: "/host/project/data/shell-workspaces",
 						defaultTtlMinutes: 15,
 						maxTtlMinutes: 30,
 						defaultTimeoutSeconds: 5,
@@ -190,6 +191,7 @@ describe("JSON profile config", () => {
 				GITHUB_TOKEN: "test-github-token",
 			},
 			dataDir: "/tmp/test-vicissitude/data/shell-workspaces",
+			hostDataDir: "/host/project/data/shell-workspaces",
 			auditLogPath: "/tmp/test-vicissitude/data/shell-workspace-audit.jsonl",
 			networkProfile: "open",
 			defaultTtlMinutes: 15,
@@ -267,7 +269,7 @@ describe("JSON profile config", () => {
 		expect(config.spotify?.recommendPlaylistId).toBe("profile-playlist");
 	});
 
-	it("profile 未指定時は既存 env の Spotify 推薦プレイリスト設定を維持する", () => {
+	it("Spotify 推薦プレイリストは env からフォールバックしない", () => {
 		const config = loadConfigFromProfile(
 			{
 				...baseProfile,
@@ -284,7 +286,7 @@ describe("JSON profile config", () => {
 			root,
 		);
 
-		expect(config.spotify?.recommendPlaylistId).toBe("env-playlist");
+		expect(config.spotify?.recommendPlaylistId).toBeUndefined();
 	});
 
 	it("JSON ファイルをパースして profile を読み込む", () => {


### PR DESCRIPTION
## Summary
- 旧 env loader を削除し、`loadConfig` を `VICISSITUDE_CONFIG_PATH` の JSON profile 必須に変更
- Spotify 推薦プレイリストと shell workspace host path の非 secret 設定を profile schema に集約
- README / configuration docs / context docs を profile 正本の説明へ更新

Closes #937

## Tests
- `bun test --path-ignore-patterns 'data/shell-workspaces/**' apps/discord/src/config.test.ts spec/core/config.spec.ts spec/core/profile-config.spec.ts spec/discord/bootstrap.spec.ts`\n- `nr validate`\n- `nr test`