### PR TITLE
LokiログをGrafanaダッシュボードに統合する

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ AI エージェントとチャットボットのメトリクスは、複数ギ�
   - `provider`, `model`: 使用した LLM provider/model。
 - セッション信頼性メトリクス（`session_errors_total`, `session_retries_total`, `session_restarts_total`）にも同じ共通ラベルを付与し、どのギルド・エージェント種別・モデルで問題が起きているかを切り分けられるようにする。
 - `llm_busy_sessions` は enqueue 中ではなく、実際に LLM prompt が処理中の間だけ増減する。
+- アプリケーションログは journald へ出力し、Loki へ転送する。本番環境ではホスト側のログコレクタ（現状は NixOS の Alloy）が `container_tag=vicissitude` の journald ログを `job=vicissitude` として収集し、standalone の monitoring profile では Promtail が同じ `job=vicissitude` へ揃えて転送する。Grafana ではメトリクスと同じダッシュボード内の Logs セクションで、ログ量と warn/error ログを確認できるようにする。
 
 ## 4. 非機能要件
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,6 +15,8 @@ volumes:
   bot-node-modules:
   bot-dist:
   prometheus-data:
+  loki-data:
+  promtail-positions:
   grafana-data:
 
 services:
@@ -123,6 +125,45 @@ services:
         tag: vicissitude-prometheus
     restart: unless-stopped
 
+  loki:
+    container_name: vicissitude-loki
+    image: docker.io/grafana/loki:latest
+    profiles: [monitoring]
+    command: ["-config.file=/etc/loki/config.yml"]
+    volumes:
+      - ./monitoring/loki-config.yml:/etc/loki/config.yml:ro
+      - loki-data:/loki
+    networks:
+      - vicissitude-net
+    logging:
+      driver: journald
+      options:
+        tag: vicissitude-loki
+    restart: unless-stopped
+
+  promtail:
+    container_name: vicissitude-promtail
+    image: docker.io/grafana/promtail:latest
+    profiles: [monitoring]
+    user: "0:0"
+    command: ["-config.file=/etc/promtail/config.yml"]
+    volumes:
+      - ./monitoring/promtail-config.yml:/etc/promtail/config.yml:ro
+      - promtail-positions:/positions
+      - /var/log/journal:/var/log/journal:ro
+      - /run/log/journal:/run/log/journal:ro
+      - /etc/machine-id:/etc/machine-id:ro
+    networks:
+      - vicissitude-net
+    depends_on:
+      loki:
+        condition: service_started
+    logging:
+      driver: journald
+      options:
+        tag: vicissitude-promtail
+    restart: unless-stopped
+
   grafana:
     container_name: vicissitude-grafana
     image: docker.io/grafana/grafana:latest
@@ -149,6 +190,8 @@ services:
     depends_on:
       prometheus:
         condition: service_healthy
+      loki:
+        condition: service_started
     logging:
       driver: journald
       options:

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1995,6 +1995,182 @@
 			],
 			"title": "Drift Audits by Namespace",
 			"type": "timeseries"
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 116
+			},
+			"id": 44,
+			"title": "Logs",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "${DS_LOKI}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"lineWidth": 2,
+						"pointSize": 5,
+						"showPoints": "never",
+						"spanNulls": false
+					},
+					"unit": "logs/s"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 117
+			},
+			"id": 45,
+			"options": {
+				"legend": {
+					"displayMode": "table",
+					"placement": "bottom",
+					"showLegend": true
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "desc"
+				}
+			},
+			"targets": [
+				{
+					"refId": "A",
+					"expr": "sum by (host) (rate({job=\"vicissitude\"}[$__rate_interval]))",
+					"legendFormat": "{{host}}"
+				}
+			],
+			"title": "Application Log Rate",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "${DS_LOKI}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"lineWidth": 2,
+						"pointSize": 5,
+						"showPoints": "never",
+						"spanNulls": false
+					},
+					"unit": "logs/s"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 117
+			},
+			"id": 46,
+			"options": {
+				"legend": {
+					"displayMode": "table",
+					"placement": "bottom",
+					"showLegend": true
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "desc"
+				}
+			},
+			"targets": [
+				{
+					"refId": "A",
+					"expr": "sum by (level, component) (rate({job=\"vicissitude\"} | json | level >= 40 [$__rate_interval]))",
+					"legendFormat": "{{level}} {{component}}"
+				}
+			],
+			"title": "Warn/Error Log Rate",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "${DS_LOKI}"
+			},
+			"gridPos": {
+				"h": 12,
+				"w": 12,
+				"x": 0,
+				"y": 125
+			},
+			"id": 47,
+			"options": {
+				"dedupStrategy": "none",
+				"enableLogDetails": true,
+				"prettifyLogMessage": true,
+				"showCommonLabels": false,
+				"showLabels": true,
+				"showTime": true,
+				"sortOrder": "Descending",
+				"wrapLogMessage": true
+			},
+			"targets": [
+				{
+					"refId": "A",
+					"expr": "{job=\"vicissitude\"} | json"
+				}
+			],
+			"title": "Recent Logs",
+			"type": "logs"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "${DS_LOKI}"
+			},
+			"gridPos": {
+				"h": 12,
+				"w": 12,
+				"x": 12,
+				"y": 125
+			},
+			"id": 48,
+			"options": {
+				"dedupStrategy": "none",
+				"enableLogDetails": true,
+				"prettifyLogMessage": true,
+				"showCommonLabels": false,
+				"showLabels": true,
+				"showTime": true,
+				"sortOrder": "Descending",
+				"wrapLogMessage": true
+			},
+			"targets": [
+				{
+					"refId": "A",
+					"expr": "{job=\"vicissitude\"} | json | level >= 40"
+				}
+			],
+			"title": "Warn/Error Logs",
+			"type": "logs"
 		}
 	],
 	"refresh": "30s",

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -8,3 +8,9 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: false
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/monitoring/loki-config.yml
+++ b/monitoring/loki-config.yml
@@ -1,0 +1,33 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -1,0 +1,26 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /positions/positions.yml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: vicissitude-journal
+    journal:
+      max_age: 24h
+      labels:
+        job: vicissitude
+    relabel_configs:
+      - source_labels: ["__journal__container_name"]
+        target_label: container
+      - source_labels: ["__journal__container_tag"]
+        target_label: service
+      - source_labels: ["__journal__hostname"]
+        target_label: host
+      - source_labels: ["service"]
+        regex: "vicissitude"
+        action: keep


### PR DESCRIPTION
## 概要
- Grafana dashboard に Loki ベースの Logs セクションを追加
- ホスト側 NixOS/Alloy の既存収集設定に合わせ、LogQL は `{job="vicissitude"}` を基準に統一
- standalone monitoring profile 用に Loki / Promtail と Grafana Loki datasource を追加
- README に本番のホスト Alloy と standalone Promtail の役割分担を記載

## dotfiles との兼ね合い
- `/home/ojii3/src/github.com/ojii3/dotfiles/modules/nixos/server/loki/default.nix` は `container_tag=vicissitude` を `job=vicissitude` として Loki へ送っているため、同じ dashboard のログパネルがそのまま使える
- production では `nr deploy` が monitoring profile を有効化しないため、compose 側 Loki/Promtail は起動しない
- compose の monitoring profile は standalone 確認用として、同じ `job=vicissitude` ラベルへ揃えている

## 検証
- `jq empty monitoring/grafana-dashboard.json`
- `podman-compose -f compose.yaml --profile monitoring config`
- `nr validate`
  - oxfmt: All matched files use the correct format
  - oxlint: Found 0 warnings and 0 errors
  - tsgo --noEmit: success
- `nr test`
  - 2361 pass
  - 0 fail