### PR TITLE
refactor(shared): sleep/isRecord/abortReasonToError を単一ソース化する

### DIFF
--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -7,7 +7,7 @@ import {
 	METRIC,
 	recordTokenMetrics,
 } from "@vicissitude/observability/metrics";
-import { JST_OFFSET_MS, raceAbort } from "@vicissitude/shared/functions";
+import { JST_OFFSET_MS, raceAbort, sleep } from "@vicissitude/shared/functions";
 import type {
 	AgentResponse,
 	AiAgent,
@@ -1026,23 +1026,6 @@ detail: ${activity.message}
 	}
 
 	protected sleep(ms: number): Promise<void> {
-		if (this.abortController?.signal.aborted) return Promise.resolve();
-		return new Promise((resolve) => {
-			let resolved = false;
-			const done = () => {
-				if (resolved) return;
-				resolved = true;
-				resolve();
-			};
-			const timer = setTimeout(done, ms);
-			this.abortController?.signal.addEventListener(
-				"abort",
-				() => {
-					clearTimeout(timer);
-					done();
-				},
-				{ once: true },
-			);
-		});
+		return sleep(ms, this.abortController?.signal);
 	}
 }

--- a/packages/agent/src/web/web-agent.ts
+++ b/packages/agent/src/web/web-agent.ts
@@ -1,4 +1,4 @@
-import { escapeUserMessageTag } from "@vicissitude/shared/functions";
+import { abortReasonToError, escapeUserMessageTag, raceAbort } from "@vicissitude/shared/functions";
 import { agentScopeNamespace } from "@vicissitude/shared/namespace";
 import type {
 	AgentResponse,
@@ -131,7 +131,7 @@ export class WebConversationAgent {
 
 		this.logger.info(`[${this.profile.name}:${this.agentId}] prompting Web session ${sessionId}`);
 		const promptSignal = createPromptSignal(request.signal, this.promptTimeoutMs);
-		if (promptSignal.aborted) throw abortReasonToError(promptSignal.reason);
+		if (promptSignal.aborted) throw abortReasonToError(promptSignal);
 		const result = await raceAbort(
 			this.sessionPort.prompt(
 				{
@@ -199,21 +199,4 @@ export class WebConversationAgent {
 function createPromptSignal(parentSignal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
 	const timeoutSignal = AbortSignal.timeout(timeoutMs);
 	return parentSignal ? AbortSignal.any([parentSignal, timeoutSignal]) : timeoutSignal;
-}
-
-function abortReasonToError(reason: unknown): Error {
-	if (reason instanceof Error) return reason;
-	return new DOMException("Web conversation request aborted", "AbortError");
-}
-
-function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
-	if (signal.aborted) return Promise.reject(abortReasonToError(signal.reason));
-
-	return new Promise<T>((resolve, reject) => {
-		const onAbort = () => reject(abortReasonToError(signal.reason));
-		signal.addEventListener("abort", onAbort, { once: true });
-		void promise.then(resolve, reject).finally(() => {
-			signal.removeEventListener("abort", onAbort);
-		});
-	});
 }

--- a/packages/mcp/src/emotion-error-info.ts
+++ b/packages/mcp/src/emotion-error-info.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@vicissitude/shared/functions";
+
 export interface EmotionPromptErrorInfo {
 	status?: number;
 	retryable?: boolean;
@@ -67,10 +69,6 @@ function parseEmbeddedJson(text: string): unknown[] {
 	} catch {
 		return [];
 	}
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
 }
 
 function findNumberField(nodes: unknown[], keys: string[]): number | undefined {

--- a/packages/mcp/src/emotion.test.ts
+++ b/packages/mcp/src/emotion.test.ts
@@ -75,4 +75,57 @@ describe("extractEmotionPromptErrorInfo", () => {
 		expect(info.retryAfterSeconds).toBe(120);
 		expect(info.reason).toBe("quota_exceeded");
 	});
+
+	test("探索キーの値が配列の場合は配列自身を展開せず要素のエラー情報も抽出しない", () => {
+		// isRecord の厳格化(配列除外)により、配列はノードとして展開されず、
+		// その要素も再帰探索の対象にならない。
+		const error = {
+			details: [{ message: "inner array message", statusCode: 429, name: "InnerError" }],
+		};
+		const info = extractEmotionPromptErrorInfo(error);
+
+		expect(info.status).toBeUndefined();
+		expect(info.message).toBeUndefined();
+		expect(info.errorClass).toBe("Object");
+		expect(info.reason).toBe("unknown");
+	});
+
+	test("cause が配列の場合も配列要素のエラー情報は抽出されない", () => {
+		const error = {
+			cause: [
+				Object.assign(new Error("cause array message"), {
+					statusCode: 503,
+					name: "CauseError",
+				}),
+			],
+		};
+		const info = extractEmotionPromptErrorInfo(error);
+
+		expect(info.status).toBeUndefined();
+		expect(info.retryable).toBeUndefined();
+		expect(info.message).toBeUndefined();
+		expect(info.errorClass).toBe("Object");
+	});
+
+	test("トップレベルが配列でも要素を展開せず errorClass は Array になる", () => {
+		const error = [{ message: "element message", statusCode: 418, name: "ElementError" }];
+		const info = extractEmotionPromptErrorInfo(error);
+
+		expect(info.status).toBeUndefined();
+		expect(info.message).toBeUndefined();
+		expect(info.errorClass).toBe("Array");
+		expect(info.reason).toBe("unknown");
+	});
+
+	test("探索キーの値が単一レコードなら従来どおりエラー情報を抽出する", () => {
+		// 配列ではなく直接レコードを置いた場合は再帰探索でき、回帰の対照となる。
+		const error = {
+			details: { message: "nested record message", statusCode: 500, name: "NestedError" },
+		};
+		const info = extractEmotionPromptErrorInfo(error);
+
+		expect(info.status).toBe(500);
+		expect(info.message).toBe("nested record message");
+		expect(info.errorClass).toBe("NestedError");
+	});
 });

--- a/packages/mcp/src/tools/discord.ts
+++ b/packages/mcp/src/tools/discord.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { filterImageUrls } from "@vicissitude/infrastructure/discord/attachment-mapper";
+import { sleep } from "@vicissitude/shared/functions";
 import type { EmotionAnalyzer, MoodWriter } from "@vicissitude/shared/ports";
 import type { Logger } from "@vicissitude/shared/types";
 import { ChannelType, type Client, type TextChannel } from "discord.js";
@@ -50,12 +51,6 @@ export interface DiscordDeps {
 export interface DiscordToolBounds {
 	guildId?: string;
 	dmUserId?: string;
-}
-
-function sleep(ms: number): Promise<void> {
-	return new Promise<void>((resolve) => {
-		setTimeout(resolve, ms);
-	});
 }
 
 /** 文字数に応じた typing 遅延（2〜5秒） */

--- a/packages/memory/src/chat-adapter.ts
+++ b/packages/memory/src/chat-adapter.ts
@@ -1,3 +1,4 @@
+import { sleep } from "@vicissitude/shared/functions";
 import type { Logger, OpencodeSessionPort } from "@vicissitude/shared/types";
 
 import type { ChatMessage } from "./types.ts";
@@ -117,12 +118,6 @@ export function appendJsonInstruction(messages: ChatMessage[]): ChatMessage[] {
 		augmented[lastIdx] = { ...lastMsg, content: `${lastMsg.content}\n\n${JSON_INSTRUCTION}` };
 	}
 	return augmented;
-}
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => {
-		setTimeout(resolve, ms);
-	});
 }
 
 export function cleanJsonResponse(text: string): string {

--- a/packages/minecraft/src/actions/combat.ts
+++ b/packages/minecraft/src/actions/combat.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { sleep } from "@vicissitude/shared/functions";
 import type mineflayer from "mineflayer";
 import pathfinderPkg from "mineflayer-pathfinder";
 import type { Entity } from "prismarine-entity";
@@ -35,12 +36,6 @@ const ATTACK_RANGE = 3;
 
 /** 攻撃クールダウン（ms） */
 const ATTACK_COOLDOWN_MS = 600;
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => {
-		setTimeout(resolve, ms);
-	});
-}
 
 /** インベントリから最適な武器を見つけて装備する */
 async function equipBestWeapon(bot: mineflayer.Bot): Promise<string> {

--- a/packages/scheduling/src/heartbeat-config.ts
+++ b/packages/scheduling/src/heartbeat-config.ts
@@ -10,6 +10,7 @@ import {
 } from "fs";
 import { dirname, resolve as resolvePath } from "path";
 
+import { isRecord, sleep } from "@vicissitude/shared/functions";
 import { discordScopeId } from "@vicissitude/shared/namespace";
 import type {
 	HeartbeatConfig,
@@ -323,10 +324,6 @@ function migrateLegacyHeartbeatConfigJson(value: unknown): { value: unknown; cha
 	return { value: { ...value, reminders }, changed };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function cloneSchedule(schedule: ReminderSchedule): ReminderSchedule {
 	if (schedule.type === "interval") {
 		return { type: "interval", minutes: schedule.minutes };
@@ -351,10 +348,4 @@ function isFileExistsError(error: unknown): boolean {
 
 function isNotFoundError(error: unknown): boolean {
 	return error instanceof Error && "code" in error && error.code === "ENOENT";
-}
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => {
-		setTimeout(resolve, ms);
-	});
 }

--- a/packages/shared/src/functions.ts
+++ b/packages/shared/src/functions.ts
@@ -24,13 +24,48 @@ export function formatTime(date: Date): string {
 	return `${h}:${mi}`;
 }
 
-// ─── delayResolve ────────────────────────────────────────────────
+// ─── sleep ───────────────────────────────────────────────────────
 
-/** 指定ミリ秒後に値を返す Promise を生成する */
-export function delayResolve<T>(ms: number, value: T): Promise<T> {
-	return new Promise((_resolve) => {
-		setTimeout(() => _resolve(value), ms);
+/**
+ * 指定ミリ秒だけ待機する Promise を返す。
+ *
+ * `signal` が渡され、かつ待機中に abort された場合は、`setTimeout` を待たず
+ * 即座に **resolve** する（reject しない）。すでに abort 済みの signal を渡した
+ * 場合も即座に resolve する。`signal` 省略時は単純な時間待機。
+ *
+ * abort を「エラー」として扱いたい（reject させたい）場合は `sleep` ではなく
+ * `raceAbort` を使うこと。`sleep` は協調的キャンセル（早期復帰）のみを提供する。
+ */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	if (signal?.aborted) return Promise.resolve();
+	return new Promise<void>((resolve) => {
+		let settled = false;
+		const done = () => {
+			if (settled) return;
+			settled = true;
+			resolve();
+		};
+		const timer = setTimeout(done, ms);
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timer);
+				done();
+			},
+			{ once: true },
+		);
 	});
+}
+
+// ─── isRecord ────────────────────────────────────────────────────
+
+/**
+ * 値が「プレーンなレコード」(非 null のオブジェクトで配列でない) かを判定する型ガード。
+ *
+ * 配列は `false` を返す。任意キーへ安全にアクセスするための前提条件として使う。
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 // ─── withTimeout / raceAbort ─────────────────────────────────────
@@ -56,11 +91,14 @@ export async function withTimeout<T>(promise: Promise<T>, ms: number, message: s
 }
 
 /**
- * AbortSignal.reason を Error に正規化する。
- * `AbortSignal.timeout` 由来は `TimeoutError` (DOMException)、
- * `AbortController.abort()` は reason 自体（Error でなければ `AbortError` に正規化）。
+ * AbortSignal を理由つき Error に正規化する。
+ *
+ * `signal.reason` が Error（`AbortSignal.timeout` 由来の `TimeoutError` DOMException 等）
+ * ならそれをそのまま返す。Error でなければ `AbortError`（name="AbortError" の DOMException）に
+ * 正規化する。`signal` 引数を受け取り、内部で `.reason` を読む契約に統一する
+ * （reason を直接受け取る私製版は廃止）。
  */
-function abortReasonToError(signal: AbortSignal): Error {
+export function abortReasonToError(signal: AbortSignal): Error {
 	const reason = signal.reason;
 	if (reason instanceof Error) return reason;
 	return new DOMException("Aborted", "AbortError");

--- a/spec/core/functions.spec.ts
+++ b/spec/core/functions.spec.ts
@@ -2,7 +2,15 @@ import { describe, expect, it, test } from "bun:test";
 
 import { splitMessage } from "@vicissitude/application/split-message";
 import { evaluateDueReminders } from "@vicissitude/scheduling/heartbeat-helpers";
-import { formatTime, formatTimestamp, withTimeout } from "@vicissitude/shared/functions";
+import {
+	abortReasonToError,
+	formatTime,
+	formatTimestamp,
+	isRecord,
+	raceAbort,
+	sleep,
+	withTimeout,
+} from "@vicissitude/shared/functions";
 import type { HeartbeatConfig } from "@vicissitude/shared/types";
 
 // ─── splitMessage ────────────────────────────────────────────────
@@ -289,5 +297,168 @@ describe("withTimeout", () => {
 	test("propagates original error when promise rejects before timeout", () => {
 		const failing = Promise.reject(new Error("original"));
 		expect(withTimeout(failing, 1000, "timed out")).rejects.toThrow("original");
+	});
+});
+
+// ─── sleep ───────────────────────────────────────────────────────
+
+describe("sleep", () => {
+	test("指定ミリ秒後に resolve する", async () => {
+		const start = Date.now();
+		await sleep(20);
+		expect(Date.now() - start).toBeGreaterThanOrEqual(15);
+	});
+
+	test("void に解決する（値を返さない）", async () => {
+		const result = await sleep(1);
+		expect(result).toBeUndefined();
+	});
+
+	test("signal 省略時は時間どおり待機して resolve する", async () => {
+		expect(await sleep(1)).toBeUndefined();
+	});
+
+	test("待機中に abort されたら setTimeout を待たず即座に resolve する（reject しない）", async () => {
+		const controller = new AbortController();
+		const start = Date.now();
+		const promise = sleep(10_000, controller.signal);
+		controller.abort();
+		expect(await promise).toBeUndefined();
+		expect(Date.now() - start).toBeLessThan(1000);
+	});
+
+	test("すでに abort 済みの signal を渡すと即座に resolve する", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		expect(await sleep(10_000, controller.signal)).toBeUndefined();
+	});
+
+	test("abort されなければ通常どおり時間待機して resolve する", async () => {
+		const controller = new AbortController();
+		expect(await sleep(5, controller.signal)).toBeUndefined();
+	});
+});
+
+// ─── isRecord ────────────────────────────────────────────────────
+
+describe("isRecord", () => {
+	test("プレーンオブジェクトは true", () => {
+		expect(isRecord({ a: 1 })).toBe(true);
+	});
+
+	test("空オブジェクトは true", () => {
+		expect(isRecord({})).toBe(true);
+	});
+
+	test("配列は false（レコードとして扱わない）", () => {
+		expect(isRecord([1, 2, 3])).toBe(false);
+	});
+
+	test("空配列も false", () => {
+		expect(isRecord([])).toBe(false);
+	});
+
+	test("null は false", () => {
+		expect(isRecord(null)).toBe(false);
+	});
+
+	test("undefined は false", () => {
+		const value: unknown = undefined;
+		expect(isRecord(value)).toBe(false);
+	});
+
+	test("文字列は false", () => {
+		expect(isRecord("str")).toBe(false);
+	});
+
+	test("数値は false", () => {
+		expect(isRecord(42)).toBe(false);
+	});
+
+	test("型ガードとして value.key へ安全にアクセスできる", () => {
+		const value: unknown = { message: "hello" };
+		if (isRecord(value)) {
+			expect(value.message).toBe("hello");
+		} else {
+			throw new Error("expected isRecord to narrow");
+		}
+	});
+});
+
+// ─── abortReasonToError ──────────────────────────────────────────
+
+describe("abortReasonToError", () => {
+	test("reason が Error ならそのまま返す", () => {
+		const controller = new AbortController();
+		const original = new Error("custom abort");
+		controller.abort(original);
+		expect(abortReasonToError(controller.signal)).toBe(original);
+	});
+
+	test("reason が非 Error なら AbortError(DOMException) に正規化する", () => {
+		const controller = new AbortController();
+		controller.abort("string reason");
+		const error = abortReasonToError(controller.signal);
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe("AbortError");
+	});
+
+	test("reason 未指定（abort()）でも AbortError に正規化する", () => {
+		const controller = new AbortController();
+		controller.abort();
+		const error = abortReasonToError(controller.signal);
+		expect(error.name).toBe("AbortError");
+	});
+
+	test("AbortSignal.timeout 由来の TimeoutError をそのまま返す", async () => {
+		const signal = AbortSignal.timeout(1);
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 10);
+		});
+		const error = abortReasonToError(signal);
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe("TimeoutError");
+	});
+});
+
+// ─── raceAbort ───────────────────────────────────────────────────
+
+describe("raceAbort", () => {
+	test("promise が先に解決したらその値を返す", async () => {
+		const controller = new AbortController();
+		const result = await raceAbort(Promise.resolve("ok"), controller.signal);
+		expect(result).toBe("ok");
+	});
+
+	test("promise が先に reject したらその error を伝播する", () => {
+		const controller = new AbortController();
+		const failing = Promise.reject(new Error("inner failure"));
+		expect(raceAbort(failing, controller.signal)).rejects.toThrow("inner failure");
+	});
+
+	test("signal が先に abort したら abortReasonToError 正規化済み Error で reject する", () => {
+		const controller = new AbortController();
+		const reason = new Error("aborted by signal");
+		// 永久 pending
+		const pending = new Promise<string>(() => {});
+		const promise = raceAbort(pending, controller.signal);
+		controller.abort(reason);
+		expect(promise).rejects.toBe(reason);
+	});
+
+	test("すでに abort 済みの signal なら即座に reject する", () => {
+		const controller = new AbortController();
+		controller.abort();
+		const pending = new Promise<string>(() => {});
+		const promise = raceAbort(pending, controller.signal);
+		expect(promise).rejects.toThrow();
+	});
+
+	test("非 Error reason での abort は AbortError に正規化して reject する", () => {
+		const controller = new AbortController();
+		const pending = new Promise<string>(() => {});
+		const promise = raceAbort(pending, controller.signal);
+		controller.abort("nope");
+		expect(promise).rejects.toMatchObject({ name: "AbortError" });
 	});
 });


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 0**（横断ユーティリティ集約 + デッドコード削除）の第1弾。横断調査で複数パッケージに散在していた重複ユーティリティを `packages/shared` に集約する。

## 変更内容

| 対象 | 内容 |
|---|---|
| `sleep(ms, signal?)` | 新設。`signal` abort 時は **resolve**（reject しない）。mcp / scheduling / minecraft / memory の各自定義を置換。`agent/runner` の `protected sleep` は `this.abortController?.signal` を渡すラッパー化（呼び出し側不変） |
| `isRecord` | 配列除外の厳格版として新設。`mcp/emotion-error-info`・`scheduling/heartbeat-config` の重複を置換 |
| `abortReasonToError` | export 昇格（signal ベースに統一）。`agent/web/web-agent` の私製 `raceAbort`/`abortReasonToError` を廃止し、呼び出しを `reason→signal` へ修正 |
| `delayResolve` | 未使用のため削除 |

## 挙動差の扱い

- **emotion-error-info の isRecord 厳格化**: 旧の非厳格版でも `collectErrorNodes` に配列要素を展開する経路は無く、配列から有用情報は元々抽出されていなかった。実質的な挙動差はゼロ。現挙動を `emotion.test.ts` に回帰ガードとして固定。
- **web-agent の非Error abort メッセージ文字列**: 内部メッセージのみ変化（`name="AbortError"` は保持、spec で固定済み）。

## 検証

- `nr validate`（fmt:check + lint --type-aware + check）green
- `nr test`: **2558 pass / 0 fail**（baseline 2554 + 新規4）

## ロードマップ

`ollama` は shared 非依存方針のため対象外。Phase 0 の残り: formatErrorMessage 集約 / デッドコード削除 / 感情weight集約 / fetchWithTimeout集約。

🤖 Generated with [Claude Code](https://claude.com/claude-code)