### PR TITLE
fix(opencode): directory付きイベント購読に修正する

### DIFF
--- a/packages/opencode/src/session-adapter.test.ts
+++ b/packages/opencode/src/session-adapter.test.ts
@@ -74,6 +74,9 @@ function createClient(stream: AsyncGenerator<Event, void, unknown>) {
 		},
 	};
 	return client as unknown as OpencodeClient & {
+		event: {
+			subscribe: ReturnType<typeof mock>;
+		};
 		session: {
 			abort: ReturnType<typeof mock>;
 		};
@@ -265,6 +268,66 @@ describe("OpencodeSessionAdapter", () => {
 		await expect(watch).resolves.toEqual({ type: "cancelled" });
 		expect(client.session.abort).toHaveBeenCalledWith({ sessionID: "session-1" });
 		expect(streamState.returnMock).toHaveBeenCalled();
+	});
+
+	test("promptAsyncAndWatchSession は session と同じ directory のイベントを購読する", async () => {
+		const stream = {
+			next: mock(() => Promise.resolve({ done: true, value: undefined })),
+			return: mock(() => Promise.resolve({ done: true, value: undefined })),
+			[Symbol.asyncIterator]() {
+				return this;
+			},
+		} as unknown as AsyncGenerator<Event, void, unknown>;
+		const client = createClient(stream);
+		const directory = "/tmp/vicissitude-opencode-session-adapter-test";
+		const adapter = new OpencodeSessionAdapter({
+			port: 4096,
+			mcpServers: {},
+			builtinTools: {},
+			directory,
+			clientFactory: mock(() =>
+				Promise.resolve({
+					client: client as unknown as OpencodeClient,
+					server: { url: "http://localhost", close: mock(() => {}) },
+				}),
+			),
+		});
+
+		await adapter.promptAsyncAndWatchSession({
+			sessionId: "session-1",
+			text: "watch",
+			model: { providerId: "provider", modelId: "model" },
+		});
+
+		expect(client.event.subscribe).toHaveBeenCalledWith({ directory });
+	});
+
+	test("waitForSessionIdle は session と同じ directory のイベントを購読する", async () => {
+		const stream = {
+			next: mock(() => Promise.resolve({ done: true, value: undefined })),
+			return: mock(() => Promise.resolve({ done: true, value: undefined })),
+			[Symbol.asyncIterator]() {
+				return this;
+			},
+		} as unknown as AsyncGenerator<Event, void, unknown>;
+		const client = createClient(stream);
+		const directory = "/tmp/vicissitude-opencode-session-adapter-test";
+		const adapter = new OpencodeSessionAdapter({
+			port: 4096,
+			mcpServers: {},
+			builtinTools: {},
+			directory,
+			clientFactory: mock(() =>
+				Promise.resolve({
+					client: client as unknown as OpencodeClient,
+					server: { url: "http://localhost", close: mock(() => {}) },
+				}),
+			),
+		});
+
+		await adapter.waitForSessionIdle("session-1");
+
+		expect(client.event.subscribe).toHaveBeenCalledWith({ directory });
 	});
 
 	test("abort リスナー登録直後に stop されてもイベント待ちでハングしない", async () => {

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -162,7 +162,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 			`[opencode] promptAsyncAndWatch: session=${params.sessionId} model=${params.model.providerId}/${params.model.modelId}`,
 		);
 		const oc = await this.getClient();
-		const { stream } = await oc.event.subscribe();
+		const { stream } = await oc.event.subscribe(this.directoryQuery());
 		this.logger?.info("[opencode] event stream subscribed");
 		const tokensByMessage = new Map<string, TokenUsage>();
 		try {
@@ -239,7 +239,7 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 	}
 	async waitForSessionIdle(sessionId: string, signal?: AbortSignal): Promise<OpencodeSessionEvent> {
 		const oc = await this.getClient();
-		const { stream } = await oc.event.subscribe();
+		const { stream } = await oc.event.subscribe(this.directoryQuery());
 		const tokensByMessage = new Map<string, TokenUsage>();
 		let unclassifiedCount = 0;
 		try {


### PR DESCRIPTION
## 概要
- OpenCode session 操作と同じ directory を event.subscribe に渡すよう修正
- promptAsyncAndWatchSession / waitForSessionIdle の購読先を揃えるテストを追加
- config/local.json は ignore 対象のローカル設定として、感情推定モデルを openai/gpt-5.4-mini に変更済み

## 原因
Discord bot の session 作成・prompt は shell workspace の directory 付きで OpenCode に投げていた一方、event.subscribe だけ directory なしで購読していました。そのため OpenCode 内部では session.idle が publish 済みでも、bot 側 watcher は対象 directory の idle を受け取れず、server.heartbeat を読み続けて llm_busy_sessions が残っていました。

## 検証
- bun test --path-ignore-patterns 'data/shell-workspaces/**' packages/opencode/src/session-adapter.test.ts spec/opencode/session-adapter.spec.ts spec/opencode/stream-helpers.spec.ts\n- nr fmt:check\n- nr validate\n- nr test\n\nFixes #957