### PR TITLE
fix(discord): x.com のURL置換を修正する

### DIFF
--- a/packages/infrastructure/src/discord/url-rewriter.test.ts
+++ b/packages/infrastructure/src/discord/url-rewriter.test.ts
@@ -3,21 +3,21 @@ import { describe, expect, test } from "bun:test";
 import { rewriteTwitterUrls } from "./url-rewriter.ts";
 
 describe("rewriteTwitterUrls — 境界条件", () => {
-	test("www 付き x.com を置換する", () => {
-		expect(rewriteTwitterUrls("https://www.x.com/user/status/1")).toBe(
-			"https://fxtwitter.com/user/status/1",
+	test("www 付き x.com の status URL を FxEmbed API URL に置換する", () => {
+		expect(rewriteTwitterUrls("https://www.x.com/user/status/123")).toBe(
+			"https://api.fxtwitter.com/2/status/123",
 		);
 	});
 
-	test("www 付き twitter.com を置換する", () => {
-		expect(rewriteTwitterUrls("https://www.twitter.com/user/status/1")).toBe(
-			"https://fxtwitter.com/user/status/1",
+	test("www 付き twitter.com の status URL を FxEmbed API URL に置換する", () => {
+		expect(rewriteTwitterUrls("https://www.twitter.com/user/status/123")).toBe(
+			"https://api.fxtwitter.com/2/status/123",
 		);
 	});
 
-	test("http (非 TLS) も置換する", () => {
-		expect(rewriteTwitterUrls("http://x.com/user/status/1")).toBe(
-			"https://fxtwitter.com/user/status/1",
+	test("http (非 TLS) の status URL も FxEmbed API URL に置換する", () => {
+		expect(rewriteTwitterUrls("http://x.com/user/status/123")).toBe(
+			"https://api.fxtwitter.com/2/status/123",
 		);
 	});
 
@@ -36,19 +36,23 @@ describe("rewriteTwitterUrls — 境界条件", () => {
 		expect(rewriteTwitterUrls(input)).toBe(input);
 	});
 
-	test("パスなしの URL も置換する", () => {
-		expect(rewriteTwitterUrls("https://x.com/")).toBe("https://fxtwitter.com/");
+	test("status ではない x.com URL は fixupx.com に置換する", () => {
+		expect(rewriteTwitterUrls("https://x.com/user")).toBe("https://fixupx.com/user");
 	});
 
-	test("mobile.x.com を置換する", () => {
-		expect(rewriteTwitterUrls("https://mobile.x.com/user/status/1")).toBe(
-			"https://fxtwitter.com/user/status/1",
+	test("status ではない twitter.com URL は fxtwitter.com に置換する", () => {
+		expect(rewriteTwitterUrls("https://twitter.com/user")).toBe("https://fxtwitter.com/user");
+	});
+
+	test("mobile.x.com の status URL を FxEmbed API URL に置換する", () => {
+		expect(rewriteTwitterUrls("https://mobile.x.com/user/status/123")).toBe(
+			"https://api.fxtwitter.com/2/status/123",
 		);
 	});
 
-	test("mobile.twitter.com を置換する", () => {
-		expect(rewriteTwitterUrls("https://mobile.twitter.com/user/status/1")).toBe(
-			"https://fxtwitter.com/user/status/1",
+	test("mobile.twitter.com の status URL を FxEmbed API URL に置換する", () => {
+		expect(rewriteTwitterUrls("https://mobile.twitter.com/user/status/123")).toBe(
+			"https://api.fxtwitter.com/2/status/123",
 		);
 	});
 
@@ -63,8 +67,22 @@ describe("rewriteTwitterUrls — 境界条件", () => {
 	});
 
 	test("コードブロック外の URL は置換しつつコードブロック内は保持する", () => {
-		const input = "https://x.com/a/1 `https://x.com/b/2` https://x.com/c/3";
-		const expected = "https://fxtwitter.com/a/1 `https://x.com/b/2` https://fxtwitter.com/c/3";
+		const input =
+			"https://x.com/a/status/123 `https://x.com/b/status/456` https://x.com/c/status/789";
+		const expected =
+			"https://api.fxtwitter.com/2/status/123 `https://x.com/b/status/456` https://api.fxtwitter.com/2/status/789";
 		expect(rewriteTwitterUrls(input)).toBe(expected);
+	});
+
+	test("status URL のクエリは API URL では取り除く", () => {
+		expect(rewriteTwitterUrls("https://x.com/user/status/123?s=20")).toBe(
+			"https://api.fxtwitter.com/2/status/123",
+		);
+	});
+
+	test("URL 直後の句読点は置換後も保持する", () => {
+		expect(rewriteTwitterUrls("見て https://x.com/user/status/123.")).toBe(
+			"見て https://api.fxtwitter.com/2/status/123.",
+		);
 	});
 });

--- a/packages/infrastructure/src/discord/url-rewriter.ts
+++ b/packages/infrastructure/src/discord/url-rewriter.ts
@@ -1,9 +1,42 @@
-const CODE_OR_TWITTER_RE =
-	/```[\s\S]*?```|`[^`]*`|https?:\/\/(?:(?:www|mobile)\.)?(?:x\.com|twitter\.com)\//g;
+const CODE_OR_URL_RE = /```[\s\S]*?```|`[^`]*`|https?:\/\/[^\s<>()]+/g;
+const TWITTER_HOST_RE = /^(?:(?:www|mobile)\.)?(x\.com|twitter\.com)$/;
+const TRAILING_PUNCTUATION_RE = /[,.!?;:]+$/;
 
 export function rewriteTwitterUrls(content: string): string {
-	return content.replaceAll(CODE_OR_TWITTER_RE, (match) => {
+	return content.replaceAll(CODE_OR_URL_RE, (match) => {
 		if (match.startsWith("`")) return match;
-		return "https://fxtwitter.com/";
+
+		const suffix = match.match(TRAILING_PUNCTUATION_RE)?.[0] ?? "";
+		const body = suffix ? match.slice(0, -suffix.length) : match;
+		const rewritten = rewriteTwitterUrl(body);
+
+		return rewritten ? `${rewritten}${suffix}` : match;
 	});
+}
+
+function rewriteTwitterUrl(rawUrl: string): string | null {
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		return null;
+	}
+
+	const sourceHost = url.hostname.match(TWITTER_HOST_RE)?.[1];
+	if (!sourceHost) return null;
+
+	const statusId = extractStatusId(url.pathname);
+	if (statusId) return `https://api.fxtwitter.com/2/status/${statusId}`;
+
+	url.protocol = "https:";
+	url.hostname = sourceHost === "x.com" ? "fixupx.com" : "fxtwitter.com";
+	return url.toString();
+}
+
+function extractStatusId(pathname: string): string | null {
+	const segments = pathname.split("/").filter(Boolean);
+	const statusIndex = segments.indexOf("status");
+	const statusId = statusIndex >= 0 ? segments[statusIndex + 1] : undefined;
+
+	return statusId && /^\d+$/.test(statusId) ? statusId : null;
 }

--- a/spec/infrastructure/discord/url-rewriter.spec.ts
+++ b/spec/infrastructure/discord/url-rewriter.spec.ts
@@ -3,21 +3,22 @@ import { describe, expect, test } from "bun:test";
 import { rewriteTwitterUrls } from "@vicissitude/infrastructure/discord/url-rewriter";
 
 describe("rewriteTwitterUrls", () => {
-	test("x.com URL を fxtwitter.com に置換する", () => {
+	test("x.com の status URL を FxEmbed API URL に置換する", () => {
 		expect(rewriteTwitterUrls("https://x.com/user/status/123")).toBe(
-			"https://fxtwitter.com/user/status/123",
+			"https://api.fxtwitter.com/2/status/123",
 		);
 	});
 
-	test("twitter.com URL を fxtwitter.com に置換する", () => {
+	test("twitter.com の status URL を FxEmbed API URL に置換する", () => {
 		expect(rewriteTwitterUrls("https://twitter.com/user/status/456")).toBe(
-			"https://fxtwitter.com/user/status/456",
+			"https://api.fxtwitter.com/2/status/456",
 		);
 	});
 
-	test("複数の URL を一括置換する", () => {
+	test("複数の status URL を一括置換する", () => {
 		const input = "見て https://x.com/a/status/1 と https://twitter.com/b/status/2";
-		const expected = "見て https://fxtwitter.com/a/status/1 と https://fxtwitter.com/b/status/2";
+		const expected =
+			"見て https://api.fxtwitter.com/2/status/1 と https://api.fxtwitter.com/2/status/2";
 		expect(rewriteTwitterUrls(input)).toBe(expected);
 	});
 
@@ -34,15 +35,15 @@ describe("rewriteTwitterUrls", () => {
 		expect(rewriteTwitterUrls("")).toBe("");
 	});
 
-	test("mobile.x.com URL を fxtwitter.com に置換する", () => {
+	test("mobile.x.com の status URL を FxEmbed API URL に置換する", () => {
 		expect(rewriteTwitterUrls("https://mobile.x.com/user/status/789")).toBe(
-			"https://fxtwitter.com/user/status/789",
+			"https://api.fxtwitter.com/2/status/789",
 		);
 	});
 
-	test("mobile.twitter.com URL を fxtwitter.com に置換する", () => {
+	test("mobile.twitter.com の status URL を FxEmbed API URL に置換する", () => {
 		expect(rewriteTwitterUrls("https://mobile.twitter.com/user/status/101")).toBe(
-			"https://fxtwitter.com/user/status/101",
+			"https://api.fxtwitter.com/2/status/101",
 		);
 	});
 


### PR DESCRIPTION
## Summary
- X/Twitter の status URL を FxEmbed API URL (`https://api.fxtwitter.com/2/status/{id}`) に正規化
- status 以外の x.com は FxEmbed 公式ドメイン規則に合わせて fixupx.com へ変換
- spec と unit test を更新

Closes #949

## Validation
- `nr validate`
  - oxfmt --check: All matched files use the correct format.
  - oxlint --type-aware: Found 0 warnings and 0 errors.
  - tsgo --noEmit: success
- `nr test`: 2364 pass, 0 fail

## Review
- review-pr: 指摘なし、追加 Issue なし