### PR TITLE
chore(opencode): OpenCode を 1.15.5 に更新する

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "vicissitude",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@opencode-ai/sdk": "^1.14.41",
+        "@opencode-ai/sdk": "^1.15.5",
         "canvas": "^3.2.1",
         "discord.js": "^14.25.1",
         "drizzle-orm": "^0.45.1",
@@ -161,7 +161,7 @@
     "packages/opencode": {
       "name": "@vicissitude/opencode",
       "dependencies": {
-        "@opencode-ai/sdk": "^1.14.41",
+        "@opencode-ai/sdk": "^1.15.5",
         "@vicissitude/shared": "workspace:*",
       },
     },
@@ -334,7 +334,7 @@
 
     "@monogrid/gainmap-js": ["@monogrid/gainmap-js@3.4.0", "", { "dependencies": { "promise-worker-transferable": "^1.0.4" }, "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.41", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-RYb2dCUv0TWIvBNnnO6ANbAPYri6rKuWizSoVFw/Pw+SCDj9ASHM5gAZ+jkskp8gYMfLLHe/Fpkun/9mr8m0IQ=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.15.5", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-ozJuEmXzrOvia5n0L1KAuvpyf9ESGmTk1FiPhn0RK5X1whbzjlTXL0NAxqNCEkqETxL35jS1KHArEiTpvtJ6FQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/containers/bot/Containerfile
+++ b/containers/bot/Containerfile
@@ -28,9 +28,8 @@ RUN apt-get update && \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN bun install -g opencode-ai@1.14.41 && \
-    cp /root/.bun/install/global/node_modules/opencode-ai/bin/.opencode /usr/local/bin/opencode && \
-    chmod 755 /usr/local/bin/opencode && \
+RUN bun install -g opencode-ai@1.15.5 && \
+    install -m 755 "$(readlink -f /root/.bun/bin/opencode)" /usr/local/bin/opencode && \
     rm -rf /root/.bun && \
     opencode --version
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,40 @@
       ];
 
       perSystem =
-        { pkgs, ... }:
+        { pkgs, system, ... }:
+        let
+          opencodeVersion = "1.15.5";
+          opencodePlatform = {
+            x86_64-linux = {
+              packageName = "opencode-linux-x64";
+              hash = "sha256-taZkHun5OsGO6VQ3ZAnnCDne+bsaRRpfPExtrerNy8Q=";
+            };
+            aarch64-linux = {
+              packageName = "opencode-linux-arm64";
+              hash = "sha256-O2hVGCK+aRHjL87VOKww6yMnzcFFJbMZoarA6vNq+V8=";
+            };
+            aarch64-darwin = {
+              packageName = "opencode-darwin-arm64";
+              hash = "sha256-B+1EjtGts6FC06aYCqKcQ5wmVnrxorA60Np15OZfqXM=";
+            };
+          }.${system};
+          opencode = pkgs.stdenvNoCC.mkDerivation {
+            pname = "opencode";
+            version = opencodeVersion;
+            src = pkgs.fetchurl {
+              url = "https://registry.npmjs.org/${opencodePlatform.packageName}/-/${opencodePlatform.packageName}-${opencodeVersion}.tgz";
+              hash = opencodePlatform.hash;
+            };
+            dontBuild = true;
+            unpackPhase = "tar -xzf $src";
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out/bin
+              install -m 755 package/bin/opencode $out/bin/opencode
+              runHook postInstall
+            '';
+          };
+        in
         {
           devShells.default = pkgs.mkShell {
             packages = with pkgs; [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.1",
-		"@opencode-ai/sdk": "^1.14.41",
+		"@opencode-ai/sdk": "^1.15.5",
 		"canvas": "^3.2.1",
 		"discord.js": "^14.25.1",
 		"drizzle-orm": "^0.45.1",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -8,7 +8,7 @@
 		"./stream-helpers": "./src/stream-helpers.ts"
 	},
 	"dependencies": {
-		"@opencode-ai/sdk": "^1.14.41",
+		"@opencode-ai/sdk": "^1.15.5",
 		"@vicissitude/shared": "workspace:*"
 	}
 }


### PR DESCRIPTION
## 概要
- OpenCode SDK を 1.15.5 に更新
- base コンテナ内の opencode CLI を 1.15.5 に更新
- devShell の opencode を npm platform binary 由来の 1.15.5 に固定
- nixpkgs lock を更新

Closes #968

## 検証
- bun install --frozen-lockfile
- nr validate
- nr test
- nix develop --command opencode --version (1.15.5)
- nix flake check
- podman build -t vicissitude-base -f containers/bot/Containerfile .
- podman run --rm vicissitude-base opencode --version (1.15.5)