### PR TITLE
fix(web): デプロイ時の Vite 一時ファイル作成失敗を避ける

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
-		"build": "vite build",
+		"build": "vite build --configLoader runner",
 		"preview": "vite preview"
 	},
 	"dependencies": {


### PR DESCRIPTION
## 概要
- Web UI build を `vite build --configLoader runner` に変更
- Vite の既定 config bundle loader が readonly mount の `/app/apps/web/node_modules/.vite-temp` に一時ファイルを書こうとして builder が失敗する問題を回避

## 確認した症状
- `vicissitude-builder` が `ENOENT: no such file or directory, mkdir /app/apps/web/node_modules/.vite-temp` で終了
- `web-dist` volume が空のため `vicissitude-web` が `Not Found` を返す

## 検証
- `TANSTACK_ROUTE_GENERATION=false nr build` in `apps/web`
- `nr validate`
- `nr test`

## 補足
- 現ホストは `Cipher` で、プロジェクト指示の deploy 対象 `Feixiao` ではないため `nr deploy` は実行していません。