### PR TITLE
fix: Darwin の direnv 評価失敗を直す

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
               podman
               python311
               podman-compose
+            ] ++ lib.optionals stdenv.isLinux [
               slirp4netns
             ];
           };

--- a/packages/mcp/src/tools/discord.ts
+++ b/packages/mcp/src/tools/discord.ts
@@ -11,12 +11,17 @@ import { z } from "zod/v4";
 const DEFAULT_ALLOWED_FILE_DIRS = ["/tmp/vicissitude-screenshots"];
 const ATTACHMENT_ALLOWED_DIRS_ENV = "DISCORD_ATTACHMENT_ALLOWED_DIRS";
 
+function normalizeAllowedDir(dir: string): string {
+	const absolute = path.resolve(dir);
+	return existsSync(absolute) ? realpathSync(absolute) : absolute;
+}
+
 function allowedFileDirs(): string[] {
 	const extra = (process.env[ATTACHMENT_ALLOWED_DIRS_ENV] ?? "")
 		.split(path.delimiter)
 		.map((dir) => dir.trim())
 		.filter((dir) => dir.length > 0);
-	return [...DEFAULT_ALLOWED_FILE_DIRS, ...extra].map((dir) => path.resolve(dir));
+	return [...DEFAULT_ALLOWED_FILE_DIRS, ...extra].map((dir) => normalizeAllowedDir(dir));
 }
 
 function validateFilePath(filePath: string): void {


### PR DESCRIPTION
## Summary
- Darwin devShell では Linux 専用の slirp4netns を除外
- 添付許可ディレクトリも realpath 化して macOS の /var と /private/var の差異を吸収

## Verification
- nix flake check
- direnv exec . nr validate
- direnv exec . nr test