### PR TITLE
fix(shell): OpenCodeのgit認証を有効化する

### DIFF
--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -149,4 +149,51 @@ describe("createGuildAgents", () => {
 		});
 		expect(agent.sessionPort.config.temperature).toBe(0.2);
 	});
+
+	test("shellWorkspace の GitHub token は Git credential helper 付きで OpenCode に渡す", () => {
+		const config = createTestConfig({
+			shellWorkspace: {
+				enabled: true,
+				image: "sandbox",
+				agent: {
+					providerId: "shell-provider",
+					modelId: "shell-model",
+					temperature: 0.4,
+					steps: 16,
+				},
+				environment: {
+					GH_TOKEN: "github-token",
+					GITHUB_TOKEN: "github-token",
+				},
+				dataDir: "/tmp/shell-workspaces",
+				auditLogPath: "/tmp/shell-audit.jsonl",
+				networkProfile: "open",
+				defaultTtlMinutes: 60,
+				maxTtlMinutes: 120,
+				defaultTimeoutSeconds: 30,
+				maxTimeoutSeconds: 120,
+				maxOutputChars: 50_000,
+			},
+		});
+		const { db, sessionStore } = createStoreLayer(config);
+		const agents = createGuildAgents(config, ["guild-1"], {
+			db,
+			sessionStore,
+			contextBuilder: { build: () => Promise.resolve("context") },
+			logger: createMockLogger(),
+			appRoot: "/app",
+			coreEnvironment: {},
+		});
+		const agent = agents.get("guild-1") as unknown as {
+			sessionPort: { config: { environment?: Record<string, string> } };
+		};
+
+		expect(agent.sessionPort.config.environment?.GH_TOKEN).toBe("github-token");
+		expect(agent.sessionPort.config.environment?.GIT_CONFIG_COUNT).toBe("1");
+		expect(agent.sessionPort.config.environment?.GIT_CONFIG_KEY_0).toBe(
+			"credential.https://github.com.helper",
+		);
+		expect(agent.sessionPort.config.environment?.GIT_CONFIG_VALUE_0).toContain("GH_TOKEN");
+		expect(agent.sessionPort.config.environment?.GIT_CONFIG_VALUE_0).not.toContain("github-token");
+	});
 });

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -46,6 +46,7 @@ import { ConsolidationScheduler } from "@vicissitude/scheduling/consolidation-sc
 import { JsonHeartbeatConfigRepository } from "@vicissitude/scheduling/heartbeat-config";
 import { HEARTBEAT_CONFIG_RELATIVE_PATH } from "@vicissitude/scheduling/heartbeat-helpers";
 import { HeartbeatScheduler } from "@vicissitude/scheduling/heartbeat-scheduler";
+import { addGitHubCredentialHelperEnvironment } from "@vicissitude/shared/github-auth-env";
 import type { MemoryNamespace } from "@vicissitude/shared/namespace";
 import type { CriticAuditorPort } from "@vicissitude/shared/ports";
 import type {
@@ -237,7 +238,7 @@ export function createGuildAgents(
 			primaryTools: profile.primaryTools,
 			temperature: opencode.temperature,
 			directory: buildOpencodeShellWorkspaceDirectory(config, agentId),
-			environment: config.shellWorkspace?.environment,
+			environment: addGitHubCredentialHelperEnvironment(config.shellWorkspace?.environment),
 			logger: deps.logger,
 		});
 		const attachmentProcessor = config.imageRecognition

--- a/packages/mcp/src/shell-workspace-server.ts
+++ b/packages/mcp/src/shell-workspace-server.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable max-lines-per-function -- MCP tool registration is declarative and easier to audit in one entry point */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { addGitHubCredentialHelperEnvironment } from "@vicissitude/shared/github-auth-env";
 import { z } from "zod";
 
 import {
@@ -18,8 +19,6 @@ const MAX_COMMAND_LENGTH = 8_000;
 const MAX_LABEL_LENGTH = 80;
 const MAX_CWD_LENGTH = 240;
 const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const GITHUB_GIT_CREDENTIAL_HELPER =
-	"!f() { echo username=x-access-token; echo password=${GH_TOKEN:-$GITHUB_TOKEN}; }; f";
 
 function readIntEnv(name: string, fallback: number): number {
 	const value = process.env[name];
@@ -57,13 +56,9 @@ function readForwardedEnvironment(env: NodeJS.ProcessEnv): Record<string, string
 		if (value !== undefined) forwarded[name] = value;
 	}
 
-	if (forwarded.GH_TOKEN || forwarded.GITHUB_TOKEN) {
-		forwarded.GIT_CONFIG_COUNT = "1";
-		forwarded.GIT_CONFIG_KEY_0 = "credential.https://github.com.helper";
-		forwarded.GIT_CONFIG_VALUE_0 = GITHUB_GIT_CREDENTIAL_HELPER;
-	}
-
-	return Object.keys(forwarded).length > 0 ? forwarded : undefined;
+	return addGitHubCredentialHelperEnvironment(
+		Object.keys(forwarded).length > 0 ? forwarded : undefined,
+	);
 }
 
 function loadShellWorkspaceConfig(): ShellWorkspaceConfig {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
 		"./ws-protocol": "./src/ws-protocol.ts",
 		"./ports": "./src/ports.ts",
 		"./tts": "./src/tts.ts",
+		"./github-auth-env": "./src/github-auth-env.ts",
 		"./test-helpers": "./src/test-helpers.ts",
 		"./sqlite": "./src/sqlite.ts"
 	}

--- a/packages/shared/src/github-auth-env.test.ts
+++ b/packages/shared/src/github-auth-env.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+
+import { addGitHubCredentialHelperEnvironment } from "./github-auth-env.ts";
+
+describe("addGitHubCredentialHelperEnvironment", () => {
+	it("GitHub token がなければ environment を変更しない", () => {
+		expect(addGitHubCredentialHelperEnvironment({ PATH: "/bin" })).toEqual({ PATH: "/bin" });
+	});
+
+	it("GH_TOKEN があれば Git HTTPS credential helper を追加する", () => {
+		const result = addGitHubCredentialHelperEnvironment({ GH_TOKEN: "secret" });
+
+		expect(result?.GIT_CONFIG_COUNT).toBe("1");
+		expect(result?.GIT_CONFIG_KEY_0).toBe("credential.https://github.com.helper");
+		expect(result?.GIT_CONFIG_VALUE_0).toContain("x-access-token");
+		expect(result?.GIT_CONFIG_VALUE_0).toContain("GH_TOKEN");
+		expect(result?.GIT_CONFIG_VALUE_0).not.toContain("secret");
+	});
+
+	it("既存の Git config env があれば末尾に追加する", () => {
+		const result = addGitHubCredentialHelperEnvironment({
+			GITHUB_TOKEN: "secret",
+			GIT_CONFIG_COUNT: "1",
+			GIT_CONFIG_KEY_0: "safe.directory",
+			GIT_CONFIG_VALUE_0: "*",
+		});
+
+		expect(result?.GIT_CONFIG_COUNT).toBe("2");
+		expect(result?.GIT_CONFIG_KEY_0).toBe("safe.directory");
+		expect(result?.GIT_CONFIG_VALUE_0).toBe("*");
+		expect(result?.GIT_CONFIG_KEY_1).toBe("credential.https://github.com.helper");
+	});
+});

--- a/packages/shared/src/github-auth-env.ts
+++ b/packages/shared/src/github-auth-env.ts
@@ -1,0 +1,26 @@
+const GITHUB_GIT_CREDENTIAL_HELPER =
+	"!f() { echo username=x-access-token; echo password=${GH_TOKEN:-$GITHUB_TOKEN}; }; f";
+
+export function addGitHubCredentialHelperEnvironment(
+	environment: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+	if (!environment) return;
+	const next = { ...environment };
+	if (!next.GH_TOKEN && !next.GITHUB_TOKEN) return next;
+
+	const index = nextGitConfigIndex(next);
+	next.GIT_CONFIG_COUNT = String(index + 1);
+	next[`GIT_CONFIG_KEY_${index}`] = "credential.https://github.com.helper";
+	next[`GIT_CONFIG_VALUE_${index}`] = GITHUB_GIT_CREDENTIAL_HELPER;
+	return next;
+}
+
+function nextGitConfigIndex(environment: Record<string, string>): number {
+	const raw = environment.GIT_CONFIG_COUNT;
+	if (raw === undefined) return 0;
+	const count = Number(raw);
+	if (!Number.isInteger(count) || count < 0) {
+		throw new Error("GIT_CONFIG_COUNT must be a non-negative integer");
+	}
+	return count;
+}


### PR DESCRIPTION
## Summary

- PR #947 のレビューで、実際に git push が失敗していた OpenCode builtin bash 経路に Git credential helper が入っていない問題を修正
- GitHub token から Git credential helper env を作る共通 helper を追加
- MCP shell-workspace 側も同じ helper を使うよう整理

## Review Finding

PR #947 は MCP shell-workspace 子コンテナには GIT_CONFIG_* を渡していたが、会話ログで失敗していた OpenCode shell-worker は OpencodeSessionAdapter の builtin bash 経路だったため、GH_TOKEN/GITHUB_TOKEN はあっても git push 用 credential helper が未設定だった。

## Verification

- nr test:unit packages/shared/src/github-auth-env.test.ts apps/discord/src/bootstrap.test.ts spec/mcp/shell-workspace.spec.ts
- nr validate
