### PR TITLE
fix(emotion): 感情推定の429検知と再投入抑制を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ AI エージェントとチャットボットのメトリクスは、複数ギ�
   - `trigger`: `home`, `mention`, `heartbeat`, `minecraft`, `mixed`, `unknown`。
   - `provider`, `model`: 使用した LLM provider/model。
 - セッション信頼性メトリクス（`session_errors_total`, `session_retries_total`, `session_restarts_total`）にも同じ共通ラベルを付与し、どのギルド・エージェント種別・モデルで問題が起きているかを切り分けられるようにする。
+- 感情推定は会話本体とは別の補助推論として扱い、失敗しても会話送信を止めない。失敗時は `emotion_estimation_errors_total` に `provider`, `model`, `error_type`, `http_status`, `retryable`, `error_class`, `retry_after`, `reason` を付けて記録し、warn ログにも provider/model/status/retry-after/reason を出力する。429 かつ長期 `retry-after` の場合は provider/model 単位でクールダウンし、再投入を `emotion_estimation_skips_total{reason="provider_cooldown"}` として記録する。
 - `llm_busy_sessions` は enqueue 中ではなく、実際に LLM prompt が処理中の間だけ増減する。
 - アプリケーションログは journald へ出力し、Loki へ転送する。本番環境ではホスト側のログコレクタ（現状は NixOS の Alloy）が `container_tag=vicissitude` の journald ログを `job=vicissitude` として収集し、standalone の monitoring profile では Promtail が同じ `job=vicissitude` へ揃えて転送する。Grafana ではメトリクスと同じダッシュボード内の Logs セクションで、ログ量と warn/error ログを確認できるようにする。
 

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -299,6 +299,9 @@ export function createMetrics(logger: Logger, port: number) {
 	collector.registerCounter(METRIC.SESSION_ERRORS, "Session errors total");
 	collector.registerCounter(METRIC.SESSION_RESTARTS, "Session restarts total");
 	collector.registerCounter(METRIC.SESSION_RETRIES, "Session retries total");
+	// Emotion estimation metrics
+	collector.registerCounter(METRIC.EMOTION_ESTIMATION_ERRORS, "Emotion estimation errors total");
+	collector.registerCounter(METRIC.EMOTION_ESTIMATION_SKIPS, "Emotion estimation skips total");
 	// Drift metrics
 	collector.registerGauge(METRIC.DRIFT_SCORE, "Character drift score per guild");
 	collector.registerCounter(METRIC.DRIFT_AUDITS, "Character drift audit results");

--- a/packages/agent/src/emotion/estimator.test.ts
+++ b/packages/agent/src/emotion/estimator.test.ts
@@ -22,4 +22,22 @@ describe("EmotionEstimator", () => {
 		expect(result).toEqual({ emotion: NEUTRAL_EMOTION, confidence: 0 });
 		expect(logger.warn).toHaveBeenCalledWith("[emotion] estimation failed:", error);
 	});
+
+	test("観測済みエラーは neutral を返すが warn ログを重複出力しない", async () => {
+		const error = Object.assign(new Error("observed provider failure"), {
+			suppressEmotionEstimatorLog: true,
+		});
+		const llm: LlmPromptPort = {
+			prompt(): Promise<string> {
+				return Promise.reject(error);
+			},
+		};
+		const logger = createMockLogger();
+		const estimator = new EmotionEstimator(llm, logger);
+
+		const result = await estimator.analyze({ text: "hello" });
+
+		expect(result).toEqual({ emotion: NEUTRAL_EMOTION, confidence: 0 });
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
 });

--- a/packages/agent/src/emotion/estimator.ts
+++ b/packages/agent/src/emotion/estimator.ts
@@ -31,6 +31,11 @@ const NEUTRAL_RESULT: EmotionAnalysisResult = {
 	confidence: 0,
 };
 
+function shouldLogEstimationFailure(error: unknown): boolean {
+	if (typeof error !== "object" || error === null) return true;
+	return (error as { suppressEmotionEstimatorLog?: unknown }).suppressEmotionEstimatorLog !== true;
+}
+
 export class EmotionEstimator implements EmotionAnalyzer {
 	constructor(
 		private readonly llm: LlmPromptPort,
@@ -54,7 +59,9 @@ export class EmotionEstimator implements EmotionAnalyzer {
 
 			return { emotion, confidence: parsed.confidence };
 		} catch (error) {
-			this.logger?.warn("[emotion] estimation failed:", error);
+			if (shouldLogEstimationFailure(error)) {
+				this.logger?.warn("[emotion] estimation failed:", error);
+			}
 			return NEUTRAL_RESULT;
 		}
 	}

--- a/packages/mcp/src/emotion-error-info.ts
+++ b/packages/mcp/src/emotion-error-info.ts
@@ -1,0 +1,237 @@
+export interface EmotionPromptErrorInfo {
+	status?: number;
+	retryable?: boolean;
+	retryAfterSeconds?: number;
+	errorClass: string;
+	reason: string;
+	message?: string;
+}
+
+export function extractEmotionPromptErrorInfo(error: unknown): EmotionPromptErrorInfo {
+	const nodes = collectErrorNodes(error);
+	const messages = collectMessages(nodes);
+	const status =
+		findNumberField(nodes, ["status", "statusCode", "status_code", "httpStatus"]) ??
+		parseStatusFromMessages(messages);
+	const retryAfterSeconds = findRetryAfterSeconds(nodes, messages);
+	const retryable = findBooleanField(nodes, ["retryable", "isRetryable", "is_retryable"]);
+	const errorClass =
+		findStringField(nodes, ["name", "errorClass", "error_class"]) ?? errorClassOf(error);
+	const reason = findReason(nodes, messages, status);
+	const message = messages.length > 0 ? messages.join(" | ").slice(0, 500) : undefined;
+	return { status, retryable, retryAfterSeconds, errorClass, reason, message };
+}
+
+function collectErrorNodes(value: unknown, seen = new Set<unknown>(), depth = 0): unknown[] {
+	if (value === null || value === undefined || depth > 5 || seen.has(value)) return [];
+	if (typeof value === "object" || typeof value === "function") {
+		seen.add(value);
+	}
+	const nodes: unknown[] = [value];
+	if (value instanceof Error) {
+		nodes.push(...parseEmbeddedJson(value.message));
+		if (value.cause !== undefined) {
+			nodes.push(...collectErrorNodes(value.cause, seen, depth + 1));
+		}
+	}
+	if (!isRecord(value)) return nodes;
+
+	for (const key of ["cause", "error", "response", "body", "data", "result", "details"]) {
+		if (key in value) {
+			nodes.push(...collectErrorNodes(value[key], seen, depth + 1));
+		}
+	}
+	const message = value.message;
+	if (typeof message === "string") {
+		nodes.push(...parseEmbeddedJson(message));
+	}
+	return nodes;
+}
+
+function collectMessages(nodes: unknown[]): string[] {
+	const messages: string[] = [];
+	for (const node of nodes) {
+		if (node instanceof Error && node.message) messages.push(node.message);
+		if (isRecord(node) && typeof node.message === "string") messages.push(node.message);
+		if (typeof node === "string") messages.push(node);
+	}
+	return [...new Set(messages)];
+}
+
+function parseEmbeddedJson(text: string): unknown[] {
+	const start = text.indexOf("{");
+	const end = text.lastIndexOf("}");
+	if (start < 0 || end <= start) return [];
+	try {
+		return [JSON.parse(text.slice(start, end + 1))];
+	} catch {
+		return [];
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function findNumberField(nodes: unknown[], keys: string[]): number | undefined {
+	const keySet = new Set(keys.map((key) => key.toLowerCase()));
+	for (const node of nodes) {
+		if (!isRecord(node)) continue;
+		for (const [key, value] of Object.entries(node)) {
+			if (!keySet.has(key.toLowerCase())) continue;
+			const numberValue = parseFiniteNumber(value);
+			if (numberValue !== undefined) return numberValue;
+		}
+	}
+}
+
+function findBooleanField(nodes: unknown[], keys: string[]): boolean | undefined {
+	const keySet = new Set(keys.map((key) => key.toLowerCase()));
+	for (const node of nodes) {
+		if (!isRecord(node)) continue;
+		for (const [key, value] of Object.entries(node)) {
+			if (!keySet.has(key.toLowerCase())) continue;
+			if (typeof value === "boolean") return value;
+			if (value === "true") return true;
+			if (value === "false") return false;
+		}
+	}
+}
+
+function findStringField(nodes: unknown[], keys: string[]): string | undefined {
+	const keySet = new Set(keys.map((key) => key.toLowerCase()));
+	for (const node of nodes) {
+		if (!isRecord(node)) continue;
+		for (const [key, value] of Object.entries(node)) {
+			if (!keySet.has(key.toLowerCase())) continue;
+			if (typeof value === "string" && value.trim()) return value.trim();
+		}
+	}
+}
+
+function parseFiniteNumber(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim()) {
+		const parsed = Number(value.trim());
+		if (Number.isFinite(parsed)) return parsed;
+	}
+}
+
+function parseStatusFromMessages(messages: string[]): number | undefined {
+	for (const message of messages) {
+		const match =
+			/"status(?:Code)?"\s*:\s*(\d{3})/i.exec(message) ??
+			/status(?:Code)?[=\s:]+(\d{3})/i.exec(message) ??
+			/status code[=\s:]+(\d{3})/i.exec(message);
+		if (match?.[1]) return Number(match[1]);
+	}
+}
+
+function findRetryAfterSeconds(nodes: unknown[], messages: string[]): number | undefined {
+	const retryAfterMs = findNumberField(nodes, ["retryAfterMs", "retry_after_ms"]);
+	if (retryAfterMs !== undefined) return Math.ceil(retryAfterMs / 1000);
+
+	const headerValue =
+		findHeaderValue(nodes, "x-ratelimit-user-retry-after") ?? findHeaderValue(nodes, "retry-after");
+	const headerSeconds = parseRetryAfterValue(headerValue);
+	if (headerSeconds !== undefined) return headerSeconds;
+
+	const fieldValue = findFieldValue(nodes, [
+		"retryAfter",
+		"retry_after",
+		"retryAfterSeconds",
+		"retry_after_seconds",
+	]);
+	const fieldSeconds = parseRetryAfterValue(fieldValue);
+	if (fieldSeconds !== undefined) return fieldSeconds;
+
+	for (const message of messages) {
+		const match = /(?:x-ratelimit-user-retry-after|retry-after|retryAfter)[^0-9]{0,30}(\d+)/i.exec(
+			message,
+		);
+		if (match?.[1]) return Number(match[1]);
+	}
+}
+
+function findFieldValue(nodes: unknown[], keys: string[]): unknown {
+	const keySet = new Set(keys.map((key) => key.toLowerCase()));
+	for (const node of nodes) {
+		if (!isRecord(node)) continue;
+		for (const [key, value] of Object.entries(node)) {
+			if (keySet.has(key.toLowerCase())) return value;
+		}
+	}
+}
+
+function parseRetryAfterValue(value: unknown): number | undefined {
+	if (value === undefined) return;
+	const numberValue = parseFiniteNumber(value);
+	if (numberValue !== undefined) return Math.max(0, Math.ceil(numberValue));
+	if (typeof value !== "string") return;
+	const parsedDate = Date.parse(value);
+	if (!Number.isFinite(parsedDate)) return;
+	return Math.max(0, Math.ceil((parsedDate - Date.now()) / 1000));
+}
+
+function findHeaderValue(nodes: unknown[], name: string): unknown {
+	for (const node of nodes) {
+		if (!isRecord(node)) continue;
+		for (const key of ["headers", "responseHeaders", "response_headers"]) {
+			if (key in node) {
+				const value = readHeader(node[key], name);
+				if (value !== undefined) return value;
+			}
+		}
+		const value = readHeader(node, name);
+		if (value !== undefined) return value;
+	}
+}
+
+function readHeader(headers: unknown, name: string): unknown {
+	if (!headers) return;
+	const lowerName = name.toLowerCase();
+	if (headers instanceof Headers) return headers.get(name) ?? undefined;
+	if (headers instanceof Map) {
+		for (const [key, value] of headers) {
+			if (String(key).toLowerCase() === lowerName) return value;
+		}
+		return;
+	}
+	if (typeof headers === "object" && "get" in headers && typeof headers.get === "function") {
+		const value = headers.get(name);
+		if (value !== null && value !== undefined) return value;
+	}
+	if (!isRecord(headers)) return;
+	for (const [key, value] of Object.entries(headers)) {
+		if (key.toLowerCase() === lowerName) return value;
+	}
+}
+
+function findReason(nodes: unknown[], messages: string[], status: number | undefined): string {
+	const headerReason = findHeaderValue(nodes, "x-ratelimit-exceeded");
+	if (typeof headerReason === "string" && headerReason.trim()) return headerReason.trim();
+	const fieldReason = findStringField(nodes, [
+		"reason",
+		"code",
+		"errorCode",
+		"error_code",
+		"type",
+		"x-ratelimit-exceeded",
+	]);
+	if (fieldReason) return fieldReason;
+	if (messages.some((message) => message.includes("quota_exceeded"))) return "quota_exceeded";
+	if (status === 429) return "rate_limited";
+	return "unknown";
+}
+
+function errorClassOf(error: unknown): string {
+	if (error instanceof Error && error.name) return error.name;
+	if (isRecord(error) && typeof error.name === "string" && error.name.trim()) {
+		return error.name.trim();
+	}
+	if (typeof error === "object" && error !== null && "constructor" in error) {
+		const ctor = error.constructor as { name?: string };
+		if (ctor.name) return ctor.name;
+	}
+	return "unknown";
+}

--- a/packages/mcp/src/emotion-observability.ts
+++ b/packages/mcp/src/emotion-observability.ts
@@ -1,0 +1,177 @@
+import { EmotionEstimator } from "@vicissitude/agent/emotion/estimator";
+import { classifyErrorType, METRIC } from "@vicissitude/observability/metrics";
+import type { EmotionAnalyzer, LlmPromptPort } from "@vicissitude/shared/ports";
+import type { Logger, MetricsCollector } from "@vicissitude/shared/types";
+
+import { extractEmotionPromptErrorInfo } from "./emotion-error-info.ts";
+export { extractEmotionPromptErrorInfo } from "./emotion-error-info.ts";
+export type { EmotionPromptErrorInfo } from "./emotion-error-info.ts";
+
+const LONG_RETRY_AFTER_THRESHOLD_SECONDS = 60;
+
+export interface EmotionAnalyzerOptions {
+	metrics?: MetricsCollector;
+	now?: () => number;
+}
+
+export interface EmotionPromptModel {
+	providerId: string;
+	modelId: string;
+}
+
+interface CooldownState {
+	untilMs: number;
+	reason: string;
+}
+
+interface ObservationContext {
+	model: EmotionPromptModel;
+	logger: Logger;
+	metrics?: MetricsCollector;
+}
+
+export function createEmotionAnalyzerFromPromptPort(
+	llm: LlmPromptPort,
+	model: EmotionPromptModel,
+	logger: Logger,
+	options: EmotionAnalyzerOptions = {},
+): EmotionAnalyzer {
+	return new EmotionEstimator(createObservedEmotionPromptPort(llm, model, logger, options), logger);
+}
+
+function createObservedEmotionPromptPort(
+	inner: LlmPromptPort,
+	model: EmotionPromptModel,
+	logger: Logger,
+	options: EmotionAnalyzerOptions,
+): LlmPromptPort {
+	let cooldown: CooldownState | null = null;
+	const now = options.now ?? Date.now;
+	const context: ObservationContext = { model, logger, metrics: options.metrics };
+
+	function activeCooldown(): CooldownState | null {
+		if (!cooldown) return null;
+		if (now() < cooldown.untilMs) return cooldown;
+		cooldown = null;
+		return null;
+	}
+
+	return {
+		async prompt(text: string): Promise<string> {
+			const cooldownState = activeCooldown();
+			if (cooldownState) {
+				skipDueToCooldown(cooldownState, context, now);
+			}
+
+			try {
+				return await inner.prompt(text);
+			} catch (error) {
+				recordFailure(error, context, now, (state) => {
+					cooldown = state;
+				});
+				throw createSuppressedEmotionPromptError("emotion estimation prompt failed", error);
+			}
+		},
+	};
+}
+
+function recordFailure(
+	error: unknown,
+	context: ObservationContext,
+	now: () => number,
+	setCooldown: (cooldown: CooldownState) => void,
+): void {
+	const info = extractEmotionPromptErrorInfo(error);
+	const retryAfter = classifyRetryAfter(info.retryAfterSeconds);
+	const errorType = classifyErrorType({
+		status: info.status,
+		retryable: info.retryable,
+		errorClass: info.errorClass,
+		message: info.message,
+	});
+	const { model, metrics, logger } = context;
+	metrics?.incrementCounter(METRIC.EMOTION_ESTIMATION_ERRORS, {
+		provider: model.providerId,
+		model: model.modelId,
+		error_type: errorType,
+		http_status: info.status === undefined ? "unknown" : String(info.status),
+		retryable: info.retryable === undefined ? "unknown" : String(info.retryable),
+		error_class: info.errorClass,
+		retry_after: retryAfter,
+		reason: info.reason,
+	});
+
+	if (shouldCooldown(info)) {
+		const untilMs = now() + info.retryAfterSeconds * 1000;
+		setCooldown({ untilMs, reason: info.reason });
+		logger.warn("[emotion] estimation provider cooldown activated", {
+			provider: model.providerId,
+			model: model.modelId,
+			error_type: errorType,
+			http_status: info.status,
+			retry_after_seconds: info.retryAfterSeconds,
+			retry_after: retryAfter,
+			reason: info.reason,
+			cooldown_until: new Date(untilMs).toISOString(),
+		});
+		return;
+	}
+
+	logger.warn("[emotion] estimation provider failure", {
+		provider: model.providerId,
+		model: model.modelId,
+		error_type: errorType,
+		http_status: info.status ?? "unknown",
+		retry_after_seconds: info.retryAfterSeconds ?? "unknown",
+		retry_after: retryAfter,
+		reason: info.reason,
+		error_class: info.errorClass,
+	});
+}
+
+function shouldCooldown(info: { status?: number; retryAfterSeconds?: number }): info is {
+	status: 429;
+	retryAfterSeconds: number;
+} {
+	return (
+		info.status === 429 &&
+		info.retryAfterSeconds !== undefined &&
+		info.retryAfterSeconds >= LONG_RETRY_AFTER_THRESHOLD_SECONDS
+	);
+}
+
+function skipDueToCooldown(
+	cooldown: CooldownState,
+	context: ObservationContext,
+	now: () => number,
+): never {
+	const { model, metrics, logger } = context;
+	const remainingSeconds = Math.ceil((cooldown.untilMs - now()) / 1000);
+	metrics?.incrementCounter(METRIC.EMOTION_ESTIMATION_SKIPS, {
+		provider: model.providerId,
+		model: model.modelId,
+		reason: "provider_cooldown",
+	});
+	logger.warn("[emotion] estimation skipped during provider cooldown", {
+		provider: model.providerId,
+		model: model.modelId,
+		remaining_seconds: remainingSeconds,
+		reason: "provider_cooldown",
+		cooldown_reason: cooldown.reason,
+	});
+	throw createSuppressedEmotionPromptError("emotion estimation skipped during provider cooldown");
+}
+
+function createSuppressedEmotionPromptError(message: string, cause?: unknown): Error {
+	const error = new Error(message, { cause }) as Error & {
+		suppressEmotionEstimatorLog: true;
+	};
+	error.name = "SuppressedEmotionPromptError";
+	error.suppressEmotionEstimatorLog = true;
+	return error;
+}
+
+function classifyRetryAfter(seconds: number | undefined): "none" | "short" | "long" {
+	if (seconds === undefined) return "none";
+	return seconds >= LONG_RETRY_AFTER_THRESHOLD_SECONDS ? "long" : "short";
+}

--- a/packages/mcp/src/emotion.test.ts
+++ b/packages/mcp/src/emotion.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { readEmotionEstimationConfigFromEnv } from "./emotion.ts";
+import { extractEmotionPromptErrorInfo, readEmotionEstimationConfigFromEnv } from "./emotion.ts";
 
 describe("readEmotionEstimationConfigFromEnv", () => {
 	test("feature が無効なら undefined を返す", () => {
@@ -43,5 +43,36 @@ describe("readEmotionEstimationConfigFromEnv", () => {
 				EMOTION_ESTIMATION_ENABLED: "true",
 			}),
 		).toThrow("EMOTION_PROVIDER_ID is required when emotion estimation is enabled");
+	});
+});
+
+describe("extractEmotionPromptErrorInfo", () => {
+	test("OpenCode prompt failure の JSON message から 429 quota_exceeded を抽出する", () => {
+		const error = new Error(
+			'Prompt failed: {"name":"AI_APICallError","statusCode":429,"isRetryable":true,"headers":{"x-ratelimit-exceeded":"quota_exceeded","x-ratelimit-user-retry-after":"465000"}}',
+		);
+		const info = extractEmotionPromptErrorInfo(error);
+
+		expect(info.status).toBe(429);
+		expect(info.retryable).toBe(true);
+		expect(info.retryAfterSeconds).toBe(465_000);
+		expect(info.errorClass).toBe("AI_APICallError");
+		expect(info.reason).toBe("quota_exceeded");
+	});
+
+	test("Headers オブジェクトの retry-after も抽出する", () => {
+		const error = Object.assign(new Error("quota exceeded"), {
+			name: "AI_APICallError",
+			statusCode: 429,
+			headers: new Headers({
+				"retry-after": "120",
+				"x-ratelimit-exceeded": "quota_exceeded",
+			}),
+		});
+		const info = extractEmotionPromptErrorInfo(error);
+
+		expect(info.status).toBe(429);
+		expect(info.retryAfterSeconds).toBe(120);
+		expect(info.reason).toBe("quota_exceeded");
 	});
 });

--- a/packages/mcp/src/emotion.ts
+++ b/packages/mcp/src/emotion.ts
@@ -1,9 +1,18 @@
-import { EmotionEstimator } from "@vicissitude/agent/emotion/estimator";
 import { OllamaChatAdapter } from "@vicissitude/ollama/ollama-chat-adapter";
 import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import type { EmotionAnalyzer, LlmPromptPort } from "@vicissitude/shared/ports";
 import type { Logger, OpencodeModel, OpencodeSessionPort } from "@vicissitude/shared/types";
+
+import {
+	createEmotionAnalyzerFromPromptPort,
+	type EmotionAnalyzerOptions,
+} from "./emotion-observability.ts";
+export {
+	createEmotionAnalyzerFromPromptPort,
+	extractEmotionPromptErrorInfo,
+} from "./emotion-observability.ts";
+export type { EmotionAnalyzerOptions, EmotionPromptErrorInfo } from "./emotion-observability.ts";
 
 const EMOTION_PROMPT_TIMEOUT_MS = 30_000;
 
@@ -44,11 +53,12 @@ export function readEmotionEstimationConfigFromEnv(
 export function createEmotionAnalyzer(
 	config: EmotionEstimationConfig | undefined,
 	logger: Logger,
+	options: EmotionAnalyzerOptions = {},
 ): EmotionAnalyzerHandle | undefined {
 	if (!config) return;
 
 	const llm = createEmotionPromptPort(config, logger);
-	const analyzer = new EmotionEstimator(llm, logger);
+	const analyzer = createEmotionAnalyzerFromPromptPort(llm, config, logger, options);
 	return {
 		analyzer,
 		close() {

--- a/packages/observability/src/metrics.ts
+++ b/packages/observability/src/metrics.ts
@@ -42,6 +42,9 @@ export const METRIC = {
 	SESSION_ERRORS: "session_errors_total",
 	SESSION_RESTARTS: "session_restarts_total",
 	SESSION_RETRIES: "session_retries_total",
+	// Emotion estimation metrics
+	EMOTION_ESTIMATION_ERRORS: "emotion_estimation_errors_total",
+	EMOTION_ESTIMATION_SKIPS: "emotion_estimation_skips_total",
 } as const;
 
 // ─── labelsToKey ─────────────────────────────────────────────────

--- a/spec/mcp/emotion-quota.spec.ts
+++ b/spec/mcp/emotion-quota.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import { createEmotionAnalyzerFromPromptPort } from "@vicissitude/mcp/emotion";
+import { METRIC } from "@vicissitude/observability/metrics";
+import { NEUTRAL_EMOTION } from "@vicissitude/shared/emotion";
+import type { LlmPromptPort } from "@vicissitude/shared/ports";
+import { createMockLogger, createMockMetrics } from "@vicissitude/shared/test-helpers";
+
+function createQuotaExceededError(retryAfterSeconds: number): Error {
+	const error = new Error("GitHub Copilot quota exceeded");
+	return Object.assign(error, {
+		name: "AI_APICallError",
+		statusCode: 429,
+		headers: {
+			"x-ratelimit-exceeded": "quota_exceeded",
+			"x-ratelimit-user-retry-after": String(retryAfterSeconds),
+		},
+	});
+}
+
+describe("感情推定の quota exceeded 検知", () => {
+	test("429 quota_exceeded を記録し、長期 retry-after 中は同じ provider/model へ再投入しない", async () => {
+		let now = 1_000_000;
+		let promptCalls = 0;
+		const llm: LlmPromptPort = {
+			prompt(): Promise<string> {
+				promptCalls += 1;
+				return Promise.reject(createQuotaExceededError(465_000));
+			},
+		};
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const analyzer = createEmotionAnalyzerFromPromptPort(
+			llm,
+			{ providerId: "github-copilot", modelId: "gpt-5-mini" },
+			logger,
+			{ metrics, now: () => now },
+		);
+
+		const first = await analyzer.analyze({ text: "短い返事" });
+
+		expect(first).toEqual({ emotion: NEUTRAL_EMOTION, confidence: 0 });
+		expect(promptCalls).toBe(1);
+		expect(metrics.incrementCounter).toHaveBeenCalledWith(
+			METRIC.EMOTION_ESTIMATION_ERRORS,
+			expect.objectContaining({
+				provider: "github-copilot",
+				model: "gpt-5-mini",
+				error_type: "rate_limit",
+				http_status: "429",
+				retry_after: "long",
+				reason: "quota_exceeded",
+			}),
+		);
+		expect(logger.warn).toHaveBeenCalledWith(
+			"[emotion] estimation provider cooldown activated",
+			expect.objectContaining({
+				provider: "github-copilot",
+				model: "gpt-5-mini",
+				http_status: 429,
+				retry_after_seconds: 465_000,
+				reason: "quota_exceeded",
+			}),
+		);
+
+		const second = await analyzer.analyze({ text: "もう一度返事" });
+
+		expect(second).toEqual({ emotion: NEUTRAL_EMOTION, confidence: 0 });
+		expect(promptCalls).toBe(1);
+		expect(metrics.incrementCounter).toHaveBeenCalledWith(
+			METRIC.EMOTION_ESTIMATION_SKIPS,
+			expect.objectContaining({
+				provider: "github-copilot",
+				model: "gpt-5-mini",
+				reason: "provider_cooldown",
+			}),
+		);
+		expect(logger.warn).toHaveBeenCalledWith(
+			"[emotion] estimation skipped during provider cooldown",
+			expect.objectContaining({
+				provider: "github-copilot",
+				model: "gpt-5-mini",
+				remaining_seconds: 465_000,
+				reason: "provider_cooldown",
+			}),
+		);
+
+		now += 465_001_000;
+		await analyzer.analyze({ text: "待機後の返事" });
+		expect(promptCalls).toBe(2);
+	});
+});

--- a/spec/mcp/tools/discord-emotion.spec.ts
+++ b/spec/mcp/tools/discord-emotion.spec.ts
@@ -1,14 +1,18 @@
 /* oxlint-disable no-non-null-assertion -- test assertions after length/null checks */
 import { describe, expect, test } from "bun:test";
 
+import { createEmotionAnalyzerFromPromptPort } from "@vicissitude/mcp/emotion";
+import { METRIC } from "@vicissitude/observability/metrics";
 import { createEmotion } from "@vicissitude/shared/emotion";
 import type { Emotion } from "@vicissitude/shared/emotion";
 import type {
 	EmotionAnalysisInput,
 	EmotionAnalysisResult,
 	EmotionAnalyzer,
+	LlmPromptPort,
 	MoodWriter,
 } from "@vicissitude/shared/ports";
+import { createMockLogger, createMockMetrics } from "@vicissitude/shared/test-helpers";
 
 import { captureTools, createDiscordClientStub } from "./discord-test-helpers";
 
@@ -45,6 +49,18 @@ function createSpyMoodWriter(): {
 		},
 		calls,
 	};
+}
+
+function createQuotaExceededError(retryAfterSeconds: number): Error {
+	const error = new Error("GitHub Copilot quota exceeded");
+	return Object.assign(error, {
+		name: "AI_APICallError",
+		statusCode: 429,
+		headers: {
+			"x-ratelimit-exceeded": "quota_exceeded",
+			"x-ratelimit-user-retry-after": String(retryAfterSeconds),
+		},
+	});
 }
 
 // ─── Tests ───────────────────────────────────────────────────────
@@ -206,5 +222,64 @@ describe("send_message / reply での感情推定トリガー", () => {
 		expect(writerCalls).toHaveLength(1);
 		// moodKey が使われ、agentId ではないことを検証
 		expect(writerCalls[0]!.agentId).toBe("discord:12345");
+	});
+
+	test("quota exceeded による感情推定失敗中も send_message は成功し、再投入は抑制される", async () => {
+		let promptCalls = 0;
+		const llm: LlmPromptPort = {
+			prompt(): Promise<string> {
+				promptCalls += 1;
+				return Promise.reject(createQuotaExceededError(465_000));
+			},
+		};
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const analyzer = createEmotionAnalyzerFromPromptPort(
+			llm,
+			{ providerId: "github-copilot", modelId: "gpt-5-mini" },
+			logger,
+			{ metrics, now: () => 1_000_000 },
+		);
+		const { writer, calls: writerCalls } = createSpyMoodWriter();
+
+		const { tools } = captureTools({
+			discordClient: createDiscordClientStub(),
+			emotionAnalyzer: analyzer,
+			moodWriter: writer,
+			agentId: "agent-1",
+			logger,
+		});
+
+		const sendMessage = tools.get("send_message");
+		const first = (await sendMessage!({
+			channel_id: "ch-1",
+			content: "一度目",
+		})) as { content: Array<{ type: string; text: string }> };
+
+		expect(first.content[0]!.text).toContain("Sent message");
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 50);
+		});
+		expect(promptCalls).toBe(1);
+
+		const second = (await sendMessage!({
+			channel_id: "ch-1",
+			content: "二度目",
+		})) as { content: Array<{ type: string; text: string }> };
+
+		expect(second.content[0]!.text).toContain("Sent message");
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 50);
+		});
+		expect(promptCalls).toBe(1);
+		expect(writerCalls).toHaveLength(0);
+		expect(metrics.incrementCounter).toHaveBeenCalledWith(
+			METRIC.EMOTION_ESTIMATION_SKIPS,
+			expect.objectContaining({
+				provider: "github-copilot",
+				model: "gpt-5-mini",
+				reason: "provider_cooldown",
+			}),
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- 感情推定の補助 LLM 呼び出し失敗を provider/model/status/retry-after/reason 付きで warn ログと metrics に記録
- 429 かつ長期 retry-after の場合、provider/model 単位のクールダウンで再投入を抑制
- quota exceeded 中でも Discord send_message/reply の本体処理が止まらない仕様テストを追加

## Verification
- nr validate
- nr test

Closes #958