### PR TITLE
fix: 優先度高の設計課題を修正する

### DIFF
--- a/packages/memory/src/consolidation-action-applier.ts
+++ b/packages/memory/src/consolidation-action-applier.ts
@@ -26,6 +26,7 @@ export interface FactApplicationResult {
 
 const DEDUPE_THRESHOLD = 0.95;
 const DUPLICATE_CANDIDATE_LIMIT = 5;
+const EMPTY_FACT_IDS: ReadonlySet<string> = new Set();
 
 export function emptyFactApplicationResult(): FactApplicationResult {
 	return { newFacts: 0, reinforced: 0, updated: 0, invalidated: 0 };
@@ -102,28 +103,24 @@ export class ConsolidationFactApplier {
 			ctx.activeFactsById.set(duplicate.id, reinforced);
 			return "reinforce";
 		}
-		const fact = createFact({
-			userId: ctx.userId,
-			category: extracted.category,
-			fact: extracted.fact,
-			keywords: extracted.keywords,
-			sourceEpisodicIds: [ctx.episodeId],
-			embedding,
-			now: ctx.now,
-			metadata: { source: "consolidation" },
-		});
+		const fact = createFactFromExtracted(ctx, extracted, embedding);
 		await this.storage.saveFact(ctx.userId, fact);
 		ctx.activeFactsById.set(fact.id, fact);
 		return "new";
 	}
 
-	private async findDuplicate(userId: string, embedding: number[]): Promise<SemanticFact | null> {
+	private async findDuplicate(
+		userId: string,
+		embedding: number[],
+		excludedFactIds: ReadonlySet<string> = EMPTY_FACT_IDS,
+	): Promise<SemanticFact | null> {
 		const candidates = await this.storage.searchFactsByEmbedding(
 			userId,
 			embedding,
-			DUPLICATE_CANDIDATE_LIMIT,
+			DUPLICATE_CANDIDATE_LIMIT + excludedFactIds.size,
 		);
 		for (const candidate of candidates) {
+			if (excludedFactIds.has(candidate.id)) continue;
 			if (cosineSimilarity(embedding, candidate.embedding) >= DEDUPE_THRESHOLD) {
 				return candidate;
 			}
@@ -148,10 +145,25 @@ export class ConsolidationFactApplier {
 		ctx: ResolvedFactApplicationContext,
 		extracted: ExtractedFact & { action: "update" },
 	): Promise<void> {
-		this.requireExistingFact(ctx, extracted.existingFactId, extracted.action);
-		await this.storage.invalidateFact(ctx.userId, extracted.existingFactId, ctx.now);
-		ctx.activeFactsById.delete(extracted.existingFactId);
-		await this.applyNew(ctx, extracted);
+		const existing = this.requireExistingFact(ctx, extracted.existingFactId, extracted.action);
+		const embedding = await this.llm.embed(extracted.fact);
+		const duplicate = await this.findDuplicate(ctx.userId, embedding, new Set([existing.id]));
+		if (duplicate) {
+			const reinforced = {
+				...duplicate,
+				sourceEpisodicIds: appendSourceEpisode(duplicate, ctx.episodeId),
+			};
+			await this.storage.updateFact(ctx.userId, duplicate.id, reinforced);
+			await this.storage.invalidateFact(ctx.userId, existing.id, ctx.now);
+			ctx.activeFactsById.delete(existing.id);
+			ctx.activeFactsById.set(duplicate.id, reinforced);
+			return;
+		}
+
+		const replacement = createFactFromExtracted(ctx, extracted, embedding);
+		await this.storage.replaceFacts(ctx.userId, [existing.id], replacement, ctx.now);
+		ctx.activeFactsById.delete(existing.id);
+		ctx.activeFactsById.set(replacement.id, replacement);
 	}
 
 	private async applyInvalidate(
@@ -193,4 +205,21 @@ function appendSourceEpisode(fact: SemanticFact, episodeId: string): string[] {
 	return fact.sourceEpisodicIds.includes(episodeId)
 		? fact.sourceEpisodicIds
 		: [...fact.sourceEpisodicIds, episodeId];
+}
+
+function createFactFromExtracted(
+	ctx: FactApplicationContext,
+	extracted: ExtractedFact,
+	embedding: number[],
+): SemanticFact {
+	return createFact({
+		userId: ctx.userId,
+		category: extracted.category,
+		fact: extracted.fact,
+		keywords: extracted.keywords,
+		sourceEpisodicIds: [ctx.episodeId],
+		embedding,
+		now: ctx.now,
+		metadata: { source: "consolidation" },
+	});
 }

--- a/packages/observability/src/log-redact.test.ts
+++ b/packages/observability/src/log-redact.test.ts
@@ -153,4 +153,29 @@ describe("redactObject - 内部ロジック", () => {
 			expect(redactObject(undef)).toBeUndefined();
 		});
 	});
+
+	describe("Error オブジェクト", () => {
+		test("列挙可能な独自プロパティも保持してマスキングする", () => {
+			const error = new Error("failed sk-abcdefghijkl") as Error & {
+				context?: string;
+			};
+			error.context = "owner=user@example.com";
+
+			const result = redactObject(error) as Record<string, unknown>;
+
+			expect(result.name).toBe("Error");
+			expect(result.message).toBe("failed [REDACTED]");
+			expect(result.context).toBe("owner=[REDACTED]");
+		});
+
+		test("循環する cause で無限再帰しない", () => {
+			const error = new Error("self reference") as Error & { cause?: unknown };
+			error.cause = error;
+
+			const result = redactObject(error) as Record<string, unknown>;
+
+			expect(result.message).toBe("self reference");
+			expect(result.cause).toBe("[circular]");
+		});
+	});
 });

--- a/packages/observability/src/log-redact.ts
+++ b/packages/observability/src/log-redact.ts
@@ -51,9 +51,37 @@ function redactRecursive(obj: unknown, seen: WeakSet<object>): unknown {
 		return obj.map((item) => redactRecursive(item, seen));
 	}
 
+	if (obj instanceof Error) {
+		return redactError(obj, seen);
+	}
+
 	const result: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(obj)) {
 		result[key] = redactRecursive(value, seen);
 	}
+	return result;
+}
+
+function redactError(error: Error, seen: WeakSet<object>): Record<string, unknown> {
+	const result: Record<string, unknown> = {
+		name: maskSecrets(error.name),
+		message: maskSecrets(error.message),
+	};
+
+	if (typeof error.stack === "string") {
+		result.stack = maskSecrets(error.stack);
+	}
+
+	if (Object.prototype.hasOwnProperty.call(error, "cause")) {
+		result.cause = redactRecursive(error.cause, seen);
+	}
+
+	for (const [key, value] of Object.entries(error)) {
+		if (key === "name" || key === "message" || key === "stack" || key === "cause") {
+			continue;
+		}
+		result[key] = redactRecursive(value, seen);
+	}
+
 	return result;
 }

--- a/packages/scheduling/src/heartbeat-config.ts
+++ b/packages/scheduling/src/heartbeat-config.ts
@@ -1,10 +1,18 @@
-import { existsSync, mkdirSync, readFileSync } from "fs";
-import { dirname, resolve } from "path";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync } from "fs";
+import { dirname, resolve as resolvePath } from "path";
 
-import type { HeartbeatConfig } from "@vicissitude/shared/types";
+import type {
+	HeartbeatConfig,
+	HeartbeatReminder,
+	ReminderSchedule,
+} from "@vicissitude/shared/types";
 import { z } from "zod";
 
 import { createDefaultHeartbeatConfig } from "./heartbeat-helpers.ts";
+
+const LOCK_POLL_INTERVAL_MS = 25;
+const LOCK_TIMEOUT_MS = 5_000;
+const LOCK_STALE_MS = 30_000;
 
 const heartbeatConfigSchema = z.object({
 	baseIntervalMinutes: z.number(),
@@ -25,27 +33,75 @@ const heartbeatConfigSchema = z.object({
 
 export class JsonHeartbeatConfigRepository {
 	private readonly filePath: string;
+	private readonly loadedSnapshots = new WeakMap<HeartbeatConfig, HeartbeatConfig>();
 
 	constructor(filePath: string) {
-		this.filePath = resolve(filePath);
+		this.filePath = resolvePath(filePath);
 	}
 
 	load(): Promise<HeartbeatConfig> {
+		const config = this.readConfig();
+		this.loadedSnapshots.set(config, cloneConfig(config));
+		return Promise.resolve(config);
+	}
+
+	async save(config: HeartbeatConfig): Promise<void> {
+		const baseline = this.loadedSnapshots.get(config);
+		let savedConfig = cloneConfig(config);
+
+		await this.withFileLock(async () => {
+			const current = this.readConfig();
+			savedConfig = baseline ? mergeConfigChanges(baseline, current, config) : cloneConfig(config);
+			await this.writeConfig(savedConfig);
+		});
+
+		this.loadedSnapshots.set(config, cloneConfig(savedConfig));
+	}
+
+	async markRemindersExecuted(reminderIds: readonly string[], executedAt: string): Promise<void> {
+		if (reminderIds.length === 0) return;
+		const ids = new Set(reminderIds);
+
+		await this.withFileLock(async () => {
+			const config = this.readConfig();
+			let changed = false;
+
+			for (const reminder of config.reminders) {
+				if (ids.has(reminder.id) && reminder.lastExecutedAt !== executedAt) {
+					reminder.lastExecutedAt = executedAt;
+					changed = true;
+				}
+			}
+
+			if (changed) {
+				await this.writeConfig(config);
+			}
+		});
+	}
+
+	private readConfig(): HeartbeatConfig {
 		if (!existsSync(this.filePath)) {
-			return Promise.resolve(createDefaultHeartbeatConfig());
+			return createDefaultHeartbeatConfig();
 		}
 		try {
 			const raw: string = readFileSync(this.filePath, "utf-8");
 			const parsed = heartbeatConfigSchema.parse(JSON.parse(raw));
-			return Promise.resolve(parsed as HeartbeatConfig);
+			return parsed as HeartbeatConfig;
 		} catch {
-			return Promise.resolve(createDefaultHeartbeatConfig());
+			return createDefaultHeartbeatConfig();
 		}
 	}
 
-	async save(config: HeartbeatConfig): Promise<void> {
+	private async writeConfig(config: HeartbeatConfig): Promise<void> {
 		this.ensureDir();
-		await Bun.write(this.filePath, JSON.stringify(config, null, 2));
+		const tempPath = `${this.filePath}.${String(process.pid)}.${String(Date.now())}.${String(Math.random()).slice(2)}.tmp`;
+		try {
+			await Bun.write(tempPath, JSON.stringify(config, null, 2));
+			renameSync(tempPath, this.filePath);
+		} catch (error) {
+			rmSync(tempPath, { force: true });
+			throw error;
+		}
 	}
 
 	private ensureDir(): void {
@@ -54,4 +110,172 @@ export class JsonHeartbeatConfigRepository {
 			mkdirSync(dir, { recursive: true });
 		}
 	}
+
+	private async withFileLock<T>(action: () => Promise<T>): Promise<T> {
+		this.ensureDir();
+		const lockPath = `${this.filePath}.lock`;
+		const deadline = Date.now() + LOCK_TIMEOUT_MS;
+		await this.acquireFileLock(lockPath, deadline);
+
+		try {
+			return await action();
+		} finally {
+			rmSync(lockPath, { recursive: true, force: true });
+		}
+	}
+
+	private async acquireFileLock(lockPath: string, deadline: number): Promise<void> {
+		try {
+			mkdirSync(lockPath);
+		} catch (error) {
+			if (!isFileExistsError(error)) {
+				throw error;
+			}
+			this.removeStaleLock(lockPath);
+			if (Date.now() >= deadline) {
+				throw new Error(`Timed out waiting for heartbeat config lock: ${lockPath}`, {
+					cause: error,
+				});
+			}
+			await sleep(LOCK_POLL_INTERVAL_MS);
+			return this.acquireFileLock(lockPath, deadline);
+		}
+	}
+
+	private removeStaleLock(lockPath: string): void {
+		try {
+			const ageMs = Date.now() - statSync(lockPath).mtimeMs;
+			if (ageMs > LOCK_STALE_MS) {
+				rmSync(lockPath, { recursive: true, force: true });
+			}
+		} catch (error) {
+			if (!isNotFoundError(error)) {
+				throw error;
+			}
+		}
+	}
+}
+
+function mergeConfigChanges(
+	baseline: HeartbeatConfig,
+	current: HeartbeatConfig,
+	next: HeartbeatConfig,
+): HeartbeatConfig {
+	const merged = cloneConfig(current);
+	if (next.baseIntervalMinutes !== baseline.baseIntervalMinutes) {
+		merged.baseIntervalMinutes = next.baseIntervalMinutes;
+	}
+
+	const baselineById = indexReminders(baseline.reminders);
+	const nextById = indexReminders(next.reminders);
+	const removedIds = new Set(baseline.reminders.map((r) => r.id).filter((id) => !nextById.has(id)));
+	merged.reminders = merged.reminders.filter((r) => !removedIds.has(r.id));
+
+	const mergedIndexes = indexReminderPositions(merged.reminders);
+	for (const nextReminder of next.reminders) {
+		const baselineReminder = baselineById.get(nextReminder.id);
+		const mergedIndex = mergedIndexes.get(nextReminder.id);
+		const currentReminder = mergedIndex === undefined ? undefined : merged.reminders[mergedIndex];
+		const reminder =
+			baselineReminder && currentReminder
+				? mergeReminderChanges(baselineReminder, currentReminder, nextReminder)
+				: cloneReminder(nextReminder);
+
+		if (mergedIndex === undefined) {
+			mergedIndexes.set(reminder.id, merged.reminders.length);
+			merged.reminders.push(reminder);
+		} else {
+			merged.reminders[mergedIndex] = reminder;
+		}
+	}
+
+	return merged;
+}
+
+function mergeReminderChanges(
+	baseline: HeartbeatReminder,
+	current: HeartbeatReminder,
+	next: HeartbeatReminder,
+): HeartbeatReminder {
+	const merged = cloneReminder(current);
+
+	if (next.description !== baseline.description) {
+		merged.description = next.description;
+	}
+	if (!schedulesEqual(next.schedule, baseline.schedule)) {
+		merged.schedule = cloneSchedule(next.schedule);
+	}
+	if (next.lastExecutedAt !== baseline.lastExecutedAt) {
+		merged.lastExecutedAt = next.lastExecutedAt;
+	}
+	if (next.enabled !== baseline.enabled) {
+		merged.enabled = next.enabled;
+	}
+	if (next.guildId !== baseline.guildId) {
+		if (next.guildId === undefined) {
+			delete merged.guildId;
+		} else {
+			merged.guildId = next.guildId;
+		}
+	}
+
+	return merged;
+}
+
+function indexReminders(reminders: readonly HeartbeatReminder[]): Map<string, HeartbeatReminder> {
+	return new Map(reminders.map((reminder) => [reminder.id, reminder]));
+}
+
+function indexReminderPositions(reminders: readonly HeartbeatReminder[]): Map<string, number> {
+	return new Map(reminders.map((reminder, index) => [reminder.id, index]));
+}
+
+function cloneConfig(config: HeartbeatConfig): HeartbeatConfig {
+	return {
+		baseIntervalMinutes: config.baseIntervalMinutes,
+		reminders: config.reminders.map(cloneReminder),
+	};
+}
+
+function cloneReminder(reminder: HeartbeatReminder): HeartbeatReminder {
+	return {
+		id: reminder.id,
+		description: reminder.description,
+		schedule: cloneSchedule(reminder.schedule),
+		lastExecutedAt: reminder.lastExecutedAt,
+		enabled: reminder.enabled,
+		...(reminder.guildId === undefined ? {} : { guildId: reminder.guildId }),
+	};
+}
+
+function cloneSchedule(schedule: ReminderSchedule): ReminderSchedule {
+	if (schedule.type === "interval") {
+		return { type: "interval", minutes: schedule.minutes };
+	}
+	return { type: "daily", hour: schedule.hour, minute: schedule.minute };
+}
+
+function schedulesEqual(left: ReminderSchedule, right: ReminderSchedule): boolean {
+	if (left.type !== right.type) return false;
+	if (left.type === "interval") {
+		return left.minutes === (right as { type: "interval"; minutes: number }).minutes;
+	}
+	return (
+		left.hour === (right as { type: "daily"; hour: number; minute: number }).hour &&
+		left.minute === (right as { type: "daily"; hour: number; minute: number }).minute
+	);
+}
+
+function isFileExistsError(error: unknown): boolean {
+	return error instanceof Error && "code" in error && error.code === "EEXIST";
+}
+
+function isNotFoundError(error: unknown): boolean {
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
 }

--- a/packages/scheduling/src/heartbeat-scheduler.test.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.test.ts
@@ -9,6 +9,7 @@ function createMockConfigRepo(config: HeartbeatConfig) {
 	return {
 		load: mock(() => Promise.resolve(config)),
 		save: mock(() => Promise.resolve()),
+		markRemindersExecuted: mock(() => Promise.resolve()),
 	};
 }
 
@@ -38,19 +39,20 @@ describe("HeartbeatScheduler", () => {
 
 	test("due reminder があるときだけ HEARTBEAT_REMINDERS_EXECUTED を増やす", async () => {
 		const metrics = createMockMetrics();
+		const configRepo = createMockConfigRepo({
+			baseIntervalMinutes: 30,
+			reminders: [
+				{
+					id: "due-1",
+					description: "check home",
+					schedule: { type: "interval", minutes: 1 },
+					lastExecutedAt: null,
+					enabled: true,
+				},
+			],
+		});
 		const scheduler = new HeartbeatScheduler({
-			configRepo: createMockConfigRepo({
-				baseIntervalMinutes: 30,
-				reminders: [
-					{
-						id: "due-1",
-						description: "check home",
-						schedule: { type: "interval", minutes: 1 },
-						lastExecutedAt: null,
-						enabled: true,
-					},
-				],
-			}),
+			configRepo,
 			heartbeatService: createMockHeartbeatService(),
 			logger: createMockLogger(),
 			metrics,
@@ -59,5 +61,34 @@ describe("HeartbeatScheduler", () => {
 		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
 
 		expect(metrics.incrementCounter).toHaveBeenCalledWith("heartbeat_reminders_executed_total");
+	});
+
+	test("実行成功時は古い config 全体を save せず、実行済み reminder ID だけ更新する", async () => {
+		const configRepo = createMockConfigRepo({
+			baseIntervalMinutes: 30,
+			reminders: [
+				{
+					id: "due-1",
+					description: "check home",
+					schedule: { type: "interval", minutes: 1 },
+					lastExecutedAt: null,
+					enabled: true,
+				},
+			],
+		});
+		const heartbeatService = {
+			execute: mock(() => Promise.resolve(new Set(["due-1"]))),
+		};
+		const scheduler = new HeartbeatScheduler({
+			configRepo,
+			heartbeatService,
+			logger: createMockLogger(),
+		});
+
+		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+
+		expect(configRepo.save).not.toHaveBeenCalled();
+		expect(configRepo.markRemindersExecuted).toHaveBeenCalledTimes(1);
+		expect(configRepo.markRemindersExecuted).toHaveBeenCalledWith(["due-1"], expect.any(String));
 	});
 });

--- a/packages/scheduling/src/heartbeat-scheduler.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.ts
@@ -98,12 +98,7 @@ export class HeartbeatScheduler {
 		}
 
 		const executedAt = new Date().toISOString();
-		for (const reminder of config.reminders) {
-			if (succeededIds.has(reminder.id)) {
-				reminder.lastExecutedAt = executedAt;
-			}
-		}
-		await this.deps.configRepo.save(config);
+		await this.deps.configRepo.markRemindersExecuted([...succeededIds], executedAt);
 		this.deps.logger.info("[heartbeat] done");
 		return true;
 	}

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -131,6 +131,7 @@ export interface GatewayPort {
 export interface HeartbeatConfigPort {
 	load(): Promise<HeartbeatConfig>;
 	save(config: HeartbeatConfig): Promise<void>;
+	markRemindersExecuted(reminderIds: readonly string[], executedAt: string): Promise<void>;
 }
 
 // ─── CriticAuditorPort ─────────────────────────────────────────

--- a/spec/memory/consolidation.spec.ts
+++ b/spec/memory/consolidation.spec.ts
@@ -327,6 +327,105 @@ describe("ConsolidationPipeline — update", () => {
 		expect(facts[0]!.sourceEpisodicIds).toEqual([episode.id]);
 	});
 
+	test("preserves old fact when update embedding fails", async () => {
+		const existingFact = createFact({
+			userId,
+			category: "preference",
+			fact: "User likes JavaScript",
+			keywords: ["javascript"],
+			sourceEpisodicIds: ["ep-old"],
+			embedding: [0.1, 0.2, 0.3],
+		});
+		await storage.saveFact(userId, existingFact);
+
+		const episode = makeEpisode();
+		await storage.saveEpisode(userId, episode);
+
+		const llmResponse: ConsolidationOutput = {
+			facts: [
+				{
+					action: "update",
+					category: "preference",
+					fact: "User now prefers TypeScript over JavaScript",
+					keywords: ["typescript", "javascript"],
+					existingFactId: existingFact.id,
+				},
+			],
+		};
+		const llm = createConsolidationLLM(llmResponse);
+		llm.embed = async () => {
+			throw new Error("embed failed");
+		};
+
+		const pipeline = new ConsolidationPipeline(llm, storage);
+
+		let error: unknown;
+		try {
+			await pipeline.consolidate(userId);
+		} catch (err) {
+			error = err;
+		}
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain("embed failed");
+
+		const facts = await storage.getFacts(userId);
+		expect(facts).toHaveLength(1);
+		expect(facts[0]!.id).toBe(existingFact.id);
+		expect(facts[0]!.fact).toBe("User likes JavaScript");
+	});
+
+	test("preserves old fact when update replacement cannot be saved", async () => {
+		const existingFact = createFact({
+			userId,
+			category: "preference",
+			fact: "User likes JavaScript",
+			keywords: ["javascript"],
+			sourceEpisodicIds: ["ep-old"],
+			embedding: [0.1, 0.2, 0.3],
+		});
+		await storage.saveFact(userId, existingFact);
+
+		const episode = makeEpisode();
+		await storage.saveEpisode(userId, episode);
+
+		const llmResponse: ConsolidationOutput = {
+			facts: [
+				{
+					action: "update",
+					category: "preference",
+					fact: "User now prefers TypeScript over JavaScript",
+					keywords: ["typescript", "javascript"],
+					existingFactId: existingFact.id,
+				},
+			],
+		};
+		const llm = createMockLLM({
+			structuredResponse: llmResponse,
+			embedding: [0.9, -0.1, 0],
+		});
+		const originalRandomUUID = crypto.randomUUID;
+		crypto.randomUUID = (() => existingFact.id) as typeof crypto.randomUUID;
+
+		try {
+			const pipeline = new ConsolidationPipeline(llm, storage);
+
+			let error: unknown;
+			try {
+				await pipeline.consolidate(userId);
+			} catch (err) {
+				error = err;
+			}
+			expect(error).toBeInstanceOf(Error);
+		} finally {
+			crypto.randomUUID = originalRandomUUID;
+		}
+
+		const facts = await storage.getFacts(userId);
+		expect(facts).toHaveLength(1);
+		expect(facts[0]!.id).toBe(existingFact.id);
+		expect(facts[0]!.fact).toBe("User likes JavaScript");
+	});
+
 	test("rejects reinforce after the same output updates that fact", async () => {
 		const existingFact = createFact({
 			userId,

--- a/spec/observability/log-redact.spec.ts
+++ b/spec/observability/log-redact.spec.ts
@@ -192,4 +192,23 @@ describe("redactObject", () => {
 	it("数値を直接渡した場合はそのまま返る", () => {
 		expect(redactObject(42)).toBe(42);
 	});
+
+	it("Error の name/message/stack/cause を保持しつつ文字列をマスキングする", () => {
+		const cause = new TypeError("inner token ghp_AAAAAAAAAA");
+		const error = new Error("outer mail user@example.com", { cause });
+
+		const result = redactObject(error) as Record<string, unknown>;
+
+		expect(result.name).toBe("Error");
+		expect(result.message).toBe("outer mail [REDACTED]");
+		expect(typeof result.stack).toBe("string");
+		expect(result.stack).toContain("outer mail [REDACTED]");
+		expect(result.stack).not.toContain("user@example.com");
+
+		const redactedCause = result.cause as Record<string, unknown>;
+		expect(redactedCause.name).toBe("TypeError");
+		expect(redactedCause.message).toBe("inner token [REDACTED]");
+		expect(typeof redactedCause.stack).toBe("string");
+		expect(redactedCause.stack).not.toContain("ghp_AAAAAAAAAA");
+	});
 });

--- a/spec/observability/logger.spec.ts
+++ b/spec/observability/logger.spec.ts
@@ -119,6 +119,24 @@ describe("ConsoleLogger", () => {
 
 			expect(output()).toContain("no extra");
 		});
+
+		it("Error 引数の name/message/stack/cause を extra に保持しつつマスキングする", () => {
+			const logger = new ConsoleLogger();
+			const cause = new TypeError("cause token ghp_AAAAAAAAAA");
+			const error = new Error("outer mail user@example.com", { cause });
+
+			logger.error("failed sk-abcdefghijkl", error);
+
+			const entry = JSON.parse(output());
+			expect(entry.msg).toBe("failed [REDACTED]");
+			expect(entry.extra.name).toBe("Error");
+			expect(entry.extra.message).toBe("outer mail [REDACTED]");
+			expect(entry.extra.stack).toContain("outer mail [REDACTED]");
+			expect(entry.extra.stack).not.toContain("user@example.com");
+			expect(entry.extra.cause.name).toBe("TypeError");
+			expect(entry.extra.cause.message).toBe("cause token [REDACTED]");
+			expect(entry.extra.cause.stack).not.toContain("ghp_AAAAAAAAAA");
+		});
 	});
 
 	// ─── child() によるコンテキスト付きロガー ────────────────────

--- a/spec/scheduling/heartbeat-config.spec.ts
+++ b/spec/scheduling/heartbeat-config.spec.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { JsonHeartbeatConfigRepository } from "@vicissitude/scheduling/heartbeat-config";
+import type { HeartbeatConfig, HeartbeatReminder } from "@vicissitude/shared/types";
+
+const EXECUTED_AT = "2026-05-16T01:23:45.000Z";
+
+const addedReminder: HeartbeatReminder = {
+	id: "guild-check",
+	description: "ギルドの様子を見る",
+	schedule: { type: "interval", minutes: 30 },
+	lastExecutedAt: null,
+	enabled: true,
+	guildId: "123456789012345678",
+};
+
+function createTempConfigPath(): { dir: string; filePath: string } {
+	const dir = mkdtempSync(join(tmpdir(), "vicissitude-heartbeat-config-"));
+	return { dir, filePath: join(dir, "heartbeat-config.json") };
+}
+
+function readConfig(filePath: string): HeartbeatConfig {
+	return JSON.parse(readFileSync(filePath, "utf-8")) as HeartbeatConfig;
+}
+
+describe("JsonHeartbeatConfigRepository", () => {
+	let tempDir: string | undefined;
+
+	afterEach(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = undefined;
+		}
+	});
+
+	test("stale な reminder 保存は並行した lastExecutedAt 更新を消さない", async () => {
+		const temp = createTempConfigPath();
+		tempDir = temp.dir;
+		const repo = new JsonHeartbeatConfigRepository(temp.filePath);
+
+		const schedulerConfig = await repo.load();
+		const mcpConfig = await repo.load();
+
+		const schedulerReminder = schedulerConfig.reminders.find((r) => r.id === "home-check");
+		if (!schedulerReminder) {
+			throw new Error("home-check reminder が見つかりません");
+		}
+		schedulerReminder.lastExecutedAt = EXECUTED_AT;
+		await repo.save(schedulerConfig);
+
+		mcpConfig.reminders.push(addedReminder);
+		await repo.save(mcpConfig);
+
+		const saved = readConfig(temp.filePath);
+		expect(saved.reminders.some((r) => r.id === addedReminder.id)).toBe(true);
+		expect(saved.reminders.find((r) => r.id === "home-check")?.lastExecutedAt).toBe(EXECUTED_AT);
+	});
+
+	test("markRemindersExecuted は現在の reminder 構成を保持して実行時刻だけ更新する", async () => {
+		const temp = createTempConfigPath();
+		tempDir = temp.dir;
+		const repo = new JsonHeartbeatConfigRepository(temp.filePath);
+
+		const config = await repo.load();
+		config.reminders.push(addedReminder);
+		await repo.save(config);
+
+		await repo.markRemindersExecuted(["home-check"], EXECUTED_AT);
+
+		const saved = readConfig(temp.filePath);
+		expect(saved.reminders.some((r) => r.id === addedReminder.id)).toBe(true);
+		expect(saved.reminders.find((r) => r.id === "home-check")?.lastExecutedAt).toBe(EXECUTED_AT);
+	});
+});


### PR DESCRIPTION
## 概要

Issue #960 のコメントで優先度高めとして挙げた 3 件を修正しました。

- scheduling: heartbeat 設定 JSON の競合更新で reminder / lastExecutedAt が失われないよう、lock 付き atomic write と stale save merge、scheduler 専用の実行済み更新 API を追加
- observability: Error の非 enumerable な name/message/stack/cause を redaction 後も保持し、secret は引き続きマスク
- memory: consolidation update で既存 fact を先に失効させず、置換作成失敗時に旧 fact が active のまま残るよう修正

Refs #960

## 検証

- `bun test --path-ignore-patterns 'data/shell-workspaces/**' spec/scheduling/heartbeat-config.spec.ts packages/scheduling/src/heartbeat-scheduler.test.ts spec/observability/log-redact.spec.ts spec/observability/logger.spec.ts packages/observability/src/log-redact.test.ts packages/observability/src/logger.test.ts spec/memory/consolidation.spec.ts packages/memory/src/consolidation.test.ts spec/memory/storage.spec.ts`\n- `nr fmt:check`\n- `nr check`\n- `nr lint`\n- `bun test --path-ignore-patterns 'data/shell-workspaces/**' packages/scheduling spec/scheduling packages/observability spec/observability packages/memory/src spec/memory`\n- `nr validate`\n- `nr test`\n