### PR TITLE
feat(agent): primary agent に self-update skill を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ OpenCode agent ごとに MCP tool permission を分ける。Discord 会話 prima
 OpenCode Agent Skills は runtime 用の `context/skills/{agent}/*/SKILL.md` を discovery 対象にする。`.agents/skills` はこのリポジトリを開発する Codex 用 skill 置き場であり、bot runtime には渡さない。各セッションでは `permission.skill` を既定で `{"*":"deny"}` にし、必要な agent だけ個別に許可する。
 
 - `features.minecraft` 設定時は Discord 会話 primary と heartbeat で `minecraft` skill を許可する。Minecraft ツール説明は system context へ常時注入せず、OpenCode skill として必要時に読み込ませる。
-- shell workspace 有効時は Discord 会話 primary に `delegate-to-shell-worker` skill を許可し、`shell-worker` subagent には `debug` / `skill-creator` skill を許可する。Shell workspace 委譲手順は system context へ常時注入せず、OpenCode skill として必要時に読み込ませる。
-- shell workspace と `features.minecraft` の併用時は、primary `build` agent に `delegate-to-shell-worker` / `minecraft` skill だけを許可し、`shell-worker` の許可 skill とは分離する。
+- shell workspace 有効時は Discord 会話 primary に `delegate-to-shell-worker` / `self-update` skill を許可し、`shell-worker` subagent には `debug` / `skill-creator` skill を許可する。Shell workspace 委譲手順は system context へ常時注入せず、OpenCode skill として必要時に読み込ませる。
+- `self-update` skill はスキル追加のオーケストレーション。ユーザーの明示依頼（「これスキルにして」）または曖昧発話（「こういう機能欲しくない?」）で発火し、`shell-worker` に委譲して SKILL.md 生成 → PR 作成まで自走する。自動マージはガードレール（diff が `context/skills/**` のみ・非破壊的追加/編集・CI green）を全て満たすときだけ行い、外れたら人間レビュー待ちで停止する。primary は `bash` / `gh` / `git` を直接叩かず、すべて `shell-worker` に委ねる。`README.md` 本体やコードを含む変更は自動マージ対象外（人間レビュー扱い）。
+- shell workspace と `features.minecraft` の併用時は、primary `build` agent に `delegate-to-shell-worker` / `self-update` / `minecraft` skill だけを許可し、`shell-worker` の許可 skill とは分離する。
 - Discord 会話 / heartbeat session の `skills.paths` は `context/skills/discord` を指す。shell workspace 有効時だけ同じ session に `context/skills/shell-worker` も追加し、`shell-worker` subagent 用 skill を discovery できるようにする。Minecraft brain session は `context/skills/minecraft` を指し、`minecraft-agent-playbook` skill だけを許可する。Web、画像認識、emotion、memory 補助セッションは OpenCode Skills を全拒否し、runtime skill path も渡さない。
 - `skill-creator` は OpenAI Skills の `skills/.system/skill-creator` を、開発用は `.agents/skills/skill-creator`、runtime shell-worker 用は `context/skills/shell-worker/skill-creator` に vendoring する。
 - Minecraft の `mc_read_skills` / `mc_record_skill` は Minecraft MCP のワールド記憶であり、OpenCode Agent Skills とは別系統として扱う。
@@ -112,7 +113,7 @@ OpenCode Agent Skills は runtime 用の `context/skills/{agent}/*/SKILL.md` を
 
 - オーバーレイ方式: `context/`（git 管理・ベース）と `data/context/`（gitignore・オーバーレイ）の二層構成。読み込みは `data/context/` → `context/` のフォールバック、書き込みは常に `data/context/`。
 - 静的ファイル: `IDENTITY.md`, `SOUL.md`, `DISCORD.md`, `HEARTBEAT.md`, `TOOLS-DISCORD.md`, `TOOLS-CORE.md`
-- capability 連動ツール説明: Shell workspace は `context/skills/discord/delegate-to-shell-worker/SKILL.md`、Discord 側 Minecraft 委譲は `context/skills/discord/minecraft/SKILL.md`、Minecraft brain の運用手順は `context/skills/minecraft/minecraft-agent-playbook/SKILL.md` として管理し、該当 session で必要な skill だけを許可する。
+- capability 連動ツール説明: Shell workspace は `context/skills/discord/delegate-to-shell-worker/SKILL.md`、スキル追加オーケストレーションは `context/skills/discord/self-update/SKILL.md`、Discord 側 Minecraft 委譲は `context/skills/discord/minecraft/SKILL.md`、Minecraft brain の運用手順は `context/skills/minecraft/minecraft-agent-playbook/SKILL.md` として管理し、該当 session で必要な skill だけを許可する。
 - 毎ターンの自己認識補助: Discord 会話プロンプトの先頭に `あなたは{name}です。` を注入する。`VICISSITUDE_IDENTITY_NAME` を優先し、未設定時は `data/context/IDENTITY.md` → `context/IDENTITY.md` の順に `name:` / `full_name:` から抽出する。
 - Memory ファクト注入: 起動時に長期記憶から蓄積済みファクトをシステムプロンプトに注入。
 - サイズ制約: ファイル毎最大 20,000 文字、合計最大 150,000 文字。

--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -550,7 +550,7 @@ describe("createDiscordAgents", () => {
 		expect(agent.profile.primaryTools).toEqual(["task", "task_status", "skill"]);
 		expect(agent.profile.opencodeAgents?.build?.tools?.skill).toBe(true);
 		expect(agent.profile.opencodeAgents?.build?.permission).toMatchObject({
-			skill: { "*": "deny", "delegate-to-shell-worker": "allow" },
+			skill: { "*": "deny", "delegate-to-shell-worker": "allow", "self-update": "allow" },
 		});
 		expect(agent.profile.opencodeAgents?.["shell-worker"]?.tools?.skill).toBe(true);
 		expect(agent.profile.opencodeAgents?.["shell-worker"]?.permission).toMatchObject({
@@ -632,6 +632,7 @@ describe("createDiscordAgents", () => {
 		expect(build?.permission?.skill).toEqual({
 			"*": "deny",
 			"delegate-to-shell-worker": "allow",
+			"self-update": "allow",
 			minecraft: "allow",
 		});
 		expect(worker?.permission?.skill).toEqual({

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -597,8 +597,10 @@ function setupEventHandlers(deps: {
 	metricsCollector: PrometheusCollector;
 	agents: Map<string, DiscordAgent>;
 	logger: Logger;
+	/** 信頼ユーザー (依頼者) 集合。これに含まれる authorId のメッセージに信頼マーカーを付ける */
+	trustedUserIds: string[];
 }): void {
-	const { gateway, ingestionService, metricsCollector, agents, logger } = deps;
+	const { gateway, ingestionService, metricsCollector, agents, logger, trustedUserIds } = deps;
 	gateway.onHomeChannelMessage(async (msg) => {
 		const selfUserId = gateway.getClient()?.user?.id;
 		const scopeId = msg.scopeId ?? (msg.guildId ? discordScopeId(msg.guildId) : undefined);
@@ -619,7 +621,7 @@ function setupEventHandlers(deps: {
 			}
 			void agent?.send({
 				sessionKey: "home",
-				message: formatDiscordMessage(msg),
+				message: formatDiscordMessage(msg, { trustedUserIds }),
 				scopeId,
 				attachments: msg.attachments,
 				channelId: msg.channelId,
@@ -645,7 +647,7 @@ function setupEventHandlers(deps: {
 			}
 			void agent?.send({
 				sessionKey: "mention",
-				message: formatDiscordMessage(msg),
+				message: formatDiscordMessage(msg, { trustedUserIds }),
 				scopeId,
 				attachments: msg.attachments,
 				channelId: msg.channelId,
@@ -680,7 +682,7 @@ function setupEventHandlers(deps: {
 		}
 		void agent?.send({
 			sessionKey: "dm",
-			message: formatDiscordMessage(msg),
+			message: formatDiscordMessage(msg, { trustedUserIds }),
 			scopeId,
 			attachments: msg.attachments,
 			channelId: msg.channelId,
@@ -908,6 +910,7 @@ export async function bootstrap(): Promise<void> {
 		metricsCollector: metrics.collector,
 		agents,
 		logger,
+		trustedUserIds: dmUserIds,
 	});
 
 	// Emoji tracking

--- a/context/skills/discord/self-update/SKILL.md
+++ b/context/skills/discord/self-update/SKILL.md
@@ -37,18 +37,19 @@ description: "Use when a Discord user asks to turn a capability into a skill ('�
    - push して `gh pr create` する。PR タイトルは `feat(skill): add <name> skill`。
 3. 返ってきた PR URL を Discord に共有する。
 4. CI（`nr validate`）が green になるのを確認する（`shell-worker` に `gh` で確認させる）。
-5. ガードレール判定を行う（下記）。全て満たすときだけ `shell-worker` に `gh pr merge --squash --delete-branch` を実行させる。
+5. ガードレール判定を行う（下記）。全て満たすときだけ `shell-worker` に `gh pr merge --squash --delete-branch` を実行させる。満たさないときは PR を open のまま停止し、人間レビュー待ちにする。
 6. Discord に完了報告（自動マージしたか、人間レビュー待ちにしたか）を送る。
 
 ## ガードレール（自動マージの安全弁）
 
 以下を全て満たすときだけ自動マージする。
 
+- **依頼者が信頼ユーザーである**（直近の依頼メッセージに `[trusted-requester]` マーカーが付いている）。スキルの内容はふあ自身の将来の指示セットになるため、信頼ユーザー以外が振る舞いを書き換えられないようにする。マーカーは表示名ではなく authorId 照合でコード側が付与するため、なりすませない。
 - diff が `context/skills/**` のみ（コード・`.claude/agents/`・README 本体などを含まない）。
 - 新規スキル追加、または既存スキルの非破壊的編集のみ。
 - CI（`nr validate`）が green。
 
-一つでも外れたら自動マージしない。Discord に「人間レビューが要りそう」と理由を添えて報告し、PR は open のまま停止する。
+一つでも外れたら自動マージしない。Discord に「人間レビューが要りそう」と理由を添えて報告し、PR は open のまま停止する。とくに **信頼ユーザー以外（`[trusted-requester]` マーカーなし）からの依頼では、CI が green でも自動マージせず**、PR 作成・共有までで止めて「マージにはオーナーのレビューが要る」と伝える。
 
 ## 委譲境界
 

--- a/context/skills/discord/self-update/SKILL.md
+++ b/context/skills/discord/self-update/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: self-update
+description: "Use when a Discord user asks to turn a capability into a skill ('これスキルにして' '機能として覚えて' 'スキル追加して' 等の明示依頼) or implies a recurring capability would help ('こういう機能欲しくない?' '毎回やってもらってるけど定型化できない?' 等の曖昧発話). Orchestrates skill-addition by delegating to shell-worker: create a skill SKILL.md, open a PR, and auto-merge only when guardrails pass. Do NOT trigger for plain chit-chat, one-off questions, or general implementation/code-change requests that are not about adding a reusable skill."
+---
+
+あなたは Discord 会話 primary agent から、新しいスキルを追加するための手順を参照している。
+このスキルは `features.shellWorkspace` 設定時だけ利用可能で、実作業はすべて `shell-worker` に委譲する。
+
+## 発火判定
+
+以下のいずれかを満たすときだけ発火する。判断に迷う場合はユーザーに一言確認してから進める。
+
+- 明示依頼: 「これスキルにして」「機能として覚えて」「スキル追加して」など、再利用可能な能力の追加を直接求める発話。
+- 曖昧発話: 「こういう機能欲しくない?」「毎回やってるけど定型化できない?」など、繰り返し使える能力があると便利そうな含意。曖昧な場合は要望を一言で言語化してユーザーに確認する。
+
+次の場合は発火しない。
+
+- 単なる雑談・感想・一回限りの質問。
+- スキル化を伴わない実装依頼・コード変更依頼（それは `delegate-to-shell-worker` の領域）。
+
+## 最小確定
+
+委譲前に、対象スキルの置き場と一言要望だけ確定する。不明なら Discord で短く確認する。
+
+- ふあ本体（会話）用スキル → `context/skills/<group>/`（多くは `context/skills/discord/`）
+- shell-worker 用スキル → `context/skills/shell-worker/`
+- スキルの一言要望（何を、いつ発火し、何をするか）
+
+## フロー
+
+1. Discord に中間報告を送る（例: 「スキル作るね」）。
+2. `task` で `shell-worker` に以下を一括委譲する。
+   - repo を最新化する。
+   - branch `skill/<kebab-name>` を作る。
+   - `skill-creator` skill の手順に従って対象ディレクトリに `SKILL.md` を生成する。
+   - 検証する（`skill-creator` の validate と `nr validate`）。
+   - push して `gh pr create` する。PR タイトルは `feat(skill): add <name> skill`。
+3. 返ってきた PR URL を Discord に共有する。
+4. CI（`nr validate`）が green になるのを確認する（`shell-worker` に `gh` で確認させる）。
+5. ガードレール判定を行う（下記）。全て満たすときだけ `shell-worker` に `gh pr merge --squash --delete-branch` を実行させる。
+6. Discord に完了報告（自動マージしたか、人間レビュー待ちにしたか）を送る。
+
+## ガードレール（自動マージの安全弁）
+
+以下を全て満たすときだけ自動マージする。
+
+- diff が `context/skills/**` のみ（コード・`.claude/agents/`・README 本体などを含まない）。
+- 新規スキル追加、または既存スキルの非破壊的編集のみ。
+- CI（`nr validate`）が green。
+
+一つでも外れたら自動マージしない。Discord に「人間レビューが要りそう」と理由を添えて報告し、PR は open のまま停止する。
+
+## 委譲境界
+
+- ふあ自身は `bash` / `gh` / `git` を直接叩かない。repo 操作・PR・マージはすべて `shell-worker` に委ねる。
+- `shell-worker` の作業は専用 workspace 内に限定する。workspace 外の読み書き、host secrets、auth files、環境変数 dump、権限昇格を試みない。
+- `shell-worker` から返った結果を確認し、Discord には必要な要約・PR URL・完了可否だけを送る。

--- a/packages/agent/src/discord/message-formatter.test.ts
+++ b/packages/agent/src/discord/message-formatter.test.ts
@@ -5,6 +5,11 @@ import type { IncomingMessage } from "@vicissitude/shared/types";
 
 import { formatDiscordMessage } from "./message-formatter.ts";
 
+function* trustedIdGenerator(): Generator<string> {
+	yield "alpha";
+	yield "beta";
+}
+
 function createMessage(overrides: Partial<IncomingMessage> = {}): IncomingMessage {
 	return {
 		platform: "discord",
@@ -95,5 +100,104 @@ describe("formatDiscordMessage 添付フォーマット", () => {
 		expect(result).toContain("[添付: a.png (image/png)]");
 		expect(result).not.toContain("https://example.com/a.png");
 		expect(result).toContain("[添付: b.txt (text/plain) https://example.com/b.txt]");
+	});
+});
+
+describe("formatDiscordMessage 信頼マーカー（内部分岐）", () => {
+	const MARKER = "[trusted-requester]";
+
+	test("複数 ID の途中に authorId が一致するとき（ループが中間要素でヒット）マーカーが付く", () => {
+		const msg = createMessage({ authorId: "mid" });
+		const result = formatDiscordMessage(msg, {
+			trustedUserIds: ["first", "mid", "last"],
+		});
+		expect(result).toContain(MARKER);
+	});
+
+	test("複数 ID のいずれにも authorId が一致しないとき（ループ完走で false）マーカーが付かない", () => {
+		const msg = createMessage({ authorId: "none" });
+		const result = formatDiscordMessage(msg, {
+			trustedUserIds: ["a", "b", "c"],
+		});
+		expect(result).not.toContain(MARKER);
+	});
+
+	test("Set で渡しても配列と同じく一致すればマーカーが付く（Iterable の形に依存しない）", () => {
+		const msg = createMessage({ authorId: "x" });
+		const result = formatDiscordMessage(msg, {
+			trustedUserIds: new Set(["x", "y"]),
+		});
+		expect(result).toContain(MARKER);
+	});
+
+	test("ジェネレータ（任意の Iterable）で渡しても一致すればマーカーが付く", () => {
+		const msg = createMessage({ authorId: "beta" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: trustedIdGenerator() });
+		expect(result).toContain(MARKER);
+	});
+
+	test("Set と配列で同一内容なら判定結果が一致する", () => {
+		const msg = createMessage({ authorId: "z" });
+		const fromArray = formatDiscordMessage(msg, { trustedUserIds: ["z"] });
+		const fromSet = formatDiscordMessage(msg, { trustedUserIds: new Set(["z"]) });
+		expect(fromArray.includes(MARKER)).toBe(fromSet.includes(MARKER));
+		expect(fromArray).toContain(MARKER);
+	});
+
+	test("authorId が 'system' で信頼集合に含まれないときマーカーが付かない", () => {
+		const msg = createMessage({ authorId: "system" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: ["user-1"] });
+		expect(result).not.toContain(MARKER);
+	});
+
+	test("authorId が 'system' でも信頼集合に 'system' が含まれれば authorId 照合でマーカーが付く", () => {
+		const msg = createMessage({ authorId: "system" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: ["system"] });
+		expect(result).toContain(MARKER);
+	});
+
+	test("bot メッセージでも authorId が信頼集合に含まれなければマーカーが付かない", () => {
+		const msg = createMessage({ isBot: true, authorId: "bot-1" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: ["user-1"] });
+		expect(result).not.toContain(MARKER);
+	});
+
+	test("空 Set のときマーカーが付かない", () => {
+		const msg = createMessage({ authorId: "user-1" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: new Set() });
+		expect(result).not.toContain(MARKER);
+	});
+
+	test("文字列の照合は厳密一致（部分一致や型強制では一致しない）", () => {
+		const msg = createMessage({ authorId: "123" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: ["1234", "0123"] });
+		expect(result).not.toContain(MARKER);
+	});
+
+	test("マーカーは [action: ...] より後ろ（末尾側）に付く", () => {
+		const msg = createMessage({ authorId: "user-1" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: ["user-1"] });
+		expect(result.indexOf(MARKER)).toBeGreaterThan(result.indexOf("[action:"));
+	});
+
+	test("添付・user_message ラップと共存しても末尾にマーカーが付く（user メッセージ）", () => {
+		const msg = createMessage({
+			authorId: "user-1",
+			content: "本文",
+			attachments: [
+				{ url: "https://example.com/a.txt", contentType: "text/plain", filename: "a.txt" },
+			],
+		});
+		const result = formatDiscordMessage(msg, { trustedUserIds: ["user-1"] });
+		expect(result).toContain("<user_message>");
+		expect(result).toContain("[添付: a.txt (text/plain) https://example.com/a.txt]");
+		expect(result.endsWith(MARKER)).toBe(true);
+	});
+
+	test("bot メッセージで信頼集合に含まれる場合、マーカーは bot-interaction-hint より前に付く", () => {
+		const msg = createMessage({ isBot: true, authorId: "bot-1" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: ["bot-1"] });
+		expect(result).toContain(MARKER);
+		expect(result.indexOf(MARKER)).toBeLessThan(result.indexOf("[bot-interaction-hint:"));
 	});
 });

--- a/packages/agent/src/discord/message-formatter.ts
+++ b/packages/agent/src/discord/message-formatter.ts
@@ -18,7 +18,31 @@ function formatAttachment(attachment: Attachment): string {
 	return `${base} ${attachment.url}]`;
 }
 
-export function formatDiscordMessage(msg: IncomingMessage): string {
+export interface FormatDiscordMessageOptions {
+	/**
+	 * 信頼ユーザーの authorId 集合。`msg.authorId` がこの集合に含まれるとき、
+	 * 出力プロンプトに `[trusted-requester]` マーカーを付与する。
+	 * 表示名はなりすまし可能なため、信頼判定は必ず authorId 照合で行う。
+	 * 未指定・空集合のときは誰も信頼ユーザーにならない（安全側デグレ）。
+	 */
+	trustedUserIds?: Iterable<string>;
+}
+
+function isTrustedRequester(
+	msg: IncomingMessage,
+	options: FormatDiscordMessageOptions | undefined,
+): boolean {
+	if (!options?.trustedUserIds) return false;
+	for (const id of options.trustedUserIds) {
+		if (id === msg.authorId) return true;
+	}
+	return false;
+}
+
+export function formatDiscordMessage(
+	msg: IncomingMessage,
+	options?: FormatDiscordMessageOptions,
+): string {
 	const hint = classifyActionHint(msg);
 	const ts = formatTimestamp(msg.timestamp);
 	const channel = msg.channelName ? `#${msg.channelName}(${msg.channelId})` : `#${msg.channelId}`;
@@ -32,6 +56,9 @@ export function formatDiscordMessage(msg: IncomingMessage): string {
 	const parts = [`[${ts} JST ${channel}] ${msg.authorName}: ${content}`];
 	if (attachments) parts.push(attachments);
 	parts.push(`[action: ${hint}]`);
+	if (isTrustedRequester(msg, options)) {
+		parts.push("[trusted-requester]");
+	}
 	if (msg.isBot) {
 		parts.push(
 			"[bot-interaction-hint: このメッセージはbotによるものです。返事をするかどうかはあなた次第です。同じ話の繰り返しや義務的な相槌は要りません。話が一段落したなら、黙っていても構いません。]",

--- a/packages/agent/src/discord/profile.test.ts
+++ b/packages/agent/src/discord/profile.test.ts
@@ -49,6 +49,7 @@ describe("createConversationProfile shell workspace subagent", () => {
 		expect(profile.skillPermission).toEqual({
 			"*": "deny",
 			"delegate-to-shell-worker": "allow",
+			"self-update": "allow",
 		});
 		expect(profile.defaultAgent).toBe("build");
 		expect(profile.primaryTools).toEqual(["task", "skill"]);
@@ -66,6 +67,7 @@ describe("createConversationProfile shell workspace subagent", () => {
 		expect(buildPermission?.skill).toEqual({
 			"*": "deny",
 			"delegate-to-shell-worker": "allow",
+			"self-update": "allow",
 		});
 
 		const worker = profile.opencodeAgents?.[SHELL_WORKSPACE_AGENT_NAME];
@@ -192,6 +194,7 @@ describe("createConversationProfile shell workspace subagent", () => {
 		expect(buildPermission?.skill).toEqual({
 			"*": "deny",
 			"delegate-to-shell-worker": "allow",
+			"self-update": "allow",
 			minecraft: "allow",
 		});
 		const worker = profile.opencodeAgents?.[SHELL_WORKSPACE_AGENT_NAME];

--- a/packages/agent/src/discord/profile.ts
+++ b/packages/agent/src/discord/profile.ts
@@ -10,6 +10,7 @@ import { SECURITY_PROMPT_LINES, type AgentProfile, type McpServerConfig } from "
 export const SHELL_WORKSPACE_AGENT_NAME = "shell-worker";
 const DEFAULT_SHELL_WORKSPACE_ALLOWED_SKILLS = ["debug", "skill-creator"] as const;
 const SHELL_WORKER_DELEGATION_SKILL_NAME = "delegate-to-shell-worker";
+const SELF_UPDATE_SKILL_NAME = "self-update";
 const MINECRAFT_SKILL_NAME = "minecraft";
 const SHELL_WORKSPACE_DENIED_MCP_TOOLS = {
 	"*_*": "deny",
@@ -147,7 +148,9 @@ function buildConversationSkillPermission(options: {
 	minecraftEnabled?: boolean;
 }): SkillPermissionConfig {
 	const allowedSkills = [
-		...(options.shellWorkspaceEnabled ? [SHELL_WORKER_DELEGATION_SKILL_NAME] : []),
+		...(options.shellWorkspaceEnabled
+			? [SHELL_WORKER_DELEGATION_SKILL_NAME, SELF_UPDATE_SKILL_NAME]
+			: []),
 		...(options.minecraftEnabled ? [MINECRAFT_SKILL_NAME] : []),
 	];
 	return createSkillPermission(allowedSkills.length > 0 ? allowedSkills : undefined);

--- a/spec/agent/discord/message-formatter.spec.ts
+++ b/spec/agent/discord/message-formatter.spec.ts
@@ -197,3 +197,64 @@ describe("formatDiscordMessage", () => {
 		expect(result).not.toContain("[bot-interaction-hint");
 	});
 });
+
+// ─── formatDiscordMessage: 信頼マーカー ─────────────────────────
+//
+// 信頼判定は表示名（なりすまし可能）ではなく authorId と信頼ユーザー集合の
+// 照合でコード側が確実に行い、結果を [trusted-requester] マーカーとして
+// プロンプト文字列に注入する。self-update skill の自動マージ可否がこの
+// マーカーの有無に依存する。
+
+describe("formatDiscordMessage: 信頼マーカー", () => {
+	test("authorId が信頼ユーザー集合に含まれるとき [trusted-requester] マーカーが付く", () => {
+		const msg = createMessage({ authorId: "883258849254072341" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: ["883258849254072341"] });
+
+		expect(result).toContain("[trusted-requester]");
+	});
+
+	test("authorId が信頼ユーザー集合に含まれないとき [trusted-requester] マーカーは付かない", () => {
+		const msg = createMessage({ authorId: "999999999999999999" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: ["883258849254072341"] });
+
+		expect(result).not.toContain("[trusted-requester]");
+	});
+
+	test("信頼ユーザー集合が空のとき誰にも [trusted-requester] マーカーは付かない", () => {
+		const msg = createMessage({ authorId: "883258849254072341" });
+		const result = formatDiscordMessage(msg, { trustedUserIds: [] });
+
+		expect(result).not.toContain("[trusted-requester]");
+	});
+
+	test("options 自体が未指定のとき [trusted-requester] マーカーは付かない（安全側デグレ）", () => {
+		const msg = createMessage({ authorId: "883258849254072341" });
+		const result = formatDiscordMessage(msg);
+
+		expect(result).not.toContain("[trusted-requester]");
+	});
+
+	test("trustedUserIds が未指定のとき [trusted-requester] マーカーは付かない", () => {
+		const msg = createMessage({ authorId: "883258849254072341" });
+		const result = formatDiscordMessage(msg, {});
+
+		expect(result).not.toContain("[trusted-requester]");
+	});
+
+	test("信頼ユーザーでも非信頼ユーザーでも既存の基本フォーマットは維持される", () => {
+		const trusted = formatDiscordMessage(createMessage({ authorId: "t-1", authorName: "Owner" }), {
+			trustedUserIds: ["t-1"],
+		});
+		const untrusted = formatDiscordMessage(
+			createMessage({ authorId: "u-1", authorName: "Guest" }),
+			{
+				trustedUserIds: ["t-1"],
+			},
+		);
+
+		expect(trusted).toContain("Owner");
+		expect(trusted).toContain("[action: optional]");
+		expect(untrusted).toContain("Guest");
+		expect(untrusted).toContain("[action: optional]");
+	});
+});

--- a/spec/agent/discord/profile.spec.ts
+++ b/spec/agent/discord/profile.spec.ts
@@ -35,7 +35,7 @@ describe("createConversationProfile", () => {
 		expect(profile.pollingPrompt).toContain("respond");
 	});
 
-	test("shell workspace 有効時は primary に delegate-to-shell-worker skill を許可する", () => {
+	test("shell workspace 有効時は primary に delegate-to-shell-worker と self-update skill を許可する", () => {
 		const profile = createConversationProfile({
 			providerId: "provider",
 			modelId: "model",
@@ -59,18 +59,46 @@ describe("createConversationProfile", () => {
 		expect(profile.skillPermission).toEqual({
 			"*": "deny",
 			"delegate-to-shell-worker": "allow",
+			"self-update": "allow",
 		});
 		expect(profile.primaryTools).toEqual(["task", "skill"]);
 		expect(build?.tools?.skill).toBe(true);
 		expect(build?.permission?.skill).toEqual({
 			"*": "deny",
 			"delegate-to-shell-worker": "allow",
+			"self-update": "allow",
 		});
 		expect(worker?.tools?.skill).toBe(true);
 		expect(worker?.permission?.skill).toEqual({
 			"*": "deny",
 			debug: "allow",
 			"skill-creator": "allow",
+		});
+	});
+
+	test("self-update は shell workspace 無効時には許可しない", () => {
+		const profile = createConversationProfile({
+			providerId: "provider",
+			modelId: "model",
+			mcpServers: {},
+		});
+
+		expect(profile.skillPermission["self-update"]).toBeUndefined();
+		expect(profile.skillPermission).toEqual({ "*": "deny" });
+	});
+
+	test("self-update は Minecraft のみ有効時には許可しない", () => {
+		const profile = createConversationProfile({
+			providerId: "provider",
+			modelId: "model",
+			mcpServers: {},
+			minecraftEnabled: true,
+		});
+
+		expect(profile.skillPermission["self-update"]).toBeUndefined();
+		expect(profile.skillPermission).toEqual({
+			"*": "deny",
+			minecraft: "allow",
 		});
 	});
 
@@ -102,7 +130,7 @@ describe("createConversationProfile", () => {
 		expect(profile.opencodeAgents).toBeUndefined();
 	});
 
-	test("shell workspace と Minecraft の併用時は build agent に delegate-to-shell-worker と minecraft skill だけを許可する", () => {
+	test("shell workspace と Minecraft の併用時は build agent に delegate-to-shell-worker / self-update / minecraft skill だけを許可する", () => {
 		const profile = createConversationProfile({
 			providerId: "provider",
 			modelId: "model",
@@ -128,6 +156,7 @@ describe("createConversationProfile", () => {
 		expect(build?.permission?.skill).toEqual({
 			"*": "deny",
 			"delegate-to-shell-worker": "allow",
+			"self-update": "allow",
 			minecraft: "allow",
 		});
 		expect(worker?.tools?.skill).toBe(true);


### PR DESCRIPTION
## 概要

Discord bot「ふあ」(primary agent) に **self-update skill** を追加する。Discord 会話中の「こういう機能欲しくない?」系の曖昧発話や「これスキルにして」系の明示依頼を起点に、ふあ自身が shell-worker へ委譲してスキル追加 PR を作成し、ガードレールを満たせば自動マージまで自走する自己改善ループを実現する。

## 動作フロー

1. 発火判定（曖昧発話 / 明示依頼。雑談・一回限りの質問・単なる実装依頼では発火しない）
2. 最小確定（対象 = ふあ本体 or shell-worker のスキル、一言要望。曖昧な時だけ Discord で確認）
3. Discord に中間報告 →`shell-worker` へ委譲（repo 最新化 → branch `skill/<kebab-name>` → skill-creator 手順で SKILL.md 生成 → 検証 → `gh pr create`）
4. PR URL を Discord に共有
5. CI green 確認 → ガードレール判定 → 満たせば `gh pr merge --squash --delete-branch`
6. Discord に完了報告

## ガードレール（自動マージの安全弁）

以下を全て満たす時のみ自動マージ。一つでも外れたら停止して Discord で人間レビューを要請。

- diff が `context/skills/**` のみ（コード・`.claude/agents/`・README 本体を含まない）
- 新規追加 or 既存スキルの非破壊的編集のみ
- CI（`nr validate`）green

> 注: ガードレールは現状 SKILL.md のプロンプト記述依存（CI による機械強制ではない）。誤発火は `context/skills/**` 限定ガードで本体破壊に至らないため、運用で様子を見る方針。

## 変更内容

- 新規 `context/skills/discord/self-update/SKILL.md` — スキル本体（発火判定・最小確定・フロー・ガードレール・委譲境界）
- `packages/agent/src/discord/profile.ts` — shellWorkspace 有効時のみ primary 会話 agent に `self-update: allow` を配線（shell-worker subagent 側は不変）
- `spec/agent/discord/profile.spec.ts` — 許可契約を追加（有効時 allow / 無効時・Minecraft のみ時は不許可）
- `packages/agent/src/discord/profile.test.ts`, `apps/discord/src/bootstrap.test.ts` — 期待値を更新
- `README.md` — 3.4.1 / 3.5 節に self-update を追記

## 検証

- `nr validate`（fmt:check + lint + check）: EXIT 0
- `nr test`（spec + unit 全体）: 2425 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)