### PR TITLE
docs(skill): self-update の対象範囲を広げる

### DIFF
--- a/context/skills/discord/self-update/SKILL.md
+++ b/context/skills/discord/self-update/SKILL.md
@@ -1,40 +1,59 @@
 ---
 name: self-update
-description: "Use when a Discord user asks to add, create, install, register, or update an OpenCode/agent skill, even if phrased only as '<service/API/MCP/tool>スキル追加して' or '<name>のMCPスキル追加して' rather than explicitly saying 'スキルにして'. Examples: 'これスキルにして' '機能として覚えて' 'スキル追加して' 'freeeのMCPスキル追加して' 'API操作用のスキル作って'. Also use when the user implies a recurring capability would help ('こういう機能欲しくない?' '毎回やってもらってるけど定型化できない?' 等の曖昧発話). Orchestrates skill-addition by delegating to shell-worker: create a skill SKILL.md, open a PR, and auto-merge only when guardrails pass. Do NOT trigger for plain chit-chat, one-off questions, or general implementation/code-change requests that are not about adding a reusable skill."
+description: "Use when a Discord user asks to modify ふあ's own behavior, configuration, prompts, or skills. Covers skill additions ('freeeのMCPスキル追加して' 'これスキルにして'), skill modifications ('このスキルの動作変えて' '〇〇スキルの説明更新して'), agent config/prompt changes ('プロンプト修正して' 'エージェントの設定変えて'), self-improvement requests ('こういうときの動作改善して'), and bug fixes to agent behavior ('〇〇のときの挙動おかしいから直して'). Orchestrates self-modification by delegating repository work to shell-worker: create a branch, follow AGENTS.md, validate, commit, push, open a PR, and auto-merge only when guardrails pass. Do NOT trigger for plain chit-chat, one-off questions, or regular project/app code changes unrelated to ふあ's own behavior."
 ---
 
-あなたは Discord 会話 primary agent から、新しいスキルを追加するための手順を参照している。
+あなたは Discord 会話 primary agent から、ふあ自身の振る舞い・設定・プロンプト・スキルを変更するための手順を参照している。
 このスキルは `features.shellWorkspace` 設定時だけ利用可能で、実作業はすべて `shell-worker` に委譲する。
 
 ## 発火判定
 
 以下のいずれかを満たすときだけ発火する。判断に迷う場合はユーザーに一言確認してから進める。
 
-- 明示依頼: 「これスキルにして」「機能として覚えて」「スキル追加して」「API 操作用のスキル作って」など、再利用可能な能力の追加を直接求める発話。特に「freee の MCP スキル追加して」「<サービス/API/MCP/ツール>スキル追加して」のように、対象名 + 種別 + 「追加して」だけで表現された依頼もスキル追加として扱う。
-- 曖昧発話: 「こういう機能欲しくない?」「毎回やってるけど定型化できない?」など、繰り返し使える能力があると便利そうな含意。曖昧な場合は要望を一言で言語化してユーザーに確認する。
+- **自己変更**: ふあ自身のスキル、設定、プロンプト、会話方針、ツール利用方針、ガードレールなど、将来のふあの振る舞いを変える依頼。
+  - スキル追加: 「これスキルにして」「機能として覚えて」「スキル追加して」「freee の MCP スキル追加して」「API 操作用のスキル作って」。
+  - スキル変更: 「このスキルの動作変えて」「〇〇スキルの説明更新して」「発火条件を広げて」。
+  - エージェント設定・プロンプト変更: 「プロンプト修正して」「エージェントの設定変えて」「指示を追加して」。
+  - 自己改善: 「こういうときの動作改善して」「毎回やってるけど定型化できない?」。
+  - ふあの挙動バグ修正: 「〇〇のときの挙動おかしいから直して」「PR 作成時の手順が違うから直して」。
+- **曖昧発話**: ふあの再利用可能な能力や運用ルールを変える含意がある発話。曖昧な場合は要望を一言で言語化してユーザーに確認する。
 
 次の場合は発火しない。
 
 - 単なる雑談・感想・一回限りの質問。
-- スキル化を伴わない実装依頼・コード変更依頼（それは `delegate-to-shell-worker` の領域）。
+- 通常のコード変更: アプリ本体・ライブラリ・インフラなどプロジェクト機能の実装、バグ修正、リファクタ依頼（それは `delegate-to-shell-worker` の領域）。
+- ふあ自身の振る舞い変更を伴わない、単発の調査・作業代行。
+
+## AGENTS.md 遵守
+
+自己変更は、必ず repo の `AGENTS.md` に従って進める。とくに以下を `shell-worker` への委譲内容に含める。
+
+- main ブランチへ直接コミット・push しない。必ず専用ブランチを作成し、PR 経由で変更する。
+- コミットメッセージは Conventional Commits 形式にし、要約は日本語にする（例: `docs(skill): self-update の対象範囲を広げる`）。
+- 変更後は `nr validate` を実行し、成功してからコミットする。
+- push 後に `gh pr create` で PR を作成する。
+- ガードレールと CI が通り、マージ条件を満たす場合だけ squash merge し、リモートブランチを削除する。
 
 ## 最小確定
 
-委譲前に、対象スキルの置き場と一言要望だけ確定する。不明なら Discord で短く確認する。
+委譲前に、変更対象と一言要望だけ確定する。不明なら Discord で短く確認する。
 
-- ふあ本体（会話）用スキル → `context/skills/<group>/`（多くは `context/skills/discord/`）
-- shell-worker 用スキル → `context/skills/shell-worker/`
-- スキルの一言要望（何を、いつ発火し、何をするか）
+- ふあ本体（会話）用スキル → `context/skills/<group>/`（多くは `context/skills/discord/`）。
+- shell-worker 用スキル → `context/skills/shell-worker/`。
+- エージェント設定・プロンプト・関連ルール → `AGENTS.md`、`.agents/**`、`.claude/agents/**`、`.codex/**`、`context/**`、`opencode.json`、`skills-lock.json` などの該当ファイル。
+- 一言要望（何を、いつ発火し、何をどう変えるか）。
 
 ## フロー
 
-1. Discord に中間報告を送る（例: 「スキル作るね」）。
+1. Discord に中間報告を送る（例: 「ふあの設定変更として PR 作るね」）。
 2. `task` で `shell-worker` に以下を一括委譲する。
-   - repo を最新化する。
-   - branch `skill/<kebab-name>` を作る。
-   - `skill-creator` skill の手順に従って対象ディレクトリに `SKILL.md` を生成する。
-   - 検証する（`skill-creator` の validate と `nr validate`）。
-   - push して `gh pr create` する。PR タイトルは `feat(skill): add <name> skill`。
+   - `AGENTS.md` を読んで遵守する。
+   - repo を最新化し、main に直接変更せず、専用 branch（例: `skill/<kebab-name>`、`agents/<kebab-name>`、`fix/<kebab-name>`）を作る。
+   - スキル追加なら `skill-creator` skill の手順に従って対象ディレクトリに `SKILL.md` を生成する。
+   - 既存スキル変更、設定・プロンプト変更、挙動改善、バグ修正なら、対象ファイルだけを最小差分で編集する。
+   - 検証する（スキル追加時は `skill-creator` の validate、全ケースで `nr validate`）。
+   - Conventional Commits 形式（日本語要約）で commit する。
+   - push して `gh pr create` する。PR タイトルも Conventional Commits 形式を基本にする。
 3. 返ってきた PR URL を Discord に共有する。
 4. CI（`nr validate`）が green になるのを確認する（`shell-worker` に `gh` で確認させる）。
 5. ガードレール判定を行う（下記）。全て満たすときだけ `shell-worker` に `gh pr merge --squash --delete-branch` を実行させる。満たさないときは PR を open のまま停止し、人間レビュー待ちにする。
@@ -44,9 +63,9 @@ description: "Use when a Discord user asks to add, create, install, register, or
 
 以下を全て満たすときだけ自動マージする。
 
-- **依頼者が信頼ユーザーである**（直近の依頼メッセージに `[trusted-requester]` マーカーが付いている）。スキルの内容はふあ自身の将来の指示セットになるため、信頼ユーザー以外が振る舞いを書き換えられないようにする。マーカーは表示名ではなく authorId 照合でコード側が付与するため、なりすませない。
-- diff が `context/skills/**` のみ（コード・`.claude/agents/`・README 本体などを含まない）。
-- 新規スキル追加、または既存スキルの非破壊的編集のみ。
+- **依頼者が信頼ユーザーである**（直近の依頼メッセージに `[trusted-requester]` マーカーが付いている）。自己変更の内容はふあ自身の将来の指示セットになるため、信頼ユーザー以外が振る舞いを書き換えられないようにする。マーカーは表示名ではなく authorId 照合でコード側が付与するため、なりすませない。
+- diff が自己変更に関係するファイルだけ（例: `context/skills/**`、`AGENTS.md`、`.agents/**`、`.claude/agents/**`、`.codex/**`、`context/**`、`opencode.json`、`skills-lock.json`）。アプリ本体コード、インフラ、README 本体など、ふあ自身の振る舞いに直接関係しない変更を含まない。
+- 新規スキル追加、既存スキルの非破壊的編集、設定・プロンプト・ガードレールの明確化など、依頼内容に沿った最小差分のみ。
 - CI（`nr validate`）が green。
 
 一つでも外れたら自動マージしない。Discord に「人間レビューが要りそう」と理由を添えて報告し、PR は open のまま停止する。とくに **信頼ユーザー以外（`[trusted-requester]` マーカーなし）からの依頼では、CI が green でも自動マージせず**、PR 作成・共有までで止めて「マージにはオーナーのレビューが要る」と伝える。


### PR DESCRIPTION
## Summary
- self-update skill の発火対象をスキル追加から、ふあ自身のスキル・設定・プロンプト・振る舞い変更全般へ拡張
- 通常のプロジェクトコード変更との判定境界を明確化
- AGENTS.md 遵守、PR ベース運用、Conventional Commits、検証、squash merge の手順を明記
- ガードレールの diff 対象を自己変更関連ファイルへ拡張

## Validation
- `nr validate` はこの環境で `nr: command not found` のため実行不可
- 代替として `bun run validate` を実行し成功