### PR TITLE
refactor: 純粋デッドコードを削除する

### DIFF
--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -4,7 +4,6 @@ import { resolve } from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { MemoryReadServices } from "@vicissitude/memory";
-import { EpisodicMemory } from "@vicissitude/memory/episodic";
 import type { MemoryLlmPort } from "@vicissitude/memory/llm-port";
 import {
 	migrateLegacyGuildMemoryNamespaces,
@@ -78,9 +77,8 @@ async function main(): Promise<void> {
 		const dbDir = resolveMemoryDbDir(MEMORY_DATA_DIR, namespace);
 		mkdirSync(dbDir, { recursive: true });
 		const storage = new MemoryStorage(resolveMemoryDbPath(MEMORY_DATA_DIR, namespace));
-		const episodic = new EpisodicMemory(storage);
 		const instance: MemoryReadServices = {
-			retrieval: new Retrieval(embedOnlyLlm, storage, episodic),
+			retrieval: new Retrieval(embedOnlyLlm, storage),
 			semantic: new SemanticMemory(storage),
 		};
 		return { instance, storage };

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -98,7 +98,7 @@ export function createMemory(opts: CreateMemoryOptions): Memory {
 	const segmenter = new Segmenter(llm, storage);
 	const consolidation = new ConsolidationPipeline(llm, storage, episodic);
 	const semantic = new SemanticMemory(storage);
-	const retrieval = new Retrieval(llm, storage, episodic);
+	const retrieval = new Retrieval(llm, storage);
 	const retrievalReview = new RetrievalReviewCommand(episodic);
 	const read: MemoryReadServices = { retrieval, semantic };
 	const commands: MemoryCommandServices = {

--- a/packages/memory/src/retrieval.ts
+++ b/packages/memory/src/retrieval.ts
@@ -1,5 +1,4 @@
 import type { Episode } from "./episode.ts";
-import type { EpisodicMemory } from "./episodic.ts";
 import { retrievability } from "./fsrs.ts";
 import type { MemoryLlmPort } from "./llm-port.ts";
 import type { SemanticFact } from "./semantic-fact.ts";
@@ -199,10 +198,7 @@ export class Retrieval {
 	constructor(
 		private llm: MemoryLlmPort,
 		private storage: MemoryStorage,
-		_deprecatedEpisodic: EpisodicMemory | null = null,
-	) {
-		void _deprecatedEpisodic;
-	}
+	) {}
 
 	/** Run all 4 searches in parallel */
 	private runSearches(

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -4,7 +4,6 @@
 	"exports": {
 		"./constants": "./src/constants.ts",
 		"./session-adapter": "./src/session-adapter.ts",
-		"./session-port": "./src/session-port.ts",
 		"./stream-helpers": "./src/stream-helpers.ts"
 	},
 	"dependencies": {

--- a/packages/opencode/src/session-port.ts
+++ b/packages/opencode/src/session-port.ts
@@ -1,6 +1,0 @@
-// Re-export from canonical location for backwards compatibility
-export type {
-	OpencodePromptParams,
-	OpencodeSessionEvent,
-	OpencodeSessionPort,
-} from "@vicissitude/shared/types";

--- a/spec/memory/fsrs-learning-loop.spec.ts
+++ b/spec/memory/fsrs-learning-loop.spec.ts
@@ -45,21 +45,6 @@ describe("FSRS learning loop — explicit retrieval review command", () => {
 		expect(after!.lastReviewedAt).toBeNull();
 	});
 
-	test("retrieve remains read-only even when an episodic dependency is available", async () => {
-		const retrievalWithEpisodic = new Retrieval(mockLlm([1, 0, 0]), storage, episodic);
-		const ep = makeEpisode({ title: "TypeScript Guide", embedding: [1, 0, 0] });
-		await storage.saveEpisode(userId, ep);
-
-		const now = new Date("2026-06-01T00:00:00Z");
-		await retrievalWithEpisodic.retrieve(userId, "TypeScript", { now });
-		await new Promise<void>((resolve) => {
-			setTimeout(resolve, 0);
-		});
-
-		const after = await storage.getEpisodeById(userId, ep.id);
-		expect(after!.lastReviewedAt).toBeNull();
-	});
-
 	test("review command updates lastReviewedAt for retrieved episodes", async () => {
 		const ep = makeEpisode({ title: "TypeScript Guide", embedding: [1, 0, 0] });
 		await storage.saveEpisode(userId, ep);


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 0** 第3弾。真に未使用と検証したデッドコードを削除する。

## 削除内容

1. **`packages/opencode/src/session-port.ts`**
   - `@vicissitude/shared/types` からの後方互換 re-export のみ。リポジトリ全体で import 0件（検証済み）。
   - `package.json` の `./session-port` サブパス export も削除。型（`OpencodePromptParams`/`OpencodeSessionEvent`/`OpencodeSessionPort`）は canonical な `@vicissitude/shared/types` から提供継続。

2. **`Retrieval` コンストラクタの死にパラメータ `_deprecatedEpisodic`**
   - 受領直後に `void` で破棄していた第3引数を削除（`new Retrieval(llm, storage)`）。
   - production 呼び出し（`memory/index.ts`、`mcp/core-server.ts`）を2引数へ更新。`episodic` 変数は `RetrievalReviewCommand` で使用継続のため温存。
   - 第3引数の存在を前提に read-only を検証していた `fsrs-learning-loop.spec.ts` のテストは、同ファイルの既存 read-only テスト（`retrieve is a pure read...`）と assert 内容が重複するため削除。

## 検証

- `nr validate` green
- `nr test`: **2567 pass / 0 fail**（重複テスト1件削除のため 2568→2567）

🤖 Generated with [Claude Code](https://claude.com/claude-code)