### PR TITLE
fix(agent): Discord送信中の追いメッセージで二重送信を防ぐ

### DIFF
--- a/packages/agent/src/runner.test.ts
+++ b/packages/agent/src/runner.test.ts
@@ -1900,6 +1900,64 @@ describe("AgentRunner 推論中断・bot デバウンス（内部ロジック）
 		secondSessionDone.resolve({ type: "cancelled" });
 	});
 
+	test("Discord 送信 tool 開始後の send() は中断せず、新着だけを次ターンへ回す", async () => {
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		let sessionWatchCount = 0;
+		const sessionPort = createSessionPort(() => {
+			sessionWatchCount += 1;
+			return sessionWatchCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+		});
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		await runner.send({ sessionKey: "k", message: "first" });
+		await Bun.sleep(0);
+		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(1);
+
+		const firstCallArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[0] as unknown[];
+		const firstParams = firstCallArgs[0] as {
+			onActivity?: (activity: { type: "tool"; tool: string; status: "running" }) => void;
+		};
+		const firstSignal = firstCallArgs[1] as AbortSignal;
+		firstParams.onActivity?.({
+			type: "tool",
+			tool: "discord_send_message",
+			status: "running",
+		});
+
+		await runner.send({ sessionKey: "k", message: "interrupt" });
+		await Bun.sleep(0);
+
+		expect(firstSignal.aborted).toBe(false);
+		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(1);
+
+		firstSessionDone.resolve({ type: "idle" });
+		for (let i = 0; i < 10; i++) {
+			// eslint-disable-next-line no-await-in-loop -- polling loop の進行を待つ
+			await Bun.sleep(0);
+		}
+
+		expect(sessionPort.promptAsyncAndWatchSession).toHaveBeenCalledTimes(2);
+		const secondCallArgs = sessionPort.promptAsyncAndWatchSession.mock.calls[1] as unknown[];
+		const secondParams = secondCallArgs[0] as { text: string };
+		expect(secondParams.text).not.toContain("first");
+		expect(secondParams.text).toContain("interrupt");
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
+
 	test("stop() が sessionAbortController を abort する", async () => {
 		const sessionDone = deferred<OpencodeSessionEvent>();
 		const sessionPort = createSessionPort(() => sessionDone.promise);

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -16,6 +16,7 @@ import type {
 	ContextBuilderPort,
 	Logger,
 	MetricsCollector,
+	OpencodeSessionActivity,
 	OpencodeSessionEvent,
 	OpencodeSessionPort,
 	SendOptions,
@@ -32,6 +33,7 @@ const DEFAULT_SUMMARY_TIMEOUT_MS = 30_000;
 const MESSAGE_DEBOUNCE_MS = 500;
 const MAX_DEBOUNCE_MS = 10_000;
 const BOT_MAX_DEBOUNCE_MS = 30_000;
+const UNINTERRUPTIBLE_DISCORD_TOOLS = new Set(["discord_send_message", "discord_reply"]);
 
 interface PendingMessage {
 	text: string;
@@ -108,6 +110,7 @@ export class AgentRunner implements AiAgent {
 	private lastPromptScopeId: string | null = null;
 	private pendingDebounceResolve: (() => void) | null = null;
 	private hasBotPending = false;
+	private promptHasUninterruptibleSideEffect = false;
 	private activePromptMetrics: ActivePromptMetrics | null = null;
 	private lastPromptMetricLabels: Record<string, string> | null = null;
 
@@ -164,8 +167,14 @@ export class AgentRunner implements AiAgent {
 		this.pendingResolve?.();
 		this.pendingDebounceResolve?.();
 
-		// 推論中（sessionWatch が pending）なら中断して旧メッセージを保全
+		// 推論中（sessionWatch が pending）なら中断して旧メッセージを保全。
+		// ただし Discord 送信系 tool が開始済みなら、外部副作用が巻き戻せないため
+		// 現在の turn を最後まで待ち、新着は次 turn に回す。
 		if (this.sessionWatch) {
+			if (this.promptHasUninterruptibleSideEffect) {
+				this.ensurePolling();
+				return Promise.resolve({ text: "", sessionId: "queued" });
+			}
 			if (this.lastPromptText !== null) {
 				this.pendingMessages.unshift({
 					text: this.lastPromptText,
@@ -174,10 +183,7 @@ export class AgentRunner implements AiAgent {
 					scopeId: this.lastPromptScopeId ?? undefined,
 				});
 			}
-			this.lastPromptText = null;
-			this.lastPromptAttachments = null;
-			this.lastPromptTrigger = null;
-			this.lastPromptScopeId = null;
+			this.clearLastPrompt();
 			this.sessionAbortController?.abort();
 		}
 
@@ -284,10 +290,8 @@ export class AgentRunner implements AiAgent {
 					// runner stop による中断
 					if (signal.aborted) return;
 					// 追いメッセージによるセッション中断 → 旧+新メッセージをまとめて再プロンプト
-					this.lastPromptText = null;
-					this.lastPromptAttachments = null;
-					this.lastPromptTrigger = null;
-					this.lastPromptScopeId = null;
+					this.clearLastPrompt();
+					this.promptHasUninterruptibleSideEffect = false;
 					this.sessionAbortController = null;
 					resetBackoffState();
 					continue;
@@ -301,6 +305,8 @@ export class AgentRunner implements AiAgent {
 						}),
 					);
 					this.finalizePromptMetrics("deleted");
+					if (this.promptHasUninterruptibleSideEffect) this.clearLastPrompt();
+					this.promptHasUninterruptibleSideEffect = false;
 					// eslint-disable-next-line no-await-in-loop -- rotation after external deletion
 					await this.forceSessionRotation();
 					resetBackoffState();
@@ -328,12 +334,20 @@ export class AgentRunner implements AiAgent {
 				await this.rotateSessionIfExpired();
 
 				if (event.type !== "error") {
-					this.lastPromptText = null;
-					this.lastPromptAttachments = null;
-					this.lastPromptTrigger = null;
-					this.lastPromptScopeId = null;
+					this.clearLastPrompt();
+					this.promptHasUninterruptibleSideEffect = false;
 					resetBackoffState();
 					// eslint-disable-next-line no-await-in-loop -- cooldown after idle to prevent busy loop
+					await this.sleep(IDLE_COOLDOWN_MS);
+					continue;
+				}
+
+				if (this.promptHasUninterruptibleSideEffect) {
+					this.finalizePromptMetrics("error");
+					this.clearLastPrompt();
+					this.promptHasUninterruptibleSideEffect = false;
+					resetBackoffState();
+					// eslint-disable-next-line no-await-in-loop -- avoid retrying a prompt that may have sent Discord messages
 					await this.sleep(IDLE_COOLDOWN_MS);
 					continue;
 				}
@@ -401,6 +415,14 @@ export class AgentRunner implements AiAgent {
 					}),
 				);
 				this.finalizePromptMetrics("error");
+				if (this.promptHasUninterruptibleSideEffect) {
+					this.clearLastPrompt();
+					this.promptHasUninterruptibleSideEffect = false;
+					resetBackoffState();
+					// eslint-disable-next-line no-await-in-loop -- avoid retrying a prompt that may have sent Discord messages
+					await this.sleep(IDLE_COOLDOWN_MS);
+					continue;
+				}
 				// 例外時は retryable 不明のため retryable:true 扱いのバックオフ
 				this.retryAttempt += 1;
 				this.metrics?.incrementCounter(
@@ -473,6 +495,7 @@ export class AgentRunner implements AiAgent {
 		this.abortController?.abort();
 		this.abortController = null;
 		this.sessionWatch = null;
+		this.promptHasUninterruptibleSideEffect = false;
 		this.sessionPort.close();
 	}
 
@@ -484,7 +507,26 @@ export class AgentRunner implements AiAgent {
 			return;
 		}
 		this.logger.info(`[${this.profile.name}:${this.agentId}] re-watching event stream`);
-		this.sessionWatch = this.sessionPort.waitForSessionIdle(sessionId, signal);
+		this.sessionWatch = this.sessionPort.waitForSessionIdle(sessionId, signal, (activity) =>
+			this.handleSessionActivity(activity),
+		);
+	}
+
+	private handleSessionActivity(activity: OpencodeSessionActivity): void {
+		if (
+			activity.type === "tool" &&
+			activity.status === "running" &&
+			UNINTERRUPTIBLE_DISCORD_TOOLS.has(activity.tool)
+		) {
+			this.promptHasUninterruptibleSideEffect = true;
+		}
+	}
+
+	private clearLastPrompt(): void {
+		this.lastPromptText = null;
+		this.lastPromptAttachments = null;
+		this.lastPromptTrigger = null;
+		this.lastPromptScopeId = null;
 	}
 
 	private async ensureSessionStarted(signal: AbortSignal): Promise<void> {
@@ -566,6 +608,7 @@ export class AgentRunner implements AiAgent {
 
 		this.sessionAbortController = new AbortController();
 		const combinedSignal = AbortSignal.any([signal, this.sessionAbortController.signal]);
+		this.promptHasUninterruptibleSideEffect = false;
 		this.startPromptMetrics(trigger, scopeId);
 		this.sessionWatch = this.sessionPort.promptAsyncAndWatchSession(
 			{
@@ -577,6 +620,7 @@ export class AgentRunner implements AiAgent {
 				},
 				system,
 				attachments: attachments.length > 0 ? attachments : undefined,
+				onActivity: (activity) => this.handleSessionActivity(activity),
 			},
 			combinedSignal,
 		);

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -342,16 +342,6 @@ export class AgentRunner implements AiAgent {
 					continue;
 				}
 
-				if (this.promptHasUninterruptibleSideEffect) {
-					this.finalizePromptMetrics("error");
-					this.clearLastPrompt();
-					this.promptHasUninterruptibleSideEffect = false;
-					resetBackoffState();
-					// eslint-disable-next-line no-await-in-loop -- avoid retrying a prompt that may have sent Discord messages
-					await this.sleep(IDLE_COOLDOWN_MS);
-					continue;
-				}
-
 				// --- error イベントのエラー戦略 ---
 				if (event.retryable === false) {
 					// retryable:false: 即時ローテーション（バックオフなし）
@@ -362,9 +352,21 @@ export class AgentRunner implements AiAgent {
 						}),
 					);
 					this.finalizePromptMetrics("error");
+					if (this.promptHasUninterruptibleSideEffect) this.clearLastPrompt();
+					this.promptHasUninterruptibleSideEffect = false;
 					// eslint-disable-next-line no-await-in-loop -- rotation after non-retryable error
 					await this.forceSessionRotation({ skipSummary: true });
 					resetBackoffState();
+					continue;
+				}
+
+				if (this.promptHasUninterruptibleSideEffect) {
+					this.finalizePromptMetrics("error");
+					this.clearLastPrompt();
+					this.promptHasUninterruptibleSideEffect = false;
+					resetBackoffState();
+					// eslint-disable-next-line no-await-in-loop -- avoid retrying a prompt that may have sent Discord messages
+					await this.sleep(IDLE_COOLDOWN_MS);
 					continue;
 				}
 

--- a/packages/opencode/src/session-adapter.test.ts
+++ b/packages/opencode/src/session-adapter.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2";
+import type { OpencodeSessionActivity } from "@vicissitude/shared/types";
 
 import { OpencodeSessionAdapter } from "./session-adapter.ts";
 type AbortListener = (...args: unknown[]) => void;
@@ -268,6 +269,87 @@ describe("OpencodeSessionAdapter", () => {
 		await expect(watch).resolves.toEqual({ type: "cancelled" });
 		expect(client.session.abort).toHaveBeenCalledWith({ sessionID: "session-1" });
 		expect(streamState.returnMock).toHaveBeenCalled();
+	});
+
+	test("promptAsyncAndWatchSession は tool activity を callback に通知する", async () => {
+		const streamState = createStream();
+		const client = createClient(streamState.stream);
+		const adapter = createAdapter(client as unknown as OpencodeClient);
+		const activities: OpencodeSessionActivity[] = [];
+		const onActivity = (activity: OpencodeSessionActivity) => {
+			activities.push(activity);
+		};
+
+		const watch = adapter.promptAsyncAndWatchSession({
+			sessionId: "session-1",
+			text: "watch",
+			model: { providerId: "provider", modelId: "model" },
+			onActivity,
+		});
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		streamState.push({
+			type: "message.part.updated",
+			properties: {
+				part: {
+					sessionID: "session-1",
+					type: "tool",
+					tool: "discord_send_message",
+					state: { status: "running" },
+				},
+			},
+		} as unknown as Event);
+		await Bun.sleep(0);
+		streamState.push({
+			type: "session.idle",
+			properties: { sessionID: "session-1" },
+		} as unknown as Event);
+
+		await expect(watch).resolves.toEqual({ type: "idle", tokens: undefined });
+		expect(activities).toContainEqual({
+			type: "tool",
+			tool: "discord_send_message",
+			status: "running",
+		});
+	});
+
+	test("waitForSessionIdle は tool activity を callback に通知する", async () => {
+		const streamState = createStream();
+		const client = createClient(streamState.stream);
+		const adapter = createAdapter(client as unknown as OpencodeClient);
+		const activities: OpencodeSessionActivity[] = [];
+		const onActivity = (activity: OpencodeSessionActivity) => {
+			activities.push(activity);
+		};
+
+		const watch = adapter.waitForSessionIdle("session-1", undefined, onActivity);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		streamState.push({
+			type: "message.part.updated",
+			properties: {
+				part: {
+					sessionID: "session-1",
+					type: "tool",
+					tool: "discord_reply",
+					state: { status: "running" },
+				},
+			},
+		} as unknown as Event);
+		await Bun.sleep(0);
+		streamState.push({
+			type: "session.idle",
+			properties: { sessionID: "session-1" },
+		} as unknown as Event);
+
+		await expect(watch).resolves.toEqual({ type: "idle", tokens: undefined });
+		expect(activities).toContainEqual({
+			type: "tool",
+			tool: "discord_reply",
+			status: "running",
+		});
 	});
 
 	test("promptAsyncAndWatchSession は session と同じ directory のイベントを購読する", async () => {

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -12,6 +12,7 @@ import {
 } from "@opencode-ai/sdk/v2";
 import type {
 	Logger,
+	OpencodeSessionActivity,
 	OpencodePromptParams,
 	OpencodeSessionEvent,
 	OpencodeModel,
@@ -23,6 +24,7 @@ import type {
 import {
 	abortSession,
 	classifyEvent,
+	extractPartActivity,
 	extractText,
 	extractTokens,
 	logPartActivity,
@@ -213,6 +215,8 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 				}
 
 				logPartActivity(typed, params.sessionId, this.logger);
+				const activity = extractPartActivity(typed, params.sessionId);
+				if (activity) params.onActivity?.(activity);
 
 				const classified = classifyEvent(typed, params.sessionId, tokensByMessage);
 				if (classified) {
@@ -237,7 +241,11 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		}
 		return { type: "idle" };
 	}
-	async waitForSessionIdle(sessionId: string, signal?: AbortSignal): Promise<OpencodeSessionEvent> {
+	async waitForSessionIdle(
+		sessionId: string,
+		signal?: AbortSignal,
+		onActivity?: (activity: OpencodeSessionActivity) => void,
+	): Promise<OpencodeSessionEvent> {
 		const oc = await this.getClient();
 		const { stream } = await oc.event.subscribe(this.directoryQuery());
 		const tokensByMessage = new Map<string, TokenUsage>();
@@ -271,6 +279,8 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 					this.logger?.info(`[opencode] waitIdle: type=${rawType} props=${JSON.stringify(props)}`);
 				}
 				logPartActivity(typed, sessionId, this.logger);
+				const activity = extractPartActivity(typed, sessionId);
+				if (activity) onActivity?.(activity);
 				const result = classifyEvent(typed, sessionId, tokensByMessage);
 				if (result) {
 					if (result.type === "error") {

--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -1,6 +1,11 @@
 import type { Event, EventMessageUpdated, OpencodeClient, Part } from "@opencode-ai/sdk/v2";
 import { withTimeout } from "@vicissitude/shared/functions";
-import type { Logger, OpencodeSessionEvent, TokenUsage } from "@vicissitude/shared/types";
+import type {
+	Logger,
+	OpencodeSessionActivity,
+	OpencodeSessionEvent,
+	TokenUsage,
+} from "@vicissitude/shared/types";
 
 export type AbortableAsyncStream<T> = AsyncIterator<T> & {
 	return?: (value?: unknown) => Promise<IteratorResult<T>>;
@@ -231,6 +236,22 @@ export function sumTokens(tokensByMessage: Map<string, TokenUsage>): TokenUsage 
 		cacheRead += t.cacheRead;
 	}
 	return { input, output, cacheRead };
+}
+
+export function extractPartActivity(
+	event: Event,
+	sessionId: string,
+): OpencodeSessionActivity | null {
+	if (event.type !== "message.part.updated") return null;
+	const { part } = event.properties;
+	if (part.sessionID !== sessionId || part.type !== "tool") return null;
+	const status = part.state.status;
+	if (status !== "running" && status !== "completed" && status !== "error") return null;
+	return {
+		type: "tool",
+		tool: part.tool,
+		status,
+	};
 }
 
 /** message.part.updated イベントからセッション内のアクティビティをログに出す */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -240,7 +240,14 @@ export interface OpencodePromptParams {
 	system?: string;
 	tools?: Record<string, boolean>;
 	attachments?: Attachment[];
+	onActivity?: (activity: OpencodeSessionActivity) => void;
 }
+
+export type OpencodeSessionActivity = {
+	type: "tool";
+	tool: string;
+	status: "running" | "completed" | "error";
+};
 
 export type OpencodeSessionEvent =
 	| { type: "idle"; tokens?: TokenUsage }
@@ -268,7 +275,11 @@ export interface OpencodeSessionPort {
 		params: OpencodePromptParams,
 		signal?: AbortSignal,
 	): Promise<OpencodeSessionEvent>;
-	waitForSessionIdle(sessionId: string, signal?: AbortSignal): Promise<OpencodeSessionEvent>;
+	waitForSessionIdle(
+		sessionId: string,
+		signal?: AbortSignal,
+		onActivity?: (activity: OpencodeSessionActivity) => void,
+	): Promise<OpencodeSessionEvent>;
 	summarizeSession(sessionId: string, model: OpencodeModel): Promise<void>;
 	deleteSession(sessionId: string): Promise<void>;
 	close(): void;

--- a/spec/agent/runner-debounce.spec.ts
+++ b/spec/agent/runner-debounce.spec.ts
@@ -431,6 +431,77 @@ describe("推論中断", () => {
 		runner.stop();
 		secondSessionDone.resolve({ type: "cancelled" });
 	});
+
+	test("Discord 送信 tool 開始後の追いメッセージでは旧プロンプトを再投入しない", async () => {
+		const firstSessionDone = deferred<OpencodeSessionEvent>();
+		const secondSessionDone = deferred<OpencodeSessionEvent>();
+		let promptCallCount = 0;
+		const sessionPort = {
+			createSession: mock(() => Promise.resolve("session-1")),
+			sessionExists: mock(() => Promise.resolve(false)),
+			prompt: mock(() => Promise.resolve({ text: "要約テキスト", tokens: undefined })),
+			promptAsync: mock(() => Promise.resolve()),
+			promptAsyncAndWatchSession: mock(() => {
+				promptCallCount += 1;
+				return promptCallCount === 1 ? firstSessionDone.promise : secondSessionDone.promise;
+			}),
+			waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
+			deleteSession: mock(() => Promise.resolve()),
+			summarizeSession: mock(() => Promise.resolve()),
+			close: mock(() => {}),
+		} as unknown as OpencodeSessionPort;
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		runner.enableDebounce = true;
+		activeRunners.add(runner);
+
+		await runner.send({ sessionKey: "k", message: "original question" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const firstCallArgs = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock
+			.calls[0] as unknown[];
+		const firstParams = firstCallArgs[0] as {
+			onActivity?: (activity: { type: "tool"; tool: string; status: "running" }) => void;
+		};
+		const firstSignal = firstCallArgs[1] as AbortSignal;
+		firstParams.onActivity?.({
+			type: "tool",
+			tool: "discord_send_message",
+			status: "running",
+		});
+
+		await runner.send({ sessionKey: "k", message: "follow up" });
+		await Bun.sleep(0);
+
+		expect(firstSignal.aborted).toBe(false);
+		expect(promptCallCount).toBe(1);
+
+		firstSessionDone.resolve({ type: "idle" });
+		for (let i = 0; i < 10; i++) {
+			// eslint-disable-next-line no-await-in-loop -- polling loop の進行を待つ
+			await Bun.sleep(0);
+		}
+
+		const calls = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBe(2);
+		const secondParams = calls.at(1)?.[0] as { text: string } | undefined;
+		expect(secondParams?.text).not.toContain("original question");
+		expect(secondParams?.text).toContain("follow up");
+
+		runner.stop();
+		secondSessionDone.resolve({ type: "cancelled" });
+	});
 });
 
 // ─── bot 用デバウンス延長 ─────────────────────────────────────────

--- a/spec/agent/runner-error-strategy.spec.ts
+++ b/spec/agent/runner-error-strategy.spec.ts
@@ -324,6 +324,55 @@ describe("retryable:false の即時ローテーション戦略", () => {
 		session2.resolve({ type: "cancelled" });
 	});
 
+	test("Discord 送信 tool 開始後でも retryable:false は旧プロンプトを再投入せず即時ローテーションする", async () => {
+		const session1 = deferred<OpencodeSessionEvent>();
+		const session2 = deferred<OpencodeSessionEvent>();
+		const sessionPort = createSessionPortWithSessions([session1.promise, session2.promise]);
+
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "agent-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: sessionPort as unknown as OpencodeSessionPort,
+			sessionMaxAgeMs: 3_600_000,
+		});
+		runner.sleepSpy = () => Promise.resolve();
+		activeRunners.add(runner);
+
+		await runner.send({ sessionKey: "k", message: "original question" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const firstCallArgs = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock
+			.calls[0] as unknown[];
+		const firstParams = firstCallArgs[0] as {
+			onActivity?: (activity: { type: "tool"; tool: string; status: "running" }) => void;
+		};
+		firstParams.onActivity?.({
+			type: "tool",
+			tool: "discord_send_message",
+			status: "running",
+		});
+
+		await runner.send({ sessionKey: "k", message: "follow up" });
+		session1.resolve({ type: "error", message: "Bad Request", retryable: false });
+		for (let i = 0; i < 10; i++) {
+			await Bun.sleep(0);
+		}
+
+		expect(sessionPort.deleteSession).toHaveBeenCalled();
+		const calls = (sessionPort.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock.calls;
+		expect(calls.length).toBeGreaterThanOrEqual(2);
+		const secondParams = calls.at(1)?.[0] as { text: string } | undefined;
+		expect(secondParams?.text).not.toContain("original question");
+		expect(secondParams?.text).toContain("follow up");
+
+		runner.stop();
+		session2.resolve({ type: "cancelled" });
+	});
+
 	test("retryable:false のローテーション後も再エラーで同じロジックが回る（ランナー停止しない）", async () => {
 		const sessions = [
 			deferred<OpencodeSessionEvent>(),

--- a/spec/opencode/stream-helpers-extract.spec.ts
+++ b/spec/opencode/stream-helpers-extract.spec.ts
@@ -15,6 +15,7 @@ import { describe, expect, mock, test } from "bun:test";
 import type { Event, OpencodeClient, Part } from "@opencode-ai/sdk/v2";
 import {
 	abortSession,
+	extractPartActivity,
 	extractText,
 	extractTokens,
 	logPartActivity,
@@ -280,5 +281,67 @@ describe("logPartActivity", () => {
 
 		expect(logger.info).not.toHaveBeenCalled();
 		expect(logger.error).not.toHaveBeenCalled();
+	});
+});
+
+// ─── extractPartActivity ─────────────────────────────────────────
+
+describe("extractPartActivity", () => {
+	const sessionId = "test-session";
+
+	function makePartEvent(partProps: Record<string, unknown>, sid: string = sessionId): Event {
+		return {
+			type: "message.part.updated",
+			properties: {
+				part: { sessionID: sid, ...partProps },
+			},
+		} as unknown as Event;
+	}
+
+	test("tool running を構造化 activity として返す", () => {
+		const event = makePartEvent({
+			type: "tool",
+			tool: "discord_send_message",
+			state: { status: "running" },
+		});
+
+		expect(extractPartActivity(event, sessionId)).toEqual({
+			type: "tool",
+			tool: "discord_send_message",
+			status: "running",
+		});
+	});
+
+	test("tool completed を構造化 activity として返す", () => {
+		const event = makePartEvent({
+			type: "tool",
+			tool: "discord_reply",
+			state: { status: "completed", output: "Sent message 1" },
+		});
+
+		expect(extractPartActivity(event, sessionId)).toEqual({
+			type: "tool",
+			tool: "discord_reply",
+			status: "completed",
+		});
+	});
+
+	test("対象 session 以外の activity は返さない", () => {
+		const event = makePartEvent(
+			{
+				type: "tool",
+				tool: "discord_send_message",
+				state: { status: "running" },
+			},
+			"other-session",
+		);
+
+		expect(extractPartActivity(event, sessionId)).toBeNull();
+	});
+
+	test("tool 以外の part は返さない", () => {
+		const event = makePartEvent({ type: "text", text: "hello" });
+
+		expect(extractPartActivity(event, sessionId)).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary
- Detect OpenCode tool activity and propagate tool-start events to AgentRunner
- Treat discord_send_message / discord_reply as committed side effects once running, so follow-up messages are queued without aborting or re-adding the old prompt
- Add spec/unit coverage for the typing-delay race while keeping Discord typing behavior intact

Closes #979

## Tests
- nix develop . -c nr validate
- nix develop . -c nr test