### PR TITLE
refactor(discord): reminder sync の重複を内部ヘルパーに統合する

### DIFF
--- a/apps/discord/src/migrations.ts
+++ b/apps/discord/src/migrations.ts
@@ -3,10 +3,11 @@ import { resolve } from "path";
 
 import type { Logger } from "@vicissitude/shared/types";
 
-/** config.minecraft の有無に応じて mc-check リマインダーの enabled を同期する */
-export function syncMcCheckReminder(
+/** config 値に応じて指定 id のリマインダーの enabled を同期する */
+function syncReminderEnabled(
 	configPath: string,
-	minecraftEnabled: boolean,
+	target: { id: string; configField: string },
+	enabled: boolean,
 	logger: Logger,
 ): void {
 	if (!existsSync(configPath)) return;
@@ -14,16 +15,30 @@ export function syncMcCheckReminder(
 		const raw = JSON.parse(readFileSync(configPath, "utf-8")) as {
 			reminders?: { id: string; enabled: boolean }[];
 		};
-		const mcCheck = raw.reminders?.find((r) => r.id === "mc-check");
-		if (!mcCheck || mcCheck.enabled === minecraftEnabled) return;
-		mcCheck.enabled = minecraftEnabled;
+		const reminder = raw.reminders?.find((r) => r.id === target.id);
+		if (!reminder || reminder.enabled === enabled) return;
+		reminder.enabled = enabled;
 		writeFileSync(configPath, JSON.stringify(raw, null, 2));
 		logger.info(
-			`[bootstrap] mc-check reminder ${minecraftEnabled ? "enabled" : "disabled"} (synced with config.minecraft)`,
+			`[bootstrap] ${target.id} reminder ${enabled ? "enabled" : "disabled"} (synced with config.${target.configField})`,
 		);
 	} catch {
 		// パース失敗時はスキップ（HeartbeatScheduler がデフォルト設定で初期化する）
 	}
+}
+
+/** config.minecraft の有無に応じて mc-check リマインダーの enabled を同期する */
+export function syncMcCheckReminder(
+	configPath: string,
+	minecraftEnabled: boolean,
+	logger: Logger,
+): void {
+	syncReminderEnabled(
+		configPath,
+		{ id: "mc-check", configField: "minecraft" },
+		minecraftEnabled,
+		logger,
+	);
 }
 
 /** config.emailCheck の有無に応じて email-check リマインダーの enabled を同期する */
@@ -32,21 +47,12 @@ export function syncEmailCheckReminder(
 	emailCheckEnabled: boolean,
 	logger: Logger,
 ): void {
-	if (!existsSync(configPath)) return;
-	try {
-		const raw = JSON.parse(readFileSync(configPath, "utf-8")) as {
-			reminders?: { id: string; enabled: boolean }[];
-		};
-		const emailCheck = raw.reminders?.find((r) => r.id === "email-check");
-		if (!emailCheck || emailCheck.enabled === emailCheckEnabled) return;
-		emailCheck.enabled = emailCheckEnabled;
-		writeFileSync(configPath, JSON.stringify(raw, null, 2));
-		logger.info(
-			`[bootstrap] email-check reminder ${emailCheckEnabled ? "enabled" : "disabled"} (synced with config.emailCheck)`,
-		);
-	} catch {
-		// パース失敗時はスキップ（HeartbeatScheduler がデフォルト設定で初期化する）
-	}
+	syncReminderEnabled(
+		configPath,
+		{ id: "email-check", configField: "emailCheck" },
+		emailCheckEnabled,
+		logger,
+	);
 }
 
 /** ltm-consolidate リマインダーを削除する（MCP ツール廃止に伴う移行） */


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 1** 第1弾。`apps/discord/src/migrations.ts` の `syncMcCheckReminder` / `syncEmailCheckReminder` がほぼ逐語コピーしていた read-modify-write 骨格を private ヘルパー `syncReminderEnabled` に統合する。

## 変更

- `existsSync→readFileSync→JSON.parse→reminders.find(id)→enabled比較→writeFileSync→info ログ→catch スキップ` の骨格を1つに集約。
- 差分（find する id・ログの config フィールド名）は `target: { id, configField }` で注入（`max-params` 4 制約も満たす）。
- **公開関数のシグネチャ・ログ文言・`JSON.stringify(raw, null, 2)` 出力・catch 挙動は完全不変**。
- `removeLegacyConsolidateReminder`（削除操作で骨格が別）・`migrateMemoryDir`（無関係）は対象外（YAGNI）。

## 検証

- `nr validate` green
- `nr test`: **2591 pass / 0 fail**（`spec/discord/migrations.spec.ts` 20 pass を無変更で通過＝挙動不変）

🤖 Generated with [Claude Code](https://claude.com/claude-code)