### PR TITLE
fix: CI を落としていた古い shell-worker permission テストを修正

### DIFF
--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -531,7 +531,6 @@ describe("createDiscordAgents", () => {
 			"discord_*": "deny",
 			"mc-bridge_*": "deny",
 			"minecraft_*": "deny",
-			"shell-workspace_*": "deny",
 		});
 		expect(agent.sessionPort.config.skillPaths).toEqual([
 			"/app/context/skills/discord",


### PR DESCRIPTION
## 概要

main の CI（Test Quality）が失敗していたのを修正する。

## 原因

shellAgent 化リファクタ（#1026）で `profile.ts` の `SHELL_WORKSPACE_DENIED_MCP_TOOLS` から `shell-workspace_*` deny キーが削除されたが、`apps/discord/src/bootstrap.test.ts` の `toMatchObject` 期待値に同キーが取り残されていた。`toMatchObject` は存在しないキーを要求して失敗するため、`createDiscordAgents > backgroundSubagents 有効時は OpenCode 実験フラグを渡す` が落ちていた。

## 修正

現行実装に合わせてテストの期待値から `"shell-workspace_*": "deny"` を削除。

## 検証

- `bun test apps/discord/src/bootstrap.test.ts` → 18 pass / 0 fail
- `nr validate` → fmt:check / lint(0 errors) / check すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)