### PR TITLE
chore(config): 会話・ハートビートモデルをqwen3.7-plusに変更

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -11,12 +11,12 @@
 	"models": {
 		"conversation": {
 			"providerId": "opencode-go",
-			"modelId": "glm-5.1",
+			"modelId": "qwen3.7-plus",
 			"temperature": 1
 		},
 		"heartbeat": {
 			"providerId": "opencode-go",
-			"modelId": "glm-5.1",
+			"modelId": "qwen3.7-plus",
 			"temperature": 0.7
 		},
 		"memory": {


### PR DESCRIPTION
## 変更内容

ふあ（Discord bot）のデフォルトモデル設定を変更しました。

### 変更差分

- `config/default.json` の `models.conversation.modelId`: `glm-5.1` → `qwen3.7-plus`
- `config/default.json` の `models.heartbeat.modelId`: `glm-5.1` → `qwen3.7-plus`

### 理由

- メインの対話モデル（conversation/heartbeat）を `glm-5.1` から `qwen3.7-plus` に変更
- `config/local.json` ですでに `qwen3.7-plus` が使用されており、デフォルト設定もこれに合わせる

### 検証結果

- `nr validate` (fmt:check + lint + check): 全項目パス