### PR TITLE
feat(scheduling): add preFilter mechanism for heartbeat reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ bare deploy で運用する。詳細は `docs/bare-deploy.md` を正本とする
 - 外部環境の状態は要約して AI に渡す（コンテキスト過負荷防止）。生データ（座標列、視界詳細等）は直接投入しない。
 - 意思決定はイベント駆動を基本とし、危険時は即応を優先する。
 - 低レベル操作は専用ライブラリに委譲し、AI は高レベル判断に集中する。
+- heartbeat scheduler は定期 tick で due リマインダーを評価し、実行前に preFilter を通す。preFilter は実行する reminder 群を返すと同時に、実行はしないが「実行済み」として interval を尊重させたい reminder id 群（`markExecutedIds`）を返せる。
+- `email-check` heartbeat（`features.emailCheck` 設定時に有効）は due になると Google Apps Script (GAS) エンドポイントへ問い合わせて新着メールを確認する。新着があればメール要約を reminder の context として AI へ渡す。新着が無い場合や GAS 取得に失敗した場合は、AI を起動せず `email-check` を `markExecutedIds` で実行済み扱いにし、interval（既定 5 分）が経過するまで毎 tick のポーリングを防ぐ。
+- GAS から渡されるメール本文抜粋は 200 文字でトランケートし、メール要約全体を `<email_context>...</email_context>` デリミタで囲んでプロンプトインジェクションを抑止する。
 
 ### 3.3 エージェントアーキテクチャ
 
@@ -227,6 +230,7 @@ AI エージェントとチャットボットのメトリクスは、複数 scop
 - `VICISSITUDE_CONFIG_PATH`: 必須。例: `config/default.json`
 - `DISCORD_TOKEN`: 必須
 - `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`: `features.githubIssues` 設定時に必須
+- `GAS_EMAIL_ENDPOINT`, `GAS_EMAIL_TOKEN`: `features.emailCheck` 設定時に必須。`email-check` heartbeat が問い合わせる GAS エンドポイントとアクセストークン
 - `HUA_GITHUB_TOKEN`: `features.shellAgent.environment` など profile の `fromEnv` 参照で指定した場合に必須
 
 `features.shellAgent.backgroundSubagents: true` を設定すると、OpenCode の `task(background=true)` / `task_status` を有効化するために `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true` を OpenCode server process へ渡す。

--- a/apps/discord/src/bootstrap.test.ts
+++ b/apps/discord/src/bootstrap.test.ts
@@ -1,12 +1,14 @@
 /* oxlint-disable max-lines, max-lines-per-function -- bootstrap の DI 結合テストはケース数に応じて長くなるため許容 */
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import os from "os";
 import { join } from "path";
 
 import { createMockLogger } from "@vicissitude/shared/test-helpers";
+import type { DueReminder } from "@vicissitude/shared/types";
 
 import {
+	buildEmailCheckPreFilter,
 	createContextLayer,
 	createDiscordAgents,
 	createWebContextLayer,
@@ -606,6 +608,153 @@ describe("createDiscordAgents", () => {
 			"discord_*": "deny",
 			"minecraft_*": "deny",
 		});
+	});
+});
+
+function emailCheckDueReminder(): DueReminder {
+	return {
+		reminder: {
+			id: "email-check",
+			description: "メール確認",
+			schedule: { type: "interval", minutes: 5 },
+			lastExecutedAt: null,
+			enabled: true,
+		},
+		overdueMinutes: 0,
+	};
+}
+
+function otherDueReminder(id: string): DueReminder {
+	return {
+		reminder: {
+			id,
+			description: id,
+			schedule: { type: "interval", minutes: 60 },
+			lastExecutedAt: null,
+			enabled: true,
+		},
+		overdueMinutes: 0,
+	};
+}
+
+function newMailFetchPayload() {
+	return {
+		hasNewMail: true,
+		count: 1,
+		emails: [
+			{ subject: "件名", from: "a@example.com", date: "2026-06-10T09:00:00Z", bodyExcerpt: "本文" },
+		],
+	};
+}
+
+describe("buildEmailCheckPreFilter 内部分岐", () => {
+	const EMAIL_CONFIG = { endpoint: "https://example.com/exec", token: "tok" };
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	const emailCheckDue = emailCheckDueReminder;
+	const otherDue = otherDueReminder;
+	const newMailPayload = newMailFetchPayload;
+
+	function mockFetchJson(payload: unknown): void {
+		globalThis.fetch = mock(() =>
+			Promise.resolve({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve(payload),
+				text: () => Promise.resolve(""),
+			} as Response),
+		) as unknown as typeof globalThis.fetch;
+	}
+
+	test("dueReminders が空なら fetch せず空 reminders を返す", async () => {
+		const fetchSpy = mock(() => Promise.reject(new Error("should not fetch")));
+		globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+		const preFilter = buildEmailCheckPreFilter(createMockLogger(), EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const result = await preFilter([]);
+
+		expect(result.reminders).toEqual([]);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	test("新着あり: 元の DueReminder オブジェクトを破壊せず複製に context を注入する", async () => {
+		mockFetchJson(newMailPayload());
+		const preFilter = buildEmailCheckPreFilter(createMockLogger(), EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const original = emailCheckDue();
+		const result = await preFilter([original]);
+
+		expect(original.context).toBeUndefined();
+		const enriched = result.reminders.find((r) => r.reminder.id === "email-check");
+		expect(enriched).not.toBe(original);
+		expect(enriched?.context).toBeDefined();
+	});
+
+	test("新着あり: reminders は [...other, ...enriched] の順で並ぶ", async () => {
+		mockFetchJson(newMailPayload());
+		const preFilter = buildEmailCheckPreFilter(createMockLogger(), EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const result = await preFilter([emailCheckDue(), otherDue("home-check")]);
+
+		expect(result.reminders.map((r) => r.reminder.id)).toEqual(["home-check", "email-check"]);
+	});
+
+	test("新着あり: 複数の email-check reminder すべてに同一 context を注入する", async () => {
+		mockFetchJson(newMailPayload());
+		const preFilter = buildEmailCheckPreFilter(createMockLogger(), EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const result = await preFilter([emailCheckDue(), emailCheckDue()]);
+
+		const enriched = result.reminders.filter((r) => r.reminder.id === "email-check");
+		expect(enriched).toHaveLength(2);
+		expect(enriched[0]?.context).toBe(enriched[1]?.context);
+		expect(enriched[0]?.context).toContain("<email_context>");
+	});
+
+	test("新着あり: 注入される context は本文抜粋を含む", async () => {
+		mockFetchJson(newMailPayload());
+		const preFilter = buildEmailCheckPreFilter(createMockLogger(), EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const result = await preFilter([emailCheckDue()]);
+
+		const enriched = result.reminders.find((r) => r.reminder.id === "email-check");
+		expect(enriched?.context).toContain("件名");
+		expect(enriched?.context).toContain("本文");
+	});
+
+	test("新着なし: 新着 0 件のときは markExecutedIds=['email-check'] で除外する", async () => {
+		mockFetchJson({ hasNewMail: false, count: 0, emails: [] });
+		const preFilter = buildEmailCheckPreFilter(createMockLogger(), EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const result = await preFilter([emailCheckDue(), otherDue("home-check")]);
+
+		expect(result.reminders.map((r) => r.reminder.id)).toEqual(["home-check"]);
+		expect(result.markExecutedIds).toEqual(["email-check"]);
+	});
+
+	test("fetch 失敗時は logger.error を呼びつつ markExecutedIds で除外する", async () => {
+		globalThis.fetch = mock(() =>
+			Promise.reject(new Error("network down")),
+		) as unknown as typeof globalThis.fetch;
+		const logger = createMockLogger();
+		const preFilter = buildEmailCheckPreFilter(logger, EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const result = await preFilter([emailCheckDue()]);
+
+		expect(logger.error).toHaveBeenCalled();
+		expect(result.reminders).toEqual([]);
+		expect(result.markExecutedIds).toEqual(["email-check"]);
 	});
 });
 

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -13,6 +13,7 @@ import { McBrainManager } from "@vicissitude/agent/minecraft/brain-manager";
 import { SessionStore } from "@vicissitude/agent/session-store";
 import { createWebConversationProfile } from "@vicissitude/agent/web/profile";
 import { WEB_AGENT_ID, WEB_SCOPE_ID, WebConversationAgent } from "@vicissitude/agent/web/web-agent";
+import { fetchNewEmails, formatEmailContext } from "@vicissitude/application/email-fetcher";
 import { HeartbeatService } from "@vicissitude/application/heartbeat-service";
 import { MessageIngestionService } from "@vicissitude/application/message-ingestion-service";
 import { ResumeContextService } from "@vicissitude/application/resume-context-service";
@@ -58,6 +59,7 @@ import type {
 	AiAgent,
 	ConversationRecorder,
 	ContextBuilderPort,
+	DueReminder,
 	Logger,
 	MemoryFactReader,
 	MetricsCollector,
@@ -778,6 +780,36 @@ export function resolveBootstrapRoot(
 	return env.APP_ROOT ?? dirname(config.contextDir);
 }
 
+// ─── Email Check PreFilter ──────────────────────────────────────
+
+function buildEmailCheckPreFilter(
+	logger: Logger,
+): ((dueReminders: DueReminder[]) => Promise<DueReminder[]>) | undefined {
+	const endpoint = process.env.GAS_EMAIL_ENDPOINT;
+	const token = process.env.GAS_EMAIL_TOKEN;
+	if (!endpoint || !token) return undefined;
+
+	return async (dueReminders: DueReminder[]): Promise<DueReminder[]> => {
+		const emailReminders = dueReminders.filter((d) => d.reminder.id === "email-check");
+		const otherReminders = dueReminders.filter((d) => d.reminder.id !== "email-check");
+
+		if (emailReminders.length === 0) return dueReminders;
+
+		try {
+			const result = await fetchNewEmails(endpoint, token);
+			if (!result.hasNewMail) {
+				return otherReminders;
+			}
+			const context = formatEmailContext(result);
+			const enriched = emailReminders.map((d) => Object.assign({}, d, { context }));
+			return [...otherReminders, ...enriched];
+		} catch (error) {
+			logger.error("[heartbeat] email check failed:", error);
+			return otherReminders;
+		}
+	};
+}
+
 // ─── Main Bootstrap ─────────────────────────────────────────────
 
 export async function bootstrap(): Promise<void> {
@@ -961,6 +993,7 @@ export async function bootstrap(): Promise<void> {
 		heartbeatService: new HeartbeatService({ agent: heartbeatRouter, logger }),
 		logger,
 		metrics: metrics.collector,
+		preFilter: buildEmailCheckPreFilter(logger),
 	});
 
 	// Session gauge

--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -52,6 +52,7 @@ import { ConsolidationScheduler } from "@vicissitude/scheduling/consolidation-sc
 import { JsonHeartbeatConfigRepository } from "@vicissitude/scheduling/heartbeat-config";
 import { HEARTBEAT_CONFIG_RELATIVE_PATH } from "@vicissitude/scheduling/heartbeat-helpers";
 import { HeartbeatScheduler } from "@vicissitude/scheduling/heartbeat-scheduler";
+import type { PreFilterResult } from "@vicissitude/scheduling/heartbeat-scheduler";
 import { addGitHubCredentialHelperEnvironment } from "@vicissitude/shared/github-auth-env";
 import type { MemoryNamespace } from "@vicissitude/shared/namespace";
 import type { CriticAuditorPort } from "@vicissitude/shared/ports";
@@ -83,6 +84,7 @@ import { DiscordGateway } from "./gateway/discord.ts";
 import {
 	migrateMemoryDir,
 	removeLegacyConsolidateReminder,
+	syncEmailCheckReminder,
 	syncMcCheckReminder,
 } from "./migrations.ts";
 import { MoodNicknameService } from "./mood-nickname.ts";
@@ -782,30 +784,30 @@ export function resolveBootstrapRoot(
 
 // ─── Email Check PreFilter ──────────────────────────────────────
 
-function buildEmailCheckPreFilter(
+export function buildEmailCheckPreFilter(
 	logger: Logger,
-): ((dueReminders: DueReminder[]) => Promise<DueReminder[]>) | undefined {
-	const endpoint = process.env.GAS_EMAIL_ENDPOINT;
-	const token = process.env.GAS_EMAIL_TOKEN;
-	if (!endpoint || !token) return undefined;
+	emailConfig?: AppConfig["emailCheck"],
+): ((dueReminders: DueReminder[]) => Promise<PreFilterResult>) | undefined {
+	if (!emailConfig) return undefined;
+	const { endpoint, token } = emailConfig;
 
-	return async (dueReminders: DueReminder[]): Promise<DueReminder[]> => {
+	return async (dueReminders: DueReminder[]): Promise<PreFilterResult> => {
 		const emailReminders = dueReminders.filter((d) => d.reminder.id === "email-check");
 		const otherReminders = dueReminders.filter((d) => d.reminder.id !== "email-check");
 
-		if (emailReminders.length === 0) return dueReminders;
+		if (emailReminders.length === 0) return { reminders: dueReminders };
 
 		try {
 			const result = await fetchNewEmails(endpoint, token);
 			if (!result.hasNewMail) {
-				return otherReminders;
+				return { reminders: otherReminders, markExecutedIds: ["email-check"] };
 			}
 			const context = formatEmailContext(result);
 			const enriched = emailReminders.map((d) => Object.assign({}, d, { context }));
-			return [...otherReminders, ...enriched];
+			return { reminders: [...otherReminders, ...enriched] };
 		} catch (error) {
 			logger.error("[heartbeat] email check failed:", error);
-			return otherReminders;
+			return { reminders: otherReminders, markExecutedIds: ["email-check"] };
 		}
 	};
 }
@@ -987,13 +989,14 @@ export async function bootstrap(): Promise<void> {
 	// Heartbeat — リマインダー同期
 	const heartbeatConfigPath = resolve(root, HEARTBEAT_CONFIG_RELATIVE_PATH);
 	syncMcCheckReminder(heartbeatConfigPath, !!config.minecraft, logger);
+	syncEmailCheckReminder(heartbeatConfigPath, !!config.emailCheck, logger);
 	removeLegacyConsolidateReminder(heartbeatConfigPath, logger);
 	const heartbeatScheduler = new HeartbeatScheduler({
 		configRepo: new JsonHeartbeatConfigRepository(heartbeatConfigPath),
 		heartbeatService: new HeartbeatService({ agent: heartbeatRouter, logger }),
 		logger,
 		metrics: metrics.collector,
-		preFilter: buildEmailCheckPreFilter(logger),
+		preFilter: buildEmailCheckPreFilter(logger, config.emailCheck),
 	});
 
 	// Session gauge

--- a/apps/discord/src/config-schema.ts
+++ b/apps/discord/src/config-schema.ts
@@ -30,6 +30,11 @@ export const githubSchema = z.object({
 	repo: z.string(),
 });
 
+export const emailCheckSchema = z.object({
+	endpoint: z.string().min(1, "GAS_EMAIL_ENDPOINT is required"),
+	token: z.string().min(1, "GAS_EMAIL_TOKEN is required"),
+});
+
 export const discordDmSchema = z.object({
 	allowedUserIds: z
 		.array(z.string().regex(DISCORD_USER_ID_RE, "Discord user ID must be numeric"))
@@ -121,6 +126,7 @@ export const appConfigSchema = z.object({
 	tts: ttsSchema.optional(),
 	minecraft: minecraftSchema.optional(),
 	github: githubSchema.optional(),
+	emailCheck: emailCheckSchema.optional(),
 	discordDm: discordDmSchema.optional(),
 	imageRecognition: imageRecognitionSchema.optional(),
 	emotionEstimation: emotionEstimationSchema.optional(),

--- a/apps/discord/src/migrations.test.ts
+++ b/apps/discord/src/migrations.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+import { createMockLogger } from "@vicissitude/shared/test-helpers";
+
+import { syncEmailCheckReminder } from "./migrations.ts";
+
+describe("syncEmailCheckReminder 内部分岐", () => {
+	const TEST_DIR = resolve(import.meta.dirname, "../.test-migrations-email-unit");
+	const configPath = resolve(TEST_DIR, "heartbeat.json");
+
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(TEST_DIR, { recursive: true, force: true });
+	});
+
+	it("reminders キー自体が無くても例外を投げずスキップする（optional chaining）", () => {
+		writeFileSync(configPath, JSON.stringify({ baseIntervalMinutes: 30 }));
+		const logger = createMockLogger();
+
+		expect(() => syncEmailCheckReminder(configPath, true, logger)).not.toThrow();
+		expect(logger.info).not.toHaveBeenCalled();
+		// ファイルは書き換えられない
+		expect(readFileSync(configPath, "utf-8")).toBe(JSON.stringify({ baseIntervalMinutes: 30 }));
+	});
+
+	it("一致時はファイルを書き換えない（writeFileSync を呼ばない）", () => {
+		const original = JSON.stringify({ reminders: [{ id: "email-check", enabled: true }] });
+		writeFileSync(configPath, original);
+		const logger = createMockLogger();
+
+		syncEmailCheckReminder(configPath, true, logger);
+
+		// 整形（pretty-print）されていない = 書き換えが起きていない
+		expect(readFileSync(configPath, "utf-8")).toBe(original);
+	});
+
+	it("差分がある時は 2 スペースインデントで整形して書き戻す", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({ reminders: [{ id: "email-check", enabled: false }] }),
+		);
+		const logger = createMockLogger();
+
+		syncEmailCheckReminder(configPath, true, logger);
+
+		const raw = readFileSync(configPath, "utf-8");
+		expect(raw).toContain('  "reminders"');
+		expect(JSON.parse(raw).reminders[0].enabled).toBe(true);
+	});
+
+	it("他の reminder の enabled には影響しない", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				reminders: [
+					{ id: "mc-check", enabled: true },
+					{ id: "email-check", enabled: false },
+				],
+			}),
+		);
+		const logger = createMockLogger();
+
+		syncEmailCheckReminder(configPath, true, logger);
+
+		const result = JSON.parse(readFileSync(configPath, "utf-8")) as {
+			reminders: { id: string; enabled: boolean }[];
+		};
+		expect(result.reminders.find((r) => r.id === "mc-check")?.enabled).toBe(true);
+		expect(result.reminders.find((r) => r.id === "email-check")?.enabled).toBe(true);
+	});
+
+	it("enabled にする時のログメッセージに enabled を含む", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({ reminders: [{ id: "email-check", enabled: false }] }),
+		);
+		const logger = createMockLogger();
+
+		syncEmailCheckReminder(configPath, true, logger);
+
+		const calls = logger.info.mock.calls as unknown as string[][];
+		expect(calls[0]?.[0]).toContain("enabled");
+	});
+
+	it("disabled にする時のログメッセージに disabled を含む", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({ reminders: [{ id: "email-check", enabled: true }] }),
+		);
+		const logger = createMockLogger();
+
+		syncEmailCheckReminder(configPath, false, logger);
+
+		const calls = logger.info.mock.calls as unknown as string[][];
+		expect(calls[0]?.[0]).toContain("disabled");
+	});
+});

--- a/apps/discord/src/migrations.ts
+++ b/apps/discord/src/migrations.ts
@@ -26,6 +26,29 @@ export function syncMcCheckReminder(
 	}
 }
 
+/** config.emailCheck の有無に応じて email-check リマインダーの enabled を同期する */
+export function syncEmailCheckReminder(
+	configPath: string,
+	emailCheckEnabled: boolean,
+	logger: Logger,
+): void {
+	if (!existsSync(configPath)) return;
+	try {
+		const raw = JSON.parse(readFileSync(configPath, "utf-8")) as {
+			reminders?: { id: string; enabled: boolean }[];
+		};
+		const emailCheck = raw.reminders?.find((r) => r.id === "email-check");
+		if (!emailCheck || emailCheck.enabled === emailCheckEnabled) return;
+		emailCheck.enabled = emailCheckEnabled;
+		writeFileSync(configPath, JSON.stringify(raw, null, 2));
+		logger.info(
+			`[bootstrap] email-check reminder ${emailCheckEnabled ? "enabled" : "disabled"} (synced with config.emailCheck)`,
+		);
+	} catch {
+		// パース失敗時はスキップ（HeartbeatScheduler がデフォルト設定で初期化する）
+	}
+}
+
 /** ltm-consolidate リマインダーを削除する（MCP ツール廃止に伴う移行） */
 export function removeLegacyConsolidateReminder(configPath: string, logger: Logger): void {
 	if (!existsSync(configPath)) return;

--- a/apps/discord/src/profile-config.ts
+++ b/apps/discord/src/profile-config.ts
@@ -90,6 +90,7 @@ export const profileConfigSchema = z.strictObject({
 		minecraft: minecraftSchema.optional(),
 		tts: ttsSchema.optional(),
 		githubIssues: z.strictObject({}).optional(),
+		emailCheck: z.strictObject({}).optional(),
 	}),
 });
 
@@ -140,6 +141,17 @@ function requireSecret(
 	const value = env[name];
 	if (value && value.trim()) return value;
 	throw new Error(`${name} is required when ${featureName} is configured`);
+}
+
+function buildEmailCheckConfig(
+	profile: ProfileConfig,
+	env: Record<string, string | undefined>,
+): AppConfig["emailCheck"] {
+	if (!profile.features.emailCheck) return undefined;
+	return {
+		endpoint: requireSecret(env, "GAS_EMAIL_ENDPOINT", "features.emailCheck"),
+		token: requireSecret(env, "GAS_EMAIL_TOKEN", "features.emailCheck"),
+	};
 }
 
 export function loadProfileConfigFile(filepath: string): ProfileConfig {
@@ -201,6 +213,7 @@ export function loadConfigFromProfile(
 					repo: requireSecret(env, "GITHUB_REPO", "features.githubIssues"),
 				}
 			: undefined,
+		emailCheck: buildEmailCheckConfig(profile, env),
 		discordDm:
 			(runtimeOverlay?.discordDm ?? profile.features.discordDm)
 				? {

--- a/config/profile.schema.json
+++ b/config/profile.schema.json
@@ -298,6 +298,11 @@
 					"type": "object",
 					"properties": {},
 					"additionalProperties": false
+				},
+				"emailCheck": {
+					"type": "object",
+					"properties": {},
+					"additionalProperties": false
 				}
 			},
 			"additionalProperties": false

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -2,6 +2,7 @@
 	"name": "@vicissitude/application",
 	"private": true,
 	"exports": {
+		"./email-fetcher": "./src/email-fetcher.ts",
 		"./heartbeat-service": "./src/heartbeat-service.ts",
 		"./message-ingestion-service": "./src/message-ingestion-service.ts",
 		"./resume-context-service": "./src/resume-context-service.ts",

--- a/packages/application/src/email-fetcher.test.ts
+++ b/packages/application/src/email-fetcher.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { fetchNewEmails, formatEmailContext } from "./email-fetcher.ts";
+import type { EmailCheckResult } from "./email-fetcher.ts";
+
+function makeResult(overrides: Partial<EmailCheckResult> = {}): EmailCheckResult {
+	return {
+		hasNewMail: true,
+		count: 1,
+		emails: [
+			{
+				subject: "件名",
+				from: "alice@example.com",
+				date: "2026-06-10T09:00:00Z",
+				bodyExcerpt: "本文の抜粋",
+			},
+		],
+		...overrides,
+	};
+}
+
+describe("fetchNewEmails", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	test("endpoint の URL に token クエリを付与して fetch する", async () => {
+		let capturedUrl: string | undefined;
+		globalThis.fetch = mock((input: string) => {
+			capturedUrl = input;
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve(makeResult()),
+				text: () => Promise.resolve(""),
+			} as Response);
+		}) as unknown as typeof globalThis.fetch;
+
+		await fetchNewEmails("https://example.com/exec", "secret-token");
+
+		expect(capturedUrl).toBeDefined();
+		const url = new URL(capturedUrl as string);
+		expect(url.searchParams.get("token")).toBe("secret-token");
+		expect(url.origin + url.pathname).toBe("https://example.com/exec");
+	});
+
+	test("既存クエリを持つ endpoint でも token を追加する", async () => {
+		let capturedUrl: string | undefined;
+		globalThis.fetch = mock((input: string) => {
+			capturedUrl = input;
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve(makeResult()),
+				text: () => Promise.resolve(""),
+			} as Response);
+		}) as unknown as typeof globalThis.fetch;
+
+		await fetchNewEmails("https://example.com/exec?foo=bar", "tok");
+
+		const url = new URL(capturedUrl as string);
+		expect(url.searchParams.get("foo")).toBe("bar");
+		expect(url.searchParams.get("token")).toBe("tok");
+	});
+
+	test("token が既存の同名クエリを上書きする（searchParams.set の挙動）", async () => {
+		let capturedUrl: string | undefined;
+		globalThis.fetch = mock((input: string) => {
+			capturedUrl = input;
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve(makeResult()),
+				text: () => Promise.resolve(""),
+			} as Response);
+		}) as unknown as typeof globalThis.fetch;
+
+		await fetchNewEmails("https://example.com/exec?token=old", "new-token");
+
+		const url = new URL(capturedUrl as string);
+		expect(url.searchParams.getAll("token")).toEqual(["new-token"]);
+	});
+
+	test("レスポンスの JSON を EmailCheckResult として返す", async () => {
+		const payload = makeResult({ count: 3 });
+		globalThis.fetch = mock(() =>
+			Promise.resolve({
+				ok: true,
+				status: 200,
+				json: () => Promise.resolve(payload),
+				text: () => Promise.resolve(""),
+			} as Response),
+		) as unknown as typeof globalThis.fetch;
+
+		const result = await fetchNewEmails("https://example.com/exec", "tok");
+
+		expect(result).toEqual(payload);
+	});
+
+	test("非 2xx レスポンスで status と body を含むエラーを throw する", async () => {
+		globalThis.fetch = mock(() =>
+			Promise.resolve({
+				ok: false,
+				status: 503,
+				json: () => Promise.resolve({}),
+				text: () => Promise.resolve("service unavailable"),
+			} as Response),
+		) as unknown as typeof globalThis.fetch;
+
+		await expect(fetchNewEmails("https://example.com/exec", "tok")).rejects.toThrow(
+			"Email check failed: 503 service unavailable",
+		);
+	});
+
+	test("非 2xx の場合は json をパースしない", async () => {
+		const jsonSpy = mock(() => Promise.resolve({}));
+		globalThis.fetch = mock(() =>
+			Promise.resolve({
+				ok: false,
+				status: 401,
+				json: jsonSpy,
+				text: () => Promise.resolve("unauthorized"),
+			} as unknown as Response),
+		) as unknown as typeof globalThis.fetch;
+
+		await expect(fetchNewEmails("https://example.com/exec", "tok")).rejects.toThrow();
+		expect(jsonSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("formatEmailContext bodyExcerpt トランケート境界値", () => {
+	function formatBody(body: string): string {
+		return formatEmailContext(
+			makeResult({
+				emails: [
+					{ subject: "s", from: "f@example.com", date: "2026-06-10T09:00:00Z", bodyExcerpt: body },
+				],
+			}),
+		);
+	}
+
+	test("199 文字はそのまま含まれる", () => {
+		const body = "x".repeat(199);
+		const output = formatBody(body);
+		expect(output).toContain(body);
+	});
+
+	test("ちょうど 200 文字はそのまま含まれる", () => {
+		const body = "x".repeat(200);
+		const output = formatBody(body);
+		expect(output).toContain(body);
+	});
+
+	test("201 文字は 200 文字に切り詰められる（201 文字目は含まれない）", () => {
+		// 本文末尾のマーカー文字。date 等の他フィールドに出ない文字を選ぶ
+		const body = "x".repeat(200) + "あ";
+		const output = formatBody(body);
+		expect(output).toContain("x".repeat(200));
+		expect(output).not.toContain("あ");
+	});
+});
+
+describe("formatEmailContext 内部フォーマット詳細", () => {
+	test("複数メールは 1 始まりの連番で列挙する", () => {
+		const output = formatEmailContext(
+			makeResult({
+				count: 3,
+				emails: [
+					{ subject: "一", from: "a@e.com", date: "d1", bodyExcerpt: "b1" },
+					{ subject: "二", from: "b@e.com", date: "d2", bodyExcerpt: "b2" },
+					{ subject: "三", from: "c@e.com", date: "d3", bodyExcerpt: "b3" },
+				],
+			}),
+		);
+
+		expect(output).toContain("1. 「一」from a@e.com (d1)");
+		expect(output).toContain("2. 「二」from b@e.com (d2)");
+		expect(output).toContain("3. 「三」from c@e.com (d3)");
+	});
+
+	test("件数は emails.length ではなく count フィールドを使う", () => {
+		// count と emails.length が不一致でも count の値が出力される
+		const output = formatEmailContext(
+			makeResult({
+				count: 99,
+				emails: [{ subject: "s", from: "f@e.com", date: "d", bodyExcerpt: "b" }],
+			}),
+		);
+
+		expect(output).toContain("新着メール 99 件:");
+	});
+
+	test("本文抜粋は件名行の次行にインデント付きで配置される", () => {
+		const output = formatEmailContext(
+			makeResult({
+				count: 1,
+				emails: [{ subject: "件名", from: "f@e.com", date: "d", bodyExcerpt: "本文" }],
+			}),
+		);
+
+		expect(output).toContain("1. 「件名」from f@e.com (d)\n   本文");
+	});
+});

--- a/packages/application/src/email-fetcher.ts
+++ b/packages/application/src/email-fetcher.ts
@@ -25,11 +25,13 @@ export async function fetchNewEmails(
 	return (await response.json()) as EmailCheckResult;
 }
 
+const EMAIL_BODY_EXCERPT_MAX_LENGTH = 200;
+
 export function formatEmailContext(result: EmailCheckResult): string {
 	if (!result.hasNewMail || result.emails.length === 0) return "";
 	const lines = result.emails.map(
 		(email, i) =>
-			`${String(i + 1)}. 「${email.subject}」from ${email.from} (${email.date})\n   ${email.bodyExcerpt}`,
+			`${String(i + 1)}. 「${email.subject}」from ${email.from} (${email.date})\n   ${email.bodyExcerpt.slice(0, EMAIL_BODY_EXCERPT_MAX_LENGTH)}`,
 	);
-	return `新着メール ${String(result.count)} 件:\n${lines.join("\n")}`;
+	return `<email_context>\n新着メール ${String(result.count)} 件:\n${lines.join("\n")}\n</email_context>`;
 }

--- a/packages/application/src/email-fetcher.ts
+++ b/packages/application/src/email-fetcher.ts
@@ -1,0 +1,35 @@
+export interface EmailData {
+	subject: string;
+	from: string;
+	date: string;
+	bodyExcerpt: string;
+}
+
+export interface EmailCheckResult {
+	hasNewMail: boolean;
+	count: number;
+	emails: EmailData[];
+}
+
+export async function fetchNewEmails(
+	endpointUrl: string,
+	accessToken: string,
+): Promise<EmailCheckResult> {
+	const url = new URL(endpointUrl);
+	url.searchParams.set("token", accessToken);
+
+	const response = await fetch(url.toString());
+	if (!response.ok) {
+		throw new Error(`Email check failed: ${String(response.status)} ${await response.text()}`);
+	}
+	return (await response.json()) as EmailCheckResult;
+}
+
+export function formatEmailContext(result: EmailCheckResult): string {
+	if (!result.hasNewMail || result.emails.length === 0) return "";
+	const lines = result.emails.map(
+		(email, i) =>
+			`${String(i + 1)}. 「${email.subject}」from ${email.from} (${email.date})\n   ${email.bodyExcerpt}`,
+	);
+	return `新着メール ${String(result.count)} 件:\n${lines.join("\n")}`;
+}

--- a/packages/application/src/heartbeat-service.ts
+++ b/packages/application/src/heartbeat-service.ts
@@ -14,7 +14,11 @@ export function buildHeartbeatPrompt(dueReminders: DueReminder[]): string {
 					? `every ${String(schedule.minutes)}min`
 					: `daily ${String(schedule.hour)}:${String(schedule.minute).padStart(2, "0")}`;
 			const lastLabel = due.reminder.lastExecutedAt ?? "never";
-			return `- [${scheduleLabel}] ${due.reminder.description}（最後: ${lastLabel}）`;
+			let line = `- [${scheduleLabel}] ${due.reminder.description}（最後: ${lastLabel}）`;
+			if (due.context) {
+				line += `\n  ${due.context}`;
+			}
+			return line;
 		})
 		.join("\n");
 

--- a/packages/scheduling/src/heartbeat-helpers.ts
+++ b/packages/scheduling/src/heartbeat-helpers.ts
@@ -46,6 +46,15 @@ export function createDefaultHeartbeatConfig(): HeartbeatConfig {
 				lastExecutedAt: null,
 				enabled: false,
 			},
+			// config.emailCheck 未設定時でも含める（heartbeat-config.json に永続化されるため条件付き追加は不整合を招く）。
+			// デフォルト無効。config.emailCheck 設定時に有効化される想定。
+			{
+				id: "email-check",
+				description: "新着メールを確認する",
+				schedule: { type: "interval", minutes: 5 },
+				lastExecutedAt: null,
+				enabled: false,
+			},
 		],
 	};
 }

--- a/packages/scheduling/src/heartbeat-scheduler.test.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.test.ts
@@ -91,4 +91,108 @@ describe("HeartbeatScheduler", () => {
 		expect(configRepo.markRemindersExecuted).toHaveBeenCalledTimes(1);
 		expect(configRepo.markRemindersExecuted).toHaveBeenCalledWith(["due-1"], expect.any(String));
 	});
+
+	test("execute が空 Set を返したら（成功 guild 無し）markRemindersExecuted を呼ばない", async () => {
+		const configRepo = createMockConfigRepo({
+			baseIntervalMinutes: 30,
+			reminders: [
+				{
+					id: "due-1",
+					description: "check home",
+					schedule: { type: "interval", minutes: 1 },
+					lastExecutedAt: null,
+					enabled: true,
+				},
+			],
+		});
+		const heartbeatService = {
+			execute: mock(() => Promise.resolve(new Set<string>())),
+		};
+		const scheduler = new HeartbeatScheduler({
+			configRepo,
+			heartbeatService,
+			logger: createMockLogger(),
+		});
+
+		// executed=true（execute は呼ばれた）だが succeededIds が空なので config 更新は無し
+		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+
+		expect(heartbeatService.execute).toHaveBeenCalledTimes(1);
+		expect(configRepo.markRemindersExecuted).not.toHaveBeenCalled();
+	});
+
+	test("preFilter 未設定なら due reminder をそのまま execute に渡す", async () => {
+		const configRepo = createMockConfigRepo({
+			baseIntervalMinutes: 30,
+			reminders: [
+				{
+					id: "due-1",
+					description: "check home",
+					schedule: { type: "interval", minutes: 1 },
+					lastExecutedAt: null,
+					enabled: true,
+				},
+			],
+		});
+		let receivedIds: string[] = [];
+		const heartbeatService = {
+			execute: mock((reminders: { reminder: { id: string } }[]) => {
+				receivedIds = reminders.map((r) => r.reminder.id);
+				return Promise.resolve(new Set(["due-1"]));
+			}),
+		};
+		const scheduler = new HeartbeatScheduler({
+			configRepo,
+			heartbeatService,
+			logger: createMockLogger(),
+		});
+
+		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+
+		expect(receivedIds).toEqual(["due-1"]);
+	});
+
+	test("preFilter の reminders が空かつ markExecutedIds が空配列なら markRemindersExecuted を呼ばない", async () => {
+		// markExecutedIds.length > 0 のガードで空配列は no-op になる境界
+		const configRepo = createMockConfigRepo({
+			baseIntervalMinutes: 1,
+			reminders: [
+				{
+					id: "email-check",
+					description: "メール確認",
+					schedule: { type: "interval", minutes: 5 },
+					lastExecutedAt: null,
+					enabled: true,
+				},
+			],
+		});
+		const heartbeatService = {
+			execute: mock(() => Promise.resolve(new Set<string>())),
+		};
+		const scheduler = new HeartbeatScheduler({
+			configRepo,
+			heartbeatService,
+			logger: createMockLogger(),
+			preFilter: mock(() => Promise.resolve({ reminders: [], markExecutedIds: [] })),
+		});
+
+		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+
+		expect(heartbeatService.execute).not.toHaveBeenCalled();
+		expect(configRepo.markRemindersExecuted).not.toHaveBeenCalled();
+	});
+
+	test("due reminder が無ければ preFilter を呼ばない", async () => {
+		const preFilter = mock(() => Promise.resolve({ reminders: [] }));
+		const scheduler = new HeartbeatScheduler({
+			configRepo: createMockConfigRepo({ baseIntervalMinutes: 30, reminders: [] }),
+			heartbeatService: createMockHeartbeatService(),
+			logger: createMockLogger(),
+			preFilter,
+		});
+
+		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+
+		expect(preFilter).not.toHaveBeenCalled();
+	});
 });

--- a/packages/scheduling/src/heartbeat-scheduler.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.ts
@@ -15,12 +15,23 @@ import { evaluateDueReminders } from "./heartbeat-helpers.ts";
 const HEARTBEAT_TICK_INTERVAL_MS = 60_000;
 const HEARTBEAT_TICK_TIMEOUT_MS = 180_000;
 
+/**
+ * preFilter の戻り値。
+ * - `reminders`: この tick で実際に実行する due reminder 群（context 注入済みを含む）。
+ * - `markExecutedIds`: 実行はしないが「実行済み」として扱い interval を尊重させる reminder id 群。
+ *   email-check が due だが新着メール無し / fetch 失敗の場合に毎 tick ポーリングを防ぐために使う。
+ */
+export interface PreFilterResult {
+	reminders: DueReminder[];
+	markExecutedIds?: readonly string[];
+}
+
 export interface HeartbeatSchedulerDeps {
 	configRepo: HeartbeatConfigPort;
 	heartbeatService: { execute(dueReminders: DueReminder[]): Promise<Set<string>> };
 	logger: Logger;
 	metrics?: MetricsCollector;
-	preFilter?: (dueReminders: DueReminder[]) => Promise<DueReminder[]>;
+	preFilter?: (dueReminders: DueReminder[]) => Promise<PreFilterResult>;
 }
 
 export class HeartbeatScheduler {
@@ -125,8 +136,13 @@ export class HeartbeatScheduler {
 		if (dueReminders.length === 0) return false;
 
 		if (this.deps.preFilter) {
-			dueReminders = await this.deps.preFilter(dueReminders);
+			const result = await this.deps.preFilter(dueReminders);
+			dueReminders = result.reminders;
 			if (dueReminders.length === 0) {
+				if (result.markExecutedIds && result.markExecutedIds.length > 0) {
+					const executedAt = new Date().toISOString();
+					await this.deps.configRepo.markRemindersExecuted([...result.markExecutedIds], executedAt);
+				}
 				this.deps.logger.info("[heartbeat] all reminders filtered out, skipping execution");
 				return false;
 			}

--- a/packages/scheduling/src/heartbeat-scheduler.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.ts
@@ -20,6 +20,7 @@ export interface HeartbeatSchedulerDeps {
 	heartbeatService: { execute(dueReminders: DueReminder[]): Promise<Set<string>> };
 	logger: Logger;
 	metrics?: MetricsCollector;
+	preFilter?: (dueReminders: DueReminder[]) => Promise<DueReminder[]>;
 }
 
 export class HeartbeatScheduler {
@@ -120,8 +121,17 @@ export class HeartbeatScheduler {
 	}
 
 	private async executeHeartbeat(config: HeartbeatConfig): Promise<boolean> {
-		const dueReminders = evaluateDueReminders(config, new Date());
+		let dueReminders = evaluateDueReminders(config, new Date());
 		if (dueReminders.length === 0) return false;
+
+		if (this.deps.preFilter) {
+			dueReminders = await this.deps.preFilter(dueReminders);
+			if (dueReminders.length === 0) {
+				this.deps.logger.info("[heartbeat] all reminders filtered out, skipping execution");
+				return false;
+			}
+		}
+
 		this.deps.logger.info(
 			`[heartbeat] ${String(dueReminders.length)} due reminder(s): ${dueReminders.map((d) => d.reminder.id).join(", ")}`,
 		);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -60,6 +60,7 @@ export interface HeartbeatConfig {
 export interface DueReminder {
 	reminder: HeartbeatReminder;
 	overdueMinutes: number;
+	context?: string;
 }
 
 // ─── Incoming Message & Message Channel ──────────────────────────

--- a/spec/application/email-fetcher.spec.ts
+++ b/spec/application/email-fetcher.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatEmailContext } from "@vicissitude/application/email-fetcher";
+import type { EmailCheckResult } from "@vicissitude/application/email-fetcher";
+
+function makeResult(overrides: Partial<EmailCheckResult> = {}): EmailCheckResult {
+	return {
+		hasNewMail: true,
+		count: 1,
+		emails: [
+			{
+				subject: "件名",
+				from: "alice@example.com",
+				date: "2026-06-10T09:00:00Z",
+				bodyExcerpt: "本文の抜粋",
+			},
+		],
+		...overrides,
+	};
+}
+
+describe("formatEmailContext", () => {
+	test("新着メールが無ければ空文字を返す", () => {
+		const result = makeResult({ hasNewMail: false, count: 0, emails: [] });
+
+		expect(formatEmailContext(result)).toBe("");
+	});
+
+	test("hasNewMail=true でも emails が空なら空文字を返す", () => {
+		const result = makeResult({ hasNewMail: true, count: 0, emails: [] });
+
+		expect(formatEmailContext(result)).toBe("");
+	});
+
+	test("出力全体を <email_context> デリミタで囲む（プロンプトインジェクション対策）", () => {
+		const output = formatEmailContext(makeResult());
+
+		expect(output.startsWith("<email_context>")).toBe(true);
+		expect(output.endsWith("</email_context>")).toBe(true);
+	});
+
+	test("件名・差出人・本文抜粋を含む", () => {
+		const output = formatEmailContext(makeResult());
+
+		expect(output).toContain("件名");
+		expect(output).toContain("alice@example.com");
+		expect(output).toContain("本文の抜粋");
+	});
+
+	test("bodyExcerpt は 200 文字でトランケートする", () => {
+		const longBody = "あ".repeat(500);
+		const output = formatEmailContext(
+			makeResult({
+				emails: [
+					{
+						subject: "長文",
+						from: "bob@example.com",
+						date: "2026-06-10T09:00:00Z",
+						bodyExcerpt: longBody,
+					},
+				],
+			}),
+		);
+
+		// トランケート後の本文は 200 文字以下（元の 500 文字は含まれない）
+		expect(output).not.toContain("あ".repeat(201));
+		expect(output).toContain("あ".repeat(200));
+	});
+
+	test("複数メールを件数とともに列挙する", () => {
+		const output = formatEmailContext(
+			makeResult({
+				count: 2,
+				emails: [
+					{
+						subject: "一通目",
+						from: "a@example.com",
+						date: "2026-06-10T09:00:00Z",
+						bodyExcerpt: "body1",
+					},
+					{
+						subject: "二通目",
+						from: "b@example.com",
+						date: "2026-06-10T10:00:00Z",
+						bodyExcerpt: "body2",
+					},
+				],
+			}),
+		);
+
+		expect(output).toContain("2");
+		expect(output).toContain("一通目");
+		expect(output).toContain("二通目");
+	});
+});

--- a/spec/application/heartbeat-service.spec.ts
+++ b/spec/application/heartbeat-service.spec.ts
@@ -28,6 +28,41 @@ describe("buildHeartbeatPrompt", () => {
 		expect(prompt).toContain("水やり");
 		expect(prompt).toContain("every 30min");
 	});
+
+	test("DueReminder.context を prompt に反映する", () => {
+		const prompt = buildHeartbeatPrompt([
+			{
+				reminder: {
+					id: "email-check",
+					description: "メール確認",
+					schedule: { type: "interval", minutes: 5 },
+					lastExecutedAt: null,
+					enabled: true,
+				},
+				overdueMinutes: 0,
+				context: "<email_context>新着メール 1 件: 「件名」</email_context>",
+			},
+		]);
+
+		expect(prompt).toContain("<email_context>新着メール 1 件: 「件名」</email_context>");
+	});
+
+	test("context が無い DueReminder は context を出力しない", () => {
+		const prompt = buildHeartbeatPrompt([
+			{
+				reminder: {
+					id: "home-check",
+					description: "様子見",
+					schedule: { type: "interval", minutes: 60 },
+					lastExecutedAt: null,
+					enabled: true,
+				},
+				overdueMinutes: 0,
+			},
+		]);
+
+		expect(prompt).not.toContain("<email_context>");
+	});
 });
 
 describe("groupByScope", () => {

--- a/spec/core/profile-config.spec.ts
+++ b/spec/core/profile-config.spec.ts
@@ -218,6 +218,51 @@ describe("JSON profile config", () => {
 		});
 	});
 
+	it("features.emailCheck 設定時に endpoint/token を env から解決する", () => {
+		const config = loadConfigFromProfile(
+			{
+				...baseProfile,
+				features: { emailCheck: {} },
+			},
+			baseEnv({
+				GAS_EMAIL_ENDPOINT: "https://script.google.com/exec",
+				GAS_EMAIL_TOKEN: "test-email-token",
+			}),
+			root,
+		);
+
+		expect(config.emailCheck).toEqual({
+			endpoint: "https://script.google.com/exec",
+			token: "test-email-token",
+		});
+	});
+
+	it("features.emailCheck 未設定なら emailCheck は undefined になる", () => {
+		const config = loadConfigFromProfile(baseProfile, baseEnv(), root);
+
+		expect(config.emailCheck).toBeUndefined();
+	});
+
+	it("features.emailCheck 設定時に GAS_EMAIL_ENDPOINT が無ければエラーにする", () => {
+		expect(() =>
+			loadConfigFromProfile(
+				{ ...baseProfile, features: { emailCheck: {} } },
+				baseEnv({ GAS_EMAIL_TOKEN: "test-email-token" }),
+				root,
+			),
+		).toThrow("GAS_EMAIL_ENDPOINT is required");
+	});
+
+	it("features.emailCheck 設定時に GAS_EMAIL_TOKEN が無ければエラーにする", () => {
+		expect(() =>
+			loadConfigFromProfile(
+				{ ...baseProfile, features: { emailCheck: {} } },
+				baseEnv({ GAS_EMAIL_ENDPOINT: "https://script.google.com/exec" }),
+				root,
+			),
+		).toThrow("GAS_EMAIL_TOKEN is required");
+	});
+
 	it("shellAgent.environment の参照元 env が未設定ならエラーにする", () => {
 		expect(() =>
 			loadConfigFromProfile(

--- a/spec/core/types.spec.ts
+++ b/spec/core/types.spec.ts
@@ -6,22 +6,26 @@ describe("createDefaultHeartbeatConfig", () => {
 	it("has expected default values", () => {
 		const config = createDefaultHeartbeatConfig();
 		expect(config.baseIntervalMinutes).toBe(1);
-		expect(config.reminders).toHaveLength(4);
+		expect(config.reminders).toHaveLength(5);
 
 		const first = config.reminders[0];
 		const second = config.reminders[1];
 		const third = config.reminders[2];
 		const fourth = config.reminders[3];
+		const fifth = config.reminders[4];
 		expect(first).toBeDefined();
 		expect(second).toBeDefined();
 		expect(third).toBeDefined();
 		expect(fourth).toBeDefined();
+		expect(fifth).toBeDefined();
 		expect(first?.id).toBe("home-check");
 		expect(second?.id).toBe("memory-update");
 		expect(third?.id).toBe("character-reinforce");
 		expect(third?.enabled).toBe(true);
 		expect(fourth?.id).toBe("mc-check");
 		expect(fourth?.enabled).toBe(false);
+		expect(fifth?.id).toBe("email-check");
+		expect(fifth?.enabled).toBe(false);
 	});
 
 	it("returns independent instances", () => {

--- a/spec/discord/bootstrap.spec.ts
+++ b/spec/discord/bootstrap.spec.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import { resolve } from "path";
+
+import type { DueReminder } from "@vicissitude/shared/types";
 
 import {
 	buildAgentDiscordEnvironment,
 	buildCoreEnvironment,
 	buildDiscordEnvironment,
+	buildEmailCheckPreFilter,
 } from "../../apps/discord/src/bootstrap.ts";
 import type { AppConfig } from "../../apps/discord/src/config.ts";
+import { createMockLogger } from "../test-helpers.ts";
 
 function makeConfig(
 	overrides: {
@@ -44,6 +48,32 @@ function makeConfig(
 }
 
 const ROOT = "/tmp/test-root";
+
+function emailCheckDue(): DueReminder {
+	return {
+		reminder: {
+			id: "email-check",
+			description: "メール確認",
+			schedule: { type: "interval", minutes: 5 },
+			lastExecutedAt: null,
+			enabled: true,
+		},
+		overdueMinutes: 0,
+	};
+}
+
+function homeCheckDue(): DueReminder {
+	return {
+		reminder: {
+			id: "home-check",
+			description: "様子見",
+			schedule: { type: "interval", minutes: 60 },
+			lastExecutedAt: null,
+			enabled: true,
+		},
+		overdueMinutes: 0,
+	};
+}
 
 describe("buildCoreEnvironment", () => {
 	it("常に必須の環境変数を含む", () => {
@@ -245,5 +275,94 @@ describe("buildDiscordEnvironment", () => {
 
 			expect(result).not.toHaveProperty("DISCORD_ATTACHMENT_ALLOWED_DIRS");
 		});
+	});
+});
+
+describe("buildEmailCheckPreFilter", () => {
+	const EMAIL_CONFIG = { endpoint: "https://script.google.com/exec", token: "tok" };
+
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	function mockFetchJson(payload: unknown, ok = true): void {
+		globalThis.fetch = mock(() =>
+			Promise.resolve({
+				ok,
+				status: ok ? 200 : 500,
+				json: () => Promise.resolve(payload),
+				text: () => Promise.resolve(""),
+			} as Response),
+		) as unknown as typeof globalThis.fetch;
+	}
+
+	it("emailConfig が未設定なら preFilter を生成しない", () => {
+		const noConfig: AppConfig["emailCheck"] = undefined;
+		expect(buildEmailCheckPreFilter(createMockLogger(), noConfig)).toBeUndefined();
+	});
+
+	it("email-check が due でなければ fetch せず dueReminders をそのまま返す", async () => {
+		const fetchSpy = mock(() => Promise.reject(new Error("should not fetch")));
+		globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+		const preFilter = buildEmailCheckPreFilter(createMockLogger(), EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const due = [homeCheckDue()];
+		const result = await preFilter(due);
+
+		expect(result.reminders).toEqual(due);
+		expect(result.markExecutedIds).toBeUndefined();
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("新着メールがあれば email-check に context を注入して reminders に含める", async () => {
+		mockFetchJson({
+			hasNewMail: true,
+			count: 1,
+			emails: [
+				{
+					subject: "件名",
+					from: "a@example.com",
+					date: "2026-06-10T09:00:00Z",
+					bodyExcerpt: "本文",
+				},
+			],
+		});
+		const preFilter = buildEmailCheckPreFilter(createMockLogger(), EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const result = await preFilter([emailCheckDue(), homeCheckDue()]);
+
+		const enriched = result.reminders.find((r) => r.reminder.id === "email-check");
+		expect(enriched?.context).toContain("<email_context>");
+		expect(result.reminders.some((r) => r.reminder.id === "home-check")).toBe(true);
+		expect(result.markExecutedIds).toBeUndefined();
+	});
+
+	it("新着メールが無ければ email-check を除外し markExecutedIds に含める", async () => {
+		mockFetchJson({ hasNewMail: false, count: 0, emails: [] });
+		const preFilter = buildEmailCheckPreFilter(createMockLogger(), EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const result = await preFilter([emailCheckDue(), homeCheckDue()]);
+
+		expect(result.reminders.some((r) => r.reminder.id === "email-check")).toBe(false);
+		expect(result.reminders.some((r) => r.reminder.id === "home-check")).toBe(true);
+		expect(result.markExecutedIds).toEqual(["email-check"]);
+	});
+
+	it("fetch 失敗時も email-check を markExecutedIds に含めて毎 tick ポーリングを防ぐ", async () => {
+		globalThis.fetch = mock(() =>
+			Promise.reject(new Error("network down")),
+		) as unknown as typeof globalThis.fetch;
+		const preFilter = buildEmailCheckPreFilter(createMockLogger(), EMAIL_CONFIG);
+		if (!preFilter) throw new Error("preFilter should be defined");
+
+		const result = await preFilter([emailCheckDue(), homeCheckDue()]);
+
+		expect(result.reminders.some((r) => r.reminder.id === "email-check")).toBe(false);
+		expect(result.markExecutedIds).toEqual(["email-check"]);
 	});
 });

--- a/spec/discord/migrations.spec.ts
+++ b/spec/discord/migrations.spec.ts
@@ -7,6 +7,7 @@ import type { Logger } from "@vicissitude/shared/types";
 import {
 	migrateMemoryDir,
 	removeLegacyConsolidateReminder,
+	syncEmailCheckReminder,
 	syncMcCheckReminder,
 } from "../../apps/discord/src/migrations.ts";
 
@@ -76,6 +77,73 @@ describe("syncMcCheckReminder", () => {
 		writeFileSync(configPath, "not json");
 		const logger = makeLogger();
 		expect(() => syncMcCheckReminder(configPath, true, logger)).not.toThrow();
+	});
+});
+
+describe("syncEmailCheckReminder", () => {
+	const TEST_DIR = resolve(import.meta.dirname, "../../.test-migrations-email-sync");
+	const configPath = resolve(TEST_DIR, "heartbeat.json");
+
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(TEST_DIR, { recursive: true, force: true });
+	});
+
+	it("ファイルが存在しない場合は何もしない", () => {
+		const logger = makeLogger();
+		syncEmailCheckReminder(resolve(TEST_DIR, "nonexistent.json"), true, logger);
+		expect(logger.info).not.toHaveBeenCalled();
+	});
+
+	it("email-check リマインダーが存在しない場合は何もしない", () => {
+		writeFileSync(configPath, JSON.stringify({ reminders: [] }));
+		const logger = makeLogger();
+		syncEmailCheckReminder(configPath, true, logger);
+		expect(logger.info).not.toHaveBeenCalled();
+	});
+
+	it("email-check の enabled が既に一致している場合は何もしない", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({ reminders: [{ id: "email-check", enabled: true }] }),
+		);
+		const logger = makeLogger();
+		syncEmailCheckReminder(configPath, true, logger);
+		expect(logger.info).not.toHaveBeenCalled();
+	});
+
+	it("emailCheckEnabled=true のとき email-check を enabled にする", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({ reminders: [{ id: "email-check", enabled: false }] }),
+		);
+		const logger = makeLogger();
+		syncEmailCheckReminder(configPath, true, logger);
+
+		const result = JSON.parse(readFileSync(configPath, "utf-8"));
+		expect(result.reminders[0].enabled).toBe(true);
+		expect(logger.info).toHaveBeenCalled();
+	});
+
+	it("emailCheckEnabled=false のとき email-check を disabled にする", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({ reminders: [{ id: "email-check", enabled: true }] }),
+		);
+		const logger = makeLogger();
+		syncEmailCheckReminder(configPath, false, logger);
+
+		const result = JSON.parse(readFileSync(configPath, "utf-8"));
+		expect(result.reminders[0].enabled).toBe(false);
+	});
+
+	it("不正な JSON の場合は例外をスローせずスキップする", () => {
+		writeFileSync(configPath, "not json");
+		const logger = makeLogger();
+		expect(() => syncEmailCheckReminder(configPath, true, logger)).not.toThrow();
 	});
 });
 

--- a/spec/scheduling/heartbeat-helpers.spec.ts
+++ b/spec/scheduling/heartbeat-helpers.spec.ts
@@ -1,7 +1,27 @@
 import { describe, expect, test } from "bun:test";
 
-import { evaluateDueReminders } from "@vicissitude/scheduling/heartbeat-helpers";
+import {
+	createDefaultHeartbeatConfig,
+	evaluateDueReminders,
+} from "@vicissitude/scheduling/heartbeat-helpers";
 import type { HeartbeatConfig } from "@vicissitude/shared/types";
+
+describe("createDefaultHeartbeatConfig", () => {
+	test("email-check リマインダーをデフォルト無効で含む", () => {
+		const config = createDefaultHeartbeatConfig();
+		const emailCheck = config.reminders.find((r) => r.id === "email-check");
+
+		expect(emailCheck).toBeDefined();
+		expect(emailCheck?.enabled).toBe(false);
+	});
+
+	test("email-check は 5 分間隔の interval スケジュール", () => {
+		const config = createDefaultHeartbeatConfig();
+		const emailCheck = config.reminders.find((r) => r.id === "email-check");
+
+		expect(emailCheck?.schedule).toEqual({ type: "interval", minutes: 5 });
+	});
+});
 
 describe("evaluateDueReminders", () => {
 	test("due reminder は config 内 reminder 参照ではなく immutable DTO として返す", () => {

--- a/spec/scheduling/heartbeat-scheduler.spec.ts
+++ b/spec/scheduling/heartbeat-scheduler.spec.ts
@@ -69,6 +69,118 @@ describe("HeartbeatScheduler", () => {
 		expect(intervalMs.at(-1)).toBe(5 * 60_000);
 	});
 
+	test("preFilter が返した reminders を heartbeatService.execute に渡す", async () => {
+		const configRepo = createMockConfigRepo({
+			baseIntervalMinutes: 1,
+			reminders: [
+				{
+					id: "email-check",
+					description: "メール確認",
+					schedule: { type: "interval", minutes: 5 },
+					lastExecutedAt: null,
+					enabled: true,
+				},
+			],
+		});
+		const enriched = {
+			reminder: {
+				id: "email-check",
+				description: "メール確認",
+				schedule: { type: "interval" as const, minutes: 5 },
+				lastExecutedAt: null,
+				enabled: true,
+			},
+			overdueMinutes: 0,
+			context: "<email_context>新着</email_context>",
+		};
+		const heartbeatService = {
+			execute: mock((reminders: { context?: string }[]) => {
+				capturedContext = reminders[0]?.context;
+				return Promise.resolve(new Set(["email-check"]));
+			}),
+		};
+		let capturedContext: string | undefined;
+		const scheduler = new HeartbeatScheduler({
+			configRepo,
+			heartbeatService,
+			logger: createMockLogger(),
+			preFilter: mock(() => Promise.resolve({ reminders: [enriched] })),
+		});
+		const tick = scheduler as unknown as { tick(): Promise<void> };
+
+		await tick.tick();
+
+		expect(heartbeatService.execute).toHaveBeenCalledTimes(1);
+		expect(capturedContext).toBe("<email_context>新着</email_context>");
+		expect(configRepo.markRemindersExecuted).toHaveBeenCalledWith(
+			["email-check"],
+			expect.any(String),
+		);
+	});
+
+	test("preFilter の reminders が空でも markExecutedIds があれば markRemindersExecuted を呼び execute はしない", async () => {
+		const configRepo = createMockConfigRepo({
+			baseIntervalMinutes: 1,
+			reminders: [
+				{
+					id: "email-check",
+					description: "メール確認",
+					schedule: { type: "interval", minutes: 5 },
+					lastExecutedAt: null,
+					enabled: true,
+				},
+			],
+		});
+		const heartbeatService = {
+			execute: mock(() => Promise.resolve(new Set<string>())),
+		};
+		const scheduler = new HeartbeatScheduler({
+			configRepo,
+			heartbeatService,
+			logger: createMockLogger(),
+			preFilter: mock(() => Promise.resolve({ reminders: [], markExecutedIds: ["email-check"] })),
+		});
+		const tick = scheduler as unknown as { tick(): Promise<void> };
+
+		await tick.tick();
+
+		expect(heartbeatService.execute).not.toHaveBeenCalled();
+		expect(configRepo.markRemindersExecuted).toHaveBeenCalledWith(
+			["email-check"],
+			expect.any(String),
+		);
+	});
+
+	test("preFilter の reminders が空で markExecutedIds も無ければ何もしない", async () => {
+		const configRepo = createMockConfigRepo({
+			baseIntervalMinutes: 1,
+			reminders: [
+				{
+					id: "email-check",
+					description: "メール確認",
+					schedule: { type: "interval", minutes: 5 },
+					lastExecutedAt: null,
+					enabled: true,
+				},
+			],
+		});
+		const heartbeatService = {
+			execute: mock(() => Promise.resolve(new Set<string>())),
+		};
+		const scheduler = new HeartbeatScheduler({
+			configRepo,
+			heartbeatService,
+			logger: createMockLogger(),
+			preFilter: mock(() => Promise.resolve({ reminders: [] })),
+		});
+		const tick = scheduler as unknown as { tick(): Promise<void> };
+
+		await tick.tick();
+
+		expect(heartbeatService.execute).not.toHaveBeenCalled();
+		expect(configRepo.markRemindersExecuted).not.toHaveBeenCalled();
+	});
+
 	test("tick timeout 後も実処理が継続中なら次 tick を開始しない", async () => {
 		restoreSetTimeout = accelerateTimeout(HEARTBEAT_TIMEOUT_MS);
 		let resolveExecute!: () => void;


### PR DESCRIPTION
## 概要

GASのメール読み取りAPIをポーリングし、新着メールがない場合はLLM起動をスキップするpreFilter機構を実装。

## 変更点

### `packages/shared/src/types.ts`
- `DueReminder` に `context?: string` を追加

### `packages/scheduling/src/heartbeat-scheduler.ts`
- `HeartbeatSchedulerDeps` に `preFilter` オプションを追加
- `executeHeartbeat` 内で `evaluateDueReminders` 後に preFilter を呼び出し、フィルタ結果が0件の場合は実行をスキップ

### `packages/application/src/heartbeat-service.ts`
- `buildHeartbeatPrompt` が `DueReminder.context` をプロンプトに含めるように修正

### `packages/application/src/email-fetcher.ts` (新規)
- `fetchNewEmails`: GAS エンドポイントから新着メールを取得
- `formatEmailContext`: メール結果をリマインダー用のコンテキスト文字列に整形

### `apps/discord/src/bootstrap.ts`
- `buildEmailCheckPreFilter` 関数を追加
- 環境変数 `GAS_EMAIL_ENDPOINT` / `GAS_EMAIL_TOKEN` が設定されている場合に preFilter として配線
- `email-check` ID のリマインダーに対してのみメールチェックを実行
- 新着メールがない場合は `email-check` リマインダーを除外
- 新着メールがある場合はコンテキストを付与してプロンプトに含める
- エラー時は `email-check` をスキップ（他のリマインダーは影響なし）

## テスト
- `nr validate` (fmt:check + lint + check) ✅
- `nr test` (2460 tests) ✅