### PR TITLE
feat(agents): Skill の出し分けを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ MCP サーバー経由で各種操作を提供する。OpenCode は MCP ツー�
 
 OpenCode SDK 組み込み: `webfetch`
 
+### 3.4.1 Agent Skills
+
+OpenCode Agent Skills は `.agents/skills/*/SKILL.md` を discovery 対象にするが、各セッションでは `permission.skill` を既定で `{"*":"deny"}` にし、必要な agent だけ個別に許可する。
+
+- Discord 会話 primary、heartbeat、Web、Minecraft、画像認識、emotion、memory 補助セッションは OpenCode Skills を全拒否する。
+- shell workspace 有効時のみ OpenCode の `skill` tool を有効化し、primary `build` agent では拒否、`shell-worker` subagent だけ `debug` skill を許可する。
+- Minecraft の `mc_read_skills` / `mc_record_skill` は Minecraft MCP のワールド記憶であり、OpenCode Agent Skills とは別系統として扱う。
+
 ### 3.5 コンテキスト管理
 
 - オーバーレイ方式: `context/`（git 管理・ベース）と `data/context/`（gitignore・オーバーレイ）の二層構成。読み込みは `data/context/` → `context/` のフォールバック、書き込みは常に `data/context/`。

--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -164,13 +164,17 @@ describe("createDiscordAgents", () => {
 		const agent = agents.get("discord:guild:123456789") as unknown as {
 			profile: {
 				mcpServers: Record<string, { type: string; environment?: Record<string, string> }>;
+				skillPermission: Record<string, string>;
 			};
+			sessionPort: { config: { skillPaths?: string[] } };
 		};
 
 		expect(Object.keys(agent.profile.mcpServers).toSorted()).toEqual(["core", "discord"]);
 		expect(agent.profile.mcpServers.core?.environment?.AGENT_ID).toBe("discord:123456789");
 		expect(agent.profile.mcpServers.discord?.environment?.AGENT_ID).toBe("discord:123456789");
 		expect(agent.profile.mcpServers.discord?.environment?.DISCORD_TOKEN).toBe("token");
+		expect(agent.profile.skillPermission).toEqual({ "*": "deny" });
+		expect(agent.sessionPort.config.skillPaths).toEqual(["/app/.agents/skills"]);
 	});
 
 	test("Discord DM agent は DM scopeId と agentId で作成される", () => {
@@ -199,8 +203,28 @@ describe("createDiscordAgents", () => {
 		expect(agent.profile.mcpServers.discord?.environment?.AGENT_ID).toBe("discord:dm:999888777");
 	});
 
-	test("deps の OpenCode 設定でモデルと temperature を上書きする", () => {
-		const config = createTestConfig();
+	test("heartbeat agent は shellWorkspace 有効時でも deps の OpenCode 設定だけを使う", () => {
+		const config = createTestConfig({
+			shellWorkspace: {
+				enabled: true,
+				image: "sandbox",
+				agent: {
+					providerId: "shell-provider",
+					modelId: "shell-model",
+					temperature: 0.4,
+					steps: 16,
+				},
+				backgroundSubagents: true,
+				dataDir: "/tmp/shell-workspaces",
+				auditLogPath: "/tmp/shell-audit.jsonl",
+				networkProfile: "open",
+				defaultTtlMinutes: 60,
+				maxTtlMinutes: 120,
+				defaultTimeoutSeconds: 30,
+				maxTimeoutSeconds: 120,
+				maxOutputChars: 50_000,
+			},
+		});
 		const { db, sessionStore } = createStoreLayer(config);
 		const agents = createDiscordAgents(
 			config,
@@ -221,8 +245,20 @@ describe("createDiscordAgents", () => {
 			},
 		);
 		const agent = agents.get("discord:guild:123456789") as unknown as {
-			profile: { model: { providerId: string; modelId: string } };
-			sessionPort: { config: { temperature?: number } };
+			profile: {
+				model: { providerId: string; modelId: string };
+				builtinTools: Record<string, boolean>;
+				skillPermission: Record<string, string>;
+				opencodeAgents?: unknown;
+			};
+			sessionPort: {
+				config: {
+					temperature?: number;
+					skillPaths?: string[];
+					directory?: string;
+					environment?: Record<string, string>;
+				};
+			};
 		};
 
 		expect(agent.profile.model).toEqual({
@@ -230,6 +266,14 @@ describe("createDiscordAgents", () => {
 			modelId: "heartbeat-model",
 		});
 		expect(agent.sessionPort.config.temperature).toBe(0.2);
+		expect(agent.profile.builtinTools.skill).toBe(false);
+		expect(agent.profile.builtinTools.bash).toBe(false);
+		expect(agent.profile.builtinTools.task).toBe(false);
+		expect(agent.profile.skillPermission).toEqual({ "*": "deny" });
+		expect(agent.profile.opencodeAgents).toBeUndefined();
+		expect(agent.sessionPort.config.skillPaths).toEqual(["/app/.agents/skills"]);
+		expect(agent.sessionPort.config.directory).toBeUndefined();
+		expect(agent.sessionPort.config.environment).toBeUndefined();
 	});
 
 	test("shellWorkspace の GitHub token は Git credential helper 付きで OpenCode に渡す", () => {
@@ -380,12 +424,19 @@ describe("createDiscordAgents", () => {
 			},
 		);
 		const agent = agents.get("discord:guild:123456789") as unknown as {
-			profile: { primaryTools?: string[]; builtinTools: Record<string, boolean> };
+			profile: {
+				primaryTools?: string[];
+				builtinTools: Record<string, boolean>;
+				opencodeAgents?: Record<string, { tools?: Record<string, boolean>; permission?: unknown }>;
+			};
 			sessionPort: { config: { environment?: Record<string, string> } };
 		};
 
+		expect(agent.profile.builtinTools.skill).toBe(true);
 		expect(agent.profile.builtinTools.task_status).toBe(true);
 		expect(agent.profile.primaryTools).toEqual(["task", "task_status"]);
+		expect(agent.profile.opencodeAgents?.build?.tools?.skill).toBe(false);
+		expect(agent.profile.opencodeAgents?.["shell-worker"]?.tools?.skill).toBe(true);
 		expect(agent.sessionPort.config.environment?.OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS).toBe(
 			"true",
 		);
@@ -406,12 +457,17 @@ describe("createWebConversationAgent", () => {
 		}) as unknown as {
 			profile: {
 				mcpServers: Record<string, { type: string; environment?: Record<string, string> }>;
+				builtinTools: Record<string, boolean>;
+				skillPermission: Record<string, string>;
 			};
-			sessionPort: { config: { port: number } };
+			sessionPort: { config: { port: number; skillPaths?: string[] } };
 		};
 
 		expect(Object.keys(agent.profile.mcpServers)).toEqual(["core"]);
 		expect(agent.profile.mcpServers.core?.environment?.AGENT_ID).toBe("web:local");
+		expect(agent.profile.builtinTools.skill).toBe(false);
+		expect(agent.profile.skillPermission).toEqual({ "*": "deny" });
 		expect(agent.sessionPort.config.port).toBe(4103);
+		expect(agent.sessionPort.config.skillPaths).toEqual(["/app/.agents/skills"]);
 	});
 });

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -42,7 +42,10 @@ import { MemoryStorage } from "@vicissitude/memory/storage";
 import { ConsoleLogger } from "@vicissitude/observability/logger";
 import { PrometheusCollector, PrometheusServer, METRIC } from "@vicissitude/observability/metrics";
 import { OllamaEmbeddingAdapter } from "@vicissitude/ollama";
-import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
+import {
+	denyAllSkillPermission,
+	OPENCODE_ALL_TOOLS_DISABLED,
+} from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import { ConsolidationScheduler } from "@vicissitude/scheduling/consolidation-scheduler";
 import { JsonHeartbeatConfigRepository } from "@vicissitude/scheduling/heartbeat-config";
@@ -221,6 +224,10 @@ function buildOpencodeShellWorkspaceEnvironment(
 
 const EMOTION_OPENCODE_PORT_OFFSET = 1000;
 
+function opencodeSkillPaths(appRoot: string): string[] {
+	return [resolve(appRoot, ".agents/skills")];
+}
+
 export function buildAgentDiscordEnvironment(
 	config: AppConfig,
 	baseEnvironment: Record<string, string>,
@@ -263,6 +270,14 @@ export function createHeartbeatAgentSpecs(guildIds: string[]): DiscordAgentSpec[
 	}));
 }
 
+function isHeartbeatAgentId(agentId: string): boolean {
+	return agentId.startsWith("discord:heartbeat:");
+}
+
+function canUseShellWorkspace(config: AppConfig, agentId: string): boolean {
+	return !!config.shellWorkspace && !isHeartbeatAgentId(agentId);
+}
+
 export function createDiscordAgents(
 	config: AppConfig,
 	agentSpecs: DiscordAgentSpec[],
@@ -292,7 +307,10 @@ export function createDiscordAgents(
 
 	for (const [index, spec] of agentSpecs.entries()) {
 		const agentPort = config.opencode.basePort + portOffset + index;
-		const shellWorkspaceDirectory = prepareOpencodeShellWorkspaceDirectory(config, spec.agentId);
+		const shellWorkspaceEnabled = canUseShellWorkspace(config, spec.agentId);
+		const shellWorkspaceDirectory = shellWorkspaceEnabled
+			? prepareOpencodeShellWorkspaceDirectory(config, spec.agentId)
+			: undefined;
 		const profile = createConversationProfile({
 			providerId: opencode.providerId,
 			modelId: opencode.modelId,
@@ -305,19 +323,25 @@ export function createDiscordAgents(
 			}),
 			minecraftEnabled: !!config.minecraft,
 			imageRecognitionEnabled: !!config.imageRecognition,
-			shellWorkspaceSubagent: config.shellWorkspace?.agent,
-			shellWorkspaceBackgroundSubagents: config.shellWorkspace?.backgroundSubagents,
+			shellWorkspaceSubagent: shellWorkspaceEnabled ? config.shellWorkspace?.agent : undefined,
+			shellWorkspaceBackgroundSubagents: shellWorkspaceEnabled
+				? config.shellWorkspace?.backgroundSubagents
+				: undefined,
 		});
 		const sessionPort = new OpencodeSessionAdapter({
 			port: agentPort,
 			mcpServers: profile.mcpServers,
 			builtinTools: profile.builtinTools,
+			skillPermission: profile.skillPermission,
+			skillPaths: opencodeSkillPaths(deps.appRoot),
 			agents: profile.opencodeAgents,
 			defaultAgent: profile.defaultAgent,
 			primaryTools: profile.primaryTools,
 			temperature: opencode.temperature,
 			directory: shellWorkspaceDirectory,
-			environment: buildOpencodeShellWorkspaceEnvironment(config, shellWorkspaceDirectory),
+			environment: shellWorkspaceEnabled
+				? buildOpencodeShellWorkspaceEnvironment(config, shellWorkspaceDirectory)
+				: undefined,
 			logger: deps.logger,
 		});
 		const attachmentProcessor = config.imageRecognition
@@ -375,6 +399,8 @@ export function createWebConversationAgent(
 		port: deps.opencodePort,
 		mcpServers: profile.mcpServers,
 		builtinTools: profile.builtinTools,
+		skillPermission: profile.skillPermission,
+		skillPaths: opencodeSkillPaths(deps.appRoot),
 		temperature: config.opencode.temperature,
 		logger: deps.logger,
 	});
@@ -518,6 +544,8 @@ export async function setupMemoryRecording(
 			port: opts.memoryPort,
 			mcpServers: {},
 			builtinTools: OPENCODE_ALL_TOOLS_DISABLED,
+			skillPermission: denyAllSkillPermission(),
+			skillPaths: opencodeSkillPaths(opts.root),
 		});
 		const chatAdapter = new MemoryChatAdapter(
 			memorySessionPort,

--- a/packages/agent/src/discord/profile.test.ts
+++ b/packages/agent/src/discord/profile.test.ts
@@ -44,7 +44,9 @@ describe("createConversationProfile shell workspace subagent", () => {
 		expect(profile.builtinTools.bash).toBe(true);
 		expect(profile.builtinTools.read).toBe(true);
 		expect(profile.builtinTools.write).toBe(true);
+		expect(profile.builtinTools.skill).toBe(true);
 		expect(profile.builtinTools.task_status).toBe(false);
+		expect(profile.skillPermission).toEqual({ "*": "deny" });
 		expect(profile.defaultAgent).toBe("build");
 		expect(profile.primaryTools).toEqual(["task"]);
 		expect(profile.pollingPrompt).toContain(SHELL_WORKSPACE_AGENT_NAME);
@@ -55,6 +57,7 @@ describe("createConversationProfile shell workspace subagent", () => {
 		const buildTools = (build as { tools?: Record<string, boolean> } | undefined)?.tools;
 		expect(buildTools?.read).toBe(false);
 		expect(buildTools?.write).toBe(false);
+		expect(buildTools?.skill).toBe(false);
 
 		const worker = profile.opencodeAgents?.[SHELL_WORKSPACE_AGENT_NAME];
 		expect(worker?.mode).toBe("subagent");
@@ -65,9 +68,11 @@ describe("createConversationProfile shell workspace subagent", () => {
 		expect(workerTools?.bash).toBe(true);
 		expect(workerTools?.read).toBe(true);
 		expect(workerTools?.write).toBe(true);
+		expect(workerTools?.skill).toBe(true);
 		expect(workerTools?.task).toBe(false);
-		const workerPermission = (worker as { permission?: Record<string, string> } | undefined)
+		const workerPermission = (worker as { permission?: Record<string, unknown> } | undefined)
 			?.permission;
+		expect(workerPermission?.skill).toEqual({ "*": "deny", debug: "allow" });
 		expect(workerPermission?.bash).toBe("allow");
 		expect(workerPermission?.read).toBe("allow");
 		expect(workerPermission?.edit).toBe("allow");
@@ -115,6 +120,8 @@ describe("createConversationProfile shell workspace subagent", () => {
 		expect(profile.builtinTools.task).toBe(false);
 		expect(profile.builtinTools.task_status).toBe(false);
 		expect(profile.builtinTools.bash).toBe(false);
+		expect(profile.builtinTools.skill).toBe(false);
+		expect(profile.skillPermission).toEqual({ "*": "deny" });
 		expect(profile.opencodeAgents).toBeUndefined();
 		expect(profile.defaultAgent).toBeUndefined();
 		expect(profile.primaryTools).toBeUndefined();

--- a/packages/agent/src/discord/profile.ts
+++ b/packages/agent/src/discord/profile.ts
@@ -1,8 +1,14 @@
-import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
+import {
+	createSkillPermission,
+	denyAllSkillPermission,
+	isSkillToolEnabled,
+	OPENCODE_ALL_TOOLS_DISABLED,
+} from "@vicissitude/opencode/constants";
 
 import { SECURITY_PROMPT_LINES, type AgentProfile, type McpServerConfig } from "../profile.ts";
 
 export const SHELL_WORKSPACE_AGENT_NAME = "shell-worker";
+const DEFAULT_SHELL_WORKSPACE_ALLOWED_SKILLS = ["debug"] as const;
 
 const T = {
 	sendMessage: "discord_send_message",
@@ -68,14 +74,19 @@ function buildShellWorkspaceAgents(
 	backgroundSubagents: boolean,
 ) {
 	if (!shellWorkspaceSubagent) return;
+	const shellWorkspaceSkillPermission = createSkillPermission(
+		DEFAULT_SHELL_WORKSPACE_ALLOWED_SKILLS,
+	);
 	return {
 		build: {
 			mode: "primary" as const,
 			tools: {
 				read: false,
 				write: false,
+				skill: false,
 			},
 			permission: {
+				skill: denyAllSkillPermission(),
 				task: "allow" as const,
 				...(backgroundSubagents ? { task_status: "allow" as const } : {}),
 				bash: "deny" as const,
@@ -97,8 +108,10 @@ function buildShellWorkspaceAgents(
 				bash: true,
 				read: true,
 				write: true,
+				skill: isSkillToolEnabled(shellWorkspaceSkillPermission),
 			},
 			permission: {
+				skill: shellWorkspaceSkillPermission,
 				task: "deny" as const,
 				bash: "allow" as const,
 				read: "allow" as const,
@@ -125,6 +138,9 @@ export function createConversationProfile(options: {
 	shellWorkspaceBackgroundSubagents?: boolean;
 }): AgentProfile {
 	const shellWorkspaceBackgroundSubagents = options.shellWorkspaceBackgroundSubagents === true;
+	const shellWorkspaceSkillEnabled =
+		!!options.shellWorkspaceSubagent &&
+		isSkillToolEnabled(createSkillPermission(DEFAULT_SHELL_WORKSPACE_ALLOWED_SKILLS));
 	const sections = [
 		MESSAGE_PROMPT_INSTRUCTIONS,
 		options.minecraftEnabled ? MINECRAFT_PROMPT_SECTION : undefined,
@@ -145,12 +161,14 @@ export function createConversationProfile(options: {
 		builtinTools: {
 			...OPENCODE_ALL_TOOLS_DISABLED,
 			webfetch: true,
+			skill: shellWorkspaceSkillEnabled,
 			bash: !!options.shellWorkspaceSubagent,
 			read: !!options.shellWorkspaceSubagent,
 			write: !!options.shellWorkspaceSubagent,
 			task: !!options.shellWorkspaceSubagent,
 			task_status: !!options.shellWorkspaceSubagent && shellWorkspaceBackgroundSubagents,
 		},
+		skillPermission: denyAllSkillPermission(),
 		opencodeAgents,
 		primaryTools: opencodeAgents
 			? ["task", ...(shellWorkspaceBackgroundSubagents ? ["task_status"] : [])]

--- a/packages/agent/src/minecraft/brain-manager.ts
+++ b/packages/agent/src/minecraft/brain-manager.ts
@@ -106,6 +106,8 @@ export class McBrainManager {
 			port: deps.opencodePort,
 			mcpServers: profile.mcpServers,
 			builtinTools: profile.builtinTools,
+			skillPermission: profile.skillPermission,
+			skillPaths: [resolve(deps.root, ".agents/skills")],
 			temperature: deps.temperature,
 			logger: deps.logger,
 		});

--- a/packages/agent/src/minecraft/profile.ts
+++ b/packages/agent/src/minecraft/profile.ts
@@ -1,4 +1,7 @@
-import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
+import {
+	denyAllSkillPermission,
+	OPENCODE_ALL_TOOLS_DISABLED,
+} from "@vicissitude/opencode/constants";
 
 import { SECURITY_PROMPT_LINES, type AgentProfile, type McpServerConfig } from "../profile.ts";
 
@@ -90,6 +93,7 @@ export function createMinecraftProfile(options: {
 		name: "minecraft",
 		mcpServers: options.mcpServers,
 		builtinTools: OPENCODE_ALL_TOOLS_DISABLED,
+		skillPermission: denyAllSkillPermission(),
 		pollingPrompt: POLLING_PROMPT,
 		model: { providerId: options.providerId, modelId: options.modelId },
 	};

--- a/packages/agent/src/profile.ts
+++ b/packages/agent/src/profile.ts
@@ -1,4 +1,5 @@
 import type { OpencodeAgentConfig } from "@vicissitude/opencode/session-adapter";
+import type { SkillPermissionConfig } from "@vicissitude/shared/types";
 
 export interface AgentProfile {
 	/** プロファイル名（例: "conversation"） */
@@ -7,6 +8,8 @@ export interface AgentProfile {
 	mcpServers: Record<string, McpServerConfig>;
 	/** OpenCode 組み込みツール設定 */
 	builtinTools: Record<string, boolean>;
+	/** OpenCode skill の既定権限。agent 個別設定で必要な skill だけ上書きする */
+	skillPermission: SkillPermissionConfig;
 	/** OpenCode agent 設定 */
 	opencodeAgents?: Record<string, OpencodeAgentConfig>;
 	/** OpenCode primary agent 専用ツール */

--- a/packages/agent/src/web/profile.ts
+++ b/packages/agent/src/web/profile.ts
@@ -1,4 +1,7 @@
-import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
+import {
+	denyAllSkillPermission,
+	OPENCODE_ALL_TOOLS_DISABLED,
+} from "@vicissitude/opencode/constants";
 
 import { SECURITY_PROMPT_LINES, type AgentProfile, type McpServerConfig } from "../profile.ts";
 
@@ -24,6 +27,7 @@ export function createWebConversationProfile(options: {
 			...OPENCODE_ALL_TOOLS_DISABLED,
 			webfetch: true,
 		},
+		skillPermission: denyAllSkillPermission(),
 		pollingPrompt: WEB_PROMPT_INSTRUCTIONS,
 		model: { providerId: options.providerId, modelId: options.modelId },
 		summaryPrompt: `あなたは Web 会話セッション要約アシスタントです。

--- a/packages/mcp/src/emotion.ts
+++ b/packages/mcp/src/emotion.ts
@@ -1,5 +1,8 @@
 import { OllamaChatAdapter } from "@vicissitude/ollama/ollama-chat-adapter";
-import { OPENCODE_ALL_TOOLS_DISABLED } from "@vicissitude/opencode/constants";
+import {
+	denyAllSkillPermission,
+	OPENCODE_ALL_TOOLS_DISABLED,
+} from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import type { EmotionAnalyzer, LlmPromptPort } from "@vicissitude/shared/ports";
 import type { Logger, OpencodeModel, OpencodeSessionPort } from "@vicissitude/shared/types";
@@ -101,6 +104,7 @@ function createEmotionPromptPort(config: EmotionEstimationConfig, logger: Logger
 			port: opencodePort,
 			mcpServers: {},
 			builtinTools: OPENCODE_ALL_TOOLS_DISABLED,
+			skillPermission: denyAllSkillPermission(),
 			logger,
 		}),
 		{ providerId: config.providerId, modelId: config.modelId },

--- a/packages/opencode/src/constants.ts
+++ b/packages/opencode/src/constants.ts
@@ -1,3 +1,5 @@
+import type { SkillPermissionConfig } from "@vicissitude/shared/types";
+
 /** OpenCode の全ビルトインツールを無効化する設定 */
 export const OPENCODE_ALL_TOOLS_DISABLED: Record<string, boolean> = {
 	question: false,
@@ -15,3 +17,24 @@ export const OPENCODE_ALL_TOOLS_DISABLED: Record<string, boolean> = {
 	skill: false,
 	invalid: false,
 };
+
+export function denyAllSkillPermission(): SkillPermissionConfig {
+	return { "*": "deny" };
+}
+
+export function createSkillPermission(
+	allowedSkills: readonly string[] | undefined,
+): SkillPermissionConfig {
+	const permission = denyAllSkillPermission();
+	for (const skill of allowedSkills ?? []) {
+		permission[skill] = "allow";
+	}
+	return permission;
+}
+
+export function isSkillToolEnabled(permission: SkillPermissionConfig): boolean {
+	return Object.entries(permission).some(([pattern, action]) => {
+		if (action === "deny") return false;
+		return pattern === "*" || pattern.trim().length > 0;
+	});
+}

--- a/packages/opencode/src/session-adapter.test.ts
+++ b/packages/opencode/src/session-adapter.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2";
+import { denyAllSkillPermission } from "@vicissitude/opencode/constants";
 import type { OpencodeSessionActivity } from "@vicissitude/shared/types";
 
 import { OpencodeSessionAdapter } from "./session-adapter.ts";
@@ -89,6 +90,7 @@ function createAdapter(client: OpencodeClient): OpencodeSessionAdapter {
 		port: 4096,
 		mcpServers: {},
 		builtinTools: {},
+		skillPermission: denyAllSkillPermission(),
 		clientFactory: mock(() =>
 			Promise.resolve({
 				client,
@@ -112,6 +114,7 @@ describe("OpencodeSessionAdapter", () => {
 			port: 4096,
 			mcpServers: {},
 			builtinTools: { task: true },
+			skillPermission: denyAllSkillPermission(),
 			agents: {
 				build: { mode: "primary", tools: { shell_exec: false } },
 				"shell-worker": {
@@ -151,6 +154,7 @@ describe("OpencodeSessionAdapter", () => {
 			port: 4096,
 			mcpServers: {},
 			builtinTools: {},
+			skillPermission: denyAllSkillPermission(),
 			directory: "/tmp/vicissitude-opencode-workspace",
 			clientFactory: mock(() =>
 				Promise.resolve({
@@ -218,6 +222,7 @@ describe("OpencodeSessionAdapter", () => {
 			port: 4096,
 			mcpServers: {},
 			builtinTools: {},
+			skillPermission: denyAllSkillPermission(),
 			environment: {
 				VICISSITUDE_OPENCODE_TEST_TOKEN: "secret-value",
 			},
@@ -366,6 +371,7 @@ describe("OpencodeSessionAdapter", () => {
 			port: 4096,
 			mcpServers: {},
 			builtinTools: {},
+			skillPermission: denyAllSkillPermission(),
 			directory,
 			clientFactory: mock(() =>
 				Promise.resolve({
@@ -398,6 +404,7 @@ describe("OpencodeSessionAdapter", () => {
 			port: 4096,
 			mcpServers: {},
 			builtinTools: {},
+			skillPermission: denyAllSkillPermission(),
 			directory,
 			clientFactory: mock(() =>
 				Promise.resolve({
@@ -637,6 +644,7 @@ describe("OpencodeSessionAdapter buildParts（画像フィルタリング）", (
 			port: 4096,
 			mcpServers: {},
 			builtinTools: {},
+			skillPermission: denyAllSkillPermission(),
 			clientFactory: mock(() =>
 				Promise.resolve({
 					client: client as unknown as OpencodeClient,

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -18,6 +18,7 @@ import type {
 	OpencodeModel,
 	OpencodeSessionPort,
 	PromptResult,
+	SkillPermissionConfig,
 	TokenUsage,
 } from "@vicissitude/shared/types";
 
@@ -41,6 +42,8 @@ export interface OpencodeSessionAdapterConfig {
 	/** `{ enabled: boolean }` は SDK の設定スキーマが許容する無効化用のフォールバック型 */
 	mcpServers: Record<string, McpLocalConfig | McpRemoteConfig | { enabled: boolean }>;
 	builtinTools: Record<string, boolean>;
+	skillPermission: SkillPermissionConfig;
+	skillPaths?: string[];
 	agents?: Record<string, AgentConfig>;
 	defaultAgent?: string;
 	primaryTools?: string[];
@@ -359,6 +362,10 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 				config: {
 					mcp: this.config.mcpServers,
 					tools: this.config.builtinTools,
+					skills: this.config.skillPaths ? { paths: this.config.skillPaths } : undefined,
+					permission: {
+						skill: this.config.skillPermission,
+					},
 					default_agent: this.config.defaultAgent,
 					agent,
 					experimental: {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -234,6 +234,10 @@ export interface OpencodeModel {
 	modelId: string;
 }
 
+export type SkillPermissionAction = "allow" | "deny" | "ask";
+
+export type SkillPermissionConfig = Record<string, SkillPermissionAction>;
+
 export interface OpencodePromptParams {
 	sessionId: string;
 	text: string;

--- a/spec/agent/discord/profile.spec.ts
+++ b/spec/agent/discord/profile.spec.ts
@@ -34,4 +34,44 @@ describe("createConversationProfile", () => {
 
 		expect(profile.pollingPrompt).toContain("respond");
 	});
+
+	test("shell workspace 有効時は shell-worker だけ debug skill を使える", () => {
+		const profile = createConversationProfile({
+			providerId: "provider",
+			modelId: "model",
+			mcpServers: {},
+			shellWorkspaceSubagent: {
+				providerId: "worker-provider",
+				modelId: "worker-model",
+				temperature: 0.4,
+				steps: 12,
+			},
+		});
+
+		const build = profile.opencodeAgents?.build as
+			| { tools?: Record<string, boolean>; permission?: Record<string, unknown> }
+			| undefined;
+		const worker = profile.opencodeAgents?.["shell-worker"] as
+			| { tools?: Record<string, boolean>; permission?: Record<string, unknown> }
+			| undefined;
+
+		expect(profile.builtinTools.skill).toBe(true);
+		expect(profile.skillPermission).toEqual({ "*": "deny" });
+		expect(build?.tools?.skill).toBe(false);
+		expect(build?.permission?.skill).toEqual({ "*": "deny" });
+		expect(worker?.tools?.skill).toBe(true);
+		expect(worker?.permission?.skill).toEqual({ "*": "deny", debug: "allow" });
+	});
+
+	test("shell workspace 無効時は OpenCode Skills を全拒否する", () => {
+		const profile = createConversationProfile({
+			providerId: "provider",
+			modelId: "model",
+			mcpServers: {},
+		});
+
+		expect(profile.builtinTools.skill).toBe(false);
+		expect(profile.skillPermission).toEqual({ "*": "deny" });
+		expect(profile.opencodeAgents).toBeUndefined();
+	});
 });

--- a/spec/agent/minecraft/profile.spec.ts
+++ b/spec/agent/minecraft/profile.spec.ts
@@ -28,6 +28,8 @@ describe("createMinecraftProfile", () => {
 		for (const tool of tools) {
 			expect(profile.pollingPrompt).toContain(tool);
 		}
+		expect(profile.builtinTools.skill).toBe(false);
+		expect(profile.skillPermission).toEqual({ "*": "deny" });
 	});
 
 	test("pollingPrompt にプレフィックスなしのツール名が残っていない", () => {

--- a/spec/agent/runner-test-helpers.ts
+++ b/spec/agent/runner-test-helpers.ts
@@ -7,6 +7,7 @@
 import { mock } from "bun:test";
 
 import { AgentRunner, type RunnerDeps } from "@vicissitude/agent/runner";
+import { denyAllSkillPermission } from "@vicissitude/opencode/constants";
 import type { ContextBuilderPort } from "@vicissitude/shared/types";
 
 import type { AgentProfile } from "../../packages/agent/src/profile.ts";
@@ -52,6 +53,7 @@ export function createProfile(overrides: Partial<AgentProfile> = {}): AgentProfi
 		name: "conversation",
 		mcpServers: {},
 		builtinTools: {},
+		skillPermission: denyAllSkillPermission(),
 		pollingPrompt: "loop forever",
 		model: { providerId: "test-provider", modelId: "test-model" },
 		...overrides,

--- a/spec/agent/web/profile.spec.ts
+++ b/spec/agent/web/profile.spec.ts
@@ -19,6 +19,8 @@ describe("createWebConversationProfile", () => {
 		});
 		expect(profile.builtinTools.webfetch).toBe(true);
 		expect(profile.builtinTools.bash).toBe(false);
+		expect(profile.builtinTools.skill).toBe(false);
+		expect(profile.skillPermission).toEqual({ "*": "deny" });
 		expect(profile.pollingPrompt).toContain("最終テキストは Web UI に表示されます");
 		expect(profile.pollingPrompt).not.toContain("discord_send_message");
 		expect(profile.pollingPrompt).not.toContain("discord_reply");

--- a/spec/agent/web/web-agent.spec.ts
+++ b/spec/agent/web/web-agent.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import { WEB_AGENT_ID, WEB_SCOPE_ID, WebConversationAgent } from "@vicissitude/agent/web/web-agent";
+import { denyAllSkillPermission } from "@vicissitude/opencode/constants";
 import { agentScopeNamespace } from "@vicissitude/shared/namespace";
 import type {
 	ContextBuilderPort,
@@ -77,6 +78,7 @@ function createAgent(overrides?: {
 			name: "web-conversation",
 			mcpServers: {},
 			builtinTools: {},
+			skillPermission: denyAllSkillPermission(),
 			pollingPrompt: "Web prompt",
 			model: { providerId: "provider", modelId: "model" },
 		},

--- a/spec/opencode/llm-logging.spec.ts
+++ b/spec/opencode/llm-logging.spec.ts
@@ -10,6 +10,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { OpencodeClient } from "@opencode-ai/sdk/v2";
+import { denyAllSkillPermission } from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import { createMockLogger } from "@vicissitude/shared/test-helpers";
 
@@ -56,6 +57,7 @@ function createAdapter(opts: { logger?: ReturnType<typeof createMockLogger> } = 
 		port: 4096,
 		mcpServers: {},
 		builtinTools: {},
+		skillPermission: denyAllSkillPermission(),
 		logger,
 		clientFactory: mock(() =>
 			Promise.resolve({
@@ -117,6 +119,7 @@ describe("OpencodeSessionAdapter prompt() LLM ログ記録", () => {
 			port: 4096,
 			mcpServers: {},
 			builtinTools: {},
+			skillPermission: denyAllSkillPermission(),
 			// logger を渡さない
 			clientFactory: mock(() =>
 				Promise.resolve({

--- a/spec/opencode/session-adapter.spec.ts
+++ b/spec/opencode/session-adapter.spec.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines -- OpenCode session adapter の仕様ケースを集約しているため許容 */
 /**
  * Issue #536: streamDisconnected 時にトークン情報が破棄されるバグの再現テスト
  *
@@ -9,6 +10,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2";
+import { denyAllSkillPermission } from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import type { OpencodeSessionEvent } from "@vicissitude/shared/types";
 
@@ -56,6 +58,7 @@ function createAdapter(client: OpencodeClient): OpencodeSessionAdapter {
 		port: 4096,
 		mcpServers: {},
 		builtinTools: {},
+		skillPermission: denyAllSkillPermission(),
 		clientFactory: mock(() =>
 			Promise.resolve({
 				client,
@@ -94,6 +97,34 @@ function makeMessageUpdatedEvent(
 }
 
 describe("OpencodeSessionAdapter deleteSession", () => {
+	test("OpenCode 起動時に skills.paths と permission.skill を渡す", async () => {
+		const client = createClient(createDoneStream());
+		const clientFactory = mock(() =>
+			Promise.resolve({
+				client,
+				server: { url: "http://localhost", close: mock(() => {}) },
+			}),
+		);
+		const adapter = new OpencodeSessionAdapter({
+			port: 4096,
+			mcpServers: {},
+			builtinTools: { skill: true },
+			skillPermission: { "*": "deny", debug: "allow" },
+			skillPaths: ["/app/.agents/skills"],
+			clientFactory,
+		});
+
+		await adapter.createSession("test session");
+
+		const calls = clientFactory.mock.calls as unknown as Array<[{ config: unknown }]>;
+		expect(calls[0]?.[0].config).toEqual(
+			expect.objectContaining({
+				skills: { paths: ["/app/.agents/skills"] },
+				permission: { skill: { "*": "deny", debug: "allow" } },
+			}),
+		);
+	});
+
 	test("SDK の delete が成功したら resolve する", async () => {
 		const client = createClient(createDoneStream());
 		const adapter = createAdapter(client);

--- a/spec/opencode/session-error-logging.spec.ts
+++ b/spec/opencode/session-error-logging.spec.ts
@@ -9,6 +9,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2";
+import { denyAllSkillPermission } from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import type { Logger } from "@vicissitude/shared/types";
 
@@ -44,6 +45,7 @@ function createAdapterWithLoggerSpy(client: OpencodeClient) {
 		port: 4096,
 		mcpServers: {},
 		builtinTools: {},
+		skillPermission: denyAllSkillPermission(),
 		logger: loggerSpy as Logger,
 		clientFactory: mock(() =>
 			Promise.resolve({

--- a/spec/opencode/session-summarize.spec.ts
+++ b/spec/opencode/session-summarize.spec.ts
@@ -10,6 +10,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { OpencodeClient } from "@opencode-ai/sdk/v2";
+import { denyAllSkillPermission } from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import type { OpencodeSessionPort } from "@vicissitude/shared/types";
 
@@ -54,6 +55,7 @@ function createAdapter(client: OpencodeClient): OpencodeSessionAdapter {
 		port: 4096,
 		mcpServers: {},
 		builtinTools: {},
+		skillPermission: denyAllSkillPermission(),
 		clientFactory: mock(() =>
 			Promise.resolve({
 				client,


### PR DESCRIPTION
## Summary
- OpenCode 起動設定に skills.paths と permission.skill を渡し、既定を deny all にしました。
- Discord/Web/Minecraft/memory/emotion は OpenCode Skills を全拒否し、shell workspace の shell-worker だけ debug skill を許可します。
- heartbeat agent は shellWorkspace 有効時でも shell-worker と skill を継承しないようにしました。

## Review
- review-pr スキルで差分レビューを実施し、heartbeat が shell workspace を継承する指摘を即修正しました。

## Verification
- bun test apps/discord/src/bootstrap.test.ts packages/agent/src/discord/profile.test.ts spec/agent/discord/profile.spec.ts
- nr validate
- nr test

Closes #993