### PR TITLE
fix(memory): new fact の既存IDを正規化する

### DIFF
--- a/packages/memory/src/consolidation-contract.ts
+++ b/packages/memory/src/consolidation-contract.ts
@@ -100,9 +100,6 @@ function validateKeywords(obj: Record<string, unknown>, i: number): void {
 
 function validateExistingFactId(obj: Record<string, unknown>, i: number): void {
 	const action = obj["action"] as ConsolidationAction;
-	if (action === "new" && obj["existingFactId"] !== undefined) {
-		throw new TypeError(`facts[${i}].existingFactId: not allowed for action "new"`);
-	}
 	if (ACTIONS_REQUIRING_EXISTING_FACT_ID.has(action) && typeof obj["existingFactId"] !== "string") {
 		throw new TypeError(`facts[${i}].existingFactId: required for action "${action}"`);
 	}

--- a/spec/memory/consolidation.spec.ts
+++ b/spec/memory/consolidation.spec.ts
@@ -914,25 +914,38 @@ describe("ConsolidationPipeline — schema validation", () => {
 		expect(pipeline.consolidate(userId)).rejects.toThrow("existingFactId");
 	});
 
-	test("rejects new action with existingFactId", async () => {
+	test("normalizes new action with redundant existingFactId", async () => {
 		const episode = makeEpisode();
 		await storage.saveEpisode(userId, episode);
 
 		const pipeline = new ConsolidationPipeline(
-			createInvalidLLM({
-				facts: [
-					{
-						action: "new",
-						category: "preference",
-						fact: "Some fact",
-						keywords: ["test"],
-						existingFactId: "fact-1",
-					},
-				],
+			createMockLLM({
+				structuredResponse: {
+					facts: [
+						{
+							action: "new",
+							category: "preference",
+							fact: "Some fact",
+							keywords: ["test"],
+							existingFactId: "fact-1",
+						},
+					],
+				},
 			}),
 			storage,
 		);
-		expect(pipeline.consolidate(userId)).rejects.toThrow("not allowed");
+		const result = await pipeline.consolidate(userId);
+		expect(result).toEqual({
+			processedEpisodes: 1,
+			newFacts: 1,
+			reinforced: 0,
+			updated: 0,
+			invalidated: 0,
+		});
+
+		const facts = await storage.getFacts(userId);
+		expect(facts).toHaveLength(1);
+		expect(facts[0]?.fact).toBe("Some fact");
 	});
 
 	test("rejects fact with non-array keywords", async () => {


### PR DESCRIPTION
## 概要
- action="new" の fact に余分な existingFactId が付いても schema 境界で拒否せず、new fact として正規化する
- Issue #994 の再現ケースを spec に追加

## 検証
- bun test spec/memory/consolidation.spec.ts
- bun test packages/memory/src/consolidation.test.ts
- nr validate
- nr test

Closes #994