### PR TITLE
feat(config): heartbeat用OpenCode設定を分離する

### DIFF
--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -5,7 +5,12 @@ import { join } from "path";
 
 import { createMockLogger } from "@vicissitude/shared/test-helpers";
 
-import { createContextLayer, createStoreLayer, createMetrics } from "./bootstrap.ts";
+import {
+	createContextLayer,
+	createGuildAgents,
+	createStoreLayer,
+	createMetrics,
+} from "./bootstrap.ts";
 import type { AppConfig } from "./config.ts";
 
 function createTestConfig(overrides?: Partial<AppConfig>): AppConfig {
@@ -19,6 +24,11 @@ function createTestConfig(overrides?: Partial<AppConfig>): AppConfig {
 			basePort: 4096,
 			sessionMaxAgeHours: 48,
 			temperature: 1.0,
+		},
+		heartbeatOpencode: {
+			providerId: "test-heartbeat-provider",
+			modelId: "test-heartbeat-model",
+			temperature: 0.3,
 		},
 		memory: {
 			providerId: "test-provider",
@@ -108,5 +118,35 @@ describe("createContextLayer", () => {
 		expect(context).toContain("core tools");
 		expect(context).toContain("shell tools");
 		expect(context).not.toContain("minecraft tools");
+	});
+});
+
+describe("createGuildAgents", () => {
+	test("deps の OpenCode 設定でモデルと temperature を上書きする", () => {
+		const config = createTestConfig();
+		const { db, sessionStore } = createStoreLayer(config);
+		const agents = createGuildAgents(config, ["guild-1"], {
+			db,
+			sessionStore,
+			contextBuilder: { build: () => Promise.resolve("context") },
+			logger: createMockLogger(),
+			appRoot: "/app",
+			coreEnvironment: {},
+			opencode: {
+				providerId: "heartbeat-provider",
+				modelId: "heartbeat-model",
+				temperature: 0.2,
+			},
+		});
+		const agent = agents.get("guild-1") as unknown as {
+			profile: { model: { providerId: string; modelId: string } };
+			sessionPort: { config: { temperature?: number } };
+		};
+
+		expect(agent.profile.model).toEqual({
+			providerId: "heartbeat-provider",
+			modelId: "heartbeat-model",
+		});
+		expect(agent.sessionPort.config.temperature).toBe(0.2);
 	});
 });

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -205,17 +205,21 @@ export function createGuildAgents(
 		compactionTokenThreshold?: number;
 		/** compaction 間のクールダウン（ms） */
 		compactionCooldownMs?: number;
+		/** この agent 群が使う OpenCode モデル設定。省略時は通常会話設定を使う */
+		opencode?: Pick<AppConfig["opencode"], "providerId" | "modelId" | "temperature">;
 	},
 ): Map<string, DiscordAgent> {
 	const agents = new Map<string, DiscordAgent>();
 	const portOffset = deps.portOffset ?? 0;
+	const opencode = deps.opencode ?? config.opencode;
 
 	for (const [index, guildId] of guildIds.entries()) {
 		const agentIdPrefix = deps.agentIdPrefix ?? "discord";
 		const agentId = `${agentIdPrefix}:${guildId}`;
 		const agentPort = config.opencode.basePort + portOffset + index;
 		const profile = createConversationProfile({
-			...config.opencode,
+			providerId: opencode.providerId,
+			modelId: opencode.modelId,
 			mcpServers: mcpServerConfigs(agentId, {
 				appRoot: deps.appRoot,
 				coreEnvironment: buildAgentCoreEnvironment(config, deps.coreEnvironment, agentPort),
@@ -231,7 +235,7 @@ export function createGuildAgents(
 			agents: profile.opencodeAgents,
 			defaultAgent: profile.defaultAgent,
 			primaryTools: profile.primaryTools,
-			temperature: config.opencode.temperature,
+			temperature: opencode.temperature,
 			directory: buildOpencodeShellWorkspaceDirectory(config, agentId),
 			environment: config.shellWorkspace?.environment,
 			logger: deps.logger,
@@ -712,6 +716,7 @@ export async function bootstrap(): Promise<void> {
 		appRoot: root,
 		coreEnvironment,
 		compactionTokenThreshold: 20_000,
+		opencode: config.heartbeatOpencode,
 	});
 	const firstHeartbeatAgent = heartbeatAgents.values().next().value as AiAgent | undefined;
 	if (!firstHeartbeatAgent) {

--- a/apps/discord/src/config-schema.ts
+++ b/apps/discord/src/config-schema.ts
@@ -110,6 +110,11 @@ export const appConfigSchema = z.object({
 		sessionMaxAgeHours: safeNumber,
 		temperature: safeNumber.min(0).max(2),
 	}),
+	heartbeatOpencode: z.object({
+		providerId: z.string(),
+		modelId: z.string(),
+		temperature: safeNumber.min(0).max(2),
+	}),
 	memory: z.object({
 		providerId: z.string(),
 		modelId: z.string(),

--- a/apps/discord/src/config.test.ts
+++ b/apps/discord/src/config.test.ts
@@ -20,6 +20,11 @@ const BASE_PROFILE = {
 			modelId: "conversation-model",
 			temperature: 0.8,
 		},
+		heartbeat: {
+			providerId: "heartbeat-provider",
+			modelId: "heartbeat-model",
+			temperature: 0.3,
+		},
 		memory: {
 			providerId: "memory-provider",
 			modelId: "memory-model",
@@ -71,6 +76,11 @@ describe("loadConfig", () => {
 			basePort: 5000,
 			sessionMaxAgeHours: 24,
 			temperature: 0.8,
+		});
+		expect(config.heartbeatOpencode).toEqual({
+			providerId: "heartbeat-provider",
+			modelId: "heartbeat-model",
+			temperature: 0.3,
 		});
 		expect(config.imageRecognition).toBeUndefined();
 		expect(config.emotionEstimation).toBeUndefined();

--- a/apps/discord/src/profile-config.ts
+++ b/apps/discord/src/profile-config.ts
@@ -55,6 +55,9 @@ export const profileConfigSchema = z.strictObject({
 		conversation: modelSelectionSchema.extend({
 			temperature: safeNumber.min(0).max(2),
 		}),
+		heartbeat: modelSelectionSchema.extend({
+			temperature: safeNumber.min(0).max(2),
+		}),
 		memory: modelSelectionSchema.extend({
 			ollamaBaseUrl: z.string().min(1),
 			embeddingModel: z.string().min(1),
@@ -168,6 +171,11 @@ export function loadConfigFromProfile(
 			basePort: profile.ports.opencodeBase,
 			sessionMaxAgeHours: profile.session.maxAgeHours,
 			temperature: profile.models.conversation.temperature,
+		},
+		heartbeatOpencode: {
+			providerId: profile.models.heartbeat.providerId,
+			modelId: profile.models.heartbeat.modelId,
+			temperature: profile.models.heartbeat.temperature,
 		},
 		memory: {
 			providerId: profile.models.memory.providerId,

--- a/config/default.json
+++ b/config/default.json
@@ -14,6 +14,11 @@
 			"modelId": "glm-5.1",
 			"temperature": 1
 		},
+		"heartbeat": {
+			"providerId": "opencode-go",
+			"modelId": "glm-5.1",
+			"temperature": 0.7
+		},
 		"memory": {
 			"providerId": "opencode-go",
 			"modelId": "kimi-k2.6",

--- a/config/profile.schema.json
+++ b/config/profile.schema.json
@@ -62,6 +62,26 @@
 					"required": ["providerId", "modelId", "temperature"],
 					"additionalProperties": false
 				},
+				"heartbeat": {
+					"type": "object",
+					"properties": {
+						"providerId": {
+							"type": "string",
+							"minLength": 1
+						},
+						"modelId": {
+							"type": "string",
+							"minLength": 1
+						},
+						"temperature": {
+							"type": "number",
+							"minimum": 0,
+							"maximum": 2
+						}
+					},
+					"required": ["providerId", "modelId", "temperature"],
+					"additionalProperties": false
+				},
 				"memory": {
 					"type": "object",
 					"properties": {
@@ -106,7 +126,7 @@
 					"additionalProperties": false
 				}
 			},
-			"required": ["conversation", "memory", "minecraft"],
+			"required": ["conversation", "heartbeat", "memory", "minecraft"],
 			"additionalProperties": false
 		},
 		"features": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,11 @@ disabled feature は key ごと省略する。`enabled: false`、`null`、空文
 			"modelId": "big-pickle",
 			"temperature": 1
 		},
+		"heartbeat": {
+			"providerId": "github-copilot",
+			"modelId": "big-pickle",
+			"temperature": 0.7
+		},
 		"memory": {
 			"providerId": "github-copilot",
 			"modelId": "gpt-4o",
@@ -112,3 +117,5 @@ profile は `apps/discord/src/profile-config.ts` の Zod schema で検証する�
 感情推定は `features.emotionEstimation` が存在する場合だけ有効になる。通常の OpenCode provider を使う場合は `providerId` と `modelId` を指定する。Ollama chat API を使う場合だけ `providerId: "ollama"` とし、同じ section に `ollamaBaseUrl` を指定する。
 
 新規設定は JSON profile に追加する。bootstrap と MCP サーバー間で渡す env はプロセス境界の内部プロトコルとして扱い、ユーザーが設定する正本にはしない。
+
+heartbeat 専用エージェントの OpenCode 設定は `models.heartbeat` に置く。通常の guild 応答は `models.conversation` を使い、heartbeat は自律行動の抑制を効かせやすいように別 temperature を指定できる。

--- a/spec/core/config.spec.ts
+++ b/spec/core/config.spec.ts
@@ -21,6 +21,11 @@ const baseProfile = {
 			modelId: "conversation-model",
 			temperature: 0.8,
 		},
+		heartbeat: {
+			providerId: "heartbeat-provider",
+			modelId: "heartbeat-model",
+			temperature: 0.3,
+		},
 		memory: {
 			providerId: "memory-provider",
 			modelId: "memory-model",
@@ -72,6 +77,11 @@ describe("loadConfig", () => {
 			basePort: 5000,
 			sessionMaxAgeHours: 24,
 			temperature: 0.8,
+		});
+		expect(config.heartbeatOpencode).toEqual({
+			providerId: "heartbeat-provider",
+			modelId: "heartbeat-model",
+			temperature: 0.3,
 		});
 		expect(config.memory).toEqual({
 			providerId: "memory-provider",

--- a/spec/core/profile-config.spec.ts
+++ b/spec/core/profile-config.spec.ts
@@ -35,6 +35,11 @@ const baseProfile = {
 			modelId: "conversation-model",
 			temperature: 0.8,
 		},
+		heartbeat: {
+			providerId: "heartbeat-provider",
+			modelId: "heartbeat-model",
+			temperature: 0.3,
+		},
 		memory: {
 			providerId: "memory-provider",
 			modelId: "memory-model",
@@ -104,6 +109,11 @@ describe("JSON profile config", () => {
 			basePort: 5000,
 			sessionMaxAgeHours: 24,
 			temperature: 0.8,
+		});
+		expect(config.heartbeatOpencode).toEqual({
+			providerId: "heartbeat-provider",
+			modelId: "heartbeat-model",
+			temperature: 0.3,
 		});
 		expect(config.memory).toEqual({
 			providerId: "memory-provider",


### PR DESCRIPTION
## Summary

- `models.heartbeat` を profile/schema/docs/default config に追加
- `createGuildAgents` が deps 経由で OpenCode provider/model/temperature を切り替えられるように変更
- heartbeat agent 作成時に `config.heartbeatOpencode` を渡し、通常 guild 応答と temperature を分離

Closes #872

## Test plan

- [x] `nr validate`
- [x] `nr test`