### PR TITLE
fix: Minecraft設定とメモリ統合の不整合を修正する

### DIFF
--- a/apps/discord/src/config-schema.ts
+++ b/apps/discord/src/config-schema.ts
@@ -94,46 +94,51 @@ export const shellAgentSchema = z.object({
 	dataDir: z.string(),
 });
 
-export const appConfigSchema = z.object({
-	discordToken: z.string().min(1, "DISCORD_TOKEN is required"),
-	webPort: safeInt,
-	gatewayPort: safeInt,
-	opencode: z.object({
-		providerId: z.string(),
-		modelId: z.string(),
-		basePort: safeInt,
-		sessionMaxAgeHours: safeNumber,
-		temperature: safeNumber.min(0).max(2),
-	}),
-	heartbeatOpencode: z.object({
-		providerId: z.string(),
-		modelId: z.string(),
-		temperature: safeNumber.min(0).max(2),
-	}),
-	memory: z.object({
-		providerId: z.string(),
-		modelId: z.string(),
-		ollamaBaseUrl: z.string(),
-		embeddingModel: z.string(),
-	}),
-	mcBrain: z
-		.object({
+export const appConfigSchema = z
+	.object({
+		discordToken: z.string().min(1, "DISCORD_TOKEN is required"),
+		webPort: safeInt,
+		gatewayPort: safeInt,
+		opencode: z.object({
+			providerId: z.string(),
+			modelId: z.string(),
+			basePort: safeInt,
+			sessionMaxAgeHours: safeNumber,
+			temperature: safeNumber.min(0).max(2),
+		}),
+		heartbeatOpencode: z.object({
 			providerId: z.string(),
 			modelId: z.string(),
 			temperature: safeNumber.min(0).max(2),
-		})
-		.optional(),
-	tts: ttsSchema.optional(),
-	minecraft: minecraftSchema.optional(),
-	github: githubSchema.optional(),
-	emailCheck: emailCheckSchema.optional(),
-	discordDm: discordDmSchema.optional(),
-	imageRecognition: imageRecognitionSchema.optional(),
-	emotionEstimation: emotionEstimationSchema.optional(),
-	shellAgent: shellAgentSchema.optional(),
-	dataDir: z.string(),
-	contextDir: z.string(),
-});
+		}),
+		memory: z.object({
+			providerId: z.string(),
+			modelId: z.string(),
+			ollamaBaseUrl: z.string(),
+			embeddingModel: z.string(),
+		}),
+		mcBrain: z
+			.object({
+				providerId: z.string(),
+				modelId: z.string(),
+				temperature: safeNumber.min(0).max(2),
+			})
+			.optional(),
+		tts: ttsSchema.optional(),
+		minecraft: minecraftSchema.optional(),
+		github: githubSchema.optional(),
+		emailCheck: emailCheckSchema.optional(),
+		discordDm: discordDmSchema.optional(),
+		imageRecognition: imageRecognitionSchema.optional(),
+		emotionEstimation: emotionEstimationSchema.optional(),
+		shellAgent: shellAgentSchema.optional(),
+		dataDir: z.string(),
+		contextDir: z.string(),
+	})
+	.refine((config) => Boolean(config.minecraft) === Boolean(config.mcBrain), {
+		message: "minecraft and mcBrain must both be configured or both be absent",
+		path: ["minecraft"],
+	});
 
 export type TtsConfig = z.infer<typeof ttsSchema>;
 export type MinecraftConfig = z.infer<typeof minecraftSchema>;

--- a/apps/discord/src/config.test.ts
+++ b/apps/discord/src/config.test.ts
@@ -31,11 +31,6 @@ const BASE_PROFILE = {
 			ollamaBaseUrl: "http://localhost:11434",
 			embeddingModel: "embedding-model",
 		},
-		minecraft: {
-			providerId: "mc-provider",
-			modelId: "mc-model",
-			temperature: 0.4,
-		},
 	},
 	features: {},
 };

--- a/apps/discord/src/profile-config.ts
+++ b/apps/discord/src/profile-config.ts
@@ -48,51 +48,59 @@ const discordDmProfileSchema = z.strictObject({
 		.min(1),
 });
 
-export const profileConfigSchema = z.strictObject({
-	$schema: z.string().min(1).optional(),
-	ports: z.strictObject({
-		web: safeInt,
-		gateway: safeInt,
-		opencodeBase: safeInt,
-	}),
-	session: z.strictObject({
-		maxAgeHours: safeNumber,
-	}),
-	models: z.strictObject({
-		conversation: modelSelectionSchema.extend({
-			temperature: safeNumber.min(0).max(2),
+export const profileConfigSchema = z
+	.strictObject({
+		$schema: z.string().min(1).optional(),
+		ports: z.strictObject({
+			web: safeInt,
+			gateway: safeInt,
+			opencodeBase: safeInt,
 		}),
-		heartbeat: modelSelectionSchema.extend({
-			temperature: safeNumber.min(0).max(2),
+		session: z.strictObject({
+			maxAgeHours: safeNumber,
 		}),
-		memory: modelSelectionSchema.extend({
-			ollamaBaseUrl: z.string().min(1),
-			embeddingModel: z.string().min(1),
-		}),
-		minecraft: modelSelectionSchema
-			.extend({
+		models: z.strictObject({
+			conversation: modelSelectionSchema.extend({
 				temperature: safeNumber.min(0).max(2),
-			})
-			.optional(),
-	}),
-	features: z.strictObject({
-		discordDm: discordDmProfileSchema.optional(),
-		imageRecognition: modelSelectionSchema.optional(),
-		emotionEstimation: emotionEstimationProfileSchema.optional(),
-		shellAgent: z
-			.strictObject({
-				agent: modelSelectionSchema,
-				environment: shellAgentProfileEnvironmentSchema.optional(),
-				git: shellAgentGitSchema.optional(),
-				backgroundSubagents: z.literal(true).optional(),
-			})
-			.optional(),
-		minecraft: minecraftSchema.optional(),
-		tts: ttsSchema.optional(),
-		githubIssues: z.strictObject({}).optional(),
-		emailCheck: z.strictObject({}).optional(),
-	}),
-});
+			}),
+			heartbeat: modelSelectionSchema.extend({
+				temperature: safeNumber.min(0).max(2),
+			}),
+			memory: modelSelectionSchema.extend({
+				ollamaBaseUrl: z.string().min(1),
+				embeddingModel: z.string().min(1),
+			}),
+			minecraft: modelSelectionSchema
+				.extend({
+					temperature: safeNumber.min(0).max(2),
+				})
+				.optional(),
+		}),
+		features: z.strictObject({
+			discordDm: discordDmProfileSchema.optional(),
+			imageRecognition: modelSelectionSchema.optional(),
+			emotionEstimation: emotionEstimationProfileSchema.optional(),
+			shellAgent: z
+				.strictObject({
+					agent: modelSelectionSchema,
+					environment: shellAgentProfileEnvironmentSchema.optional(),
+					git: shellAgentGitSchema.optional(),
+					backgroundSubagents: z.literal(true).optional(),
+				})
+				.optional(),
+			minecraft: minecraftSchema.optional(),
+			tts: ttsSchema.optional(),
+			githubIssues: z.strictObject({}).optional(),
+			emailCheck: z.strictObject({}).optional(),
+		}),
+	})
+	.superRefine((profile, ctx) => {
+		if (Boolean(profile.models.minecraft) === Boolean(profile.features.minecraft)) return;
+		ctx.addIssue({
+			code: "custom",
+			message: "models.minecraft and features.minecraft must be configured together",
+		});
+	});
 
 export type ProfileConfig = z.infer<typeof profileConfigSchema>;
 

--- a/packages/memory/src/consolidation-contract.ts
+++ b/packages/memory/src/consolidation-contract.ts
@@ -77,8 +77,14 @@ function validateFactFields(obj: Record<string, unknown>, i: number): void {
 }
 
 function validateKeywords(obj: Record<string, unknown>, i: number): void {
-	if (!Array.isArray(obj["keywords"])) {
-		throw new TypeError(`facts[${i}].keywords: expected array`);
+	const rawKeywords = obj["keywords"];
+	if (typeof rawKeywords === "string") {
+		obj["keywords"] = rawKeywords
+			.split(",")
+			.map((keyword) => keyword.trim())
+			.filter((keyword) => keyword !== "");
+	} else if (!Array.isArray(rawKeywords)) {
+		throw new TypeError(`facts[${i}].keywords: expected array or string`);
 	}
 	const keywords = obj["keywords"] as unknown[];
 	if (keywords.length > MAX_KEYWORDS_PER_FACT) {

--- a/spec/core/config.spec.ts
+++ b/spec/core/config.spec.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { resolve } from "path";
 
+import { appConfigSchema } from "../../apps/discord/src/config-schema.ts";
 import { loadConfig } from "../../apps/discord/src/config.ts";
 
 const root = "/tmp/test-vicissitude";
@@ -38,7 +39,42 @@ const baseProfile = {
 			temperature: 0.4,
 		},
 	},
-	features: {},
+	features: {
+		minecraft: {
+			host: "localhost",
+			port: 25565,
+			username: "hua",
+			authMode: "offline" as const,
+			mcpPort: 3001,
+			viewerPort: 3002,
+		},
+	},
+};
+
+const baseAppConfig = {
+	discordToken: "test-token",
+	webPort: 4100,
+	gatewayPort: 4101,
+	opencode: {
+		providerId: "conversation-provider",
+		modelId: "conversation-model",
+		basePort: 5000,
+		sessionMaxAgeHours: 24,
+		temperature: 0.8,
+	},
+	heartbeatOpencode: {
+		providerId: "heartbeat-provider",
+		modelId: "heartbeat-model",
+		temperature: 0.3,
+	},
+	memory: {
+		providerId: "memory-provider",
+		modelId: "memory-model",
+		ollamaBaseUrl: "http://localhost:11434",
+		embeddingModel: "embedding-model",
+	},
+	dataDir: "/tmp/test-vicissitude/data",
+	contextDir: "/tmp/test-vicissitude/context",
 };
 
 function env(filepath: string, overrides: Record<string, string> = {}): Record<string, string> {
@@ -48,6 +84,38 @@ function env(filepath: string, overrides: Record<string, string> = {}): Record<s
 		...overrides,
 	};
 }
+
+describe("appConfigSchema", () => {
+	const minecraft = {
+		host: "localhost",
+		port: 25565,
+		username: "hua",
+		authMode: "offline" as const,
+		mcpPort: 3001,
+		viewerPort: 3002,
+	};
+	const mcBrain = {
+		providerId: "mc-provider",
+		modelId: "mc-model",
+		temperature: 0.4,
+	};
+
+	it("minecraft と mcBrain が両方存在する設定を受理する", () => {
+		expect(appConfigSchema.safeParse({ ...baseAppConfig, minecraft, mcBrain }).success).toBe(true);
+	});
+
+	it("minecraft と mcBrain が両方不在の設定を受理する", () => {
+		expect(appConfigSchema.safeParse(baseAppConfig).success).toBe(true);
+	});
+
+	it("minecraft だけが存在する設定を reject する", () => {
+		expect(appConfigSchema.safeParse({ ...baseAppConfig, minecraft }).success).toBe(false);
+	});
+
+	it("mcBrain だけが存在する設定を reject する", () => {
+		expect(appConfigSchema.safeParse({ ...baseAppConfig, mcBrain }).success).toBe(false);
+	});
+});
 
 describe("loadConfig", () => {
 	const tempDirs: string[] = [];
@@ -107,7 +175,9 @@ describe("loadConfig", () => {
 	});
 
 	it("旧 env loader の非 secret 設定は読み込まない", () => {
-		const filepath = writeProfileFile(baseProfile);
+		const { minecraft: _model, ...models } = baseProfile.models;
+		const { minecraft: _feature, ...features } = baseProfile.features;
+		const filepath = writeProfileFile({ ...baseProfile, models, features });
 		const config = loadConfig(
 			env(filepath, {
 				OPENCODE_PROVIDER_ID: "env-provider",

--- a/spec/core/profile-config.spec.ts
+++ b/spec/core/profile-config.spec.ts
@@ -52,7 +52,16 @@ const baseProfile = {
 			temperature: 0.4,
 		},
 	},
-	features: {},
+	features: {
+		minecraft: {
+			host: "localhost",
+			port: 25565,
+			username: "hua",
+			authMode: "offline" as const,
+			mcpPort: 3001,
+			viewerPort: 3002,
+		},
+	},
 };
 
 describe("JSON profile config", () => {
@@ -76,6 +85,29 @@ describe("JSON profile config", () => {
 		const parsed = profileConfigSchema.parse(baseProfile);
 
 		expect(parsed.ports.web).toBe(4100);
+	});
+
+	it("models.minecraft と features.minecraft が両方存在する profile を受理する", () => {
+		expect(profileConfigSchema.safeParse(baseProfile).success).toBe(true);
+	});
+
+	it("models.minecraft と features.minecraft が両方不在の profile を受理する", () => {
+		const { minecraft: _model, ...models } = baseProfile.models;
+		const { minecraft: _feature, ...features } = baseProfile.features;
+
+		expect(profileConfigSchema.safeParse({ ...baseProfile, models, features }).success).toBe(true);
+	});
+
+	it("models.minecraft だけが存在する profile を reject する", () => {
+		const { minecraft: _omit, ...features } = baseProfile.features;
+
+		expect(profileConfigSchema.safeParse({ ...baseProfile, features }).success).toBe(false);
+	});
+
+	it("features.minecraft だけが存在する profile を reject する", () => {
+		const { minecraft: _omit, ...models } = baseProfile.models;
+
+		expect(profileConfigSchema.safeParse({ ...baseProfile, models }).success).toBe(false);
 	});
 
 	it("$schema metadata を含む profile も読み込める", () => {
@@ -129,7 +161,9 @@ describe("JSON profile config", () => {
 	});
 
 	it("profile の disabled feature は key ごと省略する", () => {
-		const config = loadConfigFromProfile(baseProfile, baseEnv(), root);
+		const { minecraft: _model, ...models } = baseProfile.models;
+		const { minecraft: _feature, ...features } = baseProfile.features;
+		const config = loadConfigFromProfile({ ...baseProfile, models, features }, baseEnv(), root);
 
 		expect(config.imageRecognition).toBeUndefined();
 		expect(config.emotionEstimation).toBeUndefined();
@@ -137,15 +171,13 @@ describe("JSON profile config", () => {
 		expect(config.minecraft).toBeUndefined();
 	});
 
-	it("models.minecraft 未設定の profile でも AppConfig を構築でき mcBrain は undefined になる", () => {
-		const { minecraft: _omit, ...modelsWithoutMinecraft } = baseProfile.models;
-		const config = loadConfigFromProfile(
-			{ ...baseProfile, models: modelsWithoutMinecraft },
-			baseEnv(),
-			root,
-		);
+	it("minecraft 未設定の profile でも AppConfig を構築でき mcBrain と minecraft は undefined になる", () => {
+		const { minecraft: _model, ...models } = baseProfile.models;
+		const { minecraft: _feature, ...features } = baseProfile.features;
+		const config = loadConfigFromProfile({ ...baseProfile, models, features }, baseEnv(), root);
 
 		expect(config.mcBrain).toBeUndefined();
+		expect(config.minecraft).toBeUndefined();
 	});
 
 	it("profile に feature section がある場合だけ機能設定を作る", () => {
@@ -153,6 +185,7 @@ describe("JSON profile config", () => {
 			{
 				...baseProfile,
 				features: {
+					...baseProfile.features,
 					imageRecognition: {
 						providerId: "vision-provider",
 						modelId: "vision-model",
@@ -222,7 +255,7 @@ describe("JSON profile config", () => {
 		const config = loadConfigFromProfile(
 			{
 				...baseProfile,
-				features: { emailCheck: {} },
+				features: { ...baseProfile.features, emailCheck: {} },
 			},
 			baseEnv({
 				GAS_EMAIL_ENDPOINT: "https://script.google.com/exec",
@@ -246,7 +279,7 @@ describe("JSON profile config", () => {
 	it("features.emailCheck 設定時に GAS_EMAIL_ENDPOINT が無ければエラーにする", () => {
 		expect(() =>
 			loadConfigFromProfile(
-				{ ...baseProfile, features: { emailCheck: {} } },
+				{ ...baseProfile, features: { ...baseProfile.features, emailCheck: {} } },
 				baseEnv({ GAS_EMAIL_TOKEN: "test-email-token" }),
 				root,
 			),
@@ -256,7 +289,7 @@ describe("JSON profile config", () => {
 	it("features.emailCheck 設定時に GAS_EMAIL_TOKEN が無ければエラーにする", () => {
 		expect(() =>
 			loadConfigFromProfile(
-				{ ...baseProfile, features: { emailCheck: {} } },
+				{ ...baseProfile, features: { ...baseProfile.features, emailCheck: {} } },
 				baseEnv({ GAS_EMAIL_ENDPOINT: "https://script.google.com/exec" }),
 				root,
 			),
@@ -269,6 +302,7 @@ describe("JSON profile config", () => {
 				{
 					...baseProfile,
 					features: {
+						...baseProfile.features,
 						shellAgent: {
 							agent: {
 								providerId: "shell-provider",

--- a/spec/memory/consolidation.spec.ts
+++ b/spec/memory/consolidation.spec.ts
@@ -948,7 +948,33 @@ describe("ConsolidationPipeline — schema validation", () => {
 		expect(facts[0]?.fact).toBe("Some fact");
 	});
 
-	test("rejects fact with non-array keywords", async () => {
+	test("normalizes comma-separated string keywords by trimming and removing empty entries", async () => {
+		const episode = makeEpisode();
+		await storage.saveEpisode(userId, episode);
+
+		const pipeline = new ConsolidationPipeline(
+			createMockLLM({
+				structuredResponse: {
+					facts: [
+						{
+							action: "new",
+							category: "preference",
+							fact: "Some fact",
+							keywords: " typescript, , programming, memory,  ",
+						},
+					],
+				},
+			}),
+			storage,
+		);
+		const result = await pipeline.consolidate(userId);
+
+		expect(result.newFacts).toBe(1);
+		const facts = await storage.getFacts(userId);
+		expect(facts[0]?.keywords).toEqual(["typescript", "programming", "memory"]);
+	});
+
+	test("rejects comma-separated string keywords exceeding the keyword count limit", async () => {
 		const episode = makeEpisode();
 		await storage.saveEpisode(userId, episode);
 
@@ -959,7 +985,28 @@ describe("ConsolidationPipeline — schema validation", () => {
 						action: "new",
 						category: "preference",
 						fact: "Some fact",
-						keywords: "not-an-array",
+						keywords: "one,two,three,four,five,six,seven,eight,nine,ten,eleven",
+					},
+				],
+			}),
+			storage,
+		);
+
+		expect(pipeline.consolidate(userId)).rejects.toThrow("too many keywords");
+	});
+
+	test("rejects keywords that are neither an array nor a string", async () => {
+		const episode = makeEpisode();
+		await storage.saveEpisode(userId, episode);
+
+		const pipeline = new ConsolidationPipeline(
+			createInvalidLLM({
+				facts: [
+					{
+						action: "new",
+						category: "preference",
+						fact: "Some fact",
+						keywords: 123,
 					},
 				],
 			}),


### PR DESCRIPTION
## 概要
- appConfig/profile schema で Minecraft feature と model の同時存在・不在を強制
- memory consolidation のカンマ区切り keywords を配列へ正規化
- 空 keyword 除去と上限検証を追加

Closes #1027
Closes #1038

## 検証
- nr validate
- nr test (2527 pass)