### PR TITLE
refactor(mcp): tool result ヘルパと scope 解決ガードを集約する

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -17,6 +17,7 @@
 		"./tools/mc-bridge-minecraft": "./src/tools/mc-bridge-minecraft.ts",
 		"./tools/mc-memory": "./src/tools/mc-memory.ts",
 		"./tools/memory": "./src/tools/memory.ts",
+		"./tools/result": "./src/tools/result.ts",
 		"./tools/schedule": "./src/tools/schedule.ts",
 		"./tools/meta": "./src/tools/meta.ts",
 		"./tools/meta-test-helpers": "./src/tools/meta-test-helpers.ts"

--- a/packages/mcp/src/tools/discord.ts
+++ b/packages/mcp/src/tools/discord.ts
@@ -9,6 +9,8 @@ import type { Logger } from "@vicissitude/shared/types";
 import { ChannelType, type Client, type TextChannel } from "discord.js";
 import { z } from "zod/v4";
 
+import { errorContent, resolveBoundScope, textContent } from "./result.ts";
+
 const DEFAULT_ALLOWED_FILE_DIRS = ["/tmp/vicissitude-screenshots"];
 const ATTACHMENT_ALLOWED_DIRS_ENV = "DISCORD_ATTACHMENT_ALLOWED_DIRS";
 
@@ -149,7 +151,7 @@ export function registerDiscordTools(
 			}
 			const msg = await channel.send(options);
 			triggerEmotionEstimation(content);
-			return { content: [{ type: "text", text: `Sent message ${msg.id}` }] };
+			return textContent(`Sent message ${msg.id}`);
 		},
 	);
 
@@ -190,7 +192,7 @@ export function registerDiscordTools(
 			}
 			const msg = await target.reply(options);
 			triggerEmotionEstimation(content);
-			return { content: [{ type: "text", text: `Replied with message ${msg.id}` }] };
+			return textContent(`Replied with message ${msg.id}`);
 		},
 	);
 
@@ -212,7 +214,7 @@ export function registerDiscordTools(
 			const channel = await getSendableChannel(channel_id);
 			const target = await channel.messages.fetch(message_id);
 			await target.react(emoji);
-			return { content: [{ type: "text", text: `Reacted with ${emoji}` }] };
+			return textContent(`Reacted with ${emoji}`);
 		},
 	);
 
@@ -230,7 +232,7 @@ export function registerDiscordTools(
 				const imageText = imageUrls.length > 0 ? ` [images: ${imageUrls.join(", ")}]` : "";
 				return `[${m.author.tag}] ${m.content}${imageText}`;
 			});
-			return { content: [{ type: "text", text: formatted.join("\n") }] };
+			return textContent(formatted.join("\n"));
 		},
 	);
 
@@ -243,26 +245,16 @@ export function registerDiscordTools(
 		},
 		async ({ guild_id }: { guild_id?: string }) => {
 			if (boundDmUserId) {
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: "Error: list_channels is not available in DM scope",
-						},
-					],
-					isError: true,
-				};
+				return errorContent("Error: list_channels is not available in DM scope", true);
 			}
-			const gid = boundGuildId ?? guild_id;
-			if (!gid) {
-				return { content: [{ type: "text" as const, text: "Error: guild_id is required" }] };
-			}
-			const guild = await discordClient.guilds.fetch(gid);
+			const resolved = resolveBoundScope(boundGuildId, guild_id, "Error: guild_id is required");
+			if (!resolved.ok) return resolved.result;
+			const guild = await discordClient.guilds.fetch(resolved.value);
 			const channels = await guild.channels.fetch();
 			const textChannels = channels
 				.filter((c): c is NonNullable<typeof c> => c?.isTextBased() ?? false)
 				.map((c) => `${c.name} (${c.id})`);
-			return { content: [{ type: "text" as const, text: textChannels.join("\n") }] };
+			return textContent(textChannels.join("\n"));
 		},
 	);
 

--- a/packages/mcp/src/tools/mc-bridge-discord.ts
+++ b/packages/mcp/src/tools/mc-bridge-discord.ts
@@ -9,6 +9,7 @@ import { appendEvent } from "@vicissitude/store/queries";
 import { z } from "zod/v4";
 
 import { MINECRAFT_AGENT_ID } from "./mc-bridge-constants.ts";
+import { errorContent, resolveBoundScope, textContent } from "./result.ts";
 
 export interface McBridgeDeps {
 	db: StoreDb;
@@ -46,9 +47,7 @@ export function registerDiscordBridgeTools(
 				metadata: { type: "command" },
 			};
 			appendEvent(db, MINECRAFT_AGENT_ID, JSON.stringify(event));
-			return {
-				content: [{ type: "text" as const, text: "指示を出した。あとでやっとく。" }],
-			};
+			return textContent("指示を出した。あとでやっとく。");
 		},
 	);
 
@@ -60,9 +59,7 @@ export function registerDiscordBridgeTools(
 			const label = status.connected ? "connected" : "disconnected";
 			const text = `Connection status: ${label}${status.since ? ` (${status.since})` : ""}`;
 
-			return {
-				content: [{ type: "text" as const, text }],
-			};
+			return textContent(text);
 		},
 	);
 
@@ -75,29 +72,13 @@ export function registerDiscordBridgeTools(
 				: { guild_id: z.string().min(1).describe("Caller's guild ID") },
 		},
 		({ guild_id }: { guild_id?: string }) => {
-			const gid = boundGuildId ?? guild_id;
-			if (!gid) {
-				return { content: [{ type: "text" as const, text: "Error: guild_id is required" }] };
-			}
-			const lock = tryAcquireSessionLock(db, gid);
+			const resolved = resolveBoundScope(boundGuildId, guild_id, "Error: guild_id is required");
+			if (!resolved.ok) return resolved.result;
+			const lock = tryAcquireSessionLock(db, resolved.value);
 			if (!lock.ok) {
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: "セッション開始に失敗した。別のセッションが動いてる。",
-						},
-					],
-				};
+				return errorContent("セッション開始に失敗した。別のセッションが動いてる。");
 			}
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text: "マイクラ起動するね。ちょっと待って。",
-					},
-				],
-			};
+			return textContent("マイクラ起動するね。ちょっと待って。");
 		},
 	);
 
@@ -110,29 +91,13 @@ export function registerDiscordBridgeTools(
 				: { guild_id: z.string().min(1).describe("Caller's guild ID") },
 		},
 		({ guild_id }: { guild_id?: string }) => {
-			const gid = boundGuildId ?? guild_id;
-			if (!gid) {
-				return { content: [{ type: "text" as const, text: "Error: guild_id is required" }] };
-			}
-			const released = releaseSessionLock(db, gid);
+			const resolved = resolveBoundScope(boundGuildId, guild_id, "Error: guild_id is required");
+			if (!resolved.ok) return resolved.result;
+			const released = releaseSessionLock(db, resolved.value);
 			if (!released) {
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: "停止に失敗した。セッションが動いてないみたい。",
-						},
-					],
-				};
+				return errorContent("停止に失敗した。セッションが動いてないみたい。");
 			}
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text: "マイクラ止めた。",
-					},
-				],
-			};
+			return textContent("マイクラ止めた。");
 		},
 	);
 }

--- a/packages/mcp/src/tools/mc-bridge-minecraft.ts
+++ b/packages/mcp/src/tools/mc-bridge-minecraft.ts
@@ -13,6 +13,7 @@ import {
 	parseEvents,
 } from "./event-helpers.ts";
 import { MINECRAFT_AGENT_ID } from "./mc-bridge-constants.ts";
+import { errorContent, textContent } from "./result.ts";
 
 const MAX_REPORT_CHARS = 10_000;
 type ReportImportance = "low" | "medium" | "high" | "critical";
@@ -79,14 +80,7 @@ export function registerMinecraftBridgeTools(server: McpServer, deps: { db: Stor
 		}) => {
 			const guildId = getSessionLockGuildId(db);
 			if (!guildId) {
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: "セッションが見つからない。レポートを送信できなかった。",
-						},
-					],
-				};
+				return errorContent("セッションが見つからない。レポートを送信できなかった。");
 			}
 			const targetAgentId = `discord:${guildId}`;
 			const event = {
@@ -98,9 +92,7 @@ export function registerMinecraftBridgeTools(server: McpServer, deps: { db: Stor
 				metadata: { type: "mc_report", importance, category },
 			};
 			appendEvent(db, targetAgentId, JSON.stringify(event));
-			return {
-				content: [{ type: "text" as const, text: "レポートを Discord 側に送信しました。" }],
-			};
+			return textContent("レポートを Discord 側に送信しました。");
 		},
 	);
 
@@ -113,7 +105,7 @@ export function registerMinecraftBridgeTools(server: McpServer, deps: { db: Stor
 		() => {
 			const rows = consumeEvents(db, MINECRAFT_AGENT_ID, MAX_BATCH_SIZE);
 			const text = rows.length > 0 ? formatCommands(parseEvents(rows)) : "新しい指示はありません";
-			return { content: [{ type: "text" as const, text }] };
+			return textContent(text);
 		},
 	);
 }

--- a/packages/mcp/src/tools/mc-memory.ts
+++ b/packages/mcp/src/tools/mc-memory.ts
@@ -5,6 +5,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
 
 import { createBackup, ensureDir, readWithFallbackFrom } from "../memory-helpers.ts";
+import { errorContent, textContent } from "./result.ts";
 
 const MAX_GOALS_CHARS = 20_000;
 const MAX_PROGRESS_CHARS = 20_000;
@@ -70,9 +71,7 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 		{ description: "Minecraft 目標ファイルを読む（現在の目標のみ）" },
 		() => {
 			const content = readOverlay(dataDir, GOALS_FILENAME, baseContextDir);
-			return {
-				content: [{ type: "text" as const, text: content || "(目標ファイルは空です)" }],
-			};
+			return textContent(content || "(目標ファイルは空です)");
 		},
 	);
 
@@ -91,14 +90,7 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 		},
 		({ content }: { content: string }) => {
 			writeOverlay(dataDir, GOALS_FILENAME, content);
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text: `MINECRAFT-GOALS.md を更新しました（${String(content.length)} 文字）`,
-					},
-				],
-			};
+			return textContent(`MINECRAFT-GOALS.md を更新しました（${String(content.length)} 文字）`);
 		},
 	);
 
@@ -112,9 +104,7 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 		},
 		() => {
 			const content = readOverlay(dataDir, PROGRESS_FILENAME, baseContextDir);
-			return {
-				content: [{ type: "text" as const, text: content || "(進捗ファイルは空です)" }],
-			};
+			return textContent(content || "(進捗ファイルは空です)");
 		},
 	);
 
@@ -133,14 +123,7 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 		},
 		({ content }: { content: string }) => {
 			writeOverlay(dataDir, PROGRESS_FILENAME, content);
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text: `MINECRAFT-PROGRESS.md を更新しました（${String(content.length)} 文字）`,
-					},
-				],
-			};
+			return textContent(`MINECRAFT-PROGRESS.md を更新しました（${String(content.length)} 文字）`);
 		},
 	);
 
@@ -148,9 +131,7 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 
 	server.registerTool("mc_read_skills", { description: "Minecraft スキルライブラリを読む" }, () => {
 		const content = readOverlay(dataDir, SKILLS_FILENAME, baseContextDir);
-		return {
-			content: [{ type: "text" as const, text: content || "(スキルライブラリは空です)" }],
-		};
+		return textContent(content || "(スキルライブラリは空です)");
 	});
 
 	server.registerTool(
@@ -199,19 +180,12 @@ export function registerMcMemoryTools(server: McpServer, deps: McMemoryDeps): vo
 			const entry = `${lines.join("")}\n`;
 			const updated = existing ? existing + entry : `# Minecraft スキルライブラリ\n${entry}`;
 			if (updated.length > MAX_SKILLS_CHARS) {
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: `スキルライブラリのサイズ上限（${String(MAX_SKILLS_CHARS)} 文字）に達しました。不要なスキルを整理してください。`,
-						},
-					],
-				};
+				return errorContent(
+					`スキルライブラリのサイズ上限（${String(MAX_SKILLS_CHARS)} 文字）に達しました。不要なスキルを整理してください。`,
+				);
 			}
 			writeOverlay(dataDir, SKILLS_FILENAME, updated);
-			return {
-				content: [{ type: "text" as const, text: `スキル「${name}」を記録しました` }],
-			};
+			return textContent(`スキル「${name}」を記録しました`);
 		},
 	);
 }

--- a/packages/mcp/src/tools/memory.ts
+++ b/packages/mcp/src/tools/memory.ts
@@ -12,6 +12,7 @@ import type { SemanticFact } from "@vicissitude/memory/semantic-fact";
 import { z } from "zod/v4";
 
 import type { LruCache } from "../lru-cache";
+import { errorContent, textContent } from "./result.ts";
 
 const scopeIdSchema = z.string().regex(AGENT_SCOPE_ID_RE).describe("Agent scope ID");
 
@@ -50,10 +51,7 @@ export function registerMemoryTools(
 			try {
 				const ns = resolveNamespace(scope_id);
 				if (!ns) {
-					return {
-						content: [{ type: "text" as const, text: "Error: namespace could not be resolved" }],
-						isError: true,
-					};
+					return errorContent("Error: namespace could not be resolved", true);
 				}
 
 				const effectiveLimit = limit ?? 10;
@@ -123,19 +121,14 @@ export function registerMemoryTools(
 					parts.push("No relevant memories found.");
 				}
 
-				const result = { content: [{ type: "text" as const, text: parts.join("\n") }] };
+				const result = textContent(parts.join("\n"));
 				cache?.set(cacheKey, result);
 				return result;
 			} catch (error) {
-				return {
-					content: [
-						{
-							type: "text",
-							text: `memory_retrieve error: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
+				return errorContent(
+					`memory_retrieve error: ${error instanceof Error ? error.message : String(error)}`,
+					true,
+				);
 			}
 		},
 	);
@@ -179,10 +172,7 @@ export function registerMemoryTools(
 			try {
 				const ns = resolveNamespace(scope_id);
 				if (!ns) {
-					return {
-						content: [{ type: "text" as const, text: "Error: namespace could not be resolved" }],
-						isError: true,
-					};
+					return errorContent("Error: namespace could not be resolved", true);
 				}
 				const mem = getOrCreateMemory(ns);
 				const subject = defaultSubject(ns);
@@ -201,9 +191,7 @@ export function registerMemoryTools(
 				const [facts, internalFacts] = await Promise.all([factsPromise, internalFactsPromise]);
 
 				if (facts.length === 0 && (!internalFacts || internalFacts.length === 0)) {
-					return {
-						content: [{ type: "text", text: "No facts yet." }],
-					};
+					return textContent("No facts yet.");
 				}
 
 				const parts: string[] = [];
@@ -216,19 +204,12 @@ export function registerMemoryTools(
 					parts.push(...formatFacts(internalFacts));
 				}
 
-				return {
-					content: [{ type: "text", text: parts.join("\n") }],
-				};
+				return textContent(parts.join("\n"));
 			} catch (error) {
-				return {
-					content: [
-						{
-							type: "text",
-							text: `memory_get_facts error: ${error instanceof Error ? error.message : String(error)}`,
-						},
-					],
-					isError: true,
-				};
+				return errorContent(
+					`memory_get_facts error: ${error instanceof Error ? error.message : String(error)}`,
+					true,
+				);
 			}
 		},
 	);

--- a/packages/mcp/src/tools/meta.ts
+++ b/packages/mcp/src/tools/meta.ts
@@ -1,5 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+import { textContent } from "./result.ts";
+
 type ToolDescriptionMap = Map<string, string | undefined>;
 
 interface RegisterToolLike {
@@ -36,7 +38,7 @@ export function registerMetaTools(
 				.map(([name, desc]) => {
 					return desc ? `${name}: ${desc}` : name;
 				});
-			return { content: [{ type: "text" as const, text: entries.join("\n") }] };
+			return textContent(entries.join("\n"));
 		},
 	);
 }

--- a/packages/mcp/src/tools/result.ts
+++ b/packages/mcp/src/tools/result.ts
@@ -1,0 +1,63 @@
+/**
+ * MCP tool 結果シェイプの共通ヘルパ。
+ *
+ * 各 tool に散在していた `{ content: [{ type: "text" as const, text }] }` の手書きと、
+ * `boundScopeId ?? inputScopeId` の解決ガードを単一ソース化する。
+ */
+
+/** MCP tool が返すテキスト結果のシェイプ */
+export interface ToolTextResult {
+	content: Array<{ type: "text"; text: string }>;
+	isError?: boolean;
+}
+
+/** 非エラーのテキスト結果を返す。 */
+export function textContent(text: string): ToolTextResult {
+	return { content: [{ type: "text", text }] };
+}
+
+/**
+ * エラーのテキスト結果を返す。
+ *
+ * `isError` はデフォルトで付けない（`undefined`）。これは既存の各 tool のエラー結果が
+ * 「isError あり」と「isError なし」で混在しており、置換時に挙動を完全保存するため。
+ * MCP プロトコル上 `isError` はクライアント (LLM) に観測されるため、付与の有無は
+ * 各呼び出し箇所が現状どおり明示的に選択する。
+ *
+ * @param text エラーメッセージ
+ * @param isError true を渡した場合のみ結果に `isError: true` を付与する
+ */
+export function errorContent(text: string, isError?: boolean): ToolTextResult {
+	return isError
+		? { content: [{ type: "text", text }], isError: true }
+		: { content: [{ type: "text", text }] };
+}
+
+/** `resolveBoundScope` の戻り値。`ok: true` なら解決済み値、`ok: false` なら早期 return 用のエラー結果。 */
+export type ResolveBoundResult =
+	| { ok: true; value: string }
+	| { ok: false; result: ToolTextResult };
+
+/**
+ * `boundValue ?? inputValue` を解決し、いずれも無ければエラー結果を返す。
+ *
+ * 既存の scope/guild 解決ガード（`const x = boundScopeId ?? scope_id; if (!x) return <error>`）を集約する。
+ * エラー結果は `errorContent` 経由で生成され、デフォルトでは `isError` を付けない（既存挙動を保存）。
+ *
+ * @param boundValue 束縛済みの値（boundScopeId / boundGuildId 等）
+ * @param inputValue ツール入力から渡された値（scope_id / guild_id 等）
+ * @param missingText どちらも無い場合のエラーメッセージ（例: `"Error: scope_id is required"`）
+ * @param isError エラー結果に `isError: true` を付ける場合は true
+ */
+export function resolveBoundScope(
+	boundValue: string | undefined,
+	inputValue: string | undefined,
+	missingText: string,
+	isError?: boolean,
+): ResolveBoundResult {
+	const value = boundValue ?? inputValue;
+	if (!value) {
+		return { ok: false, result: errorContent(missingText, isError) };
+	}
+	return { ok: true, value };
+}

--- a/packages/mcp/src/tools/schedule.ts
+++ b/packages/mcp/src/tools/schedule.ts
@@ -5,6 +5,8 @@ import type { HeartbeatConfigPort } from "@vicissitude/shared/ports";
 import type { HeartbeatReminder } from "@vicissitude/shared/types";
 import { z } from "zod/v4";
 
+import { errorContent, resolveBoundScope, textContent } from "./result.ts";
+
 const scopeIdSchema = z.string().regex(AGENT_SCOPE_ID_RE).describe("Agent scope ID");
 
 export function filterRemindersByScope(
@@ -28,7 +30,7 @@ function registerReadTools(
 		{ description: "Show current heartbeat configuration" },
 		async () => {
 			const config = await configPort.load();
-			return { content: [{ type: "text", text: JSON.stringify(config, null, 2) }] };
+			return textContent(JSON.stringify(config, null, 2));
 		},
 	);
 
@@ -39,12 +41,10 @@ function registerReadTools(
 			inputSchema: boundScopeId ? {} : { scope_id: scopeIdSchema },
 		},
 		async ({ scope_id }: { scope_id?: string }) => {
-			const scopeId = boundScopeId ?? scope_id;
-			if (!scopeId) {
-				return { content: [{ type: "text" as const, text: "Error: scope_id is required" }] };
-			}
+			const resolved = resolveBoundScope(boundScopeId, scope_id, "Error: scope_id is required");
+			if (!resolved.ok) return resolved.result;
 			const config = await configPort.load();
-			const visible = filterRemindersByScope(config.reminders, scopeId);
+			const visible = filterRemindersByScope(config.reminders, resolved.value);
 			const lines = visible.map((r) => {
 				const schedule =
 					r.schedule.type === "interval"
@@ -55,7 +55,7 @@ function registerReadTools(
 				const scope = r.scopeId ? `scope:${r.scopeId}` : "global";
 				return `- [${r.id}] ${r.description} (${schedule}, ${status}, ${scope}, last: ${last})`;
 			});
-			return { content: [{ type: "text" as const, text: lines.join("\n") || "No reminders" }] };
+			return textContent(lines.join("\n") || "No reminders");
 		},
 	);
 
@@ -69,14 +69,7 @@ function registerReadTools(
 			const config = await configPort.load();
 			config.baseIntervalMinutes = minutes;
 			await configPort.save(config);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Base interval set to ${String(minutes)} minutes`,
-					},
-				],
-			};
+			return textContent(`Base interval set to ${String(minutes)} minutes`);
 		},
 	);
 }
@@ -127,26 +120,20 @@ function registerAddReminder(
 			daily_minute?: number;
 			global?: boolean;
 		}) => {
-			const resolvedScopeId = boundScopeId ?? scope_id;
-			if (!resolvedScopeId) {
-				return { content: [{ type: "text" as const, text: "Error: scope_id is required" }] };
-			}
+			const resolved = resolveBoundScope(boundScopeId, scope_id, "Error: scope_id is required");
+			if (!resolved.ok) return resolved.result;
 			const config = await configPort.load();
 
 			if (config.reminders.some((r) => r.id === id)) {
-				return {
-					content: [{ type: "text" as const, text: `Error: ID "${id}" already exists` }],
-				};
+				return errorContent(`Error: ID "${id}" already exists`);
 			}
 
-			const scopeId = isGlobal ? undefined : resolvedScopeId;
+			const scopeId = isGlobal ? undefined : resolved.value;
 
 			let reminder: HeartbeatReminder;
 			if (schedule_type === "interval") {
 				if (interval_minutes === undefined) {
-					return {
-						content: [{ type: "text" as const, text: "Error: interval_minutes is required" }],
-					};
+					return errorContent("Error: interval_minutes is required");
 				}
 				reminder = {
 					id,
@@ -173,9 +160,7 @@ function registerAddReminder(
 
 			config.reminders.push(reminder);
 			await configPort.save(config);
-			return {
-				content: [{ type: "text" as const, text: `Reminder "${id}" added` }],
-			};
+			return textContent(`Reminder "${id}" added`);
 		},
 	);
 }
@@ -223,28 +208,19 @@ function registerModifyReminders(
 			daily_hour?: number;
 			daily_minute?: number;
 		}) => {
-			const scopeId = boundScopeId ?? scope_id;
-			if (!scopeId) {
-				return { content: [{ type: "text" as const, text: "Error: scope_id is required" }] };
-			}
+			const resolved = resolveBoundScope(boundScopeId, scope_id, "Error: scope_id is required");
+			if (!resolved.ok) return resolved.result;
 			const config = await configPort.load();
 			const reminder = config.reminders.find((r) => r.id === id);
 
 			if (!reminder) {
-				return {
-					content: [{ type: "text" as const, text: `Error: ID "${id}" not found` }],
-				};
+				return errorContent(`Error: ID "${id}" not found`);
 			}
 
-			if (!checkScope(reminder, scopeId)) {
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: `Error: reminder "${id}" belongs to another scope and cannot be updated`,
-						},
-					],
-				};
+			if (!checkScope(reminder, resolved.value)) {
+				return errorContent(
+					`Error: reminder "${id}" belongs to another scope and cannot be updated`,
+				);
 			}
 
 			if (description !== undefined) reminder.description = description;
@@ -261,9 +237,7 @@ function registerModifyReminders(
 			}
 
 			await configPort.save(config);
-			return {
-				content: [{ type: "text" as const, text: `Reminder "${id}" updated` }],
-			};
+			return textContent(`Reminder "${id}" updated`);
 		},
 	);
 
@@ -277,35 +251,24 @@ function registerModifyReminders(
 			},
 		},
 		async ({ scope_id, id }: { scope_id?: string; id: string }) => {
-			const scopeId = boundScopeId ?? scope_id;
-			if (!scopeId) {
-				return { content: [{ type: "text" as const, text: "Error: scope_id is required" }] };
-			}
+			const resolved = resolveBoundScope(boundScopeId, scope_id, "Error: scope_id is required");
+			if (!resolved.ok) return resolved.result;
 			const config = await configPort.load();
 			const reminder = config.reminders.find((r) => r.id === id);
 
 			if (!reminder) {
-				return {
-					content: [{ type: "text" as const, text: `Error: ID "${id}" not found` }],
-				};
+				return errorContent(`Error: ID "${id}" not found`);
 			}
 
-			if (!checkScope(reminder, scopeId)) {
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: `Error: reminder "${id}" belongs to another scope and cannot be removed`,
-						},
-					],
-				};
+			if (!checkScope(reminder, resolved.value)) {
+				return errorContent(
+					`Error: reminder "${id}" belongs to another scope and cannot be removed`,
+				);
 			}
 
 			config.reminders.splice(config.reminders.indexOf(reminder), 1);
 			await configPort.save(config);
-			return {
-				content: [{ type: "text" as const, text: `Reminder "${id}" removed` }],
-			};
+			return textContent(`Reminder "${id}" removed`);
 		},
 	);
 }

--- a/spec/mcp/tools/result.spec.ts
+++ b/spec/mcp/tools/result.spec.ts
@@ -1,0 +1,118 @@
+/* oxlint-disable no-non-null-assertion -- test assertions on fixed content shape */
+import { describe, expect, it } from "bun:test";
+
+import { errorContent, resolveBoundScope, textContent } from "@vicissitude/mcp/tools/result";
+
+// ─── textContent ────────────────────────────────────────────────
+
+describe("textContent", () => {
+	it("テキストを type:text の content 配列に包んで返す", () => {
+		const result = textContent("hello");
+
+		expect(result).toEqual({ content: [{ type: "text", text: "hello" }] });
+	});
+
+	it("isError を付けない", () => {
+		const result = textContent("hello");
+
+		expect(result.isError).toBeUndefined();
+	});
+
+	it("空文字でも content を返す", () => {
+		const result = textContent("");
+
+		expect(result.content[0]!.text).toBe("");
+	});
+});
+
+// ─── errorContent ───────────────────────────────────────────────
+
+describe("errorContent", () => {
+	it("デフォルトでは isError を付けない（既存挙動の保存）", () => {
+		const result = errorContent("Error: scope_id is required");
+
+		expect(result).toEqual({
+			content: [{ type: "text", text: "Error: scope_id is required" }],
+		});
+		expect(result.isError).toBeUndefined();
+	});
+
+	it("第2引数 true で isError: true を付ける", () => {
+		const result = errorContent("Error: namespace could not be resolved", true);
+
+		expect(result).toEqual({
+			content: [{ type: "text", text: "Error: namespace could not be resolved" }],
+			isError: true,
+		});
+	});
+
+	it("第2引数 false では isError を付けない", () => {
+		const result = errorContent("Error: guild_id is required", false);
+
+		expect(result.isError).toBeUndefined();
+	});
+
+	it("テキストをそのまま content に格納する", () => {
+		const result = errorContent("custom error message");
+
+		expect(result.content[0]!.text).toBe("custom error message");
+		expect(result.content[0]!.type).toBe("text");
+	});
+});
+
+// ─── resolveBoundScope ──────────────────────────────────────────
+
+describe("resolveBoundScope", () => {
+	it("bound 値があればそれを解決値として返す", () => {
+		const result = resolveBoundScope("bound-id", "input-id", "Error: scope_id is required");
+
+		expect(result).toEqual({ ok: true, value: "bound-id" });
+	});
+
+	it("bound 値が無く input 値があれば input を解決値として返す", () => {
+		const result = resolveBoundScope(undefined, "input-id", "Error: scope_id is required");
+
+		expect(result).toEqual({ ok: true, value: "input-id" });
+	});
+
+	it("bound 値を input 値より優先する", () => {
+		const result = resolveBoundScope("bound-id", "input-id", "Error: scope_id is required");
+
+		expect(result).toMatchObject({ ok: true, value: "bound-id" });
+	});
+
+	it("どちらも無ければ ok:false とエラー結果を返す", () => {
+		const result = resolveBoundScope(undefined, undefined, "Error: scope_id is required");
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.result).toEqual({
+				content: [{ type: "text", text: "Error: scope_id is required" }],
+			});
+		}
+	});
+
+	it("解決失敗時のエラー結果はデフォルトで isError を付けない（既存ガード挙動の保存）", () => {
+		const result = resolveBoundScope(undefined, undefined, "Error: guild_id is required");
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.result.isError).toBeUndefined();
+		}
+	});
+
+	it("isError=true 指定時はエラー結果に isError: true を付ける", () => {
+		const result = resolveBoundScope(undefined, undefined, "Error: scope is required", true);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.result.isError).toBe(true);
+		}
+	});
+
+	it("空文字の input は未指定として扱いエラーを返す", () => {
+		const result = resolveBoundScope(undefined, "", "Error: scope_id is required");
+
+		expect(result.ok).toBe(false);
+	});
+});


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 1** 第3弾。`packages/mcp/src/tools` 全域に散在していた結果シェイプの手書きと scope/guild 解決ガードを `tools/result.ts` に集約する。後続 PR（P1-4 計測ラッパ一本化 / P1-5 stdio bootstrap 共通化）の基盤。

## 追加ヘルパ（`@vicissitude/mcp/tools/result`）

```ts
textContent(text): ToolTextResult            // { content:[{type:"text",text}] }
errorContent(text, isError?): ToolTextResult // isError 省略時は付けない
resolveBoundScope(boundValue, inputValue, missingText, isError?):
  | { ok: true; value: string }
  | { ok: false; result: ToolTextResult }    // bound ?? input、無ければエラー結果
```

## 置換と挙動保存

- discord / schedule / memory / mc-bridge-discord / mc-bridge-minecraft / mc-memory / meta の `"text" as const` 手書き多数と `bound ?? input` ガードを置換。
- **`isError` は正規化せず callsite ごとに完全保存**。MCP プロトコル上 `isError` は LLM に観測されるため、勝手に正規化すると挙動変更になる（`memory` の namespace ガードは isError あり、`schedule`/`discord` の scope/guild required ガードは isError なし、等を厳密に維持）。content テキストも1文字も変えない。

## 検証

- `nr validate` green（root `nr check` 含む）
- `nr test`: **2605 pass / 0 fail**（`memory-cross-ns.spec.ts` の `isError` assert 含め無変更で通過＝挙動保存）

## フォローアップ

scope/guild required ガードを `isError: true` に正規化すべきか（純粋なエラー表明にするか）は意図的な挙動変更のため別 Issue で検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)