### PR TITLE
chore: remove Feixiao hostname constraint from deploy docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,7 +24,6 @@ Discord bot「ふあ(hua)」のプロジェクト。Bun, TypeScript, OpenCode �
 
 ## デプロイ
 
-- デプロイ前に `hostname` でホストが `Feixiao` であることを確認する。`Feixiao` 以外ではデプロイしない。
 - ソースコード・依存変更後: `nr deploy` で再デプロイ
 
 ## 計画フェーズ（Plan サブエージェント）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,6 @@ Discord bot「ふあ(hua)」のプロジェクト。Bun, TypeScript, OpenCode �
 
 ## デプロイ
 
-- デプロイ前に `hostname` でホストが `Feixiao` であることを確認する。`Feixiao` 以外ではデプロイしない。
 - ソースコード・依存変更後: `nr deploy` で再デプロイする。
 
 ## 計画フェーズ


### PR DESCRIPTION
## Summary

- `.claude/CLAUDE.md` と `AGENTS.md` から `Feixiao` ホスト確認の縛りを削除

## Test plan

- ドキュメント変更のみ。テスト不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)