### PR TITLE
fix: OpenCode の画像入力を data URL に正規化する

### DIFF
--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -5,7 +5,8 @@
 		"./discord/attachment-mapper": "./src/discord/attachment-mapper.ts",
 		"./discord/fxembed": "./src/discord/fxembed.ts",
 		"./discord/url-rewriter": "./src/discord/url-rewriter.ts",
-		"./http/github-issue-adapter": "./src/http/github-issue-adapter.ts"
+		"./http/github-issue-adapter": "./src/http/github-issue-adapter.ts",
+		"./http/image-fetcher": "./src/http/image-fetcher.ts"
 	},
 	"dependencies": {
 		"zod": "^4.3.6"

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -9,6 +9,7 @@
 	},
 	"dependencies": {
 		"@opencode-ai/sdk": "^1.15.5",
+		"@vicissitude/infrastructure": "workspace:*",
 		"@vicissitude/shared": "workspace:*"
 	}
 }

--- a/packages/opencode/src/session-adapter.test.ts
+++ b/packages/opencode/src/session-adapter.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2";
+import type { FetchedImage, ImageFetcher } from "@vicissitude/infrastructure/http/image-fetcher";
 import { denyAllSkillPermission } from "@vicissitude/opencode/constants";
 import type { OpencodeSessionActivity } from "@vicissitude/shared/types";
 
@@ -85,7 +86,20 @@ function createClient(stream: AsyncGenerator<Event, void, unknown>) {
 	};
 }
 
-function createAdapter(client: OpencodeClient): OpencodeSessionAdapter {
+function createImageFetcher(
+	resolver: (url: string) => FetchedImage | null = () => null,
+): ImageFetcher & { fetch: ReturnType<typeof mock> } {
+	return {
+		fetch: mock((url: string) => Promise.resolve(resolver(url))),
+	};
+}
+
+function createAdapter(
+	client: OpencodeClient,
+	options: {
+		imageFetcher?: ImageFetcher;
+	} = {},
+): OpencodeSessionAdapter {
 	return new OpencodeSessionAdapter({
 		port: 4096,
 		mcpServers: {},
@@ -97,6 +111,7 @@ function createAdapter(client: OpencodeClient): OpencodeSessionAdapter {
 				server: { url: "http://localhost", close: mock(() => {}) },
 			}),
 		),
+		imageFetcher: options.imageFetcher,
 	});
 }
 
@@ -617,6 +632,13 @@ describe("OpencodeSessionAdapter buildParts（画像フィルタリング）", (
 	function createBuildPartsAdapter() {
 		const promptParts: unknown[] = [];
 		const promptAsyncParts: unknown[] = [];
+		const imageFetcher = createImageFetcher((url) => {
+			if (url.endsWith(".png")) return { base64: "cG5n", mimeType: "image/png" };
+			if (url.endsWith(".jpg")) return { base64: "anBn", mimeType: "image/jpeg" };
+			if (url.endsWith(".gif")) return { base64: "Z2lm", mimeType: "image/gif" };
+			if (url.endsWith(".webp")) return { base64: "d2VicA==", mimeType: "image/webp" };
+			return null;
+		});
 		const client = {
 			event: {
 				subscribe: mock(() =>
@@ -659,8 +681,9 @@ describe("OpencodeSessionAdapter buildParts（画像フィルタリング）", (
 					server: { url: "http://localhost", close: mock(() => {}) },
 				}),
 			),
+			imageFetcher,
 		});
-		return { adapter, promptParts, promptAsyncParts };
+		return { adapter, promptParts, promptAsyncParts, imageFetcher };
 	}
 
 	const baseParams = {
@@ -680,7 +703,12 @@ describe("OpencodeSessionAdapter buildParts（画像フィルタリング）", (
 
 		expect(promptParts).toEqual([
 			{ type: "text", text: "hello" },
-			{ type: "file", mime: "image/png", filename: "img.png", url: "https://example.com/img.png" },
+			{
+				type: "file",
+				mime: "image/png",
+				filename: "img.png",
+				url: "data:image/png;base64,cG5n",
+			},
 		]);
 	});
 
@@ -697,9 +725,14 @@ describe("OpencodeSessionAdapter buildParts（画像フィルタリング）", (
 
 		expect(promptParts).toEqual([
 			{ type: "text", text: "hello" },
-			{ type: "file", mime: "image/jpeg", filename: "a.jpg", url: "https://example.com/a.jpg" },
-			{ type: "file", mime: "image/gif", filename: "b.gif", url: "https://example.com/b.gif" },
-			{ type: "file", mime: "image/webp", filename: "c.webp", url: "https://example.com/c.webp" },
+			{ type: "file", mime: "image/jpeg", filename: "a.jpg", url: "data:image/jpeg;base64,anBn" },
+			{ type: "file", mime: "image/gif", filename: "b.gif", url: "data:image/gif;base64,Z2lm" },
+			{
+				type: "file",
+				mime: "image/webp",
+				filename: "c.webp",
+				url: "data:image/webp;base64,d2VicA==",
+			},
 		]);
 	});
 
@@ -754,7 +787,7 @@ describe("OpencodeSessionAdapter buildParts（画像フィルタリング）", (
 				type: "file",
 				mime: "image/png",
 				filename: undefined,
-				url: "https://example.com/img.png",
+				url: "data:image/png;base64,cG5n",
 			},
 		]);
 	});
@@ -792,12 +825,17 @@ describe("OpencodeSessionAdapter buildParts（画像フィルタリング）", (
 
 		expect(promptParts).toEqual([
 			{ type: "text", text: "hello" },
-			{ type: "file", mime: "image/png", filename: "img.png", url: "https://example.com/img.png" },
+			{
+				type: "file",
+				mime: "image/png",
+				filename: "img.png",
+				url: "data:image/png;base64,cG5n",
+			},
 			{
 				type: "file",
 				mime: "image/jpeg",
 				filename: "photo.jpg",
-				url: "https://example.com/photo.jpg",
+				url: "data:image/jpeg;base64,anBn",
 			},
 		]);
 	});
@@ -814,7 +852,28 @@ describe("OpencodeSessionAdapter buildParts（画像フィルタリング）", (
 
 		expect(promptAsyncParts).toEqual([
 			{ type: "text", text: "hello" },
-			{ type: "file", mime: "image/png", filename: "img.png", url: "https://example.com/img.png" },
+			{
+				type: "file",
+				mime: "image/png",
+				filename: "img.png",
+				url: "data:image/png;base64,cG5n",
+			},
 		]);
+	});
+
+	test("画像 fetch に失敗した添付は raw URL を渡さずスキップする", async () => {
+		const { adapter, promptParts } = createBuildPartsAdapter();
+		await adapter.prompt({
+			...baseParams,
+			attachments: [
+				{
+					url: "https://example.com/missing.avif",
+					contentType: "image/avif",
+					filename: "missing.avif",
+				},
+			],
+		});
+
+		expect(promptParts).toEqual([{ type: "text", text: "hello" }]);
 	});
 });

--- a/packages/opencode/src/session-adapter.ts
+++ b/packages/opencode/src/session-adapter.ts
@@ -10,6 +10,10 @@ import {
 	type McpRemoteConfig,
 	type OpencodeClient,
 } from "@opencode-ai/sdk/v2";
+import {
+	HttpImageFetcher,
+	type ImageFetcher,
+} from "@vicissitude/infrastructure/http/image-fetcher";
 import type {
 	Logger,
 	OpencodeSessionActivity,
@@ -54,16 +58,23 @@ export interface OpencodeSessionAdapterConfig {
 	environment?: Record<string, string>;
 	clientFactory?: typeof createOpencode;
 	logger?: Logger;
+	imageFetcher?: ImageFetcher;
 }
 
 export type OpencodeAgentConfig = AgentConfig;
+
+type OpencodePromptPart =
+	| { type: "text"; text: string }
+	| { type: "file"; mime: string; filename?: string; url: string };
 
 export class OpencodeSessionAdapter implements OpencodeSessionPort {
 	private client: OpencodeClient | null = null;
 	private closeServer: (() => void) | null = null;
 	private readonly logger?: Logger;
+	private readonly imageFetcher: ImageFetcher;
 	constructor(private readonly config: OpencodeSessionAdapterConfig) {
 		this.logger = config.logger;
+		this.imageFetcher = config.imageFetcher ?? new HttpImageFetcher({ logger: config.logger });
 	}
 	async createSession(title: string): Promise<string> {
 		this.logger?.info(`[opencode] creating session: ${title}`);
@@ -84,28 +95,50 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 		return !result.error && !!result.data;
 	}
 
-	private buildParts(
-		params: OpencodePromptParams,
-	): Array<
-		{ type: "text"; text: string } | { type: "file"; mime: string; filename?: string; url: string }
-	> {
-		const imageAttachments: Array<{ type: "file"; mime: string; filename?: string; url: string }> =
-			[];
-		for (const a of params.attachments ?? []) {
-			if (a.contentType?.startsWith("image/")) {
-				imageAttachments.push({
-					type: "file" as const,
-					mime: a.contentType,
-					filename: a.filename,
-					url: a.url,
-				});
-			} else {
-				this.logger?.debug(
-					`[opencode] buildParts: skipping non-image attachment (contentType=${a.contentType ?? "undefined"}, filename=${a.filename ?? "undefined"})`,
-				);
-			}
-		}
+	private async buildParts(params: OpencodePromptParams): Promise<OpencodePromptPart[]> {
+		const imageAttachments = (
+			await Promise.all(
+				(params.attachments ?? []).map(async (attachment): Promise<OpencodePromptPart | null> => {
+					if (!attachment.contentType?.startsWith("image/")) {
+						this.logger?.debug(
+							`[opencode] buildParts: skipping non-image attachment (contentType=${attachment.contentType ?? "undefined"}, filename=${attachment.filename ?? "undefined"})`,
+						);
+						return null;
+					}
+					const fetched = await this.imageFetcher.fetch(attachment.url);
+					if (!fetched) {
+						this.logger?.warn(
+							`[opencode] buildParts: failed to normalize image attachment (filename=${attachment.filename ?? "undefined"}, url=${attachment.url})`,
+						);
+						return null;
+					}
+					return {
+						type: "file" as const,
+						mime: fetched.mimeType,
+						filename: attachment.filename,
+						url: `data:${fetched.mimeType};base64,${fetched.base64}`,
+					};
+				}),
+			)
+		).filter((part): part is Extract<OpencodePromptPart, { type: "file" }> => part !== null);
 		return [{ type: "text", text: params.text }, ...imageAttachments];
+	}
+
+	private async sendPromptAsync(
+		oc: OpencodeClient,
+		params: OpencodePromptParams,
+		parts: OpencodePromptPart[],
+	): Promise<void> {
+		const result = await oc.session.promptAsync({
+			sessionID: params.sessionId,
+			...this.directoryQuery(),
+			parts,
+			model: { providerID: params.model.providerId, modelID: params.model.modelId },
+			system: params.system,
+		});
+		if (result.error) {
+			throw new Error(`promptAsync failed: ${JSON.stringify(result.error)}`);
+		}
 	}
 
 	async prompt(params: OpencodePromptParams, signal?: AbortSignal): Promise<PromptResult> {
@@ -116,11 +149,12 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 			system: params.system,
 		});
 		const oc = await this.getClient();
+		const parts = await this.buildParts(params);
 		const result = await oc.session.prompt(
 			{
 				sessionID: params.sessionId,
 				...this.directoryQuery(),
-				parts: this.buildParts(params),
+				parts,
 				model: { providerID: params.model.providerId, modelID: params.model.modelId },
 				system: params.system,
 				tools: params.tools ?? {},
@@ -142,16 +176,8 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 
 	async promptAsync(params: OpencodePromptParams): Promise<void> {
 		const oc = await this.getClient();
-		const result = await oc.session.promptAsync({
-			sessionID: params.sessionId,
-			...this.directoryQuery(),
-			parts: this.buildParts(params),
-			model: { providerID: params.model.providerId, modelID: params.model.modelId },
-			system: params.system,
-		});
-		if (result.error) {
-			throw new Error(`promptAsync failed: ${JSON.stringify(result.error)}`);
-		}
+		const parts = await this.buildParts(params);
+		await this.sendPromptAsync(oc, params, parts);
 	}
 
 	/**
@@ -167,20 +193,12 @@ export class OpencodeSessionAdapter implements OpencodeSessionPort {
 			`[opencode] promptAsyncAndWatch: session=${params.sessionId} model=${params.model.providerId}/${params.model.modelId}`,
 		);
 		const oc = await this.getClient();
+		const parts = await this.buildParts(params);
 		const { stream } = await oc.event.subscribe(this.directoryQuery());
 		this.logger?.info("[opencode] event stream subscribed");
 		const tokensByMessage = new Map<string, TokenUsage>();
 		try {
-			const result = await oc.session.promptAsync({
-				sessionID: params.sessionId,
-				...this.directoryQuery(),
-				parts: this.buildParts(params),
-				model: { providerID: params.model.providerId, modelID: params.model.modelId },
-				system: params.system,
-			});
-			if (result.error) {
-				throw new Error(`promptAsync failed: ${JSON.stringify(result.error)}`);
-			}
+			await this.sendPromptAsync(oc, params, parts);
 			this.logger?.info("[opencode] promptAsync sent, watching events...");
 
 			let unclassifiedCount = 0;

--- a/spec/agent/mcp-config.spec.ts
+++ b/spec/agent/mcp-config.spec.ts
@@ -69,7 +69,11 @@ describe("mcpServerConfigs", () => {
 
 		expect(discordConfig?.type).toBe("local");
 		if (discordConfig?.type === "local") {
-			expect(discordConfig.command).toEqual(["bun", "run", "/test/root/dist/discord-server.js"]);
+			expect(discordConfig.command).toEqual([
+				"bun",
+				"run",
+				"/test/root/packages/mcp/src/discord-server.ts",
+			]);
 			expect(discordConfig.environment?.AGENT_ID).toBe("discord:123");
 			expect(discordConfig.environment?.DISCORD_TOKEN).toBe("test");
 		}

--- a/spec/opencode/session-adapter.spec.ts
+++ b/spec/opencode/session-adapter.spec.ts
@@ -10,6 +10,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2";
+import type { FetchedImage, ImageFetcher } from "@vicissitude/infrastructure/http/image-fetcher";
 import { denyAllSkillPermission } from "@vicissitude/opencode/constants";
 import { OpencodeSessionAdapter } from "@vicissitude/opencode/session-adapter";
 import type { OpencodeSessionEvent } from "@vicissitude/shared/types";
@@ -53,7 +54,20 @@ function createClient(stream: AsyncGenerator<Event, void, unknown>) {
 	return client as unknown as OpencodeClient;
 }
 
-function createAdapter(client: OpencodeClient): OpencodeSessionAdapter {
+function createImageFetcher(
+	resolver: (url: string) => FetchedImage | null = () => null,
+): ImageFetcher {
+	return {
+		fetch: mock((url: string) => Promise.resolve(resolver(url))),
+	};
+}
+
+function createAdapter(
+	client: OpencodeClient,
+	options: {
+		imageFetcher?: ImageFetcher;
+	} = {},
+): OpencodeSessionAdapter {
 	return new OpencodeSessionAdapter({
 		port: 4096,
 		mcpServers: {},
@@ -65,6 +79,7 @@ function createAdapter(client: OpencodeClient): OpencodeSessionAdapter {
 				server: { url: "http://localhost", close: mock(() => {}) },
 			}),
 		),
+		imageFetcher: options.imageFetcher,
 	});
 }
 
@@ -307,7 +322,12 @@ describe("promptAsync: attachments の FilePartInput 変換", () => {
 		} as unknown as AsyncGenerator<Event, void, unknown>;
 
 		const client = createClient(stream);
-		const adapter = createAdapter(client);
+		const adapter = createAdapter(client, {
+			imageFetcher: createImageFetcher(() => ({
+				base64: "cGhvdG8=",
+				mimeType: "image/png",
+			})),
+		});
 
 		await adapter.promptAsync({
 			sessionId: "session-1",
@@ -331,7 +351,7 @@ describe("promptAsync: attachments の FilePartInput 変換", () => {
 				type: "file",
 				mime: "image/png",
 				filename: "photo.png",
-				url: "https://cdn.example.com/photo.png",
+				url: "data:image/png;base64,cGhvdG8=",
 			},
 		]);
 	});
@@ -388,7 +408,13 @@ describe("promptAsync: attachments の FilePartInput 変換", () => {
 		} as unknown as AsyncGenerator<Event, void, unknown>;
 
 		const client = createClient(stream);
-		const adapter = createAdapter(client);
+		const adapter = createAdapter(client, {
+			imageFetcher: createImageFetcher((url) => {
+				if (url.endsWith(".jpg")) return { base64: "anBn", mimeType: "image/jpeg" };
+				if (url.endsWith(".webp")) return { base64: "d2VicA==", mimeType: "image/webp" };
+				return null;
+			}),
+		});
 
 		await adapter.promptAsync({
 			sessionId: "session-1",
@@ -414,13 +440,13 @@ describe("promptAsync: attachments の FilePartInput 変換", () => {
 				type: "file",
 				mime: "image/jpeg",
 				filename: "img.jpg",
-				url: "https://cdn.example.com/img.jpg",
+				url: "data:image/jpeg;base64,anBn",
 			},
 			{
 				type: "file",
 				mime: "image/webp",
 				filename: "logo.webp",
-				url: "https://cdn.example.com/logo.webp",
+				url: "data:image/webp;base64,d2VicA==",
 			},
 		]);
 	});
@@ -453,7 +479,12 @@ describe("promptAsyncAndWatchSession: attachments の FilePartInput 変換", () 
 		} as unknown as AsyncGenerator<Event, void, unknown>;
 
 		const client = createClient(stream);
-		const adapter = createAdapter(client);
+		const adapter = createAdapter(client, {
+			imageFetcher: createImageFetcher(() => ({
+				base64: "c2NyZWVu",
+				mimeType: "image/png",
+			})),
+		});
 
 		await adapter.promptAsyncAndWatchSession({
 			sessionId: "session-1",
@@ -477,7 +508,7 @@ describe("promptAsyncAndWatchSession: attachments の FilePartInput 変換", () 
 				type: "file",
 				mime: "image/png",
 				filename: "screen.png",
-				url: "https://cdn.example.com/screen.png",
+				url: "data:image/png;base64,c2NyZWVu",
 			},
 		]);
 	});


### PR DESCRIPTION
## 概要
- OpenCode へ渡す画像添付を URL ではなく data URL に正規化する
- 画像正規化を OpencodeSessionAdapter に集約し、通常会話と画像認識サブエージェントの両方を修正する
- stale になっていた MCP config spec を現行 entrypoint に合わせる

## 根本原因
- Discord 添付画像の URL をそのまま OpenCode の file part に渡していた
- OpenCode 側は base64 data URL を前提としており、 が発生していた
- repo 内には  が既にあったが、OpenCode adapter に未接続だった

## 検証
- bun test packages/opencode/src/session-adapter.test.ts spec/opencode/session-adapter.spec.ts packages/infrastructure/src/http/image-fetcher.test.ts
- nr validate
- nr test