### PR TITLE
fix(agent): shell-worker の MCP 権限を分離する

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ MCP サーバー経由で各種操作を提供する。OpenCode は MCP ツー�
 
 OpenCode SDK 組み込み: `webfetch`
 
+OpenCode agent ごとに MCP tool permission を分ける。Discord 会話 primary agent は Discord 送信、返信、添付、リアクション、Core 記憶・リマインダー、必要な Minecraft 委譲を担当する。`shell-worker` subagent は OpenCode builtin `bash` / Read / Write で作業し、`*_*` / `discord_*` / `core_*` / `minecraft_*` / `mc-bridge_*` / `shell-workspace_*` などの MCP tool wildcard は agent permission で `deny` する。`shell-worker` が生成した本文やファイルを Discord に出す場合も、`shell-worker` は送信せず、primary agent が Discord ツールを呼ぶ。
+
 ### 3.4.1 Agent Skills
 
 OpenCode Agent Skills は runtime 用の `context/skills/{agent}/*/SKILL.md` を discovery 対象にする。`.agents/skills` はこのリポジトリを開発する Codex 用 skill 置き場であり、bot runtime には渡さない。各セッションでは `permission.skill` を既定で `{"*":"deny"}` にし、必要な agent だけ個別に許可する。

--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -553,6 +553,14 @@ describe("createDiscordAgents", () => {
 			skill: { "*": "deny", "delegate-to-shell-worker": "allow" },
 		});
 		expect(agent.profile.opencodeAgents?.["shell-worker"]?.tools?.skill).toBe(true);
+		expect(agent.profile.opencodeAgents?.["shell-worker"]?.permission).toMatchObject({
+			"*_*": "deny",
+			"core_*": "deny",
+			"discord_*": "deny",
+			"mc-bridge_*": "deny",
+			"minecraft_*": "deny",
+			"shell-workspace_*": "deny",
+		});
 		expect(agent.sessionPort.config.skillPaths).toEqual([
 			"/app/context/skills/discord",
 			"/app/context/skills/shell-worker",
@@ -630,6 +638,11 @@ describe("createDiscordAgents", () => {
 			"*": "deny",
 			debug: "allow",
 			"skill-creator": "allow",
+		});
+		expect(worker?.permission).toMatchObject({
+			"*_*": "deny",
+			"discord_*": "deny",
+			"minecraft_*": "deny",
 		});
 	});
 });

--- a/docs/agent-capabilities-and-shell-sandbox.md
+++ b/docs/agent-capabilities-and-shell-sandbox.md
@@ -33,11 +33,16 @@ Minecraft brain の運用手順は `context/skills/minecraft/minecraft-agent-pla
 
 作業ディレクトリは永続化対象の `data/shell-workspaces` 配下なので、bot restart 後もファイルは残る。作成ファイルを Discord に添付する場合は、`shell-worker` が workspace 配下に保存した絶対 path を返し、メイン会話 agent が `discord_send_message(..., file_path)` に指定する。
 
+`shell-worker` は Discord / Core / Minecraft などの MCP ツールを直接使わない。Discord への送信、返信、添付、リアクション、メッセージ取得、Minecraft への委譲など、会話や外部環境に副作用を持つ操作は primary agent の責務とする。`shell-worker` が Discord に出したい本文や添付したいファイルを作った場合も、送信は行わず、本文案や workspace 配下の file path を primary agent へ返す。
+
 ## Permission Policy
+
+OpenCode では agent ごとの permission で MCP tool wildcard を deny できる前提とする。MCP ツールは agent 種別ごとに許可対象を分け、`shell-worker` には MCP ツールを使わせない。
 
 既定 policy:
 
 - メイン会話 agent:
+  - Discord 送信、返信、添付、リアクション、メッセージ取得は primary agent が担当する
   - `task: allow`
   - `features.shellWorkspace` 設定時のみ `skill.delegate-to-shell-worker: allow`
   - `features.minecraft` 設定時のみ `skill.minecraft: allow`
@@ -45,8 +50,20 @@ Minecraft brain の運用手順は `context/skills/minecraft/minecraft-agent-pla
   - `external_directory: deny`
 - `shell-worker` subagent:
   - `bash: allow`
+  - `read: allow`
+  - `edit: allow`
   - `task: deny`
   - `external_directory: deny`
+  - `*_*: deny`
+  - `discord_*: deny`
+  - `core_*: deny`
+  - `minecraft_*: deny`
+  - `mc-bridge_*: deny`
+  - `shell-workspace_*: deny`
+  - その他の MCP tool wildcard も既定で `deny`
+- Minecraft brain session:
+  - Minecraft 操作と mc-bridge の状態更新を担当する
+  - Discord 送信は担当しない
 - OpenCode の global builtin tool は `webfetch`、feature に連動した `skill`、`task`、shell workspace 有効時の `bash` だけを開く。
 - `primary_tools` は shell workspace 有効時に `["task", "skill"]` を基本とし、background subagent 有効時は `task_status` を追加する。Minecraft 有効時は許可 skill に `minecraft` を追加する。
 - `shell-worker` prompt では workspace 外の読み書き、host secrets、auth files、環境変数 dump、権限昇格を禁止する。

--- a/packages/agent/src/discord/profile.test.ts
+++ b/packages/agent/src/discord/profile.test.ts
@@ -91,6 +91,15 @@ describe("createConversationProfile shell workspace subagent", () => {
 		expect(workerPermission?.edit).toBe("allow");
 		expect(workerPermission?.task).toBe("deny");
 		expect(workerPermission?.external_directory).toBe("deny");
+		expect(workerPermission).toMatchObject({
+			"*_*": "deny",
+			"core_*": "deny",
+			"discord_*": "deny",
+			"mc-bridge_*": "deny",
+			"minecraft_*": "deny",
+			"shell-workspace_*": "deny",
+		});
+		expect(worker?.prompt).toContain("Return results to the primary agent");
 	});
 
 	test("background subagent 有効時は task_status を開き background 指示を含める", () => {
@@ -184,6 +193,14 @@ describe("createConversationProfile shell workspace subagent", () => {
 			"*": "deny",
 			"delegate-to-shell-worker": "allow",
 			minecraft: "allow",
+		});
+		const worker = profile.opencodeAgents?.[SHELL_WORKSPACE_AGENT_NAME];
+		const workerPermission = (worker as { permission?: Record<string, unknown> } | undefined)
+			?.permission;
+		expect(workerPermission).toMatchObject({
+			"*_*": "deny",
+			"discord_*": "deny",
+			"minecraft_*": "deny",
 		});
 	});
 });

--- a/packages/agent/src/discord/profile.ts
+++ b/packages/agent/src/discord/profile.ts
@@ -11,6 +11,14 @@ export const SHELL_WORKSPACE_AGENT_NAME = "shell-worker";
 const DEFAULT_SHELL_WORKSPACE_ALLOWED_SKILLS = ["debug", "skill-creator"] as const;
 const SHELL_WORKER_DELEGATION_SKILL_NAME = "delegate-to-shell-worker";
 const MINECRAFT_SKILL_NAME = "minecraft";
+const SHELL_WORKSPACE_DENIED_MCP_TOOLS = {
+	"*_*": "deny",
+	"core_*": "deny",
+	"discord_*": "deny",
+	"mc-bridge_*": "deny",
+	"minecraft_*": "deny",
+	"shell-workspace_*": "deny",
+} as const;
 
 const T = {
 	sendMessage: "discord_send_message",
@@ -121,9 +129,11 @@ function buildShellWorkspaceAgents(
 				read: "allow" as const,
 				edit: "allow" as const,
 				external_directory: "deny" as const,
+				...SHELL_WORKSPACE_DENIED_MCP_TOOLS,
 			},
 			prompt: `You are ${SHELL_WORKSPACE_AGENT_NAME}, a subagent dedicated to shell workspace work.
 Use the OpenCode builtin bash, Read, and Write tools for command execution and workspace file access.
+Do not use Discord, core, Minecraft, mc-bridge, or shell-workspace MCP tools. Return results to the primary agent; the primary agent handles Discord messages and other MCP-side effects.
 Keep all work inside the current workspace directory. Do not read or write outside the workspace, do not inspect host secrets, auth files, or environment dumps, and do not attempt privilege escalation.
 Network access is allowed when needed for package install, builds, and research.
 When a generated file must be sent to Discord, save it under the workspace directory and include its absolute path in your final response.

--- a/packages/opencode/src/session-adapter.test.ts
+++ b/packages/opencode/src/session-adapter.test.ts
@@ -121,6 +121,10 @@ describe("OpencodeSessionAdapter", () => {
 					mode: "subagent",
 					model: "provider/worker-model",
 					tools: { shell_exec: true },
+					permission: {
+						"*_*": "deny",
+						"discord_*": "deny",
+					},
 				},
 			},
 			defaultAgent: "build",
@@ -136,7 +140,7 @@ describe("OpencodeSessionAdapter", () => {
 		const options = calls[0]?.[0] as {
 			config: {
 				default_agent?: string;
-				agent?: Record<string, { temperature?: number; mode?: string }>;
+				agent?: Record<string, { temperature?: number; mode?: string; permission?: unknown }>;
 				experimental?: { primary_tools?: string[] };
 			};
 		};
@@ -145,6 +149,10 @@ describe("OpencodeSessionAdapter", () => {
 		expect(options.config.agent?.build?.mode).toBe("primary");
 		expect(options.config.agent?.build?.temperature).toBe(0.9);
 		expect(options.config.agent?.["shell-worker"]?.mode).toBe("subagent");
+		expect(options.config.agent?.["shell-worker"]?.permission).toEqual({
+			"*_*": "deny",
+			"discord_*": "deny",
+		});
 	});
 
 	test("session 操作に OpenCode directory を渡す", async () => {


### PR DESCRIPTION
## 概要
- shell-worker subagent に MCP tool wildcard deny を追加し、Discord/Core/Minecraft などの MCP 副作用を primary agent 側へ限定
- shell-worker prompt と仕様ドキュメントに、結果返却と Discord 送信責務の分離を明記
- profile/bootstrap/session-adapter のテストで agent 個別 permission が保持されることを検証

## 検証
- bun test packages/agent/src/discord/profile.test.ts packages/opencode/src/session-adapter.test.ts apps/discord/src/bootstrap.test.ts
- nr validate
- nr test

## レビュー後の追跡
- #1008 runtime E2E で OpenCode の MCP deny 挙動を検証する