### PR TITLE
fix(memory): critic audit の scopeId 扱いを修正する

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -365,21 +365,19 @@ export async function buildCriticAuditorAdapter(
 
 	const storageCache = new Map<string, MemoryStorage>();
 	return {
-		audit(userId: string) {
+		audit(subject: string) {
 			// gateway.start() 前に audit が呼ばれた場合、bot user id 未解決のため早期 return
-			// (namespace 解決は GUILD_ID_RE バリデーションを行うため、それより前に判定する)
+			// (namespace 解決は scopeId バリデーションを行うため、それより前に判定する)
 			const botUserId = getBotUserId();
 			if (!botUserId) return Promise.resolve({ status: "skipped", reason: "no_bot_id" });
 
-			let storage = storageCache.get(userId);
+			let storage = storageCache.get(subject);
 			if (!storage) {
 				const namespace: MemoryNamespace =
-					userId === HUA_SELF_SUBJECT
-						? INTERNAL_NAMESPACE
-						: agentScopeNamespace(discordScopeId(userId));
+					subject === HUA_SELF_SUBJECT ? INTERNAL_NAMESPACE : agentScopeNamespace(subject);
 				mkdirSync(resolveMemoryDbDir(dataDir, namespace), { recursive: true });
 				storage = new MemoryStorage(resolveMemoryDbPath(dataDir, namespace));
-				storageCache.set(userId, storage);
+				storageCache.set(subject, storage);
 			}
 			const auditor = new CriticAuditor({
 				llm,
@@ -388,7 +386,7 @@ export async function buildCriticAuditorAdapter(
 				characterDefinition,
 				botUserId,
 			});
-			return auditor.audit(userId);
+			return auditor.audit(subject);
 		},
 	};
 }

--- a/packages/scheduling/src/consolidation-scheduler.ts
+++ b/packages/scheduling/src/consolidation-scheduler.ts
@@ -145,8 +145,8 @@ export class ConsolidationScheduler {
 	): Promise<void> {
 		if (!this.criticAuditor) return;
 		try {
-			const userId = defaultSubject(namespace);
-			const result = await this.criticAuditor.audit(userId);
+			const subject = defaultSubject(namespace);
+			const result = await this.criticAuditor.audit(subject);
 			if (result.status === "skipped") {
 				this.metrics?.incrementCounter(METRIC.CRITIC_AUDITOR_SKIP_TOTAL, {
 					namespace: key,

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -167,7 +167,7 @@ export type CriticAuditOutcome = CriticAuditCompleted | CriticAuditSkipped;
 
 /** CriticAuditor ポートインターフェース */
 export interface CriticAuditorPort {
-	audit(userId: string): Promise<CriticAuditOutcome>;
+	audit(subject: string): Promise<CriticAuditOutcome>;
 }
 
 // ─── GitHubIssuePort ──────────────────────────────────────────

--- a/spec/discord/bootstrap-memory.spec.ts
+++ b/spec/discord/bootstrap-memory.spec.ts
@@ -17,6 +17,7 @@ import type { CriticResult } from "@vicissitude/memory/critic-auditor";
 import type { MemoryLlmPort, Schema } from "@vicissitude/memory/llm-port";
 import {
 	agentScopeNamespace,
+	defaultSubject,
 	discordScopeId,
 	resolveMemoryDbDir,
 	resolveMemoryDbPath,
@@ -154,15 +155,16 @@ describe("setupMemoryRecording()", () => {
 		const botUserId = "1100000000000000001";
 		const memoryDataDir = resolve(testDir, "data/memory");
 		const namespace = agentScopeNamespace(discordScopeId(guildId));
+		const subject = defaultSubject(namespace);
 		mkdirSync(resolveMemoryDbDir(memoryDataDir, namespace), { recursive: true });
 		const storage = new MemoryStorage(resolveMemoryDbPath(memoryDataDir, namespace));
 		try {
 			await Promise.all(
 				Array.from({ length: 3 }, (_, i) =>
 					storage.saveEpisode(
-						guildId,
+						subject,
 						makeEpisode({
-							userId: guildId,
+							userId: subject,
 							messages: [
 								{ role: "user", content: `hello ${i}`, authorId: "user-1" },
 								{
@@ -187,12 +189,62 @@ describe("setupMemoryRecording()", () => {
 
 		expect(adapter).toBeDefined();
 		if (!adapter) return;
-		const result = await adapter.audit(guildId);
+		const result = await adapter.audit(subject);
 
 		expect(result.status).toBe("completed");
 		expect(calls).toHaveLength(1);
 		const systemPrompt = calls[0]?.messages.find((m) => m.role === "system")?.content ?? "";
 		expect(systemPrompt).toContain("Unique persona marker");
+	});
+
+	test("buildCriticAuditorAdapter(): audit() は agent-scope の default subject をそのまま監査対象にする", async () => {
+		const contextDir = resolve(testDir, "context");
+		mkdirSync(contextDir, { recursive: true });
+		const soulPath = resolve(contextDir, "SOUL.md");
+		writeFileSync(soulPath, "# Character\nUnique scope subject marker");
+
+		const guildId = "1100000000000000003";
+		const botUserId = "1100000000000000001";
+		const memoryDataDir = resolve(testDir, "data/memory");
+		const namespace = agentScopeNamespace(discordScopeId(guildId));
+		const subject = defaultSubject(namespace);
+		mkdirSync(resolveMemoryDbDir(memoryDataDir, namespace), { recursive: true });
+		const storage = new MemoryStorage(resolveMemoryDbPath(memoryDataDir, namespace));
+		try {
+			await Promise.all(
+				Array.from({ length: 3 }, (_, i) =>
+					storage.saveEpisode(
+						subject,
+						makeEpisode({
+							userId: subject,
+							messages: [
+								{ role: "user", content: `scope hello ${i}`, authorId: "user-1" },
+								{
+									role: "assistant",
+									content: "お手伝いします。素晴らしいご質問ですね。了解しました。もちろんです。",
+									authorId: botUserId,
+									name: "ふあ",
+								},
+							],
+							startAt: new Date(Date.now() - 60_000),
+							endAt: new Date(),
+						}),
+					),
+				),
+			);
+		} finally {
+			storage.close();
+		}
+
+		const { llm, calls } = createSpyLLM({ severity: "none", summary: "ok" });
+		const adapter = await buildCriticAuditorAdapter(soulPath, llm, memoryDataDir, () => botUserId);
+
+		expect(adapter).toBeDefined();
+		if (!adapter) return;
+		const result = await adapter.audit(subject);
+
+		expect(result.status).toBe("completed");
+		expect(calls).toHaveLength(1);
 	});
 
 	test("SOUL.md が存在しない場合: MemoryResources を返す", async () => {

--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -248,7 +248,7 @@ describe("ConsolidationScheduler", () => {
 			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
 			await (scheduler as unknown as TickFn).tick();
 
-			// audit が userId = "discord:guild:222"（scopeId）で呼ばれる
+			// audit が agent-scope の default subject（scopeId）で呼ばれる
 			expect(auditor.audit).toHaveBeenCalledTimes(1);
 			expect(auditor.audit).toHaveBeenCalledWith("discord:guild:222");
 		});


### PR DESCRIPTION
## Summary
- critic auditor adapter の audit 引数を subject/scopeId として扱うよう修正
- scheduler 側の変数名を defaultSubject 契約に合わせて整理
- agent-scope の default subject で同じ namespace DB を監査できる spec を追加

## Tests
- bun test --path-ignore-patterns 'data/shell-workspaces/**' spec/discord/bootstrap-memory.spec.ts\n- bun test --path-ignore-patterns 'data/shell-workspaces/**' spec/scheduling/consolidation-scheduler-critic-audit.spec.ts spec/scheduling/consolidation-scheduler.spec.ts packages/scheduling/src/consolidation-scheduler.test.ts\n- nr validate\n- nr test\n\nCloses #971