### PR TITLE
fix(mcp): 感情推定 cooldown を共有する

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ AI エージェントとチャットボットのメトリクスは、複数 scop
   - `trigger`: `home`, `mention`, `heartbeat`, `minecraft`, `mixed`, `unknown`。
   - `provider`, `model`: 使用した LLM provider/model。
 - セッション信頼性メトリクス（`session_errors_total`, `session_retries_total`, `session_restarts_total`）にも同じ共通ラベルを付与し、どの scope・エージェント種別・モデルで問題が起きているかを切り分けられるようにする。
-- 感情推定は会話本体とは別の補助推論として扱い、失敗しても会話送信を止めない。失敗時は `emotion_estimation_errors_total` に `provider`, `model`, `error_type`, `http_status`, `retryable`, `error_class`, `retry_after`, `reason` を付けて記録し、warn ログにも provider/model/status/retry-after/reason を出力する。429 かつ長期 `retry-after` の場合は provider/model 単位でクールダウンし、再投入を `emotion_estimation_skips_total{reason="provider_cooldown"}` として記録する。
+- 感情推定は会話本体とは別の補助推論として扱い、失敗しても会話送信を止めない。失敗時は `emotion_estimation_errors_total` に `provider`, `model`, `error_type`, `http_status`, `retryable`, `error_class`, `retry_after`, `reason` を付けて記録し、warn ログにも provider/model/status/retry-after/reason を出力する。429 かつ長期 `retry-after` の場合は provider/model 単位でクールダウンし、共有 store に保存して MCP プロセス境界をまたいだ再投入を抑制する。抑制時は `emotion_estimation_skips_total{reason="provider_cooldown"}` として記録する。
 - `llm_busy_sessions` は enqueue 中ではなく、実際に LLM prompt が処理中の間だけ増減する。
 - アプリケーションログは journald へ出力し、Loki へ転送する。本番環境ではホスト側のログコレクタ（現状は NixOS の Alloy）が `container_tag=vicissitude` の journald ログを `job=vicissitude` として収集し、standalone の monitoring profile では Promtail が同じ `job=vicissitude` へ揃えて転送する。Grafana ではメトリクスと同じダッシュボード内の Logs セクションで、ログ量と warn/error ログを確認できるようにする。
 

--- a/packages/mcp/src/discord-server.ts
+++ b/packages/mcp/src/discord-server.ts
@@ -10,7 +10,7 @@ import { closeDb, createDb } from "@vicissitude/store/db";
 import { SqliteMoodStore } from "@vicissitude/store/mood-store";
 import { Client } from "discord.js";
 
-import { createEmotionAnalyzer, readEmotionEstimationConfigFromEnv } from "./emotion.ts";
+import { createEmotionAnalyzerWithStoreDb, readEmotionEstimationConfigFromEnv } from "./emotion.ts";
 import { registerDiscordTools } from "./tools/discord.ts";
 import { registerDiscordBridgeTools } from "./tools/mc-bridge-discord.ts";
 
@@ -43,9 +43,10 @@ async function main(): Promise<void> {
 
 	const db = createDb(DATA_DIR);
 	const moodStore = new SqliteMoodStore(db);
-	const emotionAnalyzer = createEmotionAnalyzer(
+	const emotionAnalyzer = createEmotionAnalyzerWithStoreDb(
 		readEmotionEstimationConfigFromEnv(process.env),
 		logger,
+		db,
 	);
 
 	const boundNamespace: MemoryNamespace | undefined =

--- a/packages/mcp/src/emotion-observability.ts
+++ b/packages/mcp/src/emotion-observability.ts
@@ -1,6 +1,10 @@
 import { EmotionEstimator } from "@vicissitude/agent/emotion/estimator";
 import { classifyErrorType, METRIC } from "@vicissitude/observability/metrics";
-import type { EmotionAnalyzer, LlmPromptPort } from "@vicissitude/shared/ports";
+import type {
+	EmotionAnalyzer,
+	EmotionProviderCooldownStore,
+	LlmPromptPort,
+} from "@vicissitude/shared/ports";
 import type { Logger, MetricsCollector } from "@vicissitude/shared/types";
 
 import { extractEmotionPromptErrorInfo } from "./emotion-error-info.ts";
@@ -10,6 +14,7 @@ export type { EmotionPromptErrorInfo } from "./emotion-error-info.ts";
 const LONG_RETRY_AFTER_THRESHOLD_SECONDS = 60;
 
 export interface EmotionAnalyzerOptions {
+	cooldownStore: EmotionProviderCooldownStore;
 	metrics?: MetricsCollector;
 	now?: () => number;
 }
@@ -34,7 +39,7 @@ export function createEmotionAnalyzerFromPromptPort(
 	llm: LlmPromptPort,
 	model: EmotionPromptModel,
 	logger: Logger,
-	options: EmotionAnalyzerOptions = {},
+	options: EmotionAnalyzerOptions,
 ): EmotionAnalyzer {
 	return new EmotionEstimator(createObservedEmotionPromptPort(llm, model, logger, options), logger);
 }
@@ -45,15 +50,11 @@ function createObservedEmotionPromptPort(
 	logger: Logger,
 	options: EmotionAnalyzerOptions,
 ): LlmPromptPort {
-	let cooldown: CooldownState | null = null;
 	const now = options.now ?? Date.now;
 	const context: ObservationContext = { model, logger, metrics: options.metrics };
 
 	function activeCooldown(): CooldownState | null {
-		if (!cooldown) return null;
-		if (now() < cooldown.untilMs) return cooldown;
-		cooldown = null;
-		return null;
+		return options.cooldownStore.getCooldown(model, now());
 	}
 
 	return {
@@ -67,7 +68,7 @@ function createObservedEmotionPromptPort(
 				return await inner.prompt(text);
 			} catch (error) {
 				recordFailure(error, context, now, (state) => {
-					cooldown = state;
+					options.cooldownStore.setCooldown(model, state);
 				});
 				throw createSuppressedEmotionPromptError("emotion estimation prompt failed", error);
 			}

--- a/packages/mcp/src/emotion.ts
+++ b/packages/mcp/src/emotion.ts
@@ -3,6 +3,8 @@ import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import type { EmotionAnalyzer, LlmPromptPort } from "@vicissitude/shared/ports";
 import type { Logger, OpencodeModel, OpencodeSessionPort } from "@vicissitude/shared/types";
+import type { StoreDb } from "@vicissitude/store/db";
+import { SqliteEmotionProviderCooldownStore } from "@vicissitude/store/emotion-provider-cooldown-store";
 
 import {
 	createEmotionAnalyzerFromPromptPort,
@@ -53,7 +55,7 @@ export function readEmotionEstimationConfigFromEnv(
 export function createEmotionAnalyzer(
 	config: EmotionEstimationConfig | undefined,
 	logger: Logger,
-	options: EmotionAnalyzerOptions = {},
+	options: EmotionAnalyzerOptions,
 ): EmotionAnalyzerHandle | undefined {
 	if (!config) return;
 
@@ -67,6 +69,18 @@ export function createEmotionAnalyzer(
 			}
 		},
 	};
+}
+
+export function createEmotionAnalyzerWithStoreDb(
+	config: EmotionEstimationConfig | undefined,
+	logger: Logger,
+	db: StoreDb,
+	options: Omit<EmotionAnalyzerOptions, "cooldownStore"> = {},
+): EmotionAnalyzerHandle | undefined {
+	return createEmotionAnalyzer(config, logger, {
+		...options,
+		cooldownStore: new SqliteEmotionProviderCooldownStore(db),
+	});
 }
 
 function createEmotionPromptPort(config: EmotionEstimationConfig, logger: Logger): LlmPromptPort {

--- a/packages/shared/src/ports.ts
+++ b/packages/shared/src/ports.ts
@@ -47,6 +47,24 @@ export interface EmotionAnalyzer {
 	analyze(input: EmotionAnalysisInput): Promise<EmotionAnalysisResult>;
 }
 
+/** 感情推定 provider/model の cooldown キー */
+export interface EmotionProviderCooldownKey {
+	readonly providerId: string;
+	readonly modelId: string;
+}
+
+/** 感情推定 provider/model の cooldown 状態 */
+export interface EmotionProviderCooldown {
+	readonly untilMs: number;
+	readonly reason: string;
+}
+
+/** 感情推定 provider/model cooldown の共有ストア */
+export interface EmotionProviderCooldownStore {
+	getCooldown(key: EmotionProviderCooldownKey, nowMs: number): EmotionProviderCooldown | null;
+	setCooldown(key: EmotionProviderCooldownKey, cooldown: EmotionProviderCooldown): void;
+}
+
 // ─── MoodStore ─────────────────────────────────────────────────
 //
 // 感情状態（VAD）の永続化ポート。

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -8,6 +8,7 @@
 		"./schema": "./src/schema.ts",
 		"./mc-bridge": "./src/mc-bridge.ts",
 		"./mood-store": "./src/mood-store.ts",
+		"./emotion-provider-cooldown-store": "./src/emotion-provider-cooldown-store.ts",
 		"./test-helpers": "./src/test-helpers.ts"
 	},
 	"dependencies": {

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -64,6 +64,15 @@ CREATE TABLE IF NOT EXISTS mood_state (
 	updated_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS emotion_provider_cooldown (
+	provider_id TEXT NOT NULL,
+	model_id TEXT NOT NULL,
+	until_ms INTEGER NOT NULL,
+	reason TEXT NOT NULL,
+	updated_at INTEGER NOT NULL,
+	PRIMARY KEY (provider_id, model_id)
+);
+
 CREATE TABLE IF NOT EXISTS agent_heartbeat (
 	agent_id TEXT PRIMARY KEY,
 	last_seen_at INTEGER NOT NULL

--- a/packages/store/src/emotion-provider-cooldown-store.ts
+++ b/packages/store/src/emotion-provider-cooldown-store.ts
@@ -1,0 +1,63 @@
+import type {
+	EmotionProviderCooldown,
+	EmotionProviderCooldownKey,
+	EmotionProviderCooldownStore,
+} from "@vicissitude/shared/ports";
+import { and, eq } from "drizzle-orm";
+
+import type { StoreDb } from "./db.ts";
+import { emotionProviderCooldown } from "./schema.ts";
+
+export class SqliteEmotionProviderCooldownStore implements EmotionProviderCooldownStore {
+	constructor(private readonly db: StoreDb) {}
+
+	getCooldown(key: EmotionProviderCooldownKey, nowMs: number): EmotionProviderCooldown | null {
+		const row = this.db
+			.select()
+			.from(emotionProviderCooldown)
+			.where(
+				and(
+					eq(emotionProviderCooldown.providerId, key.providerId),
+					eq(emotionProviderCooldown.modelId, key.modelId),
+				),
+			)
+			.get();
+
+		if (!row) return null;
+		if (row.untilMs <= nowMs) {
+			this.db
+				.delete(emotionProviderCooldown)
+				.where(
+					and(
+						eq(emotionProviderCooldown.providerId, key.providerId),
+						eq(emotionProviderCooldown.modelId, key.modelId),
+					),
+				)
+				.run();
+			return null;
+		}
+
+		return { untilMs: row.untilMs, reason: row.reason };
+	}
+
+	setCooldown(key: EmotionProviderCooldownKey, cooldown: EmotionProviderCooldown): void {
+		this.db
+			.insert(emotionProviderCooldown)
+			.values({
+				providerId: key.providerId,
+				modelId: key.modelId,
+				untilMs: cooldown.untilMs,
+				reason: cooldown.reason,
+				updatedAt: Date.now(),
+			})
+			.onConflictDoUpdate({
+				target: [emotionProviderCooldown.providerId, emotionProviderCooldown.modelId],
+				set: {
+					untilMs: cooldown.untilMs,
+					reason: cooldown.reason,
+					updatedAt: Date.now(),
+				},
+			})
+			.run();
+	}
+}

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -35,6 +35,19 @@ export const moodState = sqliteTable("mood_state", {
 	updatedAt: integer("updated_at").notNull(),
 });
 
+/** 感情推定 provider/model cooldown テーブル */
+export const emotionProviderCooldown = sqliteTable(
+	"emotion_provider_cooldown",
+	{
+		providerId: text("provider_id").notNull(),
+		modelId: text("model_id").notNull(),
+		untilMs: integer("until_ms").notNull(),
+		reason: text("reason").notNull(),
+		updatedAt: integer("updated_at").notNull(),
+	},
+	(table) => [primaryKey({ columns: [table.providerId, table.modelId] })],
+);
+
 /** エージェントハートビートテーブル（MCP wait_for_events の生存シグナル） */
 export const agentHeartbeat = sqliteTable("agent_heartbeat", {
 	agentId: text("agent_id").primaryKey(),

--- a/spec/mcp/emotion-quota.spec.ts
+++ b/spec/mcp/emotion-quota.spec.ts
@@ -5,6 +5,8 @@ import { METRIC } from "@vicissitude/observability/metrics";
 import { NEUTRAL_EMOTION } from "@vicissitude/shared/emotion";
 import type { LlmPromptPort } from "@vicissitude/shared/ports";
 import { createMockLogger, createMockMetrics } from "@vicissitude/shared/test-helpers";
+import { SqliteEmotionProviderCooldownStore } from "@vicissitude/store/emotion-provider-cooldown-store";
+import { createTestDb } from "@vicissitude/store/test-helpers";
 
 function createQuotaExceededError(retryAfterSeconds: number): Error {
 	const error = new Error("GitHub Copilot quota exceeded");
@@ -34,7 +36,11 @@ describe("感情推定の quota exceeded 検知", () => {
 			llm,
 			{ providerId: "github-copilot", modelId: "gpt-5-mini" },
 			logger,
-			{ metrics, now: () => now },
+			{
+				cooldownStore: new SqliteEmotionProviderCooldownStore(createTestDb()),
+				metrics,
+				now: () => now,
+			},
 		);
 
 		const first = await analyzer.analyze({ text: "短い返事" });
@@ -88,5 +94,55 @@ describe("感情推定の quota exceeded 検知", () => {
 		now += 465_001_000;
 		await analyzer.analyze({ text: "待機後の返事" });
 		expect(promptCalls).toBe(2);
+	});
+
+	test("cooldown は同じ provider/model の analyzer インスタンス間で共有される", async () => {
+		let now = 1_000_000;
+		let firstPromptCalls = 0;
+		let secondPromptCalls = 0;
+		const db = createTestDb();
+		const model = { providerId: "github-copilot", modelId: "gpt-5-mini" };
+		const firstStore = new SqliteEmotionProviderCooldownStore(db);
+		const secondStore = new SqliteEmotionProviderCooldownStore(db);
+		const firstAnalyzer = createEmotionAnalyzerFromPromptPort(
+			{
+				prompt(): Promise<string> {
+					firstPromptCalls += 1;
+					return Promise.reject(createQuotaExceededError(465_000));
+				},
+			},
+			model,
+			createMockLogger(),
+			{ cooldownStore: firstStore, now: () => now },
+		);
+		const secondAnalyzer = createEmotionAnalyzerFromPromptPort(
+			{
+				prompt(): Promise<string> {
+					secondPromptCalls += 1;
+					return Promise.resolve(
+						JSON.stringify({
+							valence: 0,
+							arousal: 0,
+							dominance: 0,
+							confidence: 1,
+						}),
+					);
+				},
+			},
+			model,
+			createMockLogger(),
+			{ cooldownStore: secondStore, now: () => now },
+		);
+
+		await firstAnalyzer.analyze({ text: "最初の失敗" });
+		const result = await secondAnalyzer.analyze({ text: "別プロセス相当の再投入" });
+
+		expect(result).toEqual({ emotion: NEUTRAL_EMOTION, confidence: 0 });
+		expect(firstPromptCalls).toBe(1);
+		expect(secondPromptCalls).toBe(0);
+
+		now += 465_001_000;
+		await secondAnalyzer.analyze({ text: "cooldown 後の再投入" });
+		expect(secondPromptCalls).toBe(1);
 	});
 });

--- a/spec/mcp/tools/discord-emotion.spec.ts
+++ b/spec/mcp/tools/discord-emotion.spec.ts
@@ -13,6 +13,8 @@ import type {
 	MoodWriter,
 } from "@vicissitude/shared/ports";
 import { createMockLogger, createMockMetrics } from "@vicissitude/shared/test-helpers";
+import { SqliteEmotionProviderCooldownStore } from "@vicissitude/store/emotion-provider-cooldown-store";
+import { createTestDb } from "@vicissitude/store/test-helpers";
 
 import { captureTools, createDiscordClientStub } from "./discord-test-helpers";
 
@@ -238,7 +240,11 @@ describe("send_message / reply での感情推定トリガー", () => {
 			llm,
 			{ providerId: "github-copilot", modelId: "gpt-5-mini" },
 			logger,
-			{ metrics, now: () => 1_000_000 },
+			{
+				cooldownStore: new SqliteEmotionProviderCooldownStore(createTestDb()),
+				metrics,
+				now: () => 1_000_000,
+			},
 		);
 		const { writer, calls: writerCalls } = createSpyMoodWriter();
 

--- a/spec/store/db.spec.ts
+++ b/spec/store/db.spec.ts
@@ -25,6 +25,7 @@ describe("store", () => {
 			expect(tableNames).toContain("sessions");
 			expect(tableNames).toContain("emoji_usage");
 			expect(tableNames).toContain("event_buffer");
+			expect(tableNames).toContain("emotion_provider_cooldown");
 			expect(tableNames).toContain("mc_session_lock");
 			expect(tableNames).toContain("mood_state");
 			expect(tableNames).toContain("agent_heartbeat");

--- a/spec/store/emotion-provider-cooldown-store.spec.ts
+++ b/spec/store/emotion-provider-cooldown-store.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+
+import { SqliteEmotionProviderCooldownStore } from "@vicissitude/store/emotion-provider-cooldown-store";
+import { createTestDb } from "@vicissitude/store/test-helpers";
+
+describe("SqliteEmotionProviderCooldownStore", () => {
+	it("provider/model ごとに cooldown を保存して取得できる", () => {
+		const db = createTestDb();
+		const store = new SqliteEmotionProviderCooldownStore(db);
+		const key = { providerId: "github-copilot", modelId: "gpt-5-mini" };
+
+		store.setCooldown(key, { untilMs: 70_000, reason: "quota_exceeded" });
+
+		expect(store.getCooldown(key, 10_000)).toEqual({
+			untilMs: 70_000,
+			reason: "quota_exceeded",
+		});
+	});
+
+	it("provider/model が異なる cooldown は共有しない", () => {
+		const db = createTestDb();
+		const store = new SqliteEmotionProviderCooldownStore(db);
+
+		store.setCooldown(
+			{ providerId: "github-copilot", modelId: "gpt-5-mini" },
+			{ untilMs: 70_000, reason: "quota_exceeded" },
+		);
+
+		expect(
+			store.getCooldown({ providerId: "github-copilot", modelId: "gpt-5" }, 10_000),
+		).toBeNull();
+		expect(store.getCooldown({ providerId: "openai", modelId: "gpt-5-mini" }, 10_000)).toBeNull();
+	});
+
+	it("期限切れ cooldown は削除して null を返す", () => {
+		const db = createTestDb();
+		const store = new SqliteEmotionProviderCooldownStore(db);
+		const key = { providerId: "github-copilot", modelId: "gpt-5-mini" };
+
+		store.setCooldown(key, { untilMs: 70_000, reason: "quota_exceeded" });
+
+		expect(store.getCooldown(key, 70_000)).toBeNull();
+		expect(
+			db.$client.prepare("SELECT COUNT(*) AS count FROM emotion_provider_cooldown").get() as {
+				count: number;
+			},
+		).toEqual({ count: 0 });
+	});
+});


### PR DESCRIPTION
## Summary
- 感情推定 provider/model cooldown を SQLite store に保存し、Discord MCP プロセス間で共有
- cooldown store のポート、Drizzle schema、DB テーブルを追加
- プロセス境界相当の共有挙動と store の仕様テストを追加

Fixes #966

## Tests
- nr validate
- nr test

## Deployment
- hostname は Cipher のため deploy していません