### PR TITLE
refactor(shared): formatErrorMessage を単一ソース化する

### DIFF
--- a/packages/agent/src/discord/image-attachment-describer.ts
+++ b/packages/agent/src/discord/image-attachment-describer.ts
@@ -1,4 +1,4 @@
-import { raceAbort } from "@vicissitude/shared/functions";
+import { formatErrorMessage, raceAbort } from "@vicissitude/shared/functions";
 import type {
 	Attachment,
 	AttachmentProcessor,
@@ -58,16 +58,6 @@ function appendDescriptionFailure(text: string, reason: string): string {
 
 function isAbortLike(error: unknown): boolean {
 	return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
-}
-
-function formatErrorMessage(error: unknown): string {
-	if (error instanceof Error) return `${error.name}: ${error.message}`;
-	if (typeof error === "string") return error;
-	try {
-		return JSON.stringify(error) ?? String(error);
-	} catch {
-		return String(error);
-	}
 }
 
 export interface ImageAttachmentDescriberOptions {

--- a/packages/agent/src/runner.ts
+++ b/packages/agent/src/runner.ts
@@ -7,7 +7,7 @@ import {
 	METRIC,
 	recordTokenMetrics,
 } from "@vicissitude/observability/metrics";
-import { JST_OFFSET_MS, raceAbort, sleep } from "@vicissitude/shared/functions";
+import { formatErrorMessage, JST_OFFSET_MS, raceAbort, sleep } from "@vicissitude/shared/functions";
 import type {
 	AgentResponse,
 	AiAgent,
@@ -55,16 +55,6 @@ function mergeMetricLabel(values: Array<string | undefined>, fallback: string): 
 	if (unique.length === 0) return fallback;
 	if (unique.length === 1) return unique[0] ?? fallback;
 	return "mixed";
-}
-
-function formatErrorMessage(error: unknown): string {
-	if (error instanceof Error) return error.message;
-	if (typeof error === "string") return error;
-	try {
-		return JSON.stringify(error) ?? String(error);
-	} catch {
-		return String(error);
-	}
 }
 
 function isIrrecoverableSessionError(

--- a/packages/application/src/resume-context-service.ts
+++ b/packages/application/src/resume-context-service.ts
@@ -13,6 +13,7 @@ import {
 } from "@vicissitude/memory/namespace";
 import type { SemanticFact } from "@vicissitude/memory/semantic-fact";
 import { MemoryStorage } from "@vicissitude/memory/storage";
+import { formatErrorMessage } from "@vicissitude/shared/functions";
 import type { Logger } from "@vicissitude/shared/types";
 
 const DEFAULT_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
@@ -257,9 +258,4 @@ function trimLine(text: string, maxLength: number): string {
 	const normalized = normalizeInline(text);
 	if (normalized.length <= maxLength) return normalized;
 	return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
-}
-
-function formatErrorMessage(error: unknown): string {
-	if (error instanceof Error && error.message) return error.message;
-	return String(error);
 }

--- a/packages/shared/src/functions.ts
+++ b/packages/shared/src/functions.ts
@@ -127,6 +127,32 @@ export async function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Pr
 	}
 }
 
+// ─── formatErrorMessage ─────────────────────────────────────────
+
+/**
+ * 任意の throw 値を、人間可読な 1 行メッセージへ正規化する。
+ *
+ * - `Error`: `error.message` を返す（`name` プレフィックスは付けない。
+ *   会話 context やユーザー可視文言に `TypeError:` 等の技術的接頭辞を
+ *   混入させないため）。
+ * - `string`: そのまま返す。
+ * - それ以外（オブジェクト・数値・null 等）: `JSON.stringify` で文字列化する。
+ *   `JSON.stringify` が `undefined` を返す（`undefined` 値など）場合や
+ *   循環参照で例外を投げる場合は `String(error)` にフォールバックする。
+ *
+ * ログ・内部メッセージ・添付説明文など、例外を文字列として埋め込む全ての
+ * 箇所で使う単一の正準ヘルパー。
+ */
+export function formatErrorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === "string") return error;
+	try {
+		return JSON.stringify(error) ?? String(error);
+	} catch {
+		return String(error);
+	}
+}
+
 // ─── escapeUserMessageTag ───────────────────────────────────────
 
 /** ユーザーメッセージ内の `<user_message>` / `</user_message>` タグをエスケープし、タグインジェクションを防ぐ */

--- a/spec/core/functions.spec.ts
+++ b/spec/core/functions.spec.ts
@@ -4,6 +4,7 @@ import { splitMessage } from "@vicissitude/application/split-message";
 import { evaluateDueReminders } from "@vicissitude/scheduling/heartbeat-helpers";
 import {
 	abortReasonToError,
+	formatErrorMessage,
 	formatTime,
 	formatTimestamp,
 	isRecord,
@@ -460,5 +461,52 @@ describe("raceAbort", () => {
 		const promise = raceAbort(pending, controller.signal);
 		controller.abort("nope");
 		expect(promise).rejects.toMatchObject({ name: "AbortError" });
+	});
+});
+
+// ─── formatErrorMessage ──────────────────────────────────────────
+
+describe("formatErrorMessage", () => {
+	test("Error は message のみを返す（name プレフィックスを付けない）", () => {
+		expect(formatErrorMessage(new Error("boom"))).toBe("boom");
+	});
+
+	test("Error サブクラスでも name を付けず message のみ返す", () => {
+		expect(formatErrorMessage(new TypeError("bad type"))).toBe("bad type");
+	});
+
+	test("message が空文字の Error は空文字を返す", () => {
+		expect(formatErrorMessage(new Error(""))).toBe("");
+	});
+
+	test("string はそのまま返す", () => {
+		expect(formatErrorMessage("plain string error")).toBe("plain string error");
+	});
+
+	test("空文字列はそのまま返す", () => {
+		expect(formatErrorMessage("")).toBe("");
+	});
+
+	test("プレーンオブジェクトは JSON.stringify した文字列を返す", () => {
+		expect(formatErrorMessage({ code: 500, reason: "oops" })).toBe('{"code":500,"reason":"oops"}');
+	});
+
+	test("数値は JSON.stringify した文字列を返す", () => {
+		expect(formatErrorMessage(42)).toBe("42");
+	});
+
+	test("null は JSON.stringify した文字列を返す", () => {
+		expect(formatErrorMessage(null)).toBe("null");
+	});
+
+	test("undefined は JSON.stringify が undefined を返すため String フォールバックする", () => {
+		const value: unknown = undefined;
+		expect(formatErrorMessage(value)).toBe("undefined");
+	});
+
+	test("循環参照オブジェクトは JSON.stringify が throw するため String フォールバックする", () => {
+		const circular: Record<string, unknown> = {};
+		circular.self = circular;
+		expect(formatErrorMessage(circular)).toBe("[object Object]");
 	});
 });


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 0** 第2弾。3箇所で微妙に異なる `formatErrorMessage(error: unknown): string` を `packages/shared` に集約する。

## 正準形

```ts
// @vicissitude/shared/functions
export function formatErrorMessage(error: unknown): string
```
- Error → `error.message`（**name プレフィックスなし**）
- string → そのまま
- その他 → `JSON.stringify(error) ?? String(error)`（catch で `String(error)`）

## 使用文脈調査と挙動差

| consumer | 旧 | 流れ先 | 置換後 |
|---|---|---|---|
| `runner.ts` | `error.message` | compaction 失敗ログ | 完全一致 |
| `image-attachment-describer.ts` | `${name}: ${message}` | 会話 context（**ユーザー可視**） | name プレフィックス除去（技術接頭辞混入を避ける改善。非 abort 経路は assert なし・abort 経路は別分岐で回帰なし） |
| `resume-context-service.ts` | `error.message` / `String(error)` | guild 更新失敗ログ | 非 Error 値の情報量が増す方向 |

README 3.8 のユーザー向け reply 経路（LLM の `discord_reply` ツール）には本ヘルパーの戻り値は乗らないことを確認済み。

## 検証

- `nr validate` green
- `nr test`: **2568 pass / 0 fail**（2558 + 新規10）

🤖 Generated with [Claude Code](https://claude.com/claude-code)