### PR TITLE
fix(discord): Gateway再接続時に会話ループを復旧する

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -604,6 +604,10 @@ function setupEventHandlers(deps: {
 	trustedUserIds: string[];
 }): void {
 	const { gateway, ingestionService, metricsCollector, agents, logger, trustedUserIds } = deps;
+	gateway.onResume(() => {
+		logger.info(`[bootstrap] Discord Gateway resumed; ensuring ${agents.size} conversation loops`);
+		for (const agent of agents.values()) agent.ensurePolling();
+	});
 	gateway.onHomeChannelMessage(async (msg) => {
 		const selfUserId = gateway.getClient()?.user?.id;
 		const scopeId = msg.scopeId ?? (msg.guildId ? discordScopeId(msg.guildId) : undefined);

--- a/apps/discord/src/gateway/discord.ts
+++ b/apps/discord/src/gateway/discord.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines -- Discord Gateway integration is kept in one adapter */
 import { mapAttachments } from "@vicissitude/infrastructure/discord/attachment-mapper";
 import { rewriteTwitterUrls } from "@vicissitude/infrastructure/discord/url-rewriter";
 import { discordDmScopeId, discordScopeId } from "@vicissitude/shared/namespace";
@@ -13,6 +14,7 @@ import {
 
 type MessageHandler = (msg: IncomingMessage, ch: MessageChannel) => Promise<void>;
 type EmojiUsedHandler = (guildId: string, emojiName: string) => void;
+type ResumeHandler = () => void;
 
 /** カスタム絵文字パターン: <:name:id> or <a:name:id> */
 const CUSTOM_EMOJI_RE = /<a?:(\w+):\d+>/g;
@@ -25,6 +27,8 @@ export class DiscordGateway {
 	private homeChannelIds: Set<string> = new Set();
 	private allowedDirectMessageUserIds: Set<string> = new Set();
 	private emojiUsedHandler: EmojiUsedHandler | null = null;
+	private resumeHandler: ResumeHandler | null = null;
+	private readyShardIds: Set<number> = new Set();
 
 	constructor(
 		private readonly token: string,
@@ -45,6 +49,10 @@ export class DiscordGateway {
 
 	onEmojiUsed(handler: EmojiUsedHandler): void {
 		this.emojiUsedHandler = handler;
+	}
+
+	onResume(handler: ResumeHandler): void {
+		this.resumeHandler = handler;
 	}
 
 	/**
@@ -83,6 +91,7 @@ export class DiscordGateway {
 			this.logger.info(`[discord] Logged in as ${readyClient.user.tag}`);
 		});
 
+		this.registerLifecycleHandlers(client);
 		this.registerMessageHandler(client);
 		this.registerReactionHandler(client);
 		this.registerThreadUpdateHandler(client);
@@ -94,6 +103,30 @@ export class DiscordGateway {
 		this.client = client;
 
 		this.joinHomeThreads(client);
+	}
+
+	private registerLifecycleHandlers(client: Client): void {
+		client.on(Events.ShardDisconnect, (event, shardId) => {
+			this.logger.warn(`[discord] shard ${shardId} disconnected (code=${event.code})`);
+		});
+		client.on(Events.ShardError, (error, shardId) => {
+			this.logger.error(`[discord] shard ${shardId} error`, error);
+		});
+		client.on(Events.ShardReconnecting, (shardId) => {
+			this.logger.warn(`[discord] shard ${shardId} reconnecting`);
+		});
+		client.on(Events.ShardReady, (shardId, unavailableGuilds) => {
+			const reconnected = this.readyShardIds.has(shardId);
+			this.readyShardIds.add(shardId);
+			this.logger.info(
+				`[discord] shard ${shardId} ready (unavailableGuilds=${unavailableGuilds?.size ?? 0}, reconnected=${reconnected})`,
+			);
+			if (reconnected) this.resumeHandler?.();
+		});
+		client.on(Events.ShardResume, (shardId, replayedEvents) => {
+			this.logger.info(`[discord] shard ${shardId} resumed (replayedEvents=${replayedEvents})`);
+			this.resumeHandler?.();
+		});
 	}
 
 	stop(): void {

--- a/spec/discord/gateway/discord-gateway-lifecycle.spec.ts
+++ b/spec/discord/gateway/discord-gateway-lifecycle.spec.ts
@@ -1,0 +1,113 @@
+/* oxlint-disable require-await, no-constructor-return, typescript/no-floating-promises -- テスト用モック */
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { Logger } from "@vicissitude/shared/types";
+import { Events } from "discord.js";
+
+import { DiscordGateway } from "../../../apps/discord/src/gateway/discord";
+
+function createMockClient() {
+	const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+	const mockClient = {
+		user: { id: "bot-user-id", tag: "TestBot#0001" },
+		login: mock(async () => {}),
+		destroy: mock(() => {}),
+		once: mock((_event: string, _cb: (...args: unknown[]) => void) => {}),
+		on: mock((event: string, cb: (...args: unknown[]) => void) => {
+			listeners.set(event, [...(listeners.get(event) ?? []), cb]);
+		}),
+		channels: { fetch: mock(async () => null) },
+	};
+	return {
+		mockClient,
+		emit(event: string, ...args: unknown[]) {
+			for (const listener of listeners.get(event) ?? []) listener(...args);
+		},
+	};
+}
+
+function createSpyLogger() {
+	const calls: { level: string; args: unknown[] }[] = [];
+	const logger: Logger = {
+		debug: (...args) => calls.push({ level: "debug", args }),
+		info: (...args) => calls.push({ level: "info", args }),
+		warn: (...args) => calls.push({ level: "warn", args }),
+		error: (...args) => calls.push({ level: "error", args }),
+		child: () => logger,
+	};
+	return { logger, calls };
+}
+
+let currentMockClient: ReturnType<typeof createMockClient>;
+
+mock.module("discord.js", () => {
+	// oxlint-disable-next-line typescript/no-require-imports
+	const actual = require("discord.js");
+	// oxlint-disable-next-line typescript/no-unsafe-return -- mock.module のコールバックは require() の any を spread するため
+	return {
+		...actual,
+		// oxlint-disable-next-line no-constructor-return, typescript/no-extraneous-class
+		Client: class MockedClient {
+			constructor() {
+				return currentMockClient.mockClient as unknown as MockedClient;
+			}
+		},
+	};
+});
+
+describe("DiscordGateway Gateway lifecycle", () => {
+	beforeEach(() => {
+		currentMockClient = createMockClient();
+	});
+
+	it("切断・エラー・再接続・resume を shard ID とともに記録する", async () => {
+		const { logger, calls } = createSpyLogger();
+		const gateway = new DiscordGateway("fake-token", logger);
+		await gateway.start();
+
+		currentMockClient.emit(Events.ShardDisconnect, { code: 1006, reason: "network" }, 2);
+		currentMockClient.emit(Events.ShardError, new Error("socket failed"), 2);
+		currentMockClient.emit(Events.ShardReconnecting, 2);
+		currentMockClient.emit(Events.ShardResume, 2, 7);
+
+		const messages = calls.map(({ level, args }) => `${level}:${String(args[0])}`);
+		expect(
+			messages.some((message) => message.includes("warn:[discord] shard 2 disconnected")),
+		).toBe(true);
+		expect(messages.some((message) => message.includes("error:[discord] shard 2 error"))).toBe(
+			true,
+		);
+		expect(
+			messages.some((message) => message.includes("warn:[discord] shard 2 reconnecting")),
+		).toBe(true);
+		expect(messages.some((message) => message.includes("info:[discord] shard 2 resumed"))).toBe(
+			true,
+		);
+	});
+
+	it("resume 時に登録済み復旧ハンドラを呼ぶ", async () => {
+		const { logger } = createSpyLogger();
+		const gateway = new DiscordGateway("fake-token", logger);
+		const onResume = mock(() => {});
+		gateway.onResume(onResume);
+		await gateway.start();
+
+		currentMockClient.emit(Events.ShardResume, 3, 12);
+
+		expect(onResume).toHaveBeenCalledTimes(1);
+	});
+
+	it("同一 shard の2回目の ready 時にも復旧ハンドラを呼ぶ", async () => {
+		const { logger } = createSpyLogger();
+		const gateway = new DiscordGateway("fake-token", logger);
+		const onResume = mock(() => {});
+		gateway.onResume(onResume);
+		await gateway.start();
+
+		currentMockClient.emit(Events.ShardReady, 1, new Set());
+		expect(onResume).not.toHaveBeenCalled();
+
+		currentMockClient.emit(Events.ShardReady, 1, new Set());
+		expect(onResume).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## 概要
- Discord Gateway の shard disconnect/error/reconnecting/resume/ready をログ記録
- resume または fresh reconnect 後に全会話 agent の ensurePolling() を再実行
- Gateway lifecycle の仕様テストを追加

Closes #1037

## 検証
- nr validate
- nr test (2530 pass, 0 fail)