### PR TITLE
refactor(shared): 感情→weight 計算を shared/emotion に集約する

### DIFF
--- a/packages/avatar/src/emotion-to-expression-mapper.ts
+++ b/packages/avatar/src/emotion-to-expression-mapper.ts
@@ -1,10 +1,11 @@
 import {
 	type Emotion,
 	type EmotionCategory,
-	NEUTRAL_EMOTION_THRESHOLD,
 	type VrmExpression,
 	type VrmExpressionWeight,
 	classifyEmotion,
+	computeEmotionWeight,
+	computeNeutralWeight,
 } from "@vicissitude/shared/emotion";
 import type { EmotionToExpressionMapper } from "@vicissitude/shared/ports";
 
@@ -24,16 +25,10 @@ function mapToExpression(emotion: Emotion): VrmExpressionWeight {
 	const expression = classifyEmotion(emotion);
 
 	if (expression === "neutral") {
-		return mapNeutral(v, a, d);
+		return { expression: "neutral", weight: computeNeutralWeight(emotion) };
 	}
 
 	return { expression, weight: computeWeightForCategory(expression, v, a, d) };
-}
-
-function mapNeutral(v: number, a: number, d: number): VrmExpressionWeight {
-	const distance = Math.sqrt(v * v + a * a + d * d);
-	const maxDistance = Math.sqrt(NEUTRAL_EMOTION_THRESHOLD * NEUTRAL_EMOTION_THRESHOLD * 3);
-	return { expression: "neutral", weight: clampWeight(1 - distance / maxDistance) };
 }
 
 function computeWeightForCategory(
@@ -44,30 +39,20 @@ function computeWeightForCategory(
 ): number {
 	switch (category) {
 		case "surprised":
-			return computeWeight(a, Math.abs(d));
+			return computeEmotionWeight(a, Math.abs(d));
 		case "happy":
-			return computeWeight(v, a, Math.abs(d));
+			return computeEmotionWeight(v, a, Math.abs(d));
 		case "relaxed":
-			return computeWeight(v, Math.abs(a), Math.abs(d));
+			return computeEmotionWeight(v, Math.abs(a), Math.abs(d));
 		case "angry":
-			return computeWeight(Math.abs(v), Math.abs(a), Math.abs(d));
+			return computeEmotionWeight(Math.abs(v), Math.abs(a), Math.abs(d));
 		case "fear":
-			return computeWeight(Math.abs(v), Math.abs(a), Math.abs(d));
+			return computeEmotionWeight(Math.abs(v), Math.abs(a), Math.abs(d));
 		case "sad":
-			return computeWeight(Math.abs(v), Math.abs(a), Math.abs(d));
+			return computeEmotionWeight(Math.abs(v), Math.abs(a), Math.abs(d));
 		default:
 			return assertNever(category);
 	}
-}
-
-/** 関連する軸の絶対値の平均を [0, 1] に clamp して weight を算出する */
-function computeWeight(...values: number[]): number {
-	const sum = values.reduce((acc, val) => acc + val, 0);
-	return clampWeight(sum / values.length);
-}
-
-function clampWeight(value: number): number {
-	return Math.max(0, Math.min(1, value));
 }
 
 function assertNever(_value: never): never {

--- a/packages/shared/src/emotion.ts
+++ b/packages/shared/src/emotion.ts
@@ -135,6 +135,43 @@ export function classifyEmotion(emotion: Emotion): EmotionCategory {
 	return "neutral";
 }
 
+// ─── Weight 計算ユーティリティ ─────────────────────────────────
+//
+// VAD 感情値から適用強度 (weight) を算出する純粋関数。
+// TTS スタイル・VRM Expression など複数のマッパーで共通利用する。
+
+/**
+ * 関連する軸の値の平均を [0, 1] に clamp して weight を算出する。
+ *
+ * non-neutral カテゴリの強度算出に使う。各カテゴリは「そのカテゴリに
+ * 寄与する軸（必要なら絶対値）」を引数に渡す。
+ *
+ * @example computeEmotionWeight(Math.abs(v), Math.abs(a), Math.abs(d))
+ */
+export function computeEmotionWeight(...values: number[]): number {
+	const sum = values.reduce((acc, val) => acc + val, 0);
+	return clamp01(sum / values.length);
+}
+
+/**
+ * neutral カテゴリの weight を算出する。
+ *
+ * 原点 (NEUTRAL_EMOTION) に近いほど 1 に、neutral 閾値の境界
+ * (maxDistance = √(THRESHOLD² × 3)) で 0 に近づくよう線形に減衰する。
+ * 結果は [0, 1] に clamp される。
+ */
+export function computeNeutralWeight(emotion: Emotion): number {
+	const { valence: v, arousal: a, dominance: d } = emotion;
+	const distance = Math.sqrt(v * v + a * a + d * d);
+	const maxDistance = Math.sqrt(NEUTRAL_EMOTION_THRESHOLD * NEUTRAL_EMOTION_THRESHOLD * 3);
+	return clamp01(1 - distance / maxDistance);
+}
+
+/** 値を [0, 1] に clamp する */
+function clamp01(value: number): number {
+	return Math.max(0, Math.min(1, value));
+}
+
 // ─── describeEmotion ───────────────────────────────────────────
 //
 // VAD 感情値を日本語の自然言語記述に変換する純粋関数。

--- a/packages/tts/src/emotion-to-tts-style-mapper.ts
+++ b/packages/tts/src/emotion-to-tts-style-mapper.ts
@@ -1,4 +1,9 @@
-import { type Emotion, classifyEmotion } from "@vicissitude/shared/emotion";
+import {
+	type Emotion,
+	classifyEmotion,
+	computeEmotionWeight,
+	computeNeutralWeight,
+} from "@vicissitude/shared/emotion";
 import type { EmotionToTtsStyleMapper } from "@vicissitude/shared/ports";
 import { type TtsStyleParams, createTtsStyleParams } from "@vicissitude/shared/tts";
 
@@ -12,32 +17,24 @@ export function createEmotionToTtsStyleMapper(): EmotionToTtsStyleMapper {
 }
 
 function mapToStyle(emotion: Emotion): TtsStyleParams {
-	const { valence: v, arousal: a, dominance: d } = emotion;
-
 	const style = classifyEmotion(emotion);
-	const styleWeight = computeStyleWeight(style, v, a, d);
-	const speed = computeSpeed(a);
+	const styleWeight = computeStyleWeight(emotion, style);
+	const speed = computeSpeed(emotion.arousal);
 
 	return createTtsStyleParams(style, styleWeight, speed);
 }
 
-function computeStyleWeight(style: string, v: number, a: number, d: number): number {
+function computeStyleWeight(emotion: Emotion, style: string): number {
 	if (style === "neutral") {
-		const distance = Math.sqrt(v * v + a * a + d * d);
-		const maxDistance = Math.sqrt(0.2 * 0.2 * 3);
-		return clamp(1 - distance / maxDistance, 0, 1);
+		return computeNeutralWeight(emotion);
 	}
-	return computeWeight(Math.abs(v), Math.abs(a), Math.abs(d));
+	const { valence: v, arousal: a, dominance: d } = emotion;
+	return computeEmotionWeight(Math.abs(v), Math.abs(a), Math.abs(d));
 }
 
 function computeSpeed(arousal: number): number {
 	const raw = 1.0 + arousal * 0.3;
 	return clamp(raw, 0.5, 2.0);
-}
-
-function computeWeight(...values: number[]): number {
-	const sum = values.reduce((acc, val) => acc + val, 0);
-	return clamp(sum / values.length, 0, 1);
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/spec/shared/emotion.spec.ts
+++ b/spec/shared/emotion.spec.ts
@@ -12,6 +12,8 @@ import {
 	type VrmExpressionWeight,
 	VrmExpressionWeightSchema,
 	classifyEmotion,
+	computeEmotionWeight,
+	computeNeutralWeight,
 	createEmotion,
 } from "@vicissitude/shared/emotion";
 import type { EmotionToExpressionMapper } from "@vicissitude/shared/ports";
@@ -187,6 +189,93 @@ describe("VrmExpressionWeightSchema", () => {
 
 	it("rejects invalid expression label", () => {
 		expect(() => VrmExpressionWeightSchema.parse({ expression: "unknown", weight: 0.5 })).toThrow();
+	});
+});
+
+// ─── computeEmotionWeight ───────────────────────────────────────
+
+describe("computeEmotionWeight", () => {
+	it("returns the average of the given values", () => {
+		expect(computeEmotionWeight(0.2, 0.4, 0.6)).toBeCloseTo(0.4);
+	});
+
+	it("returns the single value when given one argument", () => {
+		expect(computeEmotionWeight(0.7)).toBeCloseTo(0.7);
+	});
+
+	it("clamps an average above 1 down to 1", () => {
+		expect(computeEmotionWeight(1, 1, 2)).toBe(1);
+	});
+
+	it("clamps a negative average up to 0", () => {
+		expect(computeEmotionWeight(-0.5, -0.5)).toBe(0);
+	});
+
+	it("returns 0 for all-zero inputs", () => {
+		expect(computeEmotionWeight(0, 0, 0)).toBe(0);
+	});
+
+	it("returns 1 for all-one inputs", () => {
+		expect(computeEmotionWeight(1, 1, 1)).toBe(1);
+	});
+});
+
+// ─── computeNeutralWeight ───────────────────────────────────────
+
+describe("computeNeutralWeight", () => {
+	it("returns 1 at the origin (perfect neutral)", () => {
+		expect(computeNeutralWeight(NEUTRAL_EMOTION)).toBeCloseTo(1);
+	});
+
+	it("returns a higher weight closer to the origin", () => {
+		const veryNeutral = computeNeutralWeight(createEmotion(0.01, 0.01, 0.01));
+		const barelyNeutral = computeNeutralWeight(createEmotion(0.15, 0.15, 0.15));
+		expect(veryNeutral).toBeGreaterThan(barelyNeutral);
+	});
+
+	it("returns a value within [0, 1] across the VAD space", () => {
+		const cases: Emotion[] = [
+			createEmotion(0, 0, 0),
+			createEmotion(0.1, -0.1, 0.05),
+			createEmotion(1, 1, 1),
+			createEmotion(-1, -1, -1),
+		];
+		for (const emotion of cases) {
+			const weight = computeNeutralWeight(emotion);
+			expect(weight).toBeGreaterThanOrEqual(0);
+			expect(weight).toBeLessThanOrEqual(1);
+		}
+	});
+
+	it("reaches 0 at the neutral threshold boundary on a single axis", () => {
+		// distance = THRESHOLD, maxDistance = THRESHOLD * √3 → 1 - 1/√3 ≈ 0.4226
+		const onAxis = computeNeutralWeight(createEmotion(NEUTRAL_EMOTION_THRESHOLD, 0, 0));
+		expect(onAxis).toBeCloseTo(1 - 1 / Math.sqrt(3));
+	});
+
+	it("returns 0 once the VAD distance exceeds maxDistance", () => {
+		// 全軸が THRESHOLD → distance = THRESHOLD*√3 = maxDistance → weight = 0
+		const atMax = computeNeutralWeight(
+			createEmotion(
+				NEUTRAL_EMOTION_THRESHOLD,
+				NEUTRAL_EMOTION_THRESHOLD,
+				NEUTRAL_EMOTION_THRESHOLD,
+			),
+		);
+		expect(atMax).toBeCloseTo(0);
+
+		const beyondMax = computeNeutralWeight(createEmotion(1, 1, 1));
+		expect(beyondMax).toBe(0);
+	});
+
+	it("uses NEUTRAL_EMOTION_THRESHOLD for the max distance (0.2 hardcode equivalence)", () => {
+		// tts が 0.2 ハードコード、avatar が定数参照だったものを統一。
+		// THRESHOLD = 0.2 のとき両者は同値であることを担保する。
+		const emotion = createEmotion(0.1, -0.05, 0.08);
+		const distance = Math.sqrt(0.1 * 0.1 + 0.05 * 0.05 + 0.08 * 0.08);
+		const maxDistanceFromHardcode = Math.sqrt(0.2 * 0.2 * 3);
+		const expected = Math.max(0, Math.min(1, 1 - distance / maxDistanceFromHardcode));
+		expect(computeNeutralWeight(emotion)).toBeCloseTo(expected);
 	});
 });
 


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 0** 第4弾。tts と avatar で重複していた VAD 感情→weight 計算を `packages/shared/emotion` へ集約する。

## 追加した shared ヘルパー

| 関数 | 挙動 |
|---|---|
| `computeEmotionWeight(...values)` | 関連軸の平均を `[0,1]` に clamp。両 consumer の同一 `computeWeight` を吸収 |
| `computeNeutralWeight(emotion)` | `1 - distance/maxDistance`（`maxDistance = √(NEUTRAL_EMOTION_THRESHOLD²×3)`）。**tts が `0.2` をハードコードしていた** neutral 距離計算を定数参照へ統一（同値ゆえ挙動不変、ドリフトリスク解消） |

## 設計判断

- 汎用 `clamp(value, min, max)` は tts の speed 計算（0.5–2.0）専用のため shared に上げず tts ローカルに残置（YAGNI）。
- avatar の `computeWeightForCategory` カテゴリ別軸選択ロジックは avatar 固有の振る舞いとして維持。
- neutral 除外カテゴリ型（`WeightedExpressionCategory` / web `SyncedVrmExpression`）の一本化は web に波及するため**別 PR**（スコープ外）。

## 検証

挙動不変が要件。既存 consumer spec（tts/avatar）を**無変更で通す**ことで担保。
- `nr validate` green
- `nr test`: **2579 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)