### PR TITLE
fix(config): 会話・ハートビートモデルをglm-5.1に戻す

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -11,12 +11,12 @@
 	"models": {
 		"conversation": {
 			"providerId": "opencode-go",
-			"modelId": "qwen3.7-plus",
+			"modelId": "glm-5.1",
 			"temperature": 1
 		},
 		"heartbeat": {
 			"providerId": "opencode-go",
-			"modelId": "qwen3.7-plus",
+			"modelId": "glm-5.1",
 			"temperature": 0.7
 		},
 		"memory": {


### PR DESCRIPTION
## 概要

`config/default.json` のモデル設定が誤って `qwen3.7-plus` に変更されていたため、元の `glm-5.1` に戻します。

## 変更内容

| 項目 | 変更前（誤） | 変更後（正） |
|------|-------------|-------------|
| `models.conversation.modelId` | `qwen3.7-plus` | `glm-5.1` |
| `models.heartbeat.modelId` | `qwen3.7-plus` | `glm-5.1` |

## 検証

- `nr validate`: fmt:check OK, lint 0 errors, type check OK