### PR TITLE
fix(scheduling): critic audit skip 警告の重複を抑制する

### DIFF
--- a/packages/scheduling/src/consolidation-scheduler.test.ts
+++ b/packages/scheduling/src/consolidation-scheduler.test.ts
@@ -82,4 +82,27 @@ describe("ConsolidationScheduler critic audit observability", () => {
 		});
 		expect(logger.warn).not.toHaveBeenCalled();
 	});
+
+	test("同じ skip reason の warn ログは繰り返さない", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const criticAuditor: CriticAuditorPort = {
+			audit: mock(() => Promise.resolve({ status: "skipped", reason: "no_messages" } as const)),
+		};
+		const scheduler = new ConsolidationScheduler(
+			createConsolidator(),
+			logger,
+			metrics,
+			criticAuditor,
+		);
+
+		await executeConsolidation(scheduler);
+		await executeConsolidation(scheduler);
+
+		expect(metrics.incrementCounter).toHaveBeenCalledTimes(2);
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledWith(
+			"[critic-audit] ns=discord-guild:1234567890: skipped (no_messages)",
+		);
+	});
 });

--- a/packages/scheduling/src/consolidation-scheduler.ts
+++ b/packages/scheduling/src/consolidation-scheduler.ts
@@ -1,7 +1,11 @@
 import { METRIC } from "@vicissitude/observability/metrics";
 import { delayResolve, withTimeout } from "@vicissitude/shared/functions";
 import { defaultSubject, namespaceKey } from "@vicissitude/shared/namespace";
-import type { CriticAuditorPort, GitHubIssuePort } from "@vicissitude/shared/ports";
+import type {
+	CriticAuditSkipReason,
+	CriticAuditorPort,
+	GitHubIssuePort,
+} from "@vicissitude/shared/ports";
 import type { Logger, MemoryConsolidator, MetricsCollector } from "@vicissitude/shared/types";
 
 /** 30 minutes */
@@ -16,6 +20,7 @@ export class ConsolidationScheduler {
 	private initialTimer: ReturnType<typeof setTimeout> | null = null;
 	private running = false;
 	private executePromise: Promise<void> | null = null;
+	private readonly lastCriticAuditSkipReasons = new Map<string, CriticAuditSkipReason>();
 
 	/* oxlint-disable-next-line max-params -- DI: all dependencies are required ports */
 	constructor(
@@ -134,12 +139,15 @@ export class ConsolidationScheduler {
 				if (result.driftScore !== undefined) {
 					this.metrics?.setGauge(METRIC.DRIFT_SCORE, result.driftScore, { namespace: key });
 				}
-				if (result.reason === "low_drift") return;
+				const previousReason = this.lastCriticAuditSkipReasons.get(key);
+				this.lastCriticAuditSkipReasons.set(key, result.reason);
+				if (result.reason === "low_drift" || previousReason === result.reason) return;
 				this.logger.warn(`[critic-audit] ns=${key}: skipped (${result.reason})`);
 				return;
 			}
 
 			if (result.status === "completed") {
+				this.lastCriticAuditSkipReasons.delete(key);
 				this.metrics?.incrementCounter(METRIC.DRIFT_AUDITS, {
 					namespace: key,
 					severity: result.severity,

--- a/spec/scheduling/consolidation-scheduler-critic-audit.spec.ts
+++ b/spec/scheduling/consolidation-scheduler-critic-audit.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { discordGuildNamespace } from "@vicissitude/memory/namespace";
+import { ConsolidationScheduler } from "@vicissitude/scheduling/consolidation-scheduler";
+import type { CriticAuditorPort } from "@vicissitude/shared/ports";
+import type { ConsolidationResult, MemoryConsolidator } from "@vicissitude/shared/types";
+
+import { createMockLogger, createMockMetrics } from "../test-helpers.ts";
+
+const successResult: ConsolidationResult = {
+	processedEpisodes: 1,
+	newFacts: 0,
+	reinforced: 0,
+	updated: 0,
+	invalidated: 0,
+};
+
+function createConsolidator(): MemoryConsolidator {
+	return {
+		getActiveNamespaces: mock(() => [discordGuildNamespace("555")]),
+		consolidate: mock(() => Promise.resolve(successResult)),
+	};
+}
+
+type TickFn = { tick(): Promise<void> };
+
+describe("ConsolidationScheduler critic audit skip logging", () => {
+	test("同じ critic audit skip が続く場合は warn ログを繰り返さない", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const auditor: CriticAuditorPort = {
+			audit: mock(() => Promise.resolve({ status: "skipped", reason: "no_messages" } as const)),
+		};
+		const scheduler = new ConsolidationScheduler(createConsolidator(), logger, metrics, auditor);
+
+		await (scheduler as unknown as TickFn).tick();
+		await (scheduler as unknown as TickFn).tick();
+
+		expect(auditor.audit).toHaveBeenCalledTimes(2);
+		expect(metrics.incrementCounter).toHaveBeenCalledWith("critic_auditor_skip_total", {
+			namespace: "discord-guild:555",
+			reason: "no_messages",
+		});
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledWith(
+			"[critic-audit] ns=discord-guild:555: skipped (no_messages)",
+		);
+	});
+});


### PR DESCRIPTION
## Summary\n- Suppress repeated warn logs for the same CriticAuditor skip reason per namespace\n- Keep skip metrics and drift score updates on every audit\n- Add spec/unit coverage for repeated skip logging\n\n## Tests\n- nr validate\n- nr test\n\nCloses #951