### PR TITLE
fix(shell): GitHub認証を子コンテナへ引き継ぐ

### DIFF
--- a/docs/agent-capabilities-and-shell-sandbox.md
+++ b/docs/agent-capabilities-and-shell-sandbox.md
@@ -47,7 +47,7 @@ shell workspace は JSON profile の `features.shellWorkspace` が存在する�
 
 `shell-workspace` 有効時、core MCP には `DISCORD_ATTACHMENT_ALLOWED_DIRS` として `data/shell-workspaces` を渡す。これにより workspace 配下の生成ファイルを Discord に添付できる。
 
-JSON profile の `features.shellWorkspace.environment` には shell-worker へ渡す env 名を宣言できる。secret の実値は profile に書かず、`{ "fromEnv": "HUA_GITHUB_TOKEN" }` のように bot コンテナの環境変数を参照する。参照元 env が未設定の場合は起動時にエラーにする。
+JSON profile の `features.shellWorkspace.environment` には shell-worker と shell workspace 子コンテナへ渡す env 名を宣言できる。secret の実値は profile に書かず、`{ "fromEnv": "HUA_GITHUB_TOKEN" }` のように bot コンテナの環境変数を参照する。参照元 env が未設定の場合は起動時にエラーにする。`GH_TOKEN` / `GITHUB_TOKEN` を渡すと、子コンテナ内の `gh` と Git HTTPS credential helper が同じ token を使う。
 
 Podman mount source としてホスト側 path が必要な profile では `features.shellWorkspace.hostDataDir` に書く。OpenCode shell subagent 経路だけなら省略する。
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,11 +104,11 @@ feature section が存在する場合だけ、その feature の secret env を�
 
 Spotify の推薦プレイリストは secret ではないため `features.spotify.recommendPlaylistId` に書く。`SPOTIFY_RECOMMEND_PLAYLIST_ID` は profile 正本化に伴い読み込まない。
 
-`features.shellWorkspace.environment` は shell-worker の OpenCode server process に渡す env 名を明示する。値は profile に書かず、`fromEnv` で実行環境の secret env を参照する。たとえば `HUA_GITHUB_TOKEN` を `GH_TOKEN` / `GITHUB_TOKEN` として渡すと、`gh` と GitHub SDK の両方が同じ bot token を利用できる。
+`features.shellWorkspace.environment` は shell-worker の OpenCode server process と shell workspace 子コンテナへ渡す env 名を明示する。値は profile に書かず、`fromEnv` で実行環境の secret env を参照する。たとえば `HUA_GITHUB_TOKEN` を `GH_TOKEN` / `GITHUB_TOKEN` として渡すと、`gh` と GitHub SDK の両方が同じ bot token を利用できる。
 
 `features.shellWorkspace.hostDataDir` は shell workspace 用 MCP server が Podman mount source として使うホスト側 path を必要とする場合だけ profile に書く。OpenCode shell subagent 経路だけを使う profile では省略する。
 
-compose deploy では `HUA_GITHUB_TOKEN` を bot コンテナの `GH_TOKEN` に写す。OpenCode server と shell-worker の `bash` は bot コンテナの環境を継承するため、`gh` は auth file に依存せず `GH_TOKEN` で認証される。
+compose deploy では `HUA_GITHUB_TOKEN` を bot コンテナの `GH_TOKEN` に写す。OpenCode server と shell-worker の `bash` は bot コンテナの環境を継承するため、`gh` は auth file に依存せず `GH_TOKEN` で認証される。shell workspace 子コンテナでは `GH_TOKEN` / `GITHUB_TOKEN` がある場合だけ Git HTTPS credential helper を env 経由で追加し、`git push` も同じ token を使う。
 
 ## パースと検証
 

--- a/packages/agent/src/mcp-config.ts
+++ b/packages/agent/src/mcp-config.ts
@@ -65,8 +65,10 @@ function buildShellWorkspaceEnvironment(
 	agentId: string,
 	config: ShellWorkspaceMcpConfigOptions,
 ): Record<string, string> {
+	const forwardedEnvironment = config.environment ?? {};
+	const forwardedEnvironmentNames = Object.keys(forwardedEnvironment);
 	const env: Record<string, string> = {
-		...config.environment,
+		...forwardedEnvironment,
 		PATH: process.env.PATH ?? "",
 		HOME: process.env.HOME ?? "",
 		SHELL_WORKSPACE_AGENT_ID: agentId,
@@ -80,6 +82,9 @@ function buildShellWorkspaceEnvironment(
 		SHELL_WORKSPACE_MAX_TIMEOUT_SECONDS: String(config.maxTimeoutSeconds),
 		SHELL_WORKSPACE_MAX_OUTPUT_CHARS: String(config.maxOutputChars),
 	};
+	if (forwardedEnvironmentNames.length > 0) {
+		env.SHELL_WORKSPACE_FORWARD_ENV = forwardedEnvironmentNames.join(",");
+	}
 	if (config.hostDataDir) env.SHELL_WORKSPACE_HOST_DATA_DIR = config.hostDataDir;
 	if (process.env.XDG_RUNTIME_DIR) env.XDG_RUNTIME_DIR = process.env.XDG_RUNTIME_DIR;
 	if (process.env.TMPDIR) env.TMPDIR = process.env.TMPDIR;

--- a/packages/mcp/src/shell-workspace-server.ts
+++ b/packages/mcp/src/shell-workspace-server.ts
@@ -17,6 +17,9 @@ const CLEANUP_INTERVAL_MS = 5 * 60_000;
 const MAX_COMMAND_LENGTH = 8_000;
 const MAX_LABEL_LENGTH = 80;
 const MAX_CWD_LENGTH = 240;
+const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const GITHUB_GIT_CREDENTIAL_HELPER =
+	"!f() { echo username=x-access-token; echo password=${GH_TOKEN:-$GITHUB_TOKEN}; }; f";
 
 function readIntEnv(name: string, fallback: number): number {
 	const value = process.env[name];
@@ -37,6 +40,30 @@ function readNetworkProfileEnv(value: string | undefined): ShellWorkspaceNetwork
 	throw new Error(
 		`SHELL_WORKSPACE_NETWORK_PROFILE must be one of: ${SHELL_WORKSPACE_NETWORK_PROFILES.join(", ")}`,
 	);
+}
+
+function readForwardedEnvironment(env: NodeJS.ProcessEnv): Record<string, string> | undefined {
+	const names = (env.SHELL_WORKSPACE_FORWARD_ENV ?? "")
+		.split(",")
+		.map((name) => name.trim())
+		.filter((name) => name.length > 0);
+	const forwarded: Record<string, string> = {};
+
+	for (const name of names) {
+		if (!ENV_NAME_PATTERN.test(name)) {
+			throw new Error(`SHELL_WORKSPACE_FORWARD_ENV contains invalid env name: ${name}`);
+		}
+		const value = env[name];
+		if (value !== undefined) forwarded[name] = value;
+	}
+
+	if (forwarded.GH_TOKEN || forwarded.GITHUB_TOKEN) {
+		forwarded.GIT_CONFIG_COUNT = "1";
+		forwarded.GIT_CONFIG_KEY_0 = "credential.https://github.com.helper";
+		forwarded.GIT_CONFIG_VALUE_0 = GITHUB_GIT_CREDENTIAL_HELPER;
+	}
+
+	return Object.keys(forwarded).length > 0 ? forwarded : undefined;
 }
 
 function loadShellWorkspaceConfig(): ShellWorkspaceConfig {
@@ -62,6 +89,7 @@ function loadShellWorkspaceConfig(): ShellWorkspaceConfig {
 		dataDir: process.env.SHELL_WORKSPACE_DATA_DIR ?? DEFAULT_DATA_DIR,
 		hostDataDir: process.env.SHELL_WORKSPACE_HOST_DATA_DIR,
 		auditLogPath: process.env.SHELL_WORKSPACE_AUDIT_LOG ?? DEFAULT_AUDIT_LOG,
+		environment: readForwardedEnvironment(process.env),
 		defaultTtlMinutes,
 		maxTtlMinutes,
 		defaultTimeoutSeconds,

--- a/packages/mcp/src/shell-workspace.ts
+++ b/packages/mcp/src/shell-workspace.ts
@@ -25,6 +25,7 @@ export interface ShellWorkspaceConfig {
 	dataDir: string;
 	hostDataDir?: string;
 	auditLogPath: string;
+	environment?: Record<string, string>;
 	defaultTtlMinutes: number;
 	maxTtlMinutes: number;
 	defaultTimeoutSeconds: number;
@@ -72,7 +73,7 @@ export interface ProcessResult {
 
 export type ProcessRunner = (
 	cmd: readonly string[],
-	options: { timeoutMs: number; maxOutputChars: number },
+	options: { timeoutMs: number; maxOutputChars: number; environment?: Record<string, string> },
 ) => Promise<ProcessResult>;
 
 export interface ShellAuditRecord {
@@ -118,12 +119,14 @@ export function buildShellPodmanCmd(options: {
 	command: string;
 	timeoutSeconds: number;
 	networkProfile?: ShellWorkspaceNetworkProfile;
+	environment?: Record<string, string>;
 }): string[] {
 	const networkProfile = options.networkProfile ?? DEFAULT_NETWORK_PROFILE;
 	const workdir =
 		options.cwd === "."
 			? SHELL_WORKSPACE_CONTAINER_WORKDIR
 			: `${SHELL_WORKSPACE_CONTAINER_WORKDIR}/${options.cwd}`;
+	const environmentArgs = Object.keys(options.environment ?? {}).flatMap((name) => ["--env", name]);
 	return [
 		"podman",
 		"run",
@@ -139,6 +142,7 @@ export function buildShellPodmanCmd(options: {
 		`XDG_CONFIG_HOME=${SHELL_WORKSPACE_CONTAINER_WORKDIR}/.config`,
 		"--env",
 		`TMPDIR=${SHELL_WORKSPACE_CONTAINER_WORKDIR}/.tmp`,
+		...environmentArgs,
 		"--memory=2g",
 		"--cpus=2",
 		"--pids-limit=512",
@@ -220,12 +224,14 @@ export class ShellWorkspaceManager {
 			command: input.command,
 			timeoutSeconds,
 			networkProfile: this.config.networkProfile,
+			environment: this.config.environment,
 		});
 
 		const startedAt = this.now();
 		const result = await this.runProcess(cmd, {
 			timeoutMs: (timeoutSeconds + 5) * 1_000,
 			maxOutputChars: this.config.maxOutputChars,
+			environment: this.config.environment,
 		});
 		const durationMs = this.now() - startedAt;
 		const execResult: ShellExecResult = {
@@ -322,9 +328,13 @@ export class ShellWorkspaceManager {
 
 async function runLimitedProcess(
 	cmd: readonly string[],
-	options: { timeoutMs: number; maxOutputChars: number },
+	options: { timeoutMs: number; maxOutputChars: number; environment?: Record<string, string> },
 ): Promise<ProcessResult> {
-	const proc = Bun.spawn([...cmd], { stdout: "pipe", stderr: "pipe" });
+	const proc = Bun.spawn([...cmd], {
+		env: { ...process.env, ...options.environment },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
 
 	let timedOut = false;
 	const timeoutId = setTimeout(() => {

--- a/spec/agent/mcp-config.spec.ts
+++ b/spec/agent/mcp-config.spec.ts
@@ -81,6 +81,7 @@ describe("mcpServerConfigs", () => {
 			expect(shell.environment?.SHELL_WORKSPACE_DATA_DIR).toBe("/data/shell-workspaces");
 			expect(shell.environment?.SHELL_WORKSPACE_HOST_DATA_DIR).toBe("/host/data/shell-workspaces");
 			expect(shell.environment?.SHELL_WORKSPACE_NETWORK_PROFILE).toBe("open");
+			expect(shell.environment?.SHELL_WORKSPACE_FORWARD_ENV).toBe("GH_TOKEN,GITHUB_TOKEN");
 			expect(shell.environment?.GH_TOKEN).toBe("github-token");
 			expect(shell.environment?.GITHUB_TOKEN).toBe("github-token");
 			expect(shell.environment?.DISCORD_TOKEN).toBeUndefined();

--- a/spec/mcp/shell-workspace.spec.ts
+++ b/spec/mcp/shell-workspace.spec.ts
@@ -81,6 +81,30 @@ describe("buildShellPodmanCmd", () => {
 
 		expect(cmd).toContain("--network=none");
 	});
+
+	it("指定された environment は値を露出せず名前だけ子コンテナへ渡す", () => {
+		const cmd = buildShellPodmanCmd({
+			image: "sandbox-image",
+			workspaceDir: "/tmp/workspace",
+			cwd: ".",
+			command: "git push",
+			timeoutSeconds: 10,
+			environment: {
+				GH_TOKEN: "secret-token",
+				GIT_CONFIG_COUNT: "1",
+				GIT_CONFIG_KEY_0: "credential.https://github.com.helper",
+				GIT_CONFIG_VALUE_0: "!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f",
+			},
+		});
+
+		expect(cmd).toContain("GH_TOKEN");
+		expect(cmd).toContain("GIT_CONFIG_COUNT");
+		expect(cmd).not.toContain("GH_TOKEN=secret-token");
+		expect(cmd).not.toContain("secret-token");
+		expect(cmd).not.toContain(
+			"GIT_CONFIG_VALUE_0=!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f",
+		);
+	});
 });
 
 describe("ShellWorkspaceManager", () => {
@@ -122,6 +146,44 @@ describe("ShellWorkspaceManager", () => {
 		expect(audit.session_id).toBe(session.sessionId);
 		expect(audit.command).toBe("echo ok");
 		expect(audit.exit_code).toBe(0);
+		manager.close();
+	});
+
+	it("exec 時に GitHub 認証用 environment を Podman process へ渡す", async () => {
+		const seenOptions: Array<{
+			timeoutMs: number;
+			maxOutputChars: number;
+			environment?: Record<string, string>;
+		}> = [];
+		const runner: ProcessRunner = (_cmd, options) => {
+			seenOptions.push(options);
+			return Promise.resolve({
+				exitCode: 0,
+				output: "ok",
+				timedOut: false,
+				outputTruncated: false,
+			});
+		};
+		const config = createConfig({
+			environment: {
+				GH_TOKEN: "secret-token",
+				GIT_CONFIG_COUNT: "1",
+				GIT_CONFIG_KEY_0: "credential.https://github.com.helper",
+				GIT_CONFIG_VALUE_0: "!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f",
+			},
+			runProcess: runner,
+		});
+		const manager = new ShellWorkspaceManager(config);
+		const session = manager.startSession({});
+
+		await manager.exec({ sessionId: session.sessionId, command: "git push" });
+
+		const options = seenOptions[0];
+		expect(options).toBeDefined();
+		if (!options) throw new Error("runner options were not captured");
+		expect(options.environment?.GH_TOKEN).toBe("secret-token");
+		expect(options.environment?.GIT_CONFIG_KEY_0).toBe("credential.https://github.com.helper");
+		expect(options.environment?.GIT_CONFIG_VALUE_0).toContain("password=$GH_TOKEN");
 		manager.close();
 	});
 


### PR DESCRIPTION
## Summary

- shell-workspace の子コンテナへ profile 由来の env を明示的に forward
- GH_TOKEN / GITHUB_TOKEN がある場合に Git HTTPS credential helper を env 経由で追加
- token 値を podman コマンドラインへ出さないよう、Podman には env 名だけを渡す
- GitHub 認証の運用仕様を docs に追記

Closes #946

## Verification

- fake token を使った podman 実行で `git credential fill` が credential helper から username/password を返すことを確認
- `nr validate`
- `nr test`