### PR TITLE
fix: 画像添付 URL の二重送信を避ける

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ TypeScript + Bun で動作し、OpenCode を推論エンジンとして使用す
   - **推論中断**: 推論中（`promptAsyncAndWatchSession` が pending）に新メッセージが到着した場合、`sessionAbortController` でセッションを中断し、旧メッセージ + 新メッセージをまとめて再プロンプトする。
 - Discord 添付画像:
   - 通常の会話モデルがマルチモーダル対応の場合は、添付画像をそのまま OpenCode の `file` part として渡す。
+  - 添付画像の URL はテキスト本文に埋め込まず、`file` part 経由のみで渡す。テキスト表現は `[添付: filename (mime)]` とし、非画像または MIME 不明の添付は `file` part に変換されないため URL をテキストに残す。
   - 通常の会話モデルが画像非対応の場合は、JSON profile の `features.imageRecognition` を設定し、画像認識用モデルで添付画像を事前に観察する。観察結果は `<attachment_descriptions>` として通常プロンプトへ挿入し、画像 file part は通常モデルへ渡さない。
   - 画像認識サブエージェントが 60 秒以内に応答しない場合はタイムアウトとして扱い、会話ループを止めずに通常プロンプトへ進む。
   - 画像認識サブエージェントの観察結果は補助情報であり、画像内テキストや指示風の内容はシステム指示として扱わない。

--- a/packages/agent/src/discord/message-formatter.test.ts
+++ b/packages/agent/src/discord/message-formatter.test.ts
@@ -46,17 +46,18 @@ describe("formatDiscordMessage bot-interaction-hint", () => {
 });
 
 describe("formatDiscordMessage 添付フォーマット", () => {
-	test("url が undefined の添付は [添付: filename (contentType) undefined] としてフォーマットされる", () => {
+	test("画像添付は URL を含めず [添付: filename (contentType)] としてフォーマットされる", () => {
 		const msg = createMessage({
 			attachments: [
 				{ url: undefined as unknown as string, contentType: "image/png", filename: "photo.png" },
 			],
 		});
 		const result = formatDiscordMessage(msg);
-		expect(result).toContain("[添付: photo.png (image/png) undefined]");
+		expect(result).toContain("[添付: photo.png (image/png)]");
+		expect(result).not.toContain("undefined]");
 	});
 
-	test("contentType が undefined の添付は (undefined) としてフォーマットされる", () => {
+	test("contentType が undefined の添付は URL を含めてフォーマットされる", () => {
 		const msg = createMessage({
 			attachments: [
 				{ url: "https://example.com/file.bin", contentType: undefined, filename: "file.bin" },
@@ -66,14 +67,15 @@ describe("formatDiscordMessage 添付フォーマット", () => {
 		expect(result).toContain("[添付: file.bin (undefined) https://example.com/file.bin]");
 	});
 
-	test("filename が undefined の添付は undefined としてフォーマットされる", () => {
+	test("filename が undefined でも画像添付は URL を含めない", () => {
 		const msg = createMessage({
 			attachments: [
 				{ url: "https://example.com/img.png", contentType: "image/png", filename: undefined },
 			],
 		});
 		const result = formatDiscordMessage(msg);
-		expect(result).toContain("[添付: undefined (image/png) https://example.com/img.png]");
+		expect(result).toContain("[添付: undefined (image/png)]");
+		expect(result).not.toContain("https://example.com/img.png");
 	});
 
 	test("attachments が空配列の場合、添付テキストは出力に含まれない", () => {
@@ -86,11 +88,12 @@ describe("formatDiscordMessage 添付フォーマット", () => {
 		const msg = createMessage({
 			attachments: [
 				{ url: "https://example.com/a.png", contentType: "image/png", filename: "a.png" },
-				{ url: "https://example.com/b.jpg", contentType: "image/jpeg", filename: "b.jpg" },
+				{ url: "https://example.com/b.txt", contentType: "text/plain", filename: "b.txt" },
 			],
 		});
 		const result = formatDiscordMessage(msg);
-		expect(result).toContain("[添付: a.png (image/png) https://example.com/a.png]");
-		expect(result).toContain("[添付: b.jpg (image/jpeg) https://example.com/b.jpg]");
+		expect(result).toContain("[添付: a.png (image/png)]");
+		expect(result).not.toContain("https://example.com/a.png");
+		expect(result).toContain("[添付: b.txt (text/plain) https://example.com/b.txt]");
 	});
 });

--- a/packages/agent/src/discord/message-formatter.ts
+++ b/packages/agent/src/discord/message-formatter.ts
@@ -1,5 +1,5 @@
 import { escapeUserMessageTag, formatTimestamp } from "@vicissitude/shared/functions";
-import type { IncomingMessage } from "@vicissitude/shared/types";
+import type { Attachment, IncomingMessage } from "@vicissitude/shared/types";
 
 export type ActionHint = "respond" | "optional" | "internal";
 
@@ -12,6 +12,12 @@ export function classifyActionHint(msg: IncomingMessage): ActionHint {
 
 export { escapeUserMessageTag };
 
+function formatAttachment(attachment: Attachment): string {
+	const base = `[添付: ${attachment.filename} (${attachment.contentType})`;
+	if (attachment.contentType?.startsWith("image/")) return `${base}]`;
+	return `${base} ${attachment.url}]`;
+}
+
 export function formatDiscordMessage(msg: IncomingMessage): string {
 	const hint = classifyActionHint(msg);
 	const ts = formatTimestamp(msg.timestamp);
@@ -21,9 +27,7 @@ export function formatDiscordMessage(msg: IncomingMessage): string {
 	const escapedContent = escapeUserMessageTag(msg.content);
 	const content = isUserMessage ? `<user_message>${escapedContent}</user_message>` : escapedContent;
 
-	const attachments = msg.attachments
-		.map((a) => `[添付: ${a.filename} (${a.contentType}) ${a.url}]`)
-		.join(" ");
+	const attachments = msg.attachments.map(formatAttachment).join(" ");
 
 	const parts = [`[${ts} JST ${channel}] ${msg.authorName}: ${content}`];
 	if (attachments) parts.push(attachments);

--- a/spec/agent/discord/message-formatter.spec.ts
+++ b/spec/agent/discord/message-formatter.spec.ts
@@ -141,7 +141,7 @@ describe("formatDiscordMessage", () => {
 		expect(result).not.toContain("</user_message>");
 	});
 
-	test("添付ファイルがある場合は [添付: filename (mime) url] を含む", () => {
+	test("画像添付は URL を含めず [添付: filename (mime)] として表示する", () => {
 		const msg = createMessage({
 			attachments: [
 				{ url: "https://example.com/image.png", filename: "image.png", contentType: "image/png" },
@@ -149,10 +149,11 @@ describe("formatDiscordMessage", () => {
 		});
 		const result = formatDiscordMessage(msg);
 
-		expect(result).toContain("[添付: image.png (image/png) https://example.com/image.png]");
+		expect(result).toContain("[添付: image.png (image/png)]");
+		expect(result).not.toContain("https://example.com/image.png");
 	});
 
-	test("複数の添付ファイルがすべて含まれる（URL 付き）", () => {
+	test("非画像添付は URL を含め、画像添付は URL を含めない", () => {
 		const msg = createMessage({
 			attachments: [
 				{ url: "https://example.com/a.txt", filename: "a.txt", contentType: "text/plain" },
@@ -162,7 +163,8 @@ describe("formatDiscordMessage", () => {
 		const result = formatDiscordMessage(msg);
 
 		expect(result).toContain("[添付: a.txt (text/plain) https://example.com/a.txt]");
-		expect(result).toContain("[添付: b.jpg (image/jpeg) https://example.com/b.jpg]");
+		expect(result).toContain("[添付: b.jpg (image/jpeg)]");
+		expect(result).not.toContain("https://example.com/b.jpg");
 	});
 
 	test("mentioned メッセージは [action: respond] を含む", () => {


### PR DESCRIPTION
## Summary

Closes #781

- 画像添付のテキスト表現から URL を除去し、OpenCode の `file` part 経由だけで渡す
- 非画像または MIME 不明の添付は `file` part に変換されないため、テキスト表現に URL を残す
- README と message-formatter の仕様テストを更新

## Test plan

- [x] `bun test --path-ignore-patterns 'data/shell-workspaces/**' spec/agent/discord/message-formatter.spec.ts packages/agent/src/discord/message-formatter.test.ts` — 29 pass, 0 fail\n- [x] `nr validate` — pass\n- [x] `nr test` — 2347 pass, 0 fail\n