### PR TITLE
fix(agent): shell-worker background task 失敗を可視化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ AI エージェントとチャットボットのメトリクスは、複数 scop
 - `HUA_GITHUB_TOKEN`: `features.shellWorkspace.environment` など profile の `fromEnv` 参照で指定した場合に必須
 
 `features.shellWorkspace.backgroundSubagents: true` を設定すると、OpenCode の `task(background=true)` / `task_status` を有効化するために `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true` を OpenCode server process へ渡す。
+background shell task が `state:error` を返した場合、または `state:completed` でも `<task_result>` が空の場合は shell-worker の失敗として扱う。会話 agent はその turn を中断できる場合は中断し、内部メッセージとして失敗を再プロンプトして、Discord へ成功・開始済みとして誤報告しない。
 
 ## 6. 受け入れ条件
 

--- a/docs/agent-capabilities-and-shell-sandbox.md
+++ b/docs/agent-capabilities-and-shell-sandbox.md
@@ -51,6 +51,15 @@ JSON profile の `features.shellWorkspace.environment` には shell-worker と s
 
 Podman mount source としてホスト側 path が必要な profile では `features.shellWorkspace.hostDataDir` に書く。OpenCode shell subagent 経路だけなら省略する。
 
+## Background Task Failure Handling
+
+`features.shellWorkspace.backgroundSubagents: true` では、メイン会話 agent が OpenCode `task(background=true)` と `task_status` を使える。OpenCode が返す `task` / `task_status` 出力、または `Background task completed` synthetic text に次のどちらかが含まれる場合、Vicissitude は shell-worker の失敗として扱う。
+
+- `state: error` または `<task_error>...</task_error>`
+- `<task_result></task_result>` が空
+
+失敗を検知した場合、Runner は失敗内容を内部メッセージとして積む。Discord 送信など巻き戻せない副作用がまだ始まっていなければ現在の turn を abort し、元のユーザー依頼と失敗内容を合わせて再プロンプトする。これにより、shell-worker が実際には動いていないのに「開始した」「成功した」と報告することを避ける。
+
 ## 非目標
 
 - メイン会話 agent への builtin `bash` 直接許可。

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -113,6 +113,7 @@ export class AgentRunner implements AiAgent {
 	private promptHasUninterruptibleSideEffect = false;
 	private activePromptMetrics: ActivePromptMetrics | null = null;
 	private lastPromptMetricLabels: Record<string, string> | null = null;
+	private reportedBackgroundTaskFailures = new Set<string>();
 
 	private readonly profile: AgentProfile;
 	private readonly agentId: string;
@@ -521,7 +522,63 @@ export class AgentRunner implements AiAgent {
 			UNINTERRUPTIBLE_DISCORD_TOOLS.has(activity.tool)
 		) {
 			this.promptHasUninterruptibleSideEffect = true;
+			return;
 		}
+		if (activity.type === "backgroundTaskFailure") {
+			this.handleBackgroundTaskFailure(activity);
+		}
+	}
+
+	private handleBackgroundTaskFailure(
+		activity: Extract<OpencodeSessionActivity, { type: "backgroundTaskFailure" }>,
+	): void {
+		const key = `${activity.taskId ?? "unknown"}:${activity.reason}:${activity.message}`;
+		if (this.reportedBackgroundTaskFailures.has(key)) return;
+		this.reportedBackgroundTaskFailures.add(key);
+		this.logger.error(
+			`[${this.profile.name}:${this.agentId}] shell-worker background task failed`,
+			activity.message,
+		);
+		this.metrics?.incrementCounter(
+			METRIC.SESSION_ERRORS,
+			this.metricLabels({
+				source: "background_task",
+				error_type: activity.reason,
+				http_status: "unknown",
+				retryable: "unknown",
+				error_class: "BackgroundTaskFailure",
+			}),
+		);
+		this.pendingMessages.push({
+			text: `<internal_message>
+shell-worker background task failed.
+task_id: ${activity.taskId ?? "unknown"}
+state: ${activity.state ?? "unknown"}
+reason: ${activity.reason}
+detail: ${activity.message}
+
+この shell-worker 作業を成功・開始済みとして報告してはいけません。Discord には失敗として短く報告してください。
+</internal_message>`,
+			trigger: "internal",
+			scopeId: this.contextScopeId,
+		});
+		this.pendingResolve?.();
+		this.pendingDebounceResolve?.();
+
+		if (!this.sessionWatch || this.promptHasUninterruptibleSideEffect) {
+			this.ensurePolling();
+			return;
+		}
+		if (this.lastPromptText !== null) {
+			this.pendingMessages.unshift({
+				text: this.lastPromptText,
+				attachments: this.lastPromptAttachments ?? undefined,
+				trigger: this.lastPromptTrigger ?? "unknown",
+				scopeId: this.lastPromptScopeId ?? undefined,
+			});
+		}
+		this.clearLastPrompt();
+		this.sessionAbortController?.abort();
 	}
 
 	private clearLastPrompt(): void {

--- a/packages/opencode/src/background-task-activity.ts
+++ b/packages/opencode/src/background-task-activity.ts
@@ -1,0 +1,69 @@
+import type { Part } from "@opencode-ai/sdk/v2";
+import type { OpencodeSessionActivity } from "@vicissitude/shared/types";
+
+type ParsedTaskOutput = {
+	taskId?: string;
+	state?: string;
+	result?: string;
+	error?: string;
+	hasResult: boolean;
+	hasError: boolean;
+};
+
+export function extractBackgroundTaskFailure(part: Part): OpencodeSessionActivity | null {
+	if (part.type === "text") {
+		if (!part.text.startsWith("Background task completed:")) return null;
+		return failureFromParsedTaskOutput(parseTaskOutput(part.text));
+	}
+	if (
+		part.type !== "tool" ||
+		part.state.status !== "completed" ||
+		(part.tool !== "task" && part.tool !== "task_status")
+	) {
+		return null;
+	}
+	return failureFromParsedTaskOutput(parseTaskOutput(part.state.output));
+}
+
+function parseTaskOutput(output: string): ParsedTaskOutput {
+	return {
+		taskId: matchLine(output, "task_id"),
+		state: matchLine(output, "state"),
+		result: matchBlock(output, "task_result"),
+		error: matchBlock(output, "task_error"),
+		hasResult: output.includes("<task_result>"),
+		hasError: output.includes("<task_error>"),
+	};
+}
+
+function failureFromParsedTaskOutput(parsed: ParsedTaskOutput): OpencodeSessionActivity | null {
+	const taskLabel = parsed.taskId ? `task ${parsed.taskId}` : "task";
+	if (parsed.state === "error" || parsed.hasError) {
+		const error = parsed.error?.trim() ?? "unknown task error";
+		return {
+			type: "backgroundTaskFailure",
+			taskId: parsed.taskId,
+			state: parsed.state,
+			reason: "task_error",
+			message: `shell-worker ${taskLabel} failed: ${error}`,
+		};
+	}
+	if (parsed.hasResult && parsed.result?.trim().length === 0) {
+		return {
+			type: "backgroundTaskFailure",
+			taskId: parsed.taskId,
+			state: parsed.state,
+			reason: "empty_result",
+			message: `shell-worker ${taskLabel} completed with an empty task_result`,
+		};
+	}
+	return null;
+}
+
+function matchLine(text: string, key: "task_id" | "state"): string | undefined {
+	return text.match(new RegExp(`^${key}:\\s*(\\S+)`, "m"))?.[1];
+}
+
+function matchBlock(text: string, tag: "task_result" | "task_error"): string | undefined {
+	return text.match(new RegExp(`<${tag}>\\n?([\\s\\S]*?)\\n?<\\/${tag}>`, "m"))?.[1];
+}

--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -7,6 +7,8 @@ import type {
 	TokenUsage,
 } from "@vicissitude/shared/types";
 
+import { extractBackgroundTaskFailure } from "./background-task-activity.ts";
+
 export type AbortableAsyncStream<T> = AsyncIterator<T> & {
 	return?: (value?: unknown) => Promise<IteratorResult<T>>;
 };
@@ -244,7 +246,10 @@ export function extractPartActivity(
 ): OpencodeSessionActivity | null {
 	if (event.type !== "message.part.updated") return null;
 	const { part } = event.properties;
-	if (part.sessionID !== sessionId || part.type !== "tool") return null;
+	if (part.sessionID !== sessionId) return null;
+	const backgroundTaskFailure = extractBackgroundTaskFailure(part);
+	if (backgroundTaskFailure) return backgroundTaskFailure;
+	if (part.type !== "tool") return null;
 	const status = part.state.status;
 	if (status !== "running" && status !== "completed" && status !== "error") return null;
 	return {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -243,11 +243,19 @@ export interface OpencodePromptParams {
 	onActivity?: (activity: OpencodeSessionActivity) => void;
 }
 
-export type OpencodeSessionActivity = {
-	type: "tool";
-	tool: string;
-	status: "running" | "completed" | "error";
-};
+export type OpencodeSessionActivity =
+	| {
+			type: "tool";
+			tool: string;
+			status: "running" | "completed" | "error";
+	  }
+	| {
+			type: "backgroundTaskFailure";
+			taskId?: string;
+			state?: string;
+			reason: "task_error" | "empty_result";
+			message: string;
+	  };
 
 export type OpencodeSessionEvent =
 	| { type: "idle"; tokens?: TokenUsage }

--- a/spec/agent/runner-background-task-failure.spec.ts
+++ b/spec/agent/runner-background-task-failure.spec.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { AgentRunner } from "@vicissitude/agent/runner";
+import { createMockLogger } from "@vicissitude/shared/test-helpers";
+import type {
+	OpencodePromptParams,
+	OpencodeSessionEvent,
+	OpencodeSessionPort,
+} from "@vicissitude/shared/types";
+
+import {
+	TestAgent,
+	createContextBuilder,
+	createProfile,
+	createSessionStore,
+	deferred,
+} from "./runner-test-helpers.ts";
+
+function createSessionPort() {
+	const firstDone = deferred<OpencodeSessionEvent>();
+	const secondDone = deferred<OpencodeSessionEvent>();
+	let callCount = 0;
+	let firstSignal: AbortSignal | undefined;
+	const port = {
+		createSession: mock(() => Promise.resolve("session-1")),
+		sessionExists: mock(() => Promise.resolve(false)),
+		prompt: mock(() => Promise.resolve({ text: "", tokens: undefined })),
+		promptAsync: mock(() => Promise.resolve()),
+		promptAsyncAndWatchSession: mock((_params: OpencodePromptParams, signal?: AbortSignal) => {
+			callCount += 1;
+			if (callCount === 1) {
+				firstSignal = signal;
+				return firstDone.promise;
+			}
+			return secondDone.promise;
+		}),
+		waitForSessionIdle: mock(() => Promise.resolve({ type: "idle" as const })),
+		summarizeSession: mock(() => Promise.resolve()),
+		deleteSession: mock(() => Promise.resolve()),
+		close: mock(() => {}),
+	};
+	return {
+		port: port as unknown as OpencodeSessionPort,
+		firstDone,
+		secondDone,
+		firstSignal: () => firstSignal,
+	};
+}
+
+const activeRunners = new Set<AgentRunner>();
+
+afterEach(() => {
+	for (const runner of activeRunners) runner.stop();
+	activeRunners.clear();
+});
+
+describe("AgentRunner: background task failure", () => {
+	test("shell-worker の空結果失敗を内部メッセージとして積み、現 turn を中断して再プロンプトする", async () => {
+		const { port, firstDone, secondDone, firstSignal } = createSessionPort();
+		const runner = new TestAgent({
+			profile: createProfile(),
+			agentId: "discord:guild-1",
+			sessionStore: createSessionStore() as never,
+			contextBuilder: createContextBuilder(),
+			logger: createMockLogger(),
+			sessionPort: port,
+			sessionMaxAgeMs: 3_600_000,
+			contextScopeId: "discord:guild:guild-1",
+		});
+		activeRunners.add(runner);
+
+		await runner.send({ sessionKey: "k", message: "3分 sleep を shell-worker で実行して" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		const firstParams = (port.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock
+			.calls[0]?.[0] as OpencodePromptParams;
+		firstParams.onActivity?.({
+			type: "backgroundTaskFailure",
+			taskId: "task-1",
+			state: "completed",
+			reason: "empty_result",
+			message: "shell-worker task task-1 completed with an empty task_result",
+		});
+
+		await Bun.sleep(0);
+		expect(firstSignal()?.aborted).toBe(true);
+
+		firstDone.resolve({ type: "cancelled" });
+		await Bun.sleep(0);
+		await Bun.sleep(0);
+
+		expect(port.promptAsyncAndWatchSession).toHaveBeenCalledTimes(2);
+		const secondParams = (port.promptAsyncAndWatchSession as ReturnType<typeof mock>).mock
+			.calls[1]?.[0] as OpencodePromptParams;
+		expect(secondParams.text).toContain("3分 sleep を shell-worker で実行して");
+		expect(secondParams.text).toContain("shell-worker background task failed");
+		expect(secondParams.text).toContain("task-1");
+		expect(secondParams.text).toContain("empty task_result");
+
+		runner.stop();
+		secondDone.resolve({ type: "cancelled" });
+	});
+});

--- a/spec/opencode/background-task-failure.spec.ts
+++ b/spec/opencode/background-task-failure.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Event } from "@opencode-ai/sdk/v2";
+import { extractPartActivity } from "@vicissitude/opencode/stream-helpers";
+
+function makePartEvent(partProps: Record<string, unknown>, sessionId = "parent-session"): Event {
+	return {
+		type: "message.part.updated",
+		properties: {
+			sessionID: sessionId,
+			part: { sessionID: sessionId, ...partProps },
+			time: Date.now(),
+		},
+	} as unknown as Event;
+}
+
+describe("background task failure activity", () => {
+	test("Background task completed の空 task_result を失敗 activity として返す", () => {
+		const event = makePartEvent({
+			type: "text",
+			text: `Background task completed: 3分スリープタスク
+task_id: task-1
+state: completed
+
+<task_result>
+
+</task_result>`,
+		});
+
+		const result = extractPartActivity(event, "parent-session");
+
+		expect(result).toEqual({
+			type: "backgroundTaskFailure",
+			taskId: "task-1",
+			state: "completed",
+			reason: "empty_result",
+			message: "shell-worker task task-1 completed with an empty task_result",
+		});
+	});
+
+	test("task_status の state:error と task_error を失敗 activity として返す", () => {
+		const event = makePartEvent({
+			type: "tool",
+			tool: "task_status",
+			state: {
+				status: "completed",
+				input: { task_id: "task-2", wait: true },
+				output: `task_id: task-2
+state: error
+
+<task_error>
+Token refresh failed: 401
+</task_error>`,
+				title: "task_status",
+				metadata: {},
+				time: { start: 100, end: 110 },
+			},
+		});
+
+		const result = extractPartActivity(event, "parent-session");
+
+		expect(result).toEqual({
+			type: "backgroundTaskFailure",
+			taskId: "task-2",
+			state: "error",
+			reason: "task_error",
+			message: "shell-worker task task-2 failed: Token refresh failed: 401",
+		});
+	});
+
+	test("非空 task_result は失敗扱いしない", () => {
+		const event = makePartEvent({
+			type: "text",
+			text: `Background task completed: build
+task_id: task-3
+state: completed
+
+<task_result>
+Build succeeded
+</task_result>`,
+		});
+
+		expect(extractPartActivity(event, "parent-session")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary
- parse OpenCode task/task_status/background completion output and surface shell-worker empty/error results as structured activity
- enqueue an internal failure notice and abort the current turn when it is still safe, so Discord does not get a false success/start report
- document background task failure handling and add regression specs

## Verification
- nr validate
- nr test