### PR TITLE
feat(discord): add monthly usage percentage to Discord presence

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -83,6 +83,7 @@ import {
 	removeLegacyConsolidateReminder,
 	syncMcCheckReminder,
 } from "./migrations.ts";
+import { MonthlyUsagePresenceService } from "./monthly-usage-presence.ts";
 import { createPortLayout } from "./port-allocator.ts";
 import { createShutdown } from "./shutdown.ts";
 
@@ -959,6 +960,7 @@ export async function bootstrap(): Promise<void> {
 
 	// Session gauge
 	const sessionGaugeTimer = startSessionGauge(sessionStore, metrics.collector);
+	const monthlyUsagePresence = new MonthlyUsagePresenceService(gateway, logger);
 
 	// MCP processes (Minecraft のみ HTTP、core は stdio で OpenCode が管理)
 	const mcProcess = await mcReady;
@@ -987,6 +989,7 @@ export async function bootstrap(): Promise<void> {
 	const shutdown = createShutdown({
 		logger,
 		sessionGaugeTimer,
+		monthlyUsagePresence,
 		consolidationScheduler: memoryResources?.consolidationScheduler,
 		heartbeatScheduler,
 		gateway,
@@ -1011,6 +1014,7 @@ export async function bootstrap(): Promise<void> {
 		`[bootstrap] Polling mode for ${guildIds.length} guild(s), ${dmUserIds.length} DM user(s): ${guildIds.join(", ")}`,
 	);
 	await gateway.start();
+	monthlyUsagePresence.start();
 	heartbeatScheduler.start();
 	memoryResources?.consolidationScheduler.start();
 	// DiscordAgent は lazy start: 最初の send() 呼び出しで自動的にポーリングループが起動する

--- a/apps/discord/src/gateway/discord.ts
+++ b/apps/discord/src/gateway/discord.ts
@@ -2,7 +2,14 @@ import { mapAttachments } from "@vicissitude/infrastructure/discord/attachment-m
 import { rewriteTwitterUrls } from "@vicissitude/infrastructure/discord/url-rewriter";
 import { discordDmScopeId, discordScopeId } from "@vicissitude/shared/namespace";
 import type { IncomingMessage, Logger, MessageChannel } from "@vicissitude/shared/types";
-import { Client, Events, GatewayIntentBits, type Message, Partials } from "discord.js";
+import {
+	ActivityType,
+	Client,
+	Events,
+	GatewayIntentBits,
+	type Message,
+	Partials,
+} from "discord.js";
 
 type MessageHandler = (msg: IncomingMessage, ch: MessageChannel) => Promise<void>;
 type EmojiUsedHandler = (guildId: string, emojiName: string) => void;
@@ -98,6 +105,12 @@ export class DiscordGateway {
 		const user = this.client?.user;
 		if (!user) return;
 		user.setActivity();
+	}
+
+	setWatchingActivity(name: string): void {
+		const user = this.client?.user;
+		if (!user) return;
+		user.setActivity(name, { type: ActivityType.Watching });
 	}
 
 	private isHomeMessage(message: Message): boolean {

--- a/apps/discord/src/monthly-usage-presence.ts
+++ b/apps/discord/src/monthly-usage-presence.ts
@@ -1,0 +1,148 @@
+import { Database } from "bun:sqlite";
+
+import type { Logger } from "@vicissitude/shared/types";
+
+import type { DiscordGateway } from "./gateway/discord.ts";
+
+export const OPENCODE_DB_PATH = "/app/.local/share/opencode/opencode.db";
+export const OPENCODE_MONTHLY_LIMIT_USD = 60;
+export const MONTHLY_USAGE_PRESENCE_INTERVAL_MS = 5 * 60 * 1000;
+
+interface SqliteColumnInfo {
+	name: string;
+	type?: string;
+}
+
+export interface MonthlyUsagePresenceOptions {
+	dbPath?: string;
+	monthlyLimitUsd?: number;
+	intervalMs?: number;
+	now?: () => Date;
+}
+
+export class MonthlyUsagePresenceService {
+	private timer: ReturnType<typeof setInterval> | undefined;
+
+	private readonly dbPath: string;
+	private readonly monthlyLimitUsd: number;
+	private readonly intervalMs: number;
+	private readonly now: () => Date;
+
+	constructor(
+		private readonly gateway: DiscordGateway,
+		private readonly logger: Logger,
+		options: MonthlyUsagePresenceOptions = {},
+	) {
+		this.dbPath = options.dbPath ?? OPENCODE_DB_PATH;
+		this.monthlyLimitUsd = options.monthlyLimitUsd ?? OPENCODE_MONTHLY_LIMIT_USD;
+		this.intervalMs = options.intervalMs ?? MONTHLY_USAGE_PRESENCE_INTERVAL_MS;
+		this.now = options.now ?? (() => new Date());
+	}
+
+	start(): void {
+		if (this.timer) return;
+		this.update();
+		this.timer = setInterval(() => this.update(), this.intervalMs);
+	}
+
+	stop(): void {
+		if (!this.timer) return;
+		clearInterval(this.timer);
+		this.timer = undefined;
+	}
+
+	update(): void {
+		try {
+			const cost = readCurrentMonthCost(this.dbPath, this.now());
+			const percentage = (cost / this.monthlyLimitUsd) * 100;
+			this.gateway.setWatchingActivity(formatUsagePercentage(percentage));
+		} catch (error) {
+			this.logger.warn("[presence] failed to update monthly usage presence:", error);
+		}
+	}
+}
+
+export function formatUsagePercentage(percentage: number): string {
+	if (!Number.isFinite(percentage) || percentage < 0) return "0%";
+	if (percentage < 10) return `${percentage.toFixed(1)}%`;
+	return `${Math.round(percentage)}%`;
+}
+
+export function readCurrentMonthCost(dbPath: string, now: Date = new Date()): number {
+	const db = new Database(dbPath, { readonly: true, create: false });
+	try {
+		const columns = getTableColumns(db, "session");
+		if (!columns.some((column) => column.name === "cost")) {
+			throw new Error("OpenCode session table has no cost column");
+		}
+
+		const dateColumn = selectDateColumn(columns);
+		if (!dateColumn) {
+			throw new Error("OpenCode session table has no known timestamp column");
+		}
+
+		const range = currentMonthRange(now);
+		const where = buildCurrentMonthWhere(dateColumn);
+		const row = db
+			.query<{ total: number | null }, Array<string | number>>(
+				`SELECT COALESCE(SUM(COALESCE("cost", 0)), 0) AS total FROM "session" WHERE ${where.sql}`,
+			)
+			.get(...where.params(range));
+		return row?.total ?? 0;
+	} finally {
+		db.close();
+	}
+}
+
+function getTableColumns(db: Database, tableName: string): SqliteColumnInfo[] {
+	const quotedTableName = `"${tableName.replaceAll('"', '""')}"`;
+	const rows = db.query<SqliteColumnInfo, []>(`PRAGMA table_info(${quotedTableName})`).all();
+	if (rows.length === 0) throw new Error(`OpenCode ${tableName} table not found`);
+	return rows;
+}
+
+function selectDateColumn(columns: SqliteColumnInfo[]): SqliteColumnInfo | undefined {
+	const candidates = [
+		"created_at",
+		"createdAt",
+		"updated_at",
+		"updatedAt",
+		"time",
+		"timestamp",
+		"started_at",
+	];
+	return candidates
+		.map((name) => columns.find((column) => column.name === name))
+		.find((column): column is SqliteColumnInfo => !!column);
+}
+
+function currentMonthRange(now: Date) {
+	const start = new Date(now.getFullYear(), now.getMonth(), 1);
+	const end = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+	return {
+		startIso: start.toISOString(),
+		endIso: end.toISOString(),
+		startMs: start.getTime(),
+		endMs: end.getTime(),
+		startSec: Math.floor(start.getTime() / 1000),
+		endSec: Math.floor(end.getTime() / 1000),
+	};
+}
+
+function buildCurrentMonthWhere(column: SqliteColumnInfo): {
+	sql: string;
+	params: (range: ReturnType<typeof currentMonthRange>) => Array<string | number>;
+} {
+	const columnName = `"${column.name.replaceAll('"', '""')}"`;
+	const type = (column.type ?? "").toUpperCase();
+	if (type.includes("INT") || type.includes("REAL") || type.includes("NUM")) {
+		return {
+			sql: `((${columnName} >= ? AND ${columnName} < ?) OR (${columnName} >= ? AND ${columnName} < ?))`,
+			params: (range) => [range.startMs, range.endMs, range.startSec, range.endSec],
+		};
+	}
+	return {
+		sql: `${columnName} >= ? AND ${columnName} < ?`,
+		params: (range) => [range.startIso, range.endIso],
+	};
+}

--- a/apps/discord/src/shutdown.ts
+++ b/apps/discord/src/shutdown.ts
@@ -3,6 +3,7 @@ import type { Logger } from "@vicissitude/shared/types";
 export interface ShutdownDeps {
 	logger: Logger;
 	sessionGaugeTimer: ReturnType<typeof setInterval>;
+	monthlyUsagePresence?: { stop(): void };
 	consolidationScheduler?: { stop(): void };
 	heartbeatScheduler: { stop(): void };
 	gateway: { stop(): void };
@@ -39,6 +40,7 @@ export function createShutdown(deps: ShutdownDeps): () => Promise<void> {
 		};
 
 		await safe("sessionGauge", () => clearInterval(deps.sessionGaugeTimer));
+		await safe("monthlyUsagePresence", () => deps.monthlyUsagePresence?.stop());
 		await safe("consolidation", () => deps.consolidationScheduler?.stop());
 		await safe("heartbeatScheduler", () => deps.heartbeatScheduler.stop());
 		await safe("gateway", () => deps.gateway.stop());

--- a/spec/discord/bootstrap-shutdown.spec.ts
+++ b/spec/discord/bootstrap-shutdown.spec.ts
@@ -23,6 +23,7 @@ function makeDeps(overrides: Partial<ShutdownDeps> = {}): ShutdownDeps & { callO
 			return l;
 		})(),
 		sessionGaugeTimer: setInterval(() => {}, 100_000),
+		monthlyUsagePresence: { stop: mock(track("monthlyUsagePresence")) },
 		consolidationScheduler: { stop: mock(track("consolidation")) },
 		heartbeatScheduler: { stop: mock(track("heartbeatScheduler")) },
 		gateway: { stop: mock(track("gateway")) },
@@ -40,6 +41,7 @@ function makeDeps(overrides: Partial<ShutdownDeps> = {}): ShutdownDeps & { callO
 		factReader: { close: mock(track("factReader")) },
 		chatAdapter: { close: mock(track("chatAdapter")) },
 		recorder: { close: mock(track("recorder")) },
+		resumeContextService: { close: mock(track("resumeContextService")) },
 		mcProcess: { kill: mock(track("mcProcess")) },
 		closeDb: mock(track("db")),
 		...overrides,
@@ -71,7 +73,7 @@ describe("createShutdown()", () => {
 	});
 
 	describe("シャットダウン順序", () => {
-		it("15 コンポーネントが定義順にシャットダウンされる", async () => {
+		it("17 コンポーネントが定義順にシャットダウンされる", async () => {
 			const deps = makeDeps();
 			// clearInterval のスパイで sessionGauge の順序を記録
 			clearIntervalSpy.mockImplementation((..._args: unknown[]) => {
@@ -83,6 +85,7 @@ describe("createShutdown()", () => {
 
 			expect(deps.callOrder).toEqual([
 				"sessionGauge",
+				"monthlyUsagePresence",
 				"consolidation",
 				"heartbeatScheduler",
 				"gateway",
@@ -95,6 +98,7 @@ describe("createShutdown()", () => {
 				"factReader",
 				"chatAdapter",
 				"recorder",
+				"resumeContextService",
 				"mcProcess",
 				"db",
 			]);
@@ -218,11 +222,13 @@ describe("createShutdown()", () => {
 
 		it("全オプショナル依存が undefined でも正常にシャットダウンされる", async () => {
 			const deps = makeDeps({
+				monthlyUsagePresence: undefined,
 				consolidationScheduler: undefined,
 				webAgent: undefined,
 				mcBrainManager: undefined,
 				chatAdapter: undefined,
 				recorder: undefined,
+				resumeContextService: undefined,
 				mcProcess: undefined,
 			});
 			clearIntervalSpy.mockImplementation((..._args: unknown[]) => {

--- a/spec/discord/monthly-usage-presence.spec.ts
+++ b/spec/discord/monthly-usage-presence.spec.ts
@@ -1,0 +1,65 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync } from "fs";
+import { join, resolve } from "path";
+
+import {
+	formatUsagePercentage,
+	readCurrentMonthCost,
+} from "../../apps/discord/src/monthly-usage-presence.ts";
+
+const tempDir = resolve(".tmp/monthly-usage-presence-spec");
+
+afterEach(() => {
+	rmSync(tempDir, { recursive: true, force: true });
+});
+
+function createDb(name: string, schema: string): string {
+	mkdirSync(tempDir, { recursive: true });
+	const dbPath = join(tempDir, name);
+	const db = new Database(dbPath);
+	for (const statement of schema
+		.split(";")
+		.map((part) => part.trim())
+		.filter(Boolean)) {
+		db.query(statement).run();
+	}
+	db.close();
+	return dbPath;
+}
+
+describe("monthly usage presence", () => {
+	it("current month の session.cost だけを合計する（Unix ms）", () => {
+		const dbPath = createDb(
+			"unix-ms.db",
+			`
+CREATE TABLE session (id TEXT PRIMARY KEY, cost REAL, time INTEGER);
+INSERT INTO session VALUES ('prev', 12.5, 1706745600000);
+INSERT INTO session VALUES ('current-1', 10, 1709251200000);
+INSERT INTO session VALUES ('current-2', 5.25, 1711843200000);
+INSERT INTO session VALUES ('next', 99, 1711929600000);
+`,
+		);
+
+		expect(readCurrentMonthCost(dbPath, new Date("2024-03-15T00:00:00.000Z"))).toBe(15.25);
+	});
+
+	it("current month の session.cost だけを合計する（ISO text）", () => {
+		const dbPath = createDb(
+			"iso.db",
+			`
+CREATE TABLE session (id TEXT PRIMARY KEY, cost REAL, created_at TEXT);
+INSERT INTO session VALUES ('prev', 12.5, '2024-02-29T23:59:59.000Z');
+INSERT INTO session VALUES ('current', 7.5, '2024-03-01T00:00:00.000Z');
+INSERT INTO session VALUES ('next', 99, '2024-04-01T00:00:00.000Z');
+`,
+		);
+
+		expect(readCurrentMonthCost(dbPath, new Date("2024-03-15T00:00:00.000Z"))).toBe(7.5);
+	});
+
+	it("usage percentage は低い値だけ小数 1 桁で表示する", () => {
+		expect(formatUsagePercentage(8.75)).toBe("8.8%");
+		expect(formatUsagePercentage(12.3)).toBe("12%");
+	});
+});

--- a/spec/gateway/discord-presence.spec.ts
+++ b/spec/gateway/discord-presence.spec.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 import type { Logger } from "@vicissitude/shared/types";
-import { Events } from "discord.js";
+import { ActivityType, Events } from "discord.js";
 
 import { DiscordGateway } from "../../apps/discord/src/gateway/discord";
 
@@ -87,6 +87,13 @@ describe("DiscordGateway — プレゼンス表示 API 契約", () => {
 
 			const setActivity = currentMockClient?.user.setActivity;
 			expect(setActivity).toHaveBeenCalled();
+		});
+
+		it("setWatchingActivity は Watching activity として設定する", () => {
+			gateway.setWatchingActivity("12%");
+
+			const setActivity = currentMockClient?.user.setActivity;
+			expect(setActivity).toHaveBeenCalledWith("12%", { type: ActivityType.Watching });
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Display current monthly OpenCode Go usage as a Discord Watching activity
- Query the local SQLite database and calculate usage against the 0 monthly limit
- Refresh the presence every 5 minutes and stop the service during shutdown

## Validation
- bun run validate