### PR TITLE
refactor(shared): タイムアウト付き fetch を shared/http に集約する

### DIFF
--- a/packages/infrastructure/src/discord/fxembed.ts
+++ b/packages/infrastructure/src/discord/fxembed.ts
@@ -1,8 +1,7 @@
+import { type FetchLike, fetchJsonWithTimeout } from "@vicissitude/shared/http";
 import { z } from "zod";
 
 const FXTWITTER_API_BASE = "https://api.fxtwitter.com";
-
-type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
 
 export const FxEmbedPhotoSchema = z.object({
 	id: z.string(),
@@ -145,37 +144,23 @@ export class HttpFxEmbedClient implements FxEmbedClient {
 
 	async getStatus(statusId: string): Promise<FxEmbedStatus | null> {
 		const url = `${FXTWITTER_API_BASE}/2/status/${encodeURIComponent(statusId)}`;
-		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), this.timeoutMs);
-		try {
-			const res = await this.fetchFn(url, { signal: controller.signal });
-			if (!res.ok) return null;
-			const json = await res.json();
-			const parsed = FxEmbedStatusResponseSchema.safeParse(json);
-			if (!parsed.success) return null;
-			return parsed.data.status;
-		} catch {
-			return null;
-		} finally {
-			clearTimeout(timer);
-		}
+		const r = await fetchJsonWithTimeout(
+			this.fetchFn,
+			url,
+			FxEmbedStatusResponseSchema,
+			this.timeoutMs,
+		);
+		return r?.status ?? null;
 	}
 
 	async getProfile(handle: string): Promise<FxEmbedUser | null> {
 		const url = `${FXTWITTER_API_BASE}/2/profile/${encodeURIComponent(handle)}`;
-		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), this.timeoutMs);
-		try {
-			const res = await this.fetchFn(url, { signal: controller.signal });
-			if (!res.ok) return null;
-			const json = await res.json();
-			const parsed = FxEmbedProfileResponseSchema.safeParse(json);
-			if (!parsed.success) return null;
-			return parsed.data.user;
-		} catch {
-			return null;
-		} finally {
-			clearTimeout(timer);
-		}
+		const r = await fetchJsonWithTimeout(
+			this.fetchFn,
+			url,
+			FxEmbedProfileResponseSchema,
+			this.timeoutMs,
+		);
+		return r?.user ?? null;
 	}
 }

--- a/packages/infrastructure/src/http/image-fetcher.ts
+++ b/packages/infrastructure/src/http/image-fetcher.ts
@@ -1,4 +1,7 @@
+import { type FetchLike, fetchWithTimeout } from "@vicissitude/shared/http";
 import type { Logger } from "@vicissitude/shared/types";
+
+export type { FetchLike };
 
 /** 取得成功時の画像データ */
 export interface FetchedImage {
@@ -20,12 +23,6 @@ export const DEFAULT_MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
 export const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
 
 const IMAGE_MIME_PREFIX = "image/";
-
-/**
- * `typeof fetch` には Bun/Node 固有の `preconnect` 等が含まれ、
- * テスト用スタブの型付けが煩雑になるので、本ファイルが実際に呼び出す形だけに限定する。
- */
-export type FetchLike = (url: string, init?: { signal?: AbortSignal }) => Promise<Response>;
 
 export interface HttpImageFetcherOptions {
 	logger?: Logger;
@@ -55,10 +52,8 @@ export class HttpImageFetcher implements ImageFetcher {
 	}
 
 	async fetch(url: string): Promise<FetchedImage | null> {
-		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), this.timeoutMs);
 		try {
-			const res = await this.fetchFn(url, { signal: controller.signal });
+			const res = await fetchWithTimeout(this.fetchFn, url, this.timeoutMs);
 			if (!res.ok) {
 				this.logger?.warn(`[image-fetcher] HTTP ${res.status} for ${url}`);
 				return null;
@@ -90,8 +85,6 @@ export class HttpImageFetcher implements ImageFetcher {
 		} catch (err) {
 			this.logger?.warn(`[image-fetcher] fetch failed: ${url}`, err);
 			return null;
-		} finally {
-			clearTimeout(timer);
 		}
 	}
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,7 @@
 		"./types": "./src/types.ts",
 		"./namespace": "./src/namespace.ts",
 		"./functions": "./src/functions.ts",
+		"./http": "./src/http.ts",
 		"./emotion": "./src/emotion.ts",
 		"./ws-protocol": "./src/ws-protocol.ts",
 		"./ports": "./src/ports.ts",

--- a/packages/shared/src/http.ts
+++ b/packages/shared/src/http.ts
@@ -1,0 +1,82 @@
+// ─── FetchLike ───────────────────────────────────────────────────
+//
+// `typeof fetch` には Bun/Node 固有の `preconnect` 等が含まれ、テスト用スタブの
+// 型付けが煩雑になる。本ヘルパーが実際に呼び出す形（URL と signal だけを渡す）に
+// 限定した最小インターフェースを公開する。
+//
+// init を `{ signal?: AbortSignal }` に絞っているが、引数反変により
+// `(url, init?: RequestInit) => Promise<Response>` 形の fetch 実装や
+// グローバルの `fetch` もそのまま代入できる（より広い init を受ける関数は、
+// より狭い init を要求する関数型へ代入可能）。
+
+/**
+ * タイムアウト付き fetch ヘルパーが要求する最小の fetch インターフェース。
+ *
+ * グローバル `fetch`・`(url, init?: RequestInit) => Promise<Response>` 形の
+ * 実装・テスト用スタブのいずれも代入できる。
+ */
+export type FetchLike = (url: string, init?: { signal?: AbortSignal }) => Promise<Response>;
+
+// ─── fetchWithTimeout ────────────────────────────────────────────
+
+/**
+ * `timeoutMs` を経過したら abort される `AbortSignal` を付けて `fetchFn` を呼ぶ。
+ *
+ * タイムアウト発火時は `fetchFn` に渡した signal が abort され、その実装次第で
+ * 通常は `Promise` が reject される（グローバル `fetch` は `TimeoutError` で
+ * reject する）。本関数自身は例外を握り潰さず、`fetchFn` の reject を
+ * そのまま伝播する。タイムアウトを「null フォールバック」したい場合は呼び出し側で
+ * try/catch するか、{@link fetchJsonWithTimeout} を使う。
+ *
+ * `clearTimeout` 相当の後始末は `AbortSignal.timeout` 側で管理されるため不要。
+ */
+export function fetchWithTimeout(
+	fetchFn: FetchLike,
+	url: string,
+	timeoutMs: number,
+): Promise<Response> {
+	return fetchFn(url, { signal: AbortSignal.timeout(timeoutMs) });
+}
+
+// ─── fetchJsonWithTimeout ────────────────────────────────────────
+
+/**
+ * `safeParse` だけを要求する構造的バリデータインターフェース。
+ *
+ * zod の `ZodType`（v3 / v4.3 / v4.4 ...）は構造的にこれを満たすため、
+ * 本モジュールは zod へ依存せず任意の zod バージョン・自前バリデータを受け取れる。
+ * zod を直接型引数に取ると、重複インストール（複数 minor 共存）時に branded な
+ * internal 版数型が結合して TS2345 を招くため、それを避ける狙いがある。
+ */
+export interface SafeParseable<T> {
+	safeParse(data: unknown): { success: true; data: T } | { success: false };
+}
+
+/**
+ * {@link fetchWithTimeout} で JSON を取得し `schema.safeParse` で検証する。
+ *
+ * 以下のいずれの場合も例外を投げず `null` を返す（フォールバック前提の API 用）:
+ * - `res.ok` が false（HTTP 4xx/5xx）
+ * - `res.json()` が失敗（不正な JSON）
+ * - `schema.safeParse` が失敗（想定外のレスポンス形状）
+ * - `fetchFn` がタイムアウト等で reject
+ *
+ * 成功時は parse 済みデータ（`T`）を返す。
+ */
+export async function fetchJsonWithTimeout<T>(
+	fetchFn: FetchLike,
+	url: string,
+	schema: SafeParseable<T>,
+	timeoutMs: number,
+): Promise<T | null> {
+	try {
+		const res = await fetchWithTimeout(fetchFn, url, timeoutMs);
+		if (!res.ok) return null;
+		const json = await res.json();
+		const parsed = schema.safeParse(json);
+		if (!parsed.success) return null;
+		return parsed.data;
+	} catch {
+		return null;
+	}
+}

--- a/spec/shared/http.spec.ts
+++ b/spec/shared/http.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	fetchJsonWithTimeout,
+	fetchWithTimeout,
+	type FetchLike,
+	type SafeParseable,
+} from "@vicissitude/shared/http";
+import { z } from "zod";
+
+/** 指定ステータス・JSON body の Response を返す stub fetch */
+function stubFetch(body: unknown, status = 200): FetchLike {
+	return () =>
+		Promise.resolve(
+			new Response(JSON.stringify(body), {
+				status,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+}
+
+/** 即時 reject する stub fetch */
+function rejectingFetch(message: string): FetchLike {
+	return () => Promise.reject(new Error(message));
+}
+
+/** JSON として不正な body を返す stub fetch */
+const malformedJsonFetch: FetchLike = () =>
+	Promise.resolve(
+		new Response("not-json", {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		}),
+	);
+
+/** signal が abort されるまで pending し、abort で TimeoutError を投げる stub fetch */
+const abortAwareFetch: FetchLike = (_url, init) =>
+	new Promise((_resolve, reject) => {
+		init?.signal?.addEventListener("abort", () => {
+			reject(new DOMException("timeout", "TimeoutError"));
+		});
+	});
+
+describe("fetchWithTimeout", () => {
+	test("正常系: fetchFn の Response をそのまま解決する", async () => {
+		const res = new Response("ok", { status: 200 });
+		const fetchFn: FetchLike = () => Promise.resolve(res);
+
+		const result = await fetchWithTimeout(fetchFn, "https://example.com", 1000);
+
+		expect(result).toBe(res);
+	});
+
+	test("fetchFn に渡される URL は呼び出し時の URL である", async () => {
+		let receivedUrl: string | undefined;
+		const fetchFn: FetchLike = (url) => {
+			receivedUrl = url;
+			return Promise.resolve(new Response("ok"));
+		};
+
+		await fetchWithTimeout(fetchFn, "https://example.com/path", 1000);
+
+		expect(receivedUrl).toBe("https://example.com/path");
+	});
+
+	test("fetchFn には abort 可能な AbortSignal が渡される", async () => {
+		let receivedSignal: AbortSignal | undefined;
+		const fetchFn: FetchLike = (_url, init) => {
+			receivedSignal = init?.signal;
+			return Promise.resolve(new Response("ok"));
+		};
+
+		await fetchWithTimeout(fetchFn, "https://example.com", 1000);
+
+		expect(receivedSignal).toBeInstanceOf(AbortSignal);
+	});
+
+	test("タイムアウト経過後に signal が abort される", async () => {
+		let receivedSignal: AbortSignal | undefined;
+		// signal を捕捉しつつ即座に解決する（fetch 自体はタイムアウト前に終わる想定）
+		const fetchFn: FetchLike = (_url, init) => {
+			receivedSignal = init?.signal;
+			return Promise.resolve(new Response("ok"));
+		};
+
+		await fetchWithTimeout(fetchFn, "https://example.com", 10);
+		expect(receivedSignal?.aborted).toBe(false);
+
+		// タイムアウト時間を超えて待つと signal が abort される
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 30);
+		});
+		expect(receivedSignal?.aborted).toBe(true);
+	});
+
+	test("fetchFn が reject した場合は例外をそのまま伝播する", () => {
+		const promise = fetchWithTimeout(rejectingFetch("ECONNRESET"), "https://example.com", 1000);
+
+		expect(promise).rejects.toThrow("ECONNRESET");
+	});
+});
+
+const TestSchema = z.object({
+	code: z.number(),
+	value: z.string(),
+});
+
+describe("fetchJsonWithTimeout", () => {
+	test("正常系: zod schema を渡すと構造的に通り parse 済みデータを返す", async () => {
+		const fetchFn = stubFetch({ code: 200, value: "hello" });
+
+		// zod の ZodType は構造的に SafeParseable<T> を満たす（zod バージョン非依存）
+		const result = await fetchJsonWithTimeout(fetchFn, "https://example.com", TestSchema, 1000);
+
+		expect(result).toEqual({ code: 200, value: "hello" });
+	});
+
+	test("zod 非依存の素の SafeParseable オブジェクトでも動く", async () => {
+		const fetchFn = stubFetch({ id: 7, label: "ok" });
+		// safeParse だけを実装した自前バリデータ（zod に一切依存しない）
+		const schema: SafeParseable<{ id: number; label: string }> = {
+			safeParse(data) {
+				if (
+					typeof data === "object" &&
+					data !== null &&
+					typeof (data as { id?: unknown }).id === "number" &&
+					typeof (data as { label?: unknown }).label === "string"
+				) {
+					return { success: true, data: data as { id: number; label: string } };
+				}
+				return { success: false };
+			},
+		};
+
+		const result = await fetchJsonWithTimeout(fetchFn, "https://example.com", schema, 1000);
+
+		expect(result).toEqual({ id: 7, label: "ok" });
+	});
+
+	test("res.ok が false の場合は null を返す", async () => {
+		const fetchFn = stubFetch({ code: 404, value: "x" }, 404);
+
+		const result = await fetchJsonWithTimeout(fetchFn, "https://example.com", TestSchema, 1000);
+
+		expect(result).toBeNull();
+	});
+
+	test("JSON parse に失敗した場合は null を返す", async () => {
+		const result = await fetchJsonWithTimeout(
+			malformedJsonFetch,
+			"https://example.com",
+			TestSchema,
+			1000,
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test("schema 検証に失敗した場合は null を返す", async () => {
+		// code が string で schema (number) に不適合
+		const fetchFn = stubFetch({ code: "200", value: "hello" });
+
+		const result = await fetchJsonWithTimeout(fetchFn, "https://example.com", TestSchema, 1000);
+
+		expect(result).toBeNull();
+	});
+
+	test("fetchFn が reject した場合も例外を投げず null を返す", async () => {
+		const result = await fetchJsonWithTimeout(
+			rejectingFetch("network down"),
+			"https://example.com",
+			TestSchema,
+			1000,
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test("タイムアウトで fetchFn が reject しても null を返す", async () => {
+		const start = Date.now();
+		const result = await fetchJsonWithTimeout(
+			abortAwareFetch,
+			"https://example.com",
+			TestSchema,
+			20,
+		);
+		const elapsed = Date.now() - start;
+
+		expect(result).toBeNull();
+		expect(elapsed).toBeLessThan(1000);
+	});
+});


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 0** 第5弾（最終）。infrastructure で重複していたタイムアウト付き fetch の定型を `packages/shared/http` へ集約する。

## 追加した shared モジュール（`@vicissitude/shared/http`）

| API | 役割 |
|---|---|
| `FetchLike` | テスト差し替え可能な fetch 型。image-fetcher / fxembed の各自再定義を一本化 |
| `fetchWithTimeout(fetchFn, url, timeoutMs)` | `AbortSignal.timeout` を使う低レベル版（手動 clearTimeout 不要） |
| `fetchJsonWithTimeout(fetchFn, url, schema, timeoutMs)` | ok判定 / json / safeParse / catch→null を内包 |

### `fetchJsonWithTimeout` の schema 型は構造的型

```ts
export interface SafeParseable<T> {
  safeParse(data: unknown): { success: true; data: T } | { success: false };
}
```

`z.ZodType` への依存を外し `safeParse` のみ要求する構造的型にした。これにより zod の branded internal 版数型に結合せず、**zod の二重インストール（4.3.6 / 4.4.3 共存）でも型エラーにならない**。zod schema は構造的にこの型を満たす。zod 重複の根本対応は #1051 で追跡。

## consumer の集約

- **fxembed**: `getStatus`/`getProfile` のほぼ逐語コピー（AbortController定型→fetch→ok→json→safeParse→catch null）を `fetchJsonWithTimeout` 1呼び出しに集約。
- **image-fetcher**: タイムアウト定型を `fetchWithTimeout` へ。画像固有処理（mime/size/base64）は維持。co-located test 互換のため shared の `FetchLike` を re-export。

`ollama`（shared 非依存方針）は対象外。

## 検証

挙動不変。既存 consumer spec（fxembed / image-fetcher）を無変更で通すことで担保。
- `nr validate` green（root `nr check` で zod 型不整合が無いことも確認）
- `nr test`: **2591 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)