### PR TITLE
fix: 影響度の高い設計課題を追加修正する

### DIFF
--- a/context/TOOLS-CORE.md
+++ b/context/TOOLS-CORE.md
@@ -40,7 +40,7 @@ Discord の全メッセージは自動的に記憶に取り込まれる（ingest
 
 ### genius
 
-> `GENIUS_ACCESS_TOKEN` が設定されている場合のみ有効。
+> `GENIUS_ACCESS_TOKEN` が設定されている場合のみ有効。Spotify 設定は不要。
 
 - `core_fetch_lyrics(title, artist)` - Genius API から楽曲の歌詞を取得
 - `core_save_listening_fact(track, impression)` - 楽曲を聴いた感想を Memory（internal namespace, category=experience）に保存

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -36,6 +36,54 @@ import { registerMetaTools } from "./tools/meta.ts";
 import { registerScheduleTools } from "./tools/schedule.ts";
 import { registerSpotifyTools } from "./tools/spotify.ts";
 
+type CoreServer = Parameters<typeof registerSpotifyTools>[0];
+type CoreLogger = Parameters<typeof registerSpotifyTools>[2];
+
+interface MediaToolEnvironment extends Record<string, string | undefined> {
+	SPOTIFY_CLIENT_ID?: string;
+	SPOTIFY_CLIENT_SECRET?: string;
+	SPOTIFY_REFRESH_TOKEN?: string;
+	SPOTIFY_RECOMMEND_PLAYLIST_ID?: string;
+	GENIUS_ACCESS_TOKEN?: string;
+}
+
+interface MediaToolRegistrars {
+	registerSpotify: typeof registerSpotifyTools;
+	registerListening: (accessToken: string) => void;
+}
+
+function hasValue(value: string | undefined): value is string {
+	return value !== undefined && value.trim().length > 0;
+}
+
+export function registerConfiguredMediaTools(
+	server: CoreServer,
+	env: MediaToolEnvironment,
+	registrars: MediaToolRegistrars,
+	logger?: CoreLogger,
+): void {
+	if (
+		hasValue(env.SPOTIFY_CLIENT_ID) &&
+		hasValue(env.SPOTIFY_CLIENT_SECRET) &&
+		hasValue(env.SPOTIFY_REFRESH_TOKEN)
+	) {
+		registrars.registerSpotify(
+			server,
+			{
+				clientId: env.SPOTIFY_CLIENT_ID,
+				clientSecret: env.SPOTIFY_CLIENT_SECRET,
+				refreshToken: env.SPOTIFY_REFRESH_TOKEN,
+				recommendPlaylistId: env.SPOTIFY_RECOMMEND_PLAYLIST_ID,
+			},
+			logger,
+		);
+	}
+
+	if (hasValue(env.GENIUS_ACCESS_TOKEN)) {
+		registrars.registerListening(env.GENIUS_ACCESS_TOKEN);
+	}
+}
+
 /**
  * core MCP サーバーのエントリポイント（stdio モード）。
  *
@@ -160,43 +208,34 @@ async function main(): Promise<void> {
 		registerDiscordBridgeTools(server, { db }, boundGuildId);
 	}
 
-	if (
-		process.env.SPOTIFY_CLIENT_ID &&
-		process.env.SPOTIFY_CLIENT_SECRET &&
-		process.env.SPOTIFY_REFRESH_TOKEN
-	) {
-		registerSpotifyTools(
-			server,
-			{
-				clientId: process.env.SPOTIFY_CLIENT_ID,
-				clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
-				refreshToken: process.env.SPOTIFY_REFRESH_TOKEN,
-				recommendPlaylistId: process.env.SPOTIFY_RECOMMEND_PLAYLIST_ID,
+	registerConfiguredMediaTools(
+		server,
+		process.env,
+		{
+			registerSpotify: registerSpotifyTools,
+			registerListening: (accessToken) => {
+				const geniusClient = new GeniusClient(accessToken);
+				memoryCache.getOrCreate(INTERNAL_NAMESPACE);
+				const internalStorage = memoryCache.getStorage(INTERNAL_NAMESPACE);
+				if (!internalStorage)
+					throw new Error("unreachable: getOrCreate failed to populate memoryCache");
+				const listeningMemory = new ListeningMemory(internalStorage, {
+					embed: (text) => ollama.embed(text),
+				});
+				registerListeningTools(server, {
+					fetchLyrics: (title, artist) => geniusClient.fetchLyrics(title, artist),
+					saveListening: async (record) => {
+						await listeningMemory.saveListening({
+							track: record.track,
+							impression: record.impression,
+							listenedAt: record.listenedAt,
+						});
+					},
+				});
 			},
-			logger,
-		);
-
-		if (process.env.GENIUS_ACCESS_TOKEN) {
-			const geniusClient = new GeniusClient(process.env.GENIUS_ACCESS_TOKEN);
-			memoryCache.getOrCreate(INTERNAL_NAMESPACE);
-			const internalStorage = memoryCache.getStorage(INTERNAL_NAMESPACE);
-			if (!internalStorage)
-				throw new Error("unreachable: getOrCreate failed to populate memoryCache");
-			const listeningMemory = new ListeningMemory(internalStorage, {
-				embed: (text) => ollama.embed(text),
-			});
-			registerListeningTools(server, {
-				fetchLyrics: (title, artist) => geniusClient.fetchLyrics(title, artist),
-				saveListening: async (record) => {
-					await listeningMemory.saveListening({
-						track: record.track,
-						impression: record.impression,
-						listenedAt: record.listenedAt,
-					});
-				},
-			});
-		}
-	}
+		},
+		logger,
+	);
 
 	registerMetaTools(server, toolDescriptions);
 
@@ -221,4 +260,6 @@ async function main(): Promise<void> {
 	await server.connect(transport);
 }
 
-void main();
+if (import.meta.main) {
+	void main();
+}

--- a/packages/memory/src/storage-schema.test.ts
+++ b/packages/memory/src/storage-schema.test.ts
@@ -80,6 +80,7 @@ describe("sqlite-schema", () => {
 			const triggers = getNames(db, "trigger", "semantic_facts");
 			expect(triggers).toContain("facts_fts_ai");
 			expect(triggers).toContain("facts_fts_ad");
+			expect(triggers).toContain("facts_fts_au");
 		});
 	});
 
@@ -240,6 +241,26 @@ describe("sqlite-schema", () => {
 
 			const cols = db.prepare("PRAGMA table_info(message_queue)").all() as ColumnInfo[];
 			expect(cols.map((c) => c.name)).toContain("author_id");
+		});
+
+		test("adds missing semantic_facts FTS UPDATE trigger to existing DB", () => {
+			db.exec(`CREATE TABLE semantic_facts (
+				id TEXT PRIMARY KEY, user_id TEXT NOT NULL, category TEXT NOT NULL, fact TEXT NOT NULL,
+				keywords TEXT NOT NULL, source_episodic_ids TEXT NOT NULL, embedding TEXT NOT NULL,
+				valid_at INTEGER NOT NULL, invalid_at INTEGER, created_at INTEGER NOT NULL,
+				metadata TEXT NOT NULL DEFAULT '{}')`);
+			db.exec("CREATE VIRTUAL TABLE semantic_facts_fts USING fts5(id UNINDEXED, fact, keywords)");
+			db.exec(`CREATE TRIGGER facts_fts_ai AFTER INSERT ON semantic_facts BEGIN
+				INSERT INTO semantic_facts_fts(id, fact, keywords) VALUES (new.id, new.fact, new.keywords); END`);
+			db.exec(`CREATE TRIGGER facts_fts_ad AFTER DELETE ON semantic_facts BEGIN
+				DELETE FROM semantic_facts_fts WHERE id = old.id; END`);
+
+			createAllTables(db);
+
+			const triggers = getNames(db, "trigger", "semantic_facts");
+			expect(triggers).toContain("facts_fts_ai");
+			expect(triggers).toContain("facts_fts_ad");
+			expect(triggers).toContain("facts_fts_au");
 		});
 	});
 });

--- a/packages/memory/src/storage-schema.ts
+++ b/packages/memory/src/storage-schema.ts
@@ -50,6 +50,9 @@ export function createFactTables(db: Database): void {
 		INSERT INTO semantic_facts_fts(id, fact, keywords) VALUES (new.id, new.fact, new.keywords); END`);
 	db.exec(`CREATE TRIGGER IF NOT EXISTS facts_fts_ad AFTER DELETE ON semantic_facts BEGIN
 		DELETE FROM semantic_facts_fts WHERE id = old.id; END`);
+	db.exec(`CREATE TRIGGER IF NOT EXISTS facts_fts_au AFTER UPDATE OF fact, keywords ON semantic_facts BEGIN
+		DELETE FROM semantic_facts_fts WHERE id = old.id;
+		INSERT INTO semantic_facts_fts(id, fact, keywords) VALUES (new.id, new.fact, new.keywords); END`);
 }
 
 export function createMessageQueue(db: Database): void {

--- a/packages/observability/src/metrics.ts
+++ b/packages/observability/src/metrics.ts
@@ -174,6 +174,13 @@ interface HistogramConfig {
 	buckets: number[];
 }
 
+interface HistogramEntry {
+	labels: Record<string, string>;
+	buckets: Map<number, number>;
+	sum: number;
+	count: number;
+}
+
 const DEFAULT_DURATION_BUCKETS = [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120];
 
 function mergeLabels(
@@ -183,24 +190,10 @@ function mergeLabels(
 	return base && Object.keys(base).length > 0 ? { ...base, ...extra } : extra;
 }
 
-function parseLabelsFromKey(key: string): Record<string, string> {
-	const labels: Record<string, string> = {};
-	if (key.length === 0) return labels;
-	const inner = key.slice(1, -1);
-	for (const pair of inner.split(",")) {
-		const eq = pair.indexOf("=");
-		if (eq > 0) labels[pair.slice(0, eq)] = pair.slice(eq + 2, -1);
-	}
-	return labels;
-}
-
 export class PrometheusCollector implements MetricsCollector {
 	private counters = new Map<string, Map<string, number>>();
 	private gauges = new Map<string, Map<string, number>>();
-	private histograms = new Map<
-		string,
-		Map<string, { buckets: Map<number, number>; sum: number; count: number }>
-	>();
+	private histograms = new Map<string, Map<string, HistogramEntry>>();
 	private histogramConfigs = new Map<string, HistogramConfig>();
 	private metricMeta = new Map<string, MetricMeta>();
 
@@ -267,10 +260,12 @@ export class PrometheusCollector implements MetricsCollector {
 		const map = this.histograms.get(name);
 		if (!config || !map) return;
 
-		const key = labelsToKey(labels ?? {});
+		const baseLabels = labels ?? {};
+		const key = labelsToKey(baseLabels);
 		let entry = map.get(key);
 		if (!entry) {
 			entry = {
+				labels: { ...baseLabels },
 				buckets: new Map(config.buckets.map((b) => [b, 0])),
 				sum: 0,
 				count: 0,
@@ -322,16 +317,16 @@ export class PrometheusCollector implements MetricsCollector {
 		const config = this.histogramConfigs.get(name);
 		if (!map || !config) return;
 
-		for (const [key, entry] of map) {
-			const baseLabels = parseLabelsFromKey(key);
+		for (const [, entry] of map) {
+			const baseLabels = entry.labels;
 			for (const bucket of config.buckets) {
 				const le = mergeLabels(baseLabels, { le: String(bucket) });
 				lines.push(`${name}_bucket${labelsToKey(le)} ${entry.buckets.get(bucket) ?? 0}`);
 			}
 			const infLabels = mergeLabels(baseLabels, { le: "+Inf" });
 			lines.push(`${name}_bucket${labelsToKey(infLabels)} ${entry.count}`);
-			lines.push(`${name}_sum${key} ${entry.sum}`);
-			lines.push(`${name}_count${key} ${entry.count}`);
+			lines.push(`${name}_sum${labelsToKey(baseLabels)} ${entry.sum}`);
+			lines.push(`${name}_count${labelsToKey(baseLabels)} ${entry.count}`);
 		}
 	}
 }

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -309,7 +309,10 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 
 	async deleteSession(sessionId: string): Promise<void> {
 		const oc = await this.getClient();
-		await oc.session.delete({ sessionID: sessionId, ...this.directoryQuery() });
+		const result = await oc.session.delete({ sessionID: sessionId, ...this.directoryQuery() });
+		if (result.error) {
+			throw new Error(`deleteSession failed: ${JSON.stringify(result.error)}`);
+		}
 	}
 
 	close(): void {

--- a/spec/core/profile-config.spec.ts
+++ b/spec/core/profile-config.spec.ts
@@ -138,6 +138,22 @@ describe("JSON profile config", () => {
 		expect(config.spotify).toBeUndefined();
 	});
 
+	it("Genius feature は Spotify secret なしで AppConfig に反映する", () => {
+		const config = loadConfigFromProfile(
+			{
+				...baseProfile,
+				features: {
+					genius: {},
+				},
+			},
+			baseEnv({ GENIUS_ACCESS_TOKEN: "genius-token" }),
+			root,
+		);
+
+		expect(config.genius?.accessToken).toBe("genius-token");
+		expect(config.spotify).toBeUndefined();
+	});
+
 	it("profile に feature section がある場合だけ機能設定を作る", () => {
 		const config = loadConfigFromProfile(
 			{

--- a/spec/mcp/core-server.spec.ts
+++ b/spec/mcp/core-server.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import { registerConfiguredMediaTools } from "@vicissitude/mcp/core-server";
+
+type RegisterArgs = Parameters<typeof registerConfiguredMediaTools>;
+type Server = RegisterArgs[0];
+type Registrars = RegisterArgs[2];
+type SpotifyConfig = Parameters<Registrars["registerSpotify"]>[1];
+
+function createCapture() {
+	const spotifyConfigs: SpotifyConfig[] = [];
+	const listeningTokens: string[] = [];
+	const server = {} as Server;
+	const registrars: Registrars = {
+		registerSpotify: (_server, config) => {
+			spotifyConfigs.push(config);
+		},
+		registerListening: (accessToken) => {
+			listeningTokens.push(accessToken);
+		},
+	};
+
+	return { listeningTokens, registrars, server, spotifyConfigs };
+}
+
+describe("registerConfiguredMediaTools", () => {
+	test("Genius token があれば Spotify 設定なしでも listening tool を登録する", () => {
+		const capture = createCapture();
+
+		registerConfiguredMediaTools(
+			capture.server,
+			{ GENIUS_ACCESS_TOKEN: "genius-token" },
+			capture.registrars,
+		);
+
+		expect(capture.listeningTokens).toEqual(["genius-token"]);
+		expect(capture.spotifyConfigs).toEqual([]);
+	});
+
+	test("Spotify 設定が揃っていれば Spotify tool を登録する", () => {
+		const capture = createCapture();
+
+		registerConfiguredMediaTools(
+			capture.server,
+			{
+				SPOTIFY_CLIENT_ID: "spotify-client-id",
+				SPOTIFY_CLIENT_SECRET: "spotify-client-secret",
+				SPOTIFY_REFRESH_TOKEN: "spotify-refresh-token",
+				SPOTIFY_RECOMMEND_PLAYLIST_ID: "playlist-id",
+			},
+			capture.registrars,
+		);
+
+		expect(capture.spotifyConfigs).toEqual([
+			{
+				clientId: "spotify-client-id",
+				clientSecret: "spotify-client-secret",
+				refreshToken: "spotify-refresh-token",
+				recommendPlaylistId: "playlist-id",
+			},
+		]);
+		expect(capture.listeningTokens).toEqual([]);
+	});
+
+	test("Spotify 設定が欠けている場合は Spotify tool を登録しない", () => {
+		const capture = createCapture();
+
+		registerConfiguredMediaTools(
+			capture.server,
+			{
+				SPOTIFY_CLIENT_ID: "spotify-client-id",
+				SPOTIFY_CLIENT_SECRET: "spotify-client-secret",
+				GENIUS_ACCESS_TOKEN: "genius-token",
+			},
+			capture.registrars,
+		);
+
+		expect(capture.spotifyConfigs).toEqual([]);
+		expect(capture.listeningTokens).toEqual(["genius-token"]);
+	});
+});

--- a/spec/memory/storage.spec.ts
+++ b/spec/memory/storage.spec.ts
@@ -841,6 +841,30 @@ describe("MemoryStorage — FTS5 facts", () => {
 		const results = await storage.searchFacts(userId, "dark", 10);
 		expect(results).toHaveLength(0);
 	});
+
+	test("FTS5 follows updateFact changes to fact and keywords", async () => {
+		const fact = makeFact({
+			fact: "Prefers matcha latte",
+			keywords: ["oolong"],
+		});
+		await storage.saveFact(userId, fact);
+
+		await storage.updateFact(userId, fact.id, {
+			fact: "Prefers sourdough toast",
+			keywords: ["espresso"],
+		});
+
+		const byUpdatedFact = await storage.searchFacts(userId, "sourdough", 10);
+		expect(byUpdatedFact).toHaveLength(1);
+		expect(byUpdatedFact[0]!.fact).toBe("Prefers sourdough toast");
+
+		const byUpdatedKeyword = await storage.searchFacts(userId, "espresso", 10);
+		expect(byUpdatedKeyword).toHaveLength(1);
+		expect(byUpdatedKeyword[0]!.id).toBe(fact.id);
+
+		expect(await storage.searchFacts(userId, "matcha", 10)).toHaveLength(0);
+		expect(await storage.searchFacts(userId, "oolong", 10)).toHaveLength(0);
+	});
 });
 
 describe("MemoryStorage — search limit clamping", () => {

--- a/spec/observability/metrics.spec.ts
+++ b/spec/observability/metrics.spec.ts
@@ -142,6 +142,19 @@ describe("PrometheusCollector histogram", () => {
 		expect(output).toContain('latency_bucket{endpoint="/api",le="5"} 1');
 		expect(output).toContain('latency_bucket{endpoint="/api",le="+Inf"} 1');
 	});
+
+	it("特殊文字を含む labels 付きの histogram", () => {
+		const c = new PrometheusCollector();
+		c.registerHistogram("latency", "latency", [1]);
+		c.observeHistogram("latency", 0.5, { route: '/api,foo=bar"baz\\qux' });
+		const output = c.serialize();
+		const labels = 'route="/api,foo=bar\\"baz\\\\qux"';
+
+		expect(output).toContain(`latency_bucket{le="1",${labels}} 1`);
+		expect(output).toContain(`latency_bucket{le="+Inf",${labels}} 1`);
+		expect(output).toContain(`latency_sum{${labels}} 0.5`);
+		expect(output).toContain(`latency_count{${labels}} 1`);
+	});
 });
 
 // ─── serialize 全体フォーマット ──────────────────────────────────

--- a/spec/opencode/session-adapter.spec.ts
+++ b/spec/opencode/session-adapter.spec.ts
@@ -65,6 +65,16 @@ function createAdapter(client: OpencodeClient): OpencodeSessionAdapter {
 	});
 }
 
+function createDoneStream(): AsyncGenerator<Event, void, unknown> {
+	return {
+		next: mock(() => Promise.resolve({ done: true, value: undefined })),
+		return: mock(() => Promise.resolve({ done: true, value: undefined })),
+		[Symbol.asyncIterator]() {
+			return this;
+		},
+	} as unknown as AsyncGenerator<Event, void, unknown>;
+}
+
 function makeMessageUpdatedEvent(
 	sessionId: string,
 	messageId: string,
@@ -82,6 +92,35 @@ function makeMessageUpdatedEvent(
 		},
 	} as unknown as Event;
 }
+
+describe("OpencodeSessionAdapter deleteSession", () => {
+	test("SDK の delete が成功したら resolve する", async () => {
+		const client = createClient(createDoneStream());
+		const adapter = createAdapter(client);
+
+		await adapter.deleteSession("session-1");
+
+		expect(client.session.delete).toHaveBeenCalledWith({ sessionID: "session-1" });
+	});
+
+	test("SDK の delete が error を返したら reject する", async () => {
+		const client = createClient(createDoneStream());
+		(client.session.delete as ReturnType<typeof mock>).mockImplementation(() =>
+			Promise.resolve({ data: null, error: { message: "session not found" } }),
+		);
+		const adapter = createAdapter(client);
+
+		let caught: unknown;
+		try {
+			await adapter.deleteSession("missing-session");
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(Error);
+		expect((caught as Error).message).toBe('deleteSession failed: {"message":"session not found"}');
+	});
+});
 
 // ─── 振る舞いテスト ──────────────────────────────────────────────
 


### PR DESCRIPTION
## 概要

Issue #960 の残件から、影響度が大きく分離して修正できる項目を追加対応しました。

- memory: `updateFact()` 後に FTS index が更新されない問題を UPDATE trigger で修正
- observability: histogram label の復元を廃止し、元 labels を保持して Prometheus 出力するよう修正
- opencode: `deleteSession()` が SDK error を成功扱いしないよう修正
- mcp/listening: Genius/listening tools の登録条件を Spotify credentials から分離
- mcp: `core-server` の import 時に `main()` が走る副作用を `import.meta.main` guard で隔離

## 検証

- `bun test --path-ignore-patterns 'data/shell-workspaces/**' packages/memory/src/storage-schema.test.ts spec/memory/storage.spec.ts spec/observability/metrics.spec.ts spec/opencode/session-adapter.spec.ts spec/mcp/core-server.spec.ts spec/core/profile-config.spec.ts`\n- `nr check`\n- `nr lint`\n- `nr fmt:check`\n- `git diff --check`\n- `nr validate`\n- `nr test`\n\nCloses part of #960