### PR TITLE
feat(deploy): Nix ベースのベアボーンデプロイ導線を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ TypeScript + Bun で動作し、OpenCode を推論エンジンとして使用す
 
 `nr deploy` は Discord bot と同じ compose スタック内で Web UI もビルド・配信する。`apps/web` の Vite build 成果物は `web-dist` volume に出力され、`web` サービスが `ports.web` の既定値である `4000` 番を公開して静的配信する。
 
+Podman を使わないベアボーン運用は `docs/bare-deploy.md` を正本とする。Nix flake で runtime を固定し、Linux では systemd user service、macOS では LaunchAgent で `bot` と `web` を常駐させる。
+
 ## コンセプト
 
 そこで生きているかような自然な存在、AITuber もどきを作る。ただし、特段バーチャルにこだわらない。当面はDiscordが本拠地。

--- a/apps/web/vite.config.test.ts
+++ b/apps/web/vite.config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { createWebViteConfig, resolveWebBuildOutDir } from "./vite.config";
+
+describe("vite.config", () => {
+	test("WEB_DIST_DIR 未指定時は既定の dist を使う", () => {
+		expect(resolveWebBuildOutDir({})).toBe("dist");
+	});
+
+	test("WEB_DIST_DIR 指定時は build outDir に反映する", () => {
+		const env = {
+			WEB_DIST_DIR: "/tmp/vicissitude-custom-dist",
+			WEB_PORT: "4100",
+			TANSTACK_ROUTE_GENERATION: "false",
+		};
+
+		expect(resolveWebBuildOutDir(env)).toBe("/tmp/vicissitude-custom-dist");
+		const config = createWebViteConfig(env);
+		expect(config.build?.outDir).toBe("/tmp/vicissitude-custom-dist");
+		expect(config.server?.port).toBe(4100);
+	});
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,19 +3,31 @@ import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-export default defineConfig({
-	plugins: [
-		tanstackRouter({
-			target: "react",
-			autoCodeSplitting: true,
-			enableRouteGeneration: process.env.TANSTACK_ROUTE_GENERATION !== "false",
-		}),
-		react(),
-		tailwindcss(),
-	],
-	server: {
-		port: Number(process.env.WEB_PORT ?? 4000),
-		host: true,
-		allowedHosts: true,
-	},
-});
+export function resolveWebBuildOutDir(env: NodeJS.ProcessEnv = process.env): string {
+	const outDir = env.WEB_DIST_DIR?.trim();
+	return outDir && outDir.length > 0 ? outDir : "dist";
+}
+
+export function createWebViteConfig(env: NodeJS.ProcessEnv = process.env) {
+	return defineConfig({
+		plugins: [
+			tanstackRouter({
+				target: "react",
+				autoCodeSplitting: true,
+				enableRouteGeneration: env.TANSTACK_ROUTE_GENERATION !== "false",
+			}),
+			react(),
+			tailwindcss(),
+		],
+		build: {
+			outDir: resolveWebBuildOutDir(env),
+		},
+		server: {
+			port: Number(env.WEB_PORT ?? 4000),
+			host: true,
+			allowedHosts: true,
+		},
+	});
+}
+
+export default createWebViteConfig();

--- a/deploy/common/nix.sh
+++ b/deploy/common/nix.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+vicissitude_find_nix() {
+	if command -v nix >/dev/null 2>&1; then
+		command -v nix
+		return 0
+	fi
+
+	local candidate
+	for candidate in \
+		"${HOME}/.nix-profile/bin/nix" \
+		"/nix/var/nix/profiles/default/bin/nix" \
+		"/run/current-system/sw/bin/nix"
+	do
+		if [[ -x "$candidate" ]]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+vicissitude_require_nix() {
+	local nix_bin
+	if ! nix_bin="$(vicissitude_find_nix)"; then
+		echo "[bare-deploy] nix コマンドが見つかりません。PATH または標準 profile を確認してください。" >&2
+		return 1
+	fi
+
+	export PATH
+	PATH="$(dirname "$nix_bin")${PATH:+:$PATH}"
+	printf '%s\n' "$nix_bin"
+}

--- a/deploy/common/run-bot.sh
+++ b/deploy/common/run-bot.sh
@@ -6,6 +6,9 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 RUNTIME_ENV="${HOME}/.config/vicissitude/runtime.env"
 SECRETS_ENV="${HOME}/.config/vicissitude/secrets.env"
 
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/nix.sh"
+
 if [[ -f "$RUNTIME_ENV" ]]; then
 	set -a
 	# shellcheck disable=SC1090
@@ -32,4 +35,5 @@ mkdir -p \
 	"$APP_ROOT/data"
 
 cd "$APP_ROOT"
-exec nix run .#vicissitude -- "$@"
+NIX_BIN="$(vicissitude_require_nix)"
+exec "$NIX_BIN" run .#vicissitude -- "$@"

--- a/deploy/common/run-bot.sh
+++ b/deploy/common/run-bot.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+RUNTIME_ENV="${HOME}/.config/vicissitude/runtime.env"
+SECRETS_ENV="${HOME}/.config/vicissitude/secrets.env"
+
+if [[ -f "$RUNTIME_ENV" ]]; then
+	set -a
+	# shellcheck disable=SC1090
+	source "$RUNTIME_ENV"
+	set +a
+fi
+
+export APP_ROOT="${APP_ROOT:-$REPO_ROOT}"
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export VICISSITUDE_CONFIG_PATH="${VICISSITUDE_CONFIG_PATH:-$APP_ROOT/config/default.json}"
+
+if [[ -f "$SECRETS_ENV" ]]; then
+	set -a
+	# shellcheck disable=SC1090
+	source "$SECRETS_ENV"
+	set +a
+fi
+
+mkdir -p \
+	"$XDG_CONFIG_HOME/vicissitude" \
+	"$XDG_DATA_HOME/opencode" \
+	"$XDG_DATA_HOME/vicissitude" \
+	"$APP_ROOT/data"
+
+cd "$APP_ROOT"
+exec nix run .#vicissitude -- "$@"

--- a/deploy/common/run-web.sh
+++ b/deploy/common/run-web.sh
@@ -6,6 +6,9 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 RUNTIME_ENV="${HOME}/.config/vicissitude/runtime.env"
 SECRETS_ENV="${HOME}/.config/vicissitude/secrets.env"
 
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/nix.sh"
+
 if [[ -f "$RUNTIME_ENV" ]]; then
 	set -a
 	# shellcheck disable=SC1090
@@ -29,8 +32,9 @@ fi
 mkdir -p "$XDG_CONFIG_HOME/vicissitude" "$XDG_DATA_HOME/vicissitude"
 
 cd "$APP_ROOT"
+NIX_BIN="$(vicissitude_require_nix)"
 if [[ ! -f "$WEB_DIST_DIR/index.html" ]]; then
-	nix run .#vicissitude-build-web
+	"$NIX_BIN" run .#vicissitude-build-web
 fi
 
-exec nix run .#vicissitude-web -- "$@"
+exec "$NIX_BIN" run .#vicissitude-web -- "$@"

--- a/deploy/common/run-web.sh
+++ b/deploy/common/run-web.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+RUNTIME_ENV="${HOME}/.config/vicissitude/runtime.env"
+SECRETS_ENV="${HOME}/.config/vicissitude/secrets.env"
+
+if [[ -f "$RUNTIME_ENV" ]]; then
+	set -a
+	# shellcheck disable=SC1090
+	source "$RUNTIME_ENV"
+	set +a
+fi
+
+export APP_ROOT="${APP_ROOT:-$REPO_ROOT}"
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export WEB_DIST_DIR="${WEB_DIST_DIR:-$APP_ROOT/apps/web/dist}"
+export WEB_PORT="${WEB_PORT:-4000}"
+
+if [[ -f "$SECRETS_ENV" ]]; then
+	set -a
+	# shellcheck disable=SC1090
+	source "$SECRETS_ENV"
+	set +a
+fi
+
+mkdir -p "$XDG_CONFIG_HOME/vicissitude" "$XDG_DATA_HOME/vicissitude"
+
+cd "$APP_ROOT"
+if [[ ! -f "$WEB_DIST_DIR/index.html" ]]; then
+	nix run .#vicissitude-build-web
+fi
+
+exec nix run .#vicissitude-web -- "$@"

--- a/deploy/common/update.sh
+++ b/deploy/common/update.sh
@@ -6,6 +6,9 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 RUNTIME_ENV="${HOME}/.config/vicissitude/runtime.env"
 SECRETS_ENV="${HOME}/.config/vicissitude/secrets.env"
 
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/nix.sh"
+
 if [[ -f "$RUNTIME_ENV" ]]; then
 	set -a
 	# shellcheck disable=SC1090
@@ -27,6 +30,7 @@ if [[ -f "$SECRETS_ENV" ]]; then
 fi
 
 cd "$APP_ROOT"
+NIX_BIN="$(vicissitude_require_nix)"
 
 branch="$(git branch --show-current)"
 if [[ "$branch" != "main" ]]; then
@@ -43,8 +47,8 @@ fi
 git fetch origin refs/heads/main:refs/remotes/origin/main
 git pull --ff-only origin main
 
-nix run .#vicissitude-validate
-nix run .#vicissitude-build-web
+"$NIX_BIN" run .#vicissitude-validate
+"$NIX_BIN" run .#vicissitude-build-web
 
 if command -v systemctl >/dev/null 2>&1 && systemctl --user list-unit-files >/dev/null 2>&1; then
 	systemctl --user restart vicissitude-web.service vicissitude-bot.service

--- a/deploy/common/update.sh
+++ b/deploy/common/update.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+RUNTIME_ENV="${HOME}/.config/vicissitude/runtime.env"
+SECRETS_ENV="${HOME}/.config/vicissitude/secrets.env"
+
+if [[ -f "$RUNTIME_ENV" ]]; then
+	set -a
+	# shellcheck disable=SC1090
+	source "$RUNTIME_ENV"
+	set +a
+fi
+
+export APP_ROOT="${APP_ROOT:-$REPO_ROOT}"
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export VICISSITUDE_CONFIG_PATH="${VICISSITUDE_CONFIG_PATH:-$APP_ROOT/config/default.json}"
+export WEB_DIST_DIR="${WEB_DIST_DIR:-$APP_ROOT/apps/web/dist}"
+
+if [[ -f "$SECRETS_ENV" ]]; then
+	set -a
+	# shellcheck disable=SC1090
+	source "$SECRETS_ENV"
+	set +a
+fi
+
+cd "$APP_ROOT"
+
+branch="$(git branch --show-current)"
+if [[ "$branch" != "main" ]]; then
+	echo "[bare-deploy] update は main ブランチから実行してください: current=${branch}" >&2
+	exit 1
+fi
+
+worktree_status="$(git status --porcelain)"
+if [[ -n "$worktree_status" ]]; then
+	echo "[bare-deploy] update 元に未コミット変更があります。clean worktree にしてください。" >&2
+	exit 1
+fi
+
+git fetch origin refs/heads/main:refs/remotes/origin/main
+git pull --ff-only origin main
+
+nix run .#vicissitude-validate
+nix run .#vicissitude-build-web
+
+if command -v systemctl >/dev/null 2>&1 && systemctl --user list-unit-files >/dev/null 2>&1; then
+	systemctl --user restart vicissitude-web.service vicissitude-bot.service
+	exit 0
+fi
+
+if command -v launchctl >/dev/null 2>&1; then
+	uid="$(id -u)"
+	launchctl kickstart -k "gui/${uid}/dev.ojii3.vicissitude.web" >/dev/null 2>&1 || true
+	launchctl kickstart -k "gui/${uid}/dev.ojii3.vicissitude.bot" >/dev/null 2>&1 || true
+	exit 0
+fi
+
+echo "[bare-deploy] update 完了。service の再起動は手動で行ってください。"

--- a/deploy/linux/install.sh
+++ b/deploy/linux/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+	echo "[bare-deploy] Linux 以外では install-linux を使えません。" >&2
+	exit 1
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+CONFIG_DIR="${HOME}/.config/vicissitude"
+SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
+BIN_DIR="${HOME}/.local/bin"
+DATA_DIR="${HOME}/.local/share/vicissitude"
+RUNTIME_ENV="${CONFIG_DIR}/runtime.env"
+SECRETS_ENV="${CONFIG_DIR}/secrets.env"
+
+mkdir -p "$CONFIG_DIR" "$SYSTEMD_USER_DIR" "$BIN_DIR" "$DATA_DIR"
+
+cat >"$RUNTIME_ENV" <<EOF
+APP_ROOT=${REPO_ROOT}
+VICISSITUDE_CONFIG_PATH=${REPO_ROOT}/config/default.json
+WEB_DIST_DIR=${REPO_ROOT}/apps/web/dist
+XDG_CONFIG_HOME=${HOME}/.config
+XDG_DATA_HOME=${HOME}/.local/share
+WEB_PORT=4000
+EOF
+
+if [[ ! -f "$SECRETS_ENV" ]]; then
+	cat >"$SECRETS_ENV" <<EOF
+DISCORD_TOKEN=
+# Optional: GitHub integration
+# GITHUB_TOKEN=
+# GITHUB_OWNER=
+# GITHUB_REPO=
+# Optional: shell workspace / GitHub auth
+# HUA_GITHUB_TOKEN=
+EOF
+fi
+
+ln -sfn "${REPO_ROOT}/deploy/common/run-bot.sh" "${BIN_DIR}/vicissitude-bot"
+ln -sfn "${REPO_ROOT}/deploy/common/run-web.sh" "${BIN_DIR}/vicissitude-web"
+ln -sfn "${REPO_ROOT}/deploy/common/update.sh" "${BIN_DIR}/vicissitude-update"
+
+install -m 0644 "${REPO_ROOT}/deploy/linux/vicissitude-bot.service" "${SYSTEMD_USER_DIR}/vicissitude-bot.service"
+install -m 0644 "${REPO_ROOT}/deploy/linux/vicissitude-web.service" "${SYSTEMD_USER_DIR}/vicissitude-web.service"
+
+cd "$REPO_ROOT"
+nix run .#vicissitude-validate
+nix run .#vicissitude-build-web
+
+systemctl --user daemon-reload
+systemctl --user enable --now vicissitude-bot.service vicissitude-web.service
+
+if command -v loginctl >/dev/null 2>&1; then
+	if [[ "$(loginctl show-user "$USER" -p Linger --value 2>/dev/null || true)" != "yes" ]]; then
+		echo "[bare-deploy] ログアウト後も動かすなら: sudo loginctl enable-linger ${USER}"
+	fi
+fi
+
+echo "[bare-deploy] installed. update は ${BIN_DIR}/vicissitude-update を使ってください。"

--- a/deploy/linux/install.sh
+++ b/deploy/linux/install.sh
@@ -15,6 +15,9 @@ DATA_DIR="${HOME}/.local/share/vicissitude"
 RUNTIME_ENV="${CONFIG_DIR}/runtime.env"
 SECRETS_ENV="${CONFIG_DIR}/secrets.env"
 
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/deploy/common/nix.sh"
+
 mkdir -p "$CONFIG_DIR" "$SYSTEMD_USER_DIR" "$BIN_DIR" "$DATA_DIR"
 
 cat >"$RUNTIME_ENV" <<EOF
@@ -46,8 +49,9 @@ install -m 0644 "${REPO_ROOT}/deploy/linux/vicissitude-bot.service" "${SYSTEMD_U
 install -m 0644 "${REPO_ROOT}/deploy/linux/vicissitude-web.service" "${SYSTEMD_USER_DIR}/vicissitude-web.service"
 
 cd "$REPO_ROOT"
-nix run .#vicissitude-validate
-nix run .#vicissitude-build-web
+NIX_BIN="$(vicissitude_require_nix)"
+"$NIX_BIN" run .#vicissitude-validate
+"$NIX_BIN" run .#vicissitude-build-web
 
 systemctl --user daemon-reload
 systemctl --user enable --now vicissitude-bot.service vicissitude-web.service

--- a/deploy/linux/vicissitude-bot.service
+++ b/deploy/linux/vicissitude-bot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Vicissitude Discord Bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/vicissitude-bot
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/deploy/linux/vicissitude-web.service
+++ b/deploy/linux/vicissitude-web.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Vicissitude Web UI
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/vicissitude-web
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/deploy/macos/dev.ojii3.vicissitude.bot.plist.template
+++ b/deploy/macos/dev.ojii3.vicissitude.bot.plist.template
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>dev.ojii3.vicissitude.bot</string>
+	<key>KeepAlive</key>
+	<true/>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>__HOME__/.local/bin/vicissitude-bot</string>
+	</array>
+	<key>StandardOutPath</key>
+	<string>__HOME__/.local/share/vicissitude/logs/bot.log</string>
+	<key>StandardErrorPath</key>
+	<string>__HOME__/.local/share/vicissitude/logs/bot.log</string>
+</dict>
+</plist>

--- a/deploy/macos/dev.ojii3.vicissitude.web.plist.template
+++ b/deploy/macos/dev.ojii3.vicissitude.web.plist.template
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>dev.ojii3.vicissitude.web</string>
+	<key>KeepAlive</key>
+	<true/>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>__HOME__/.local/bin/vicissitude-web</string>
+	</array>
+	<key>StandardOutPath</key>
+	<string>__HOME__/.local/share/vicissitude/logs/web.log</string>
+	<key>StandardErrorPath</key>
+	<string>__HOME__/.local/share/vicissitude/logs/web.log</string>
+</dict>
+</plist>

--- a/deploy/macos/install.sh
+++ b/deploy/macos/install.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+	echo "[bare-deploy] macOS 以外では install-macos を使えません。" >&2
+	exit 1
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+CONFIG_DIR="${HOME}/.config/vicissitude"
+LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
+BIN_DIR="${HOME}/.local/bin"
+DATA_DIR="${HOME}/.local/share/vicissitude"
+RUNTIME_ENV="${CONFIG_DIR}/runtime.env"
+SECRETS_ENV="${CONFIG_DIR}/secrets.env"
+BOT_PLIST="${LAUNCH_AGENTS_DIR}/dev.ojii3.vicissitude.bot.plist"
+WEB_PLIST="${LAUNCH_AGENTS_DIR}/dev.ojii3.vicissitude.web.plist"
+
+mkdir -p "$CONFIG_DIR" "$LAUNCH_AGENTS_DIR" "$BIN_DIR" "$DATA_DIR/logs"
+
+cat >"$RUNTIME_ENV" <<EOF
+APP_ROOT=${REPO_ROOT}
+VICISSITUDE_CONFIG_PATH=${REPO_ROOT}/config/default.json
+WEB_DIST_DIR=${REPO_ROOT}/apps/web/dist
+XDG_CONFIG_HOME=${HOME}/.config
+XDG_DATA_HOME=${HOME}/.local/share
+WEB_PORT=4000
+EOF
+
+if [[ ! -f "$SECRETS_ENV" ]]; then
+	cat >"$SECRETS_ENV" <<EOF
+DISCORD_TOKEN=
+# Optional: GitHub integration
+# GITHUB_TOKEN=
+# GITHUB_OWNER=
+# GITHUB_REPO=
+# Optional: shell workspace / GitHub auth
+# HUA_GITHUB_TOKEN=
+EOF
+fi
+
+ln -sfn "${REPO_ROOT}/deploy/common/run-bot.sh" "${BIN_DIR}/vicissitude-bot"
+ln -sfn "${REPO_ROOT}/deploy/common/run-web.sh" "${BIN_DIR}/vicissitude-web"
+ln -sfn "${REPO_ROOT}/deploy/common/update.sh" "${BIN_DIR}/vicissitude-update"
+
+sed \
+	-e "s|__HOME__|${HOME}|g" \
+	"${REPO_ROOT}/deploy/macos/dev.ojii3.vicissitude.bot.plist.template" >"$BOT_PLIST"
+sed \
+	-e "s|__HOME__|${HOME}|g" \
+	"${REPO_ROOT}/deploy/macos/dev.ojii3.vicissitude.web.plist.template" >"$WEB_PLIST"
+
+cd "$REPO_ROOT"
+nix run .#vicissitude-validate
+nix run .#vicissitude-build-web
+
+uid="$(id -u)"
+launchctl bootout "gui/${uid}" "$BOT_PLIST" >/dev/null 2>&1 || true
+launchctl bootout "gui/${uid}" "$WEB_PLIST" >/dev/null 2>&1 || true
+launchctl bootstrap "gui/${uid}" "$BOT_PLIST"
+launchctl bootstrap "gui/${uid}" "$WEB_PLIST"
+launchctl kickstart -k "gui/${uid}/dev.ojii3.vicissitude.bot"
+launchctl kickstart -k "gui/${uid}/dev.ojii3.vicissitude.web"
+
+echo "[bare-deploy] installed. update は ${BIN_DIR}/vicissitude-update を使ってください。"

--- a/deploy/macos/install.sh
+++ b/deploy/macos/install.sh
@@ -17,6 +17,9 @@ SECRETS_ENV="${CONFIG_DIR}/secrets.env"
 BOT_PLIST="${LAUNCH_AGENTS_DIR}/dev.ojii3.vicissitude.bot.plist"
 WEB_PLIST="${LAUNCH_AGENTS_DIR}/dev.ojii3.vicissitude.web.plist"
 
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/deploy/common/nix.sh"
+
 mkdir -p "$CONFIG_DIR" "$LAUNCH_AGENTS_DIR" "$BIN_DIR" "$DATA_DIR/logs"
 
 cat >"$RUNTIME_ENV" <<EOF
@@ -52,8 +55,9 @@ sed \
 	"${REPO_ROOT}/deploy/macos/dev.ojii3.vicissitude.web.plist.template" >"$WEB_PLIST"
 
 cd "$REPO_ROOT"
-nix run .#vicissitude-validate
-nix run .#vicissitude-build-web
+NIX_BIN="$(vicissitude_require_nix)"
+"$NIX_BIN" run .#vicissitude-validate
+"$NIX_BIN" run .#vicissitude-build-web
 
 uid="$(id -u)"
 launchctl bootout "gui/${uid}" "$BOT_PLIST" >/dev/null 2>&1 || true

--- a/docs/bare-deploy.md
+++ b/docs/bare-deploy.md
@@ -1,0 +1,101 @@
+# Bare Deploy
+
+## 方針
+
+Podman compose を使わず、単一ホスト上で Vicissitude を常駐させるための運用を定義する。
+
+- 実行環境の固定: `flake.nix`
+- プロセス管理: Linux は systemd user service、macOS は LaunchAgent
+- mutable state / auth: ホスト側の XDG path
+- 再デプロイ対象: repo checkout と build artifact
+
+コンテナが担っていた「再現性」と「state の分離」を、Nix とディレクトリ設計へ移す。
+
+## ディレクトリ境界
+
+### Immutable
+
+- repo checkout
+- `context/`
+- `config/*.json`
+- `opencode.json`
+- runtime skill 定義
+- `deploy/`
+
+### Mutable
+
+- `data/`
+- `apps/web/dist`
+- `~/.config/vicissitude/secrets.env`
+- `~/.config/vicissitude/runtime.env`
+- `~/.config/opencode/opencode.json`
+- `~/.local/share/opencode/auth.json`
+- `~/.local/share/opencode/mcp-auth.json`
+
+`deploy` は `~/.config/opencode` や `~/.local/share/opencode` を作り直さない。初回認証後は service restart / update 後もそのまま維持する。
+
+## 起動構成
+
+bare deploy ではプロセスを 2 つに分ける。
+
+- `vicissitude-bot`: Discord bot 本体と gateway
+- `vicissitude-web`: `apps/web/dist` の静的配信
+
+`bot` は `nix run .#vicissitude`、`web` は `nix run .#vicissitude-web` を使う。Linux では headless GL 用に必要なら `Xvfb` を自動起動する。
+
+## セットアップ
+
+### Linux
+
+```bash
+nix run .#install-linux
+```
+
+これにより以下を行う。
+
+- `~/.config/vicissitude/runtime.env` を生成
+- `~/.local/bin/vicissitude-{bot,web,update}` を作成
+- `~/.config/systemd/user/vicissitude-{bot,web}.service` を配置
+- `bun install --frozen-lockfile` を Nix runtime 上で実行
+- `nr validate` と `nr build:web` 相当を Nix 経由で実行
+- user service を `enable --now`
+
+ログアウト後も常駐させるには、必要に応じて別途 `sudo loginctl enable-linger <user>` を実行する。
+
+### macOS
+
+```bash
+nix run .#install-macos
+```
+
+これにより以下を行う。
+
+- `~/.config/vicissitude/runtime.env` を生成
+- `~/.local/bin/vicissitude-{bot,web,update}` を作成
+- `~/Library/LaunchAgents/dev.ojii3.vicissitude.{bot,web}.plist` を配置
+- `bun install --frozen-lockfile` を Nix runtime 上で実行
+- `nr validate` と `nr build:web` 相当を Nix 経由で実行
+- LaunchAgent を `bootstrap` / `kickstart`
+
+## 更新
+
+```bash
+~/.local/bin/vicissitude-update
+```
+
+update は次を行う。
+
+1. `main` ブランチかつ clean worktree であることを確認
+2. `git fetch` + `git pull --ff-only`
+3. `bun install --frozen-lockfile` を含む `nix run .#vicissitude-validate`
+4. `bun install --frozen-lockfile` を含む `nix run .#vicissitude-build-web`
+5. 既存 service を restart
+
+認証ファイルと `data/` は更新対象に含めない。
+
+## Shell Workspace について
+
+`features.shellWorkspace` は現在も Podman 前提である。Linux では Nix runtime に `podman` を含めるが、macOS では自動セットアップしない。
+
+- Linux: profile を有効化できる
+- macOS: `features.shellWorkspace` を無効化するか、別途 Podman 実行環境を用意する

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,18 @@ YAML は採用しない。人間には短く書けるが、暗黙の型変換、
 
 `nr deploy` は `apps/web` も compose スタック内で扱う。`installer` は Web UI の Vite build に必要な devDependencies も含めて依存関係を解決し、`builder` は bot/MCP の Bun bundle に加えて `apps/web` を build する。Web build 成果物は `web-dist` volume に出力し、`web` サービスが `WEB_PORT`（既定値 `4000`）で静的配信する。
 
+## Bare Deploy 時の state / auth
+
+Nix ベースの bare deploy では、state と auth を XDG path に置く。
+
+- `~/.config/vicissitude/runtime.env`: service wrapper が使う runtime 設定
+- `~/.config/vicissitude/secrets.env`: secret env
+- `~/.config/opencode/opencode.json`: OpenCode user config
+- `~/.local/share/opencode/auth.json`: OpenCode auth
+- `~/.local/share/opencode/mcp-auth.json`: MCP auth
+
+`deploy/common/update.sh` はこれらのファイルを上書きせず、repo checkout と `apps/web/dist` だけを更新する。
+
 ## 形式
 
 profile は `config/*.json` に置き、起動時に `VICISSITUDE_CONFIG_PATH=config/default.json` のように指定する。`loadConfig` は profile を必須とし、旧 env 由来の非 secret 設定は読み込まない。

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,14 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
+        "x86_64-darwin"
         "aarch64-darwin"
       ];
 
       perSystem =
         { pkgs, system, ... }:
         let
+          inherit (pkgs) lib stdenv;
           opencodeVersion = "1.15.5";
           opencodePlatform = {
             x86_64-linux = {
@@ -29,6 +31,10 @@
             aarch64-darwin = {
               packageName = "opencode-darwin-arm64";
               hash = "sha256-B+1EjtGts6FC06aYCqKcQ5wmVnrxorA60Np15OZfqXM=";
+            };
+            x86_64-darwin = {
+              packageName = "opencode-darwin-x64";
+              hash = "sha256-+KxzBty9aCKS72WzKouy5r3LvSrAWZCOHUvwBAWrv0Y=";
             };
           }.${system};
           opencode = pkgs.stdenvNoCC.mkDerivation {
@@ -47,20 +53,155 @@
               runHook postInstall
             '';
           };
+          baseRuntimePackages = with pkgs; [
+            bun
+            ni
+            jq
+            nodejs-slim
+            opencode
+            git
+            gh
+            ripgrep
+            fd
+            sqlite
+            python311
+            pkg-config
+          ];
+          linuxRuntimePackages = with pkgs; [
+            podman
+            slirp4netns
+            cairo
+            pango
+            libjpeg
+            giflib
+            librsvg
+            libGL
+            libxi
+            xauth
+            xorg-server
+          ];
+          runtimePackages =
+            baseRuntimePackages
+            ++ lib.optionals stdenv.isLinux linuxRuntimePackages;
+          linuxLibraryPath = lib.makeLibraryPath [
+            pkgs.stdenv.cc.cc.lib
+            pkgs.cairo
+            pkgs.pango
+            pkgs.libjpeg
+            pkgs.giflib
+            pkgs.librsvg
+            pkgs.libGL
+            pkgs.libxi
+          ];
+          makeRepoShellApp =
+            name: text:
+            pkgs.writeShellApplication {
+              inherit name;
+              runtimeInputs = runtimePackages;
+              text = ''
+                if [ ! -f package.json ]; then
+                  echo "[nix-app] package.json が見つかりません。repo root で実行してください。" >&2
+                  exit 1
+                fi
+
+                ${lib.optionalString stdenv.isLinux ''
+                  export LD_LIBRARY_PATH="${linuxLibraryPath}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+                  export CXXFLAGS="-include cstdint''${CXXFLAGS:+ $CXXFLAGS}"
+                ''}
+
+                ${text}
+              '';
+            };
+          botApp = makeRepoShellApp "vicissitude-bot" ''
+            if [ "$(uname -s)" = "Linux" ] && [ -z "''${DISPLAY:-}" ] && command -v Xvfb >/dev/null 2>&1; then
+              XVFB_DISPLAY="''${XVFB_DISPLAY:-:99}"
+              Xvfb "$XVFB_DISPLAY" -screen 0 1280x720x24 >/tmp/vicissitude-xvfb.log 2>&1 &
+              xvfb_pid=$!
+              trap 'kill "$xvfb_pid" >/dev/null 2>&1 || true' EXIT INT TERM
+              export DISPLAY="$XVFB_DISPLAY"
+            fi
+
+            exec nr start "$@"
+          '';
+          webApp = makeRepoShellApp "vicissitude-web" ''
+            exec nr start:web "$@"
+          '';
+          buildWebApp = makeRepoShellApp "vicissitude-build-web" ''
+            bun install --frozen-lockfile
+            exec nr build:web "$@"
+          '';
+          validateApp = makeRepoShellApp "vicissitude-validate" ''
+            bun install --frozen-lockfile
+            exec nr validate "$@"
+          '';
+          installLinuxApp = makeRepoShellApp "install-linux" ''
+            exec ./deploy/linux/install.sh "$@"
+          '';
+          installMacosApp = makeRepoShellApp "install-macos" ''
+            exec ./deploy/macos/install.sh "$@"
+          '';
+          updateApp = makeRepoShellApp "vicissitude-update" ''
+            exec ./deploy/common/update.sh "$@"
+          '';
         in
         {
-          devShells.default = pkgs.mkShell {
-            packages = with pkgs; [
-              bun
-              jq
-              nodejs-slim
+          packages = {
+            inherit
               opencode
-              podman
-              python311
-              podman-compose
-            ] ++ lib.optionals stdenv.isLinux [
-              slirp4netns
-            ];
+              botApp
+              webApp
+              buildWebApp
+              validateApp
+              installLinuxApp
+              installMacosApp
+              updateApp
+              ;
+          };
+
+          apps = {
+            vicissitude = {
+              type = "app";
+              program = "${botApp}/bin/vicissitude-bot";
+              meta.description = "Run the Vicissitude Discord bot on bare metal";
+            };
+            vicissitude-web = {
+              type = "app";
+              program = "${webApp}/bin/vicissitude-web";
+              meta.description = "Serve the Vicissitude web UI on bare metal";
+            };
+            vicissitude-build-web = {
+              type = "app";
+              program = "${buildWebApp}/bin/vicissitude-build-web";
+              meta.description = "Build the Vicissitude web UI";
+            };
+            vicissitude-validate = {
+              type = "app";
+              program = "${validateApp}/bin/vicissitude-validate";
+              meta.description = "Validate the Vicissitude workspace under the Nix runtime";
+            };
+            install-linux = {
+              type = "app";
+              program = "${installLinuxApp}/bin/install-linux";
+              meta.description = "Install Vicissitude bare deploy as systemd user services";
+            };
+            install-macos = {
+              type = "app";
+              program = "${installMacosApp}/bin/install-macos";
+              meta.description = "Install Vicissitude bare deploy as LaunchAgents";
+            };
+            vicissitude-update = {
+              type = "app";
+              program = "${updateApp}/bin/vicissitude-update";
+              meta.description = "Update a bare-metal Vicissitude checkout and restart services";
+            };
+          };
+
+          devShells.default = pkgs.mkShell {
+            packages = runtimePackages ++ lib.optionals stdenv.isLinux [ pkgs.podman-compose ];
+            shellHook = lib.optionalString stdenv.isLinux ''
+              export LD_LIBRARY_PATH="${linuxLibraryPath}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+              export CXXFLAGS="-include cstdint''${CXXFLAGS:+ $CXXFLAGS}"
+            '';
           };
         };
     };

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
 	"scripts": {
 		"postinstall": "bun scripts/link-workspaces.ts",
 		"start": "VICISSITUDE_CONFIG_PATH=${VICISSITUDE_CONFIG_PATH:-config/default.json} bun run apps/discord/src/index.ts",
+		"start:web": "WEB_DIST_DIR=${WEB_DIST_DIR:-apps/web/dist} bun run scripts/serve-web.ts",
 		"dev": "VICISSITUDE_CONFIG_PATH=${VICISSITUDE_CONFIG_PATH:-config/default.json} bun --watch run apps/discord/src/index.ts",
 		"generate:routes": "cd apps/web && bunx @tanstack/router-cli generate",
+		"build:web": "cd apps/web && TANSTACK_ROUTE_GENERATION=false bun run build",
 		"check": "bun run generate:routes && tsgo --noEmit",
 		"lint": "oxlint --type-aware",
 		"lint:fix": "oxlint --type-aware --fix",

--- a/scripts/bare-deploy.test.ts
+++ b/scripts/bare-deploy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function runShell(command: string, env: Record<string, string>): string {
+	const bashPath = Bun.which("bash");
+	if (!bashPath) throw new Error("bash is required for bare deploy tests");
+
+	const proc = Bun.spawnSync([bashPath, "-lc", command], {
+		cwd: process.cwd(),
+		env: {
+			...process.env,
+			...env,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (proc.exitCode !== 0) {
+		throw new Error(proc.stderr.toString() || proc.stdout.toString());
+	}
+	return proc.stdout.toString().trim();
+}
+
+describe("deploy/common/nix.sh", () => {
+	test("PATH に nix がなくても ~/.nix-profile/bin/nix を解決する", () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "vicissitude-nix-home-"));
+		const fakeNix = join(homeDir, ".nix-profile", "bin", "nix");
+		mkdirSync(join(homeDir, ".nix-profile", "bin"), { recursive: true });
+		writeFileSync(fakeNix, "#!/usr/bin/env bash\nprintf '%s\\n' \"$0\"\n");
+		chmodSync(fakeNix, 0o755);
+
+		const output = runShell(
+			"source deploy/common/nix.sh && PATH=/usr/bin:/bin && vicissitude_require_nix",
+			{
+				HOME: homeDir,
+				PATH: "/usr/bin:/bin",
+			},
+		);
+
+		expect(output).toBe(fakeNix);
+	});
+});


### PR DESCRIPTION
## 概要
- Nix ベースの bare deploy 導線を追加
- Linux systemd user service / macOS LaunchAgent 用 install/update wrapper を追加
- state/auth を XDG path に逃がす運用ドキュメントを追加

## 検証
- nix flake check
- nix run .#vicissitude-validate
- nix run .#vicissitude-build-web
- bash -n deploy/common/run-bot.sh deploy/common/run-web.sh deploy/common/update.sh deploy/linux/install.sh deploy/macos/install.sh