### PR TITLE
refactor(mcp): wrapServerWithMetrics を一本化し型を健全化する

### DIFF
--- a/packages/mcp/src/tool-metrics.ts
+++ b/packages/mcp/src/tool-metrics.ts
@@ -2,21 +2,53 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { METRIC } from "@vicissitude/observability/metrics";
 import type { Logger, MetricsCollector } from "@vicissitude/shared/types";
 
+/** registerTool の config 第2引数（説明文のみ参照する）。 */
+interface ToolConfigLike {
+	description?: string;
+}
+
+/** registerTool のハンドラ。引数・戻り値はツールごとに異なるため広めに受ける。 */
+type ToolHandler = (...args: unknown[]) => unknown;
+
+/** McpServer のうち、本ラッパが介入する registerTool だけを抽出した構造的な型。 */
+interface RegisterToolLike {
+	registerTool(name: string, config: ToolConfigLike, cb: ToolHandler): unknown;
+}
+
 export interface MetricsOptions {
 	metrics: MetricsCollector;
 	logger?: Logger;
 	toolDescriptions?: Map<string, string | undefined>;
+	/**
+	 * 計測に使うカウンタ名。省略時は `mcp_tool_calls_total`。
+	 * Minecraft MCP など別系統のカウンタへ記録したい場合に指定する。
+	 */
+	metricName?: string;
+}
+
+function isThenable(value: unknown): value is Promise<unknown> {
+	return (
+		value !== null &&
+		value !== undefined &&
+		typeof (value as { then?: unknown }).then === "function"
+	);
 }
 
 /**
- * server.registerTool() 呼び出しをインターセプトし、各ツールのハンドラ実行時にカウンタをインクリメントする。
+ * server.registerTool() 呼び出しをインターセプトし、各ツールのハンドラ実行を計測する。
  * Proxy を使って McpServer を薄くラップすることで、個々のツール登録関数を変更せずに全ツールを計測できる。
+ *
+ * 記録仕様:
+ * - ハンドラ完了後に `metricName` カウンタを `{ tool, outcome: "success"|"error" }` ラベルで 1 加算する。
+ * - 同期/非同期（Promise）いずれのハンドラも outcome を判定する。
+ * - エラー時は outcome="error" を記録し、logger があれば error ログを出してから rethrow する。
+ * - `toolDescriptions` が渡された場合は登録時に `set(name, config.description)` で説明を記録する。
  */
 export function wrapServerWithMetrics(server: McpServer, options: MetricsOptions): McpServer {
-	const { metrics, logger } = options;
+	const { metrics, logger, toolDescriptions, metricName = METRIC.MCP_TOOL_CALLS } = options;
 
 	function increment(toolName: string, outcome: "success" | "error"): void {
-		metrics.incrementCounter(METRIC.MCP_TOOL_CALLS, { tool: toolName, outcome });
+		metrics.incrementCounter(metricName, { tool: toolName, outcome });
 	}
 
 	function handleError(name: string, err: unknown): never {
@@ -32,41 +64,31 @@ export function wrapServerWithMetrics(server: McpServer, options: MetricsOptions
 		get(target, prop, receiver) {
 			// oxlint-disable-next-line typescript/no-unsafe-return -- Proxy の get トラップは any を返す
 			if (prop !== "registerTool") return Reflect.get(target, prop, receiver);
-			// oxlint-disable-next-line no-explicit-any -- McpServer.registerTool() のコールバック型を正確に表現できないため any で受ける
-			return (name: string, config: any, cb: (...handlerArgs: any[]) => any) => {
-				// oxlint-disable-next-line typescript/no-unsafe-argument -- config は McpServer.registerTool の第2引数で any 型
-				options.toolDescriptions?.set(name, config?.description);
-				// oxlint-disable-next-line no-explicit-any -- handler の引数型はツールごとに異なる
-				// oxlint-disable-next-line no-explicit-any -- wrappedCb は元の cb と同じ戻り値型を維持する必要がある
-				const wrappedCb = (...handlerArgs: any[]): any => {
-					// oxlint-disable-next-line no-explicit-any -- cb の戻り値は同期/非同期で異なるため any で受ける
-					let result: any;
+			const delegate = target as unknown as RegisterToolLike;
+			return (name: string, config: ToolConfigLike, cb: ToolHandler): unknown => {
+				toolDescriptions?.set(name, config?.description);
+				const wrappedCb: ToolHandler = (...handlerArgs: unknown[]): unknown => {
+					let result: unknown;
 					try {
-						// oxlint-disable-next-line typescript/no-unsafe-argument -- handlerArgs は any[] で cb に透過的に渡す
 						result = cb(...handlerArgs);
 					} catch (err) {
 						handleError(name, err);
 					}
 
-					if (result !== null && result !== undefined && typeof result.then === "function") {
+					if (isThenable(result)) {
 						return result.then(
-							// oxlint-disable-next-line no-explicit-any -- Promise の resolve 値はツールごとに異なる
-							(value: any) => {
+							(value) => {
 								increment(name, "success");
-								// oxlint-disable-next-line typescript/no-unsafe-return -- Promise resolve 値を透過的に返す
 								return value;
 							},
-							(err: unknown) => {
-								handleError(name, err);
-							},
+							(err: unknown) => handleError(name, err),
 						);
 					}
 
 					increment(name, "success");
 					return result;
 				};
-				// oxlint-disable-next-line typescript/no-unsafe-argument -- config は McpServer.registerTool の第2引数で any 型
-				return target.registerTool(name, config, wrappedCb);
+				return delegate.registerTool(name, config, wrappedCb);
 			};
 		},
 	});

--- a/packages/minecraft/src/mcp-tools.ts
+++ b/packages/minecraft/src/mcp-tools.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { wrapServerWithMetrics } from "@vicissitude/mcp/tool-metrics";
 import { METRIC } from "@vicissitude/observability/metrics";
 import type { Logger, MetricsCollector } from "@vicissitude/shared/types";
 import { z } from "zod/v4";
@@ -201,30 +202,6 @@ function registerViewerUrlTool(server: McpServer, ctx: BotContext, viewerPort: n
 	);
 }
 
-/**
- * server.registerTool() 呼び出しをインターセプトし、各ツールのハンドラ実行時にメトリクスを記録する
- * Proxy を使って McpServer を薄くラップすることで、個々のツール登録関数を変更せずに全ツールを計測できる
- */
-function wrapServerWithMetrics(server: McpServer, metrics: MetricsCollector): McpServer {
-	return new Proxy(server, {
-		get(target, prop, receiver) {
-			// oxlint-disable-next-line typescript/no-unsafe-return -- Proxy の get トラップは any を返す
-			if (prop !== "registerTool") return Reflect.get(target, prop, receiver);
-			// oxlint-disable-next-line no-explicit-any -- McpServer.registerTool() のコールバック型を正確に表現できないため any で受ける
-			return (name: string, config: any, cb: (...handlerArgs: any[]) => any) => {
-				// oxlint-disable-next-line no-explicit-any -- handler の引数型はツールごとに異なる
-				const wrappedCb = (...handlerArgs: any[]) => {
-					metrics.incrementCounter(METRIC.MC_MCP_TOOL_CALLS, { tool: name });
-					// oxlint-disable-next-line typescript/no-unsafe-return, typescript/no-unsafe-argument -- cb の引数・戻り値は any 型で透過的に渡す
-					return cb(...handlerArgs);
-				};
-				// oxlint-disable-next-line typescript/no-unsafe-argument -- config は McpServer.registerTool の第2引数で any 型
-				return target.registerTool(name, config, wrappedCb);
-			};
-		},
-	});
-}
-
 interface MinecraftToolsOptions {
 	metrics?: MetricsCollector;
 	logger: Logger;
@@ -246,7 +223,13 @@ interface RegisterMinecraftToolsParams {
 
 export function registerMinecraftTools(params: RegisterMinecraftToolsParams): void {
 	const { server, ctx, jobManager, viewerPort, options } = params;
-	const s = options.metrics ? wrapServerWithMetrics(server, options.metrics) : server;
+	const s = options.metrics
+		? wrapServerWithMetrics(server, {
+				metrics: options.metrics,
+				logger: options.logger,
+				metricName: METRIC.MC_MCP_TOOL_CALLS,
+			})
+		: server;
 	registerObserveStateTool(s, ctx, jobManager);
 	registerRecoverStateTool(s, ctx, jobManager, options.stuckRecovery);
 	registerRecentEventsTool(s, ctx);

--- a/spec/mcp/tool-metrics.spec.ts
+++ b/spec/mcp/tool-metrics.spec.ts
@@ -217,6 +217,85 @@ describe("wrapServerWithMetrics", () => {
 	});
 
 	// -----------------------------------------------------------------------
+	// 3b. metricName による記録先カウンタの切り替え
+	// -----------------------------------------------------------------------
+	describe("metricName 指定時", () => {
+		it("成功時に指定したカウンタへ outcome ラベル付きで記録される", () => {
+			const metrics = createMockMetrics() as MockMetrics;
+			const { server, handlers } = createFakeServer();
+			const wrapped = wrapServerWithMetrics(server, {
+				metrics,
+				metricName: METRIC.MC_MCP_TOOL_CALLS,
+			});
+
+			wrapped.registerTool("observe_state", { description: "x" }, () => ({
+				content: [{ type: "text" as const, text: "ok" }],
+			}));
+
+			call(handlers, "observe_state", {});
+
+			expect(metrics.incrementCounter).toHaveBeenCalledWith(METRIC.MC_MCP_TOOL_CALLS, {
+				tool: "observe_state",
+				outcome: "success",
+			});
+		});
+
+		it("エラー時に指定したカウンタへ outcome:error で記録される", () => {
+			const metrics = createMockMetrics() as MockMetrics;
+			const { server, handlers } = createFakeServer();
+			const wrapped = wrapServerWithMetrics(server, {
+				metrics,
+				metricName: METRIC.MC_MCP_TOOL_CALLS,
+			});
+
+			wrapped.registerTool("recover_state", { description: "x" }, () => {
+				throw new Error("boom");
+			});
+
+			expect(() => call(handlers, "recover_state", {})).toThrow("boom");
+			expect(metrics.incrementCounter).toHaveBeenCalledWith(METRIC.MC_MCP_TOOL_CALLS, {
+				tool: "recover_state",
+				outcome: "error",
+			});
+		});
+
+		it("metricName 省略時は MCP_TOOL_CALLS に記録される", () => {
+			const metrics = createMockMetrics() as MockMetrics;
+			const { server, handlers } = createFakeServer();
+			const wrapped = wrapServerWithMetrics(server, { metrics });
+
+			wrapped.registerTool("ping", { description: "x" }, () => ({
+				content: [{ type: "text" as const, text: "pong" }],
+			}));
+
+			call(handlers, "ping", {});
+
+			expect(metrics.incrementCounter).toHaveBeenCalledWith(METRIC.MCP_TOOL_CALLS, {
+				tool: "ping",
+				outcome: "success",
+			});
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 3c. toolDescriptions への説明記録
+	// -----------------------------------------------------------------------
+	describe("toolDescriptions 指定時", () => {
+		it("登録したツールの説明が toolDescriptions に記録される", () => {
+			const metrics = createMockMetrics() as MockMetrics;
+			const { server } = createFakeServer();
+			const toolDescriptions = new Map<string, string | undefined>();
+			const wrapped = wrapServerWithMetrics(server, { metrics, toolDescriptions });
+
+			wrapped.registerTool("ping", { description: "ping tool" }, () => ({
+				content: [{ type: "text" as const, text: "pong" }],
+			}));
+
+			expect(toolDescriptions.get("ping")).toBe("ping tool");
+		});
+	});
+
+	// -----------------------------------------------------------------------
 	// 4. logger 省略時
 	// -----------------------------------------------------------------------
 	describe("logger 省略時", () => {


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 1** 第4弾。mcp と minecraft に重複していた `registerTool` 計測 Proxy ラッパを mcp の `wrapServerWithMetrics` に統合し、型を健全化する。

## 変更

- `MetricsOptions` に `metricName?`（省略時 `MCP_TOOL_CALLS`）を追加。minecraft は `METRIC.MC_MCP_TOOL_CALLS` を渡して同一実装を共有。minecraft 側の private ラッパ（72行）を削除。
- 構造的型 `RegisterToolLike`/`ToolHandler`/`isThenable` で `any` を `unknown` ベースに置換し、**oxlint 抑制を 10+ → 1**（Proxy `get` の `Reflect.get` 由来の1件のみ不可避）に削減。

## 意図的なメトリクス変更（ユーザー承認済み）

`mc_mcp_tool_calls_total` に `outcome={success,error}` ラベルが付き、記録タイミングが「呼び出し前1回」→「完了後 success/error」に変わる。minecraft tool error 時に `logger.error` が出るようになる（観測改善）。合計値は不変。`MC_MCP_TOOL_CALLS` を assert する spec は存在せず回帰なし。

## 検証

- `nr validate` green（root `nr check` 含む）
- `nr test`: **2609 pass / 0 fail**

## フォローアップ

tool description 記録の二系統（`createToolDescriptionRecorder` ⇔ metrics ラッパの `toolDescriptions`）の統合は別 Issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)