### PR TITLE
fix(discord): OpenCode使用量プレゼンスの時刻列を更新する

### DIFF
--- a/apps/discord/src/monthly-usage-presence.ts
+++ b/apps/discord/src/monthly-usage-presence.ts
@@ -103,6 +103,8 @@ function getTableColumns(db: Database, tableName: string): SqliteColumnInfo[] {
 
 function selectDateColumn(columns: SqliteColumnInfo[]): SqliteColumnInfo | undefined {
 	const candidates = [
+		"time_created",
+		"time_updated",
 		"created_at",
 		"createdAt",
 		"updated_at",

--- a/spec/discord/monthly-usage-presence.spec.ts
+++ b/spec/discord/monthly-usage-presence.spec.ts
@@ -44,6 +44,21 @@ INSERT INTO session VALUES ('next', 99, 1711929600000);
 		expect(readCurrentMonthCost(dbPath, new Date("2024-03-15T00:00:00.000Z"))).toBe(15.25);
 	});
 
+	it("OpenCode v1.15.5 の time_created で current month の session.cost を合計する", () => {
+		const dbPath = createDb(
+			"opencode-time-created.db",
+			`
+CREATE TABLE session (id TEXT PRIMARY KEY, cost REAL NOT NULL DEFAULT 0, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL);
+INSERT INTO session VALUES ('prev', 12.5, 1706745600000, 1706745600000);
+INSERT INTO session VALUES ('current-1', 10, 1709251200000, 1709251200000);
+INSERT INTO session VALUES ('current-2', 5.25, 1711843200000, 1711843200000);
+INSERT INTO session VALUES ('next', 99, 1711929600000, 1711929600000);
+`,
+		);
+
+		expect(readCurrentMonthCost(dbPath, new Date("2024-03-15T00:00:00.000Z"))).toBe(15.25);
+	});
+
 	it("current month の session.cost だけを合計する（ISO text）", () => {
 		const dbPath = createDb(
 			"iso.db",


### PR DESCRIPTION
## 概要
- OpenCode v1.15.5 の session テーブルで使われている `time_created` / `time_updated` を月次使用量 presence の時刻列候補に追加
- 現行スキーマに合わせた仕様テストを追加

## 検証
- `nr test:spec`（1786 pass / 0 fail）
- `nr validate`
- `nr test`（2454 pass / 0 fail）
- 実 OpenCode DB に対して `readCurrentMonthCost` が例外なく実行できることを確認

## 補足
- `config/local.json` は git 管理外のため PR には含めず、ローカルで `features.imageRecognition.modelId` を `gpt-5.4-mini` に変更済みです。