### PR TITLE
fix(memory): CriticAuditor のスキップを観測可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ OpenCode SDK 組み込み: `webfetch`
 | SemanticMemory        | 意味記憶（ファクト）の保存・検索・無効化                            |
 | Retrieval             | テキスト + ベクトル + FSRS のハイブリッド検索（RRF でマージ）       |
 
+CriticAuditor は直近 90 分の Bot 応答を監査し、キャラクタードリフトを検出する。監査を実行しなかった場合も silent stop と区別できるよう、スキップ理由（`no_bot_id` / `no_messages` / `low_drift`）を返し、`critic_auditor_skip_total{reason=...}` で観測できるようにする。`no_bot_id` / `no_messages` は警告ログにも出力する。
+
 #### ストレージ (`packages/store`)
 
 | コンポーネント  | 役割                                   |

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -301,6 +301,7 @@ export function createMetrics(logger: Logger, port: number) {
 	// Drift metrics
 	collector.registerGauge(METRIC.DRIFT_SCORE, "Character drift score per guild");
 	collector.registerCounter(METRIC.DRIFT_AUDITS, "Character drift audit results");
+	collector.registerCounter(METRIC.CRITIC_AUDITOR_SKIP_TOTAL, "Critic auditor skipped audits");
 	collector.setGauge(METRIC.BOT_INFO, 1, { bot_name: "hua" });
 	return { collector, server: new PrometheusServer(collector, logger, port) };
 }
@@ -343,7 +344,7 @@ export async function buildCriticAuditorAdapter(
 			// gateway.start() 前に audit が呼ばれた場合、bot user id 未解決のため早期 return
 			// (namespace 解決は GUILD_ID_RE バリデーションを行うため、それより前に判定する)
 			const botUserId = getBotUserId();
-			if (!botUserId) return Promise.resolve(null);
+			if (!botUserId) return Promise.resolve({ status: "skipped", reason: "no_bot_id" });
 
 			let storage = storageCache.get(userId);
 			if (!storage) {

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -2038,6 +2038,58 @@
 			],
 			"title": "Drift Audits by Namespace (1h)",
 			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "${DS_PROMETHEUS}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"drawStyle": "line",
+						"fillOpacity": 20,
+						"lineWidth": 1,
+						"pointSize": 5,
+						"showPoints": "never",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "normal"
+						}
+					},
+					"unit": "short"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 8,
+				"x": 0,
+				"y": 127
+			},
+			"id": 39,
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom"
+				},
+				"tooltip": {
+					"mode": "multi"
+				}
+			},
+			"targets": [
+				{
+					"expr": "sum by (reason) (increase(critic_auditor_skip_total[1h]))",
+					"legendFormat": "{{reason}}"
+				}
+			],
+			"title": "Critic Auditor Skips by Reason (1h)",
+			"type": "timeseries"
 		}
 	],
 	"schemaVersion": 39,

--- a/packages/memory/src/critic-auditor.test.ts
+++ b/packages/memory/src/critic-auditor.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { CriticAuditor } from "./critic-auditor.ts";
+import type { DriftScore, DriftScoreCalculator } from "./drift-score.ts";
+import type { Episode } from "./episode.ts";
+import type { MemoryLlmPort, Schema } from "./llm-port.ts";
+import { MemoryStorage } from "./storage.ts";
+import type { ChatMessage } from "./types.ts";
+
+const USER_ID = "1234567890";
+const BOT_USER_ID = "9999999999";
+const NOW_MS = Date.parse("2026-01-01T00:00:00Z");
+
+function createEpisode(messages: ChatMessage[]): Episode {
+	return {
+		id: crypto.randomUUID(),
+		userId: USER_ID,
+		title: "episode",
+		summary: "summary",
+		messages,
+		embedding: [0.1, 0.2, 0.3],
+		surprise: 0.1,
+		stability: 1,
+		difficulty: 0.3,
+		startAt: new Date(NOW_MS - 60_000),
+		endAt: new Date(NOW_MS - 30_000),
+		createdAt: new Date(NOW_MS - 60_000),
+		lastReviewedAt: null,
+		consolidatedAt: null,
+	};
+}
+
+function createLlm(): MemoryLlmPort {
+	return {
+		chat: mock(() => Promise.resolve("ok")),
+		chatStructured<T>(_messages: ChatMessage[], schema: Schema<T>): Promise<T> {
+			return Promise.resolve(schema.parse({ severity: "none", summary: "ok" }));
+		},
+		embed: mock(() => Promise.resolve([0.1, 0.2, 0.3])),
+	};
+}
+
+function createDriftCalculator(score: number) {
+	const driftScore: DriftScore = {
+		score,
+		textFeatureScore: score,
+		semanticScore: 0,
+		features: {
+			periodRate: 0,
+			politeRate: 0,
+			bannedPhraseCount: 0,
+			empathyPhraseCount: 0,
+			wrongPronounCount: 0,
+			avgSentenceLength: 0,
+			messageCount: 1,
+		},
+		computedAt: new Date(NOW_MS),
+	};
+	return {
+		computeFromMessages: mock(() => Promise.resolve(driftScore)),
+	} as unknown as DriftScoreCalculator & {
+		computeFromMessages: ReturnType<typeof mock>;
+	};
+}
+
+function createAuditor(storage: MemoryStorage, driftCalculator: DriftScoreCalculator) {
+	return new CriticAuditor({
+		llm: createLlm(),
+		storage,
+		driftCalculator,
+		characterDefinition: "ふあ",
+		botUserId: BOT_USER_ID,
+		nowProvider: () => NOW_MS,
+	});
+}
+
+describe("CriticAuditor skip observability", () => {
+	test("bot authorId に一致する assistant メッセージがない場合は no_messages を返す", async () => {
+		const storage = new MemoryStorage();
+		const driftCalculator = createDriftCalculator(0.5);
+		try {
+			await storage.saveEpisode(
+				USER_ID,
+				createEpisode([{ role: "assistant", content: "hello", authorId: "other-bot" }]),
+			);
+
+			const result = await createAuditor(storage, driftCalculator).audit(USER_ID);
+
+			expect(result).toEqual({ status: "skipped", reason: "no_messages" });
+			expect(driftCalculator.computeFromMessages).not.toHaveBeenCalled();
+		} finally {
+			storage.close();
+		}
+	});
+
+	test("低ドリフトかつエピソード数が少ない場合は low_drift と driftScore を返す", async () => {
+		const storage = new MemoryStorage();
+		const driftCalculator = createDriftCalculator(0.01);
+		try {
+			await storage.saveEpisode(
+				USER_ID,
+				createEpisode([{ role: "assistant", content: "うん", authorId: BOT_USER_ID }]),
+			);
+
+			const result = await createAuditor(storage, driftCalculator).audit(USER_ID);
+
+			expect(result).toEqual({ status: "skipped", reason: "low_drift", driftScore: 0.01 });
+			expect(driftCalculator.computeFromMessages).toHaveBeenCalledTimes(1);
+		} finally {
+			storage.close();
+		}
+	});
+});

--- a/packages/memory/src/critic-auditor.ts
+++ b/packages/memory/src/critic-auditor.ts
@@ -9,6 +9,7 @@ import { escapeXmlContent } from "./utils.ts";
 // ─── Public types ───────────────────────────────────────────────
 
 export type CriticSeverity = "none" | "minor" | "major";
+export type CriticSkipReason = "no_messages" | "low_drift";
 
 export interface CriticResult {
 	severity: CriticSeverity;
@@ -19,6 +20,14 @@ export interface CriticResult {
 	issueTitle?: string;
 	issueBody?: string;
 }
+
+export interface CriticSkipped {
+	status: "skipped";
+	reason: CriticSkipReason;
+	driftScore?: number;
+}
+
+export type CriticAuditOutcome = (CriticResult & { status: "completed" }) | CriticSkipped;
 
 // ─── Constants ──────────────────────────────────────────────────
 
@@ -59,7 +68,7 @@ export class CriticAuditor {
 	}
 
 	/** 直近の応答を監査し、キャラクター一貫性を評価する */
-	async audit(userId: string): Promise<CriticResult | null> {
+	async audit(userId: string): Promise<CriticAuditOutcome> {
 		const sinceMs = this.nowProvider() - NINETY_MINUTES_MS;
 		const episodes = await this.storage.getRecentEpisodes(userId, sinceMs, RECENT_EPISODE_LIMIT);
 
@@ -69,14 +78,14 @@ export class CriticAuditor {
 		const assistantMessages: ChatMessage[] = episodes.flatMap((ep) =>
 			ep.messages.filter((m) => m.role === "assistant" && m.authorId === this.botUserId),
 		);
-		if (assistantMessages.length === 0) return null;
+		if (assistantMessages.length === 0) return { status: "skipped", reason: "no_messages" };
 
 		// ドリフトスコア計算
 		const driftScore = await this.driftCalculator.computeFromMessages(assistantMessages);
 
 		// コスト最適化: スコアが低くエピソード数も少ない場合はスキップ
 		if (driftScore.score < DRIFT_SKIP_THRESHOLD && episodes.length < MIN_EPISODES_FOR_CHEAP_SKIP) {
-			return null;
+			return { status: "skipped", reason: "low_drift", driftScore: driftScore.score };
 		}
 
 		// 既存ガイドラインを取得
@@ -103,7 +112,7 @@ export class CriticAuditor {
 			await this.storage.saveFact(userId, fact);
 		}
 
-		return { ...result, driftScore: driftScore.score };
+		return { ...result, status: "completed", driftScore: driftScore.score };
 	}
 }
 

--- a/packages/observability/src/metrics.ts
+++ b/packages/observability/src/metrics.ts
@@ -41,6 +41,7 @@ export const METRIC = {
 	// Drift metrics
 	DRIFT_SCORE: "drift_score",
 	DRIFT_AUDITS: "drift_audits_total",
+	CRITIC_AUDITOR_SKIP_TOTAL: "critic_auditor_skip_total",
 	// Cost metrics
 	LLM_COST_DOLLARS: "llm_cost_dollars_total",
 	// Session error metrics

--- a/packages/scheduling/src/consolidation-scheduler.test.ts
+++ b/packages/scheduling/src/consolidation-scheduler.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { METRIC } from "@vicissitude/observability/metrics";
+import { discordGuildNamespace } from "@vicissitude/shared/namespace";
+import type { CriticAuditorPort } from "@vicissitude/shared/ports";
+import { createMockLogger, createMockMetrics } from "@vicissitude/shared/test-helpers";
+import type { MemoryConsolidator } from "@vicissitude/shared/types";
+
+import { ConsolidationScheduler } from "./consolidation-scheduler.ts";
+
+function createConsolidator(): MemoryConsolidator {
+	return {
+		getActiveNamespaces: mock(() => [discordGuildNamespace("1234567890")]),
+		consolidate: mock(() =>
+			Promise.resolve({
+				processedEpisodes: 0,
+				newFacts: 0,
+				reinforced: 0,
+				updated: 0,
+				invalidated: 0,
+			}),
+		),
+	};
+}
+
+async function executeConsolidation(scheduler: ConsolidationScheduler): Promise<void> {
+	await (
+		scheduler as unknown as {
+			executeConsolidation(): Promise<void>;
+		}
+	).executeConsolidation();
+}
+
+describe("ConsolidationScheduler critic audit observability", () => {
+	test("critic audit skip は reason ラベル付き counter と warn ログに出る", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const criticAuditor: CriticAuditorPort = {
+			audit: mock(() => Promise.resolve({ status: "skipped", reason: "no_bot_id" } as const)),
+		};
+		const scheduler = new ConsolidationScheduler(
+			createConsolidator(),
+			logger,
+			metrics,
+			criticAuditor,
+		);
+
+		await executeConsolidation(scheduler);
+
+		expect(metrics.incrementCounter).toHaveBeenCalledWith(METRIC.CRITIC_AUDITOR_SKIP_TOTAL, {
+			namespace: "discord-guild:1234567890",
+			reason: "no_bot_id",
+		});
+		expect(logger.warn).toHaveBeenCalledWith(
+			"[critic-audit] ns=discord-guild:1234567890: skipped (no_bot_id)",
+		);
+	});
+
+	test("low_drift skip は drift score を更新し、warn ログを出さない", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const criticAuditor: CriticAuditorPort = {
+			audit: mock(() =>
+				Promise.resolve({ status: "skipped", reason: "low_drift", driftScore: 0.01 } as const),
+			),
+		};
+		const scheduler = new ConsolidationScheduler(
+			createConsolidator(),
+			logger,
+			metrics,
+			criticAuditor,
+		);
+
+		await executeConsolidation(scheduler);
+
+		expect(metrics.incrementCounter).toHaveBeenCalledWith(METRIC.CRITIC_AUDITOR_SKIP_TOTAL, {
+			namespace: "discord-guild:1234567890",
+			reason: "low_drift",
+		});
+		expect(metrics.setGauge).toHaveBeenCalledWith(METRIC.DRIFT_SCORE, 0.01, {
+			namespace: "discord-guild:1234567890",
+		});
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+});

--- a/packages/scheduling/src/consolidation-scheduler.ts
+++ b/packages/scheduling/src/consolidation-scheduler.ts
@@ -126,7 +126,20 @@ export class ConsolidationScheduler {
 		try {
 			const userId = defaultSubject(namespace);
 			const result = await this.criticAuditor.audit(userId);
-			if (result) {
+			if (result.status === "skipped") {
+				this.metrics?.incrementCounter(METRIC.CRITIC_AUDITOR_SKIP_TOTAL, {
+					namespace: key,
+					reason: result.reason,
+				});
+				if (result.driftScore !== undefined) {
+					this.metrics?.setGauge(METRIC.DRIFT_SCORE, result.driftScore, { namespace: key });
+				}
+				if (result.reason === "low_drift") return;
+				this.logger.warn(`[critic-audit] ns=${key}: skipped (${result.reason})`);
+				return;
+			}
+
+			if (result.status === "completed") {
 				this.metrics?.incrementCounter(METRIC.DRIFT_AUDITS, {
 					namespace: key,
 					severity: result.severity,

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -138,15 +138,28 @@ export interface HeartbeatConfigPort {
 // CriticAuditor の抽象ポート。scheduling パッケージが memory パッケージへの
 // 直接依存を避けるために使用する。
 
+export type CriticAuditSkipReason = "no_bot_id" | "no_messages" | "low_drift";
+
+export interface CriticAuditSkipped {
+	status: "skipped";
+	reason: CriticAuditSkipReason;
+	driftScore?: number;
+}
+
+export interface CriticAuditCompleted {
+	status: "completed";
+	severity: string;
+	summary: string;
+	driftScore?: number;
+	issueTitle?: string;
+	issueBody?: string;
+}
+
+export type CriticAuditOutcome = CriticAuditCompleted | CriticAuditSkipped;
+
 /** CriticAuditor ポートインターフェース */
 export interface CriticAuditorPort {
-	audit(userId: string): Promise<{
-		severity: string;
-		summary: string;
-		driftScore?: number;
-		issueTitle?: string;
-		issueBody?: string;
-	} | null>;
+	audit(userId: string): Promise<CriticAuditOutcome>;
 }
 
 // ─── GitHubIssuePort ──────────────────────────────────────────

--- a/spec/discord/bootstrap-memory.spec.ts
+++ b/spec/discord/bootstrap-memory.spec.ts
@@ -188,7 +188,7 @@ describe("setupMemoryRecording()", () => {
 		if (!adapter) return;
 		const result = await adapter.audit(guildId);
 
-		expect(result).not.toBeNull();
+		expect(result.status).toBe("completed");
 		expect(calls).toHaveLength(1);
 		const systemPrompt = calls[0]?.messages.find((m) => m.role === "system")?.content ?? "";
 		expect(systemPrompt).toContain("Unique persona marker");
@@ -268,9 +268,9 @@ describe("setupMemoryRecording()", () => {
 		expect(typeof adapter?.audit).toBe("function");
 	});
 
-	test("buildCriticAuditorAdapter(): getBotUserId が undefined の間は audit() が null を返す", async () => {
+	test("buildCriticAuditorAdapter(): getBotUserId が undefined の間は no_bot_id skip を返す", async () => {
 		// gateway.start() 前に consolidationScheduler が起動するケースは現状ないが、
-		// 防衛的に bot user id 未解決時の audit は no-op（null 返却）になることを期待する。
+		// 防衛的に bot user id 未解決時の audit は no_bot_id skip になることを期待する。
 		const contextDir = resolve(testDir, "context");
 		mkdirSync(contextDir, { recursive: true });
 		const soulPath = resolve(contextDir, "SOUL.md");
@@ -287,8 +287,8 @@ describe("setupMemoryRecording()", () => {
 		expect(adapter).toBeDefined();
 		if (!adapter) return;
 
-		// bot user id 未解決時は audit は null を返して early-return すること
+		// bot user id 未解決時は namespace validation 前に no_bot_id skip すること
 		const auditResult = await adapter.audit("guild-1");
-		expect(auditResult).toBeNull();
+		expect(auditResult).toEqual({ status: "skipped", reason: "no_bot_id" });
 	});
 });

--- a/spec/memory/critic-auditor.spec.ts
+++ b/spec/memory/critic-auditor.spec.ts
@@ -46,7 +46,7 @@ describe("CriticAuditor", () => {
 		storage.close();
 	});
 
-	test("assistant メッセージがない場合は null を返す", async () => {
+	test("assistant メッセージがない場合は no_messages skip を返す", async () => {
 		// エピソードはあるが assistant メッセージがない
 		const episode = makeEpisode({
 			messages: [{ role: "user", content: "hello", authorId: "user-1" }],
@@ -64,7 +64,7 @@ describe("CriticAuditor", () => {
 		});
 		const result = await auditor.audit(userId);
 
-		expect(result).toBeNull();
+		expect(result).toEqual({ status: "skipped", reason: "no_messages" });
 	});
 
 	test("authorId が欠損または別 bot の assistant メッセージはスキップされる", async () => {
@@ -95,8 +95,8 @@ describe("CriticAuditor", () => {
 		});
 		const result = await auditor.audit(userId);
 
-		// botUserId にマッチする assistant メッセージがないので null
-		expect(result).toBeNull();
+		// botUserId にマッチする assistant メッセージがないので no_messages
+		expect(result).toEqual({ status: "skipped", reason: "no_messages" });
 	});
 
 	test("name が一致しても authorId が一致しなければスキップされる（ニックネーム不一致対策）", async () => {
@@ -125,10 +125,10 @@ describe("CriticAuditor", () => {
 		});
 		const result = await auditor.audit(userId);
 
-		expect(result).toBeNull();
+		expect(result).toEqual({ status: "skipped", reason: "no_messages" });
 	});
 
-	test("ドリフトスコアが低く(< 0.03)エピソード数が少ない(< 3)場合はスキップして null", async () => {
+	test("ドリフトスコアが低く(< 0.03)エピソード数が少ない(< 3)場合は low_drift skip を返す", async () => {
 		// 低ドリフトの assistant メッセージ 1 件のみ
 		const episode = makeEpisode({
 			messages: [
@@ -149,7 +149,7 @@ describe("CriticAuditor", () => {
 		});
 		const result = await auditor.audit(userId);
 
-		expect(result).toBeNull();
+		expect(result).toEqual({ status: "skipped", reason: "low_drift", driftScore: 0 });
 	});
 
 	test("ドリフトスコアが閾値以上の場合は LLM を呼んで CriticResult を返す（authorId でフィルタ）", async () => {
@@ -184,9 +184,10 @@ describe("CriticAuditor", () => {
 		});
 		const result = await auditor.audit(userId);
 
-		expect(result).not.toBeNull();
-		expect(result!.severity).toBe("major");
-		expect(result!.summary).toBe("AI assistant-like response detected");
+		expect(result.status).toBe("completed");
+		if (result.status !== "completed") throw new Error("expected completed audit");
+		expect(result.severity).toBe("major");
+		expect(result.summary).toBe("AI assistant-like response detected");
 		expect(calls).toHaveLength(1);
 	});
 
@@ -220,8 +221,9 @@ describe("CriticAuditor", () => {
 		});
 		const result = await auditor.audit(userId);
 
-		expect(result).not.toBeNull();
-		expect(result!.severity).toBe("minor");
+		expect(result.status).toBe("completed");
+		if (result.status !== "completed") throw new Error("expected completed audit");
+		expect(result.severity).toBe("minor");
 
 		const guidelines = await storage.getFactsByCategory(userId, "guideline");
 		expect(guidelines).toHaveLength(1);
@@ -257,8 +259,9 @@ describe("CriticAuditor", () => {
 		});
 		const result = await auditor.audit(userId);
 
-		expect(result).not.toBeNull();
-		expect(result!.severity).toBe("none");
+		expect(result.status).toBe("completed");
+		if (result.status !== "completed") throw new Error("expected completed audit");
+		expect(result.severity).toBe("none");
 
 		const guidelines = await storage.getFactsByCategory(userId, "guideline");
 		expect(guidelines).toHaveLength(0);

--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -2,7 +2,11 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { discordGuildNamespace } from "@vicissitude/memory/namespace";
 import { ConsolidationScheduler } from "@vicissitude/scheduling/consolidation-scheduler";
-import type { CriticAuditorPort, GitHubIssuePort } from "@vicissitude/shared/ports";
+import type {
+	CriticAuditCompleted,
+	CriticAuditorPort,
+	GitHubIssuePort,
+} from "@vicissitude/shared/ports";
 import type { ConsolidationResult, MemoryConsolidator } from "@vicissitude/shared/types";
 
 import { createMockLogger, createMockMetrics } from "../test-helpers.ts";
@@ -27,9 +31,13 @@ function createMockCriticAuditor(
 	overrides: Partial<CriticAuditorPort> = {},
 ): CriticAuditorPort & { audit: ReturnType<typeof mock> } {
 	return {
-		audit: mock(() => Promise.resolve(null)),
+		audit: mock(() => Promise.resolve({ status: "skipped", reason: "low_drift" } as const)),
 		...overrides,
 	} as CriticAuditorPort & { audit: ReturnType<typeof mock> };
+}
+
+function completed(params: Omit<CriticAuditCompleted, "status">): CriticAuditCompleted {
+	return { status: "completed", ...params };
 }
 
 function createMockGitHubIssuePort(overrides: Partial<GitHubIssuePort> = {}): GitHubIssuePort & {
@@ -249,7 +257,9 @@ describe("ConsolidationScheduler", () => {
 			const logger = createMockLogger();
 			const metrics = createMockMetrics();
 			const auditor = createMockCriticAuditor({
-				audit: mock(() => Promise.resolve({ severity: "minor", summary: "slightly off" })),
+				audit: mock(() =>
+					Promise.resolve(completed({ severity: "minor", summary: "slightly off" })),
+				),
 			});
 			const consolidator = createMockConsolidator({
 				getActiveNamespaces: mock(() => [discordGuildNamespace("333")]),
@@ -270,7 +280,7 @@ describe("ConsolidationScheduler", () => {
 			const metrics = createMockMetrics();
 			const auditor = createMockCriticAuditor({
 				audit: mock(() =>
-					Promise.resolve({ severity: "major", summary: "AI assistant-like response" }),
+					Promise.resolve(completed({ severity: "major", summary: "AI assistant-like response" })),
 				),
 			});
 			const consolidator = createMockConsolidator({
@@ -287,11 +297,11 @@ describe("ConsolidationScheduler", () => {
 			);
 		});
 
-		test("audit が null を返す → メトリクス・warn ともに呼ばれない", async () => {
+		test("audit が low_drift skip を返す → skip メトリクスが記録され warn は呼ばれない", async () => {
 			const logger = createMockLogger();
 			const metrics = createMockMetrics();
 			const auditor = createMockCriticAuditor({
-				audit: mock(() => Promise.resolve(null)),
+				audit: mock(() => Promise.resolve({ status: "skipped", reason: "low_drift" } as const)),
 			});
 			const consolidator = createMockConsolidator({
 				getActiveNamespaces: mock(() => [discordGuildNamespace("555")]),
@@ -302,6 +312,10 @@ describe("ConsolidationScheduler", () => {
 			await (scheduler as unknown as TickFn).tick();
 
 			expect(auditor.audit).toHaveBeenCalledTimes(1);
+			expect(metrics.incrementCounter).toHaveBeenCalledWith("critic_auditor_skip_total", {
+				namespace: "discord-guild:555",
+				reason: "low_drift",
+			});
 			expect(metrics.incrementCounter).not.toHaveBeenCalledWith(
 				"drift_audits_total",
 				expect.anything(),
@@ -316,7 +330,7 @@ describe("ConsolidationScheduler", () => {
 			const auditor = createMockCriticAuditor({
 				audit: mock((userId: string) => {
 					if (userId === "666") return Promise.reject(auditError);
-					return Promise.resolve({ severity: "minor", summary: "ok" });
+					return Promise.resolve(completed({ severity: "minor", summary: "ok" }));
 				}),
 			});
 			const ns1 = discordGuildNamespace("666");
@@ -348,7 +362,9 @@ describe("ConsolidationScheduler", () => {
 			const logger = createMockLogger();
 			const metrics = createMockMetrics();
 			const auditor = createMockCriticAuditor({
-				audit: mock(() => Promise.resolve({ severity: "minor", summary: "ok", driftScore: 0.42 })),
+				audit: mock(() =>
+					Promise.resolve(completed({ severity: "minor", summary: "ok", driftScore: 0.42 })),
+				),
 			});
 			const consolidator = createMockConsolidator({
 				getActiveNamespaces: mock(() => [discordGuildNamespace("333")]),
@@ -367,7 +383,7 @@ describe("ConsolidationScheduler", () => {
 			const logger = createMockLogger();
 			const metrics = createMockMetrics();
 			const auditor = createMockCriticAuditor({
-				audit: mock(() => Promise.resolve({ severity: "none", summary: "ok" })),
+				audit: mock(() => Promise.resolve(completed({ severity: "none", summary: "ok" }))),
 			});
 			const ns1 = discordGuildNamespace("888");
 			const ns2 = discordGuildNamespace("999");
@@ -408,12 +424,14 @@ describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", 
 		const issuePort = createMockGitHubIssuePort();
 		const auditor = createMockCriticAuditor({
 			audit: mock(() =>
-				Promise.resolve({
-					severity: "major",
-					summary: "character drift detected",
-					issueTitle: "[character-drift] guild 111: AI assistant-like response",
-					issueBody: "## 概要\nキャラクター逸脱が検出されました。",
-				}),
+				Promise.resolve(
+					completed({
+						severity: "major",
+						summary: "character drift detected",
+						issueTitle: "[character-drift] guild 111: AI assistant-like response",
+						issueBody: "## 概要\nキャラクター逸脱が検出されました。",
+					}),
+				),
 			),
 		});
 		const consolidator = createMockConsolidator({
@@ -451,12 +469,14 @@ describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", 
 		});
 		const auditor = createMockCriticAuditor({
 			audit: mock(() =>
-				Promise.resolve({
-					severity: "major",
-					summary: "repeated drift",
-					issueTitle: duplicateTitle,
-					issueBody: "drift body",
-				}),
+				Promise.resolve(
+					completed({
+						severity: "major",
+						summary: "repeated drift",
+						issueTitle: duplicateTitle,
+						issueBody: "drift body",
+					}),
+				),
 			),
 		});
 		const consolidator = createMockConsolidator({
@@ -480,11 +500,13 @@ describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", 
 		const issuePort = createMockGitHubIssuePort();
 		const auditor = createMockCriticAuditor({
 			audit: mock(() =>
-				Promise.resolve({
-					severity: "major",
-					summary: "drift detected but no issue info",
-					// issueTitle, issueBody を省略
-				}),
+				Promise.resolve(
+					completed({
+						severity: "major",
+						summary: "drift detected but no issue info",
+						// issueTitle, issueBody を省略
+					}),
+				),
 			),
 		});
 		const consolidator = createMockConsolidator({
@@ -505,12 +527,14 @@ describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", 
 		const metrics = createMockMetrics();
 		const auditor = createMockCriticAuditor({
 			audit: mock(() =>
-				Promise.resolve({
-					severity: "major",
-					summary: "drift detected",
-					issueTitle: "[character-drift] guild 444: drift",
-					issueBody: "body",
-				}),
+				Promise.resolve(
+					completed({
+						severity: "major",
+						summary: "drift detected",
+						issueTitle: "[character-drift] guild 444: drift",
+						issueBody: "body",
+					}),
+				),
 			),
 		});
 		const consolidator = createMockConsolidator({
@@ -536,12 +560,14 @@ describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", 
 		});
 		const auditor = createMockCriticAuditor({
 			audit: mock(() =>
-				Promise.resolve({
-					severity: "major",
-					summary: "drift detected",
-					issueTitle: "[character-drift] guild 555: drift",
-					issueBody: "body",
-				}),
+				Promise.resolve(
+					completed({
+						severity: "major",
+						summary: "drift detected",
+						issueTitle: "[character-drift] guild 555: drift",
+						issueBody: "body",
+					}),
+				),
 			),
 		});
 		const consolidator = createMockConsolidator({


### PR DESCRIPTION
Closes #852

## Summary

- CriticAuditor の戻り値を completed / skipped の明示的な結果に変更
- skipped reason として no_bot_id / no_messages / low_drift を返し、critic_auditor_skip_total に記録
- no_bot_id / no_messages は warn ログにも出し、low_drift は通常スキップとして metrics のみに記録
- Grafana dashboard に skip reason 別パネルを追加

## Test plan

- [x] bun test --path-ignore-patterns 'data/shell-workspaces/**' packages/memory/src/critic-auditor.test.ts packages/scheduling/src/consolidation-scheduler.test.ts spec/memory/critic-auditor.spec.ts spec/scheduling/consolidation-scheduler.spec.ts spec/discord/bootstrap-memory.spec.ts
- [x] nr validate
- [x] nr test