### PR TITLE
refactor(mcp): stdio MCP サーバーのブートストラップを共通化する

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"exports": {
 		"./core-server": "./src/core-server.ts",
+		"./run-stdio-mcp-server": "./src/run-stdio-mcp-server.ts",
 		"./discord-server": "./src/discord-server.ts",
 		"./http-server": "./src/http-server.ts",
 		"./memory-cache": "./src/memory-cache.ts",

--- a/packages/mcp/src/core-server.ts
+++ b/packages/mcp/src/core-server.ts
@@ -1,8 +1,6 @@
 import { mkdirSync } from "fs";
 import { resolve } from "path";
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { MemoryReadServices } from "@vicissitude/memory";
 import type { MemoryLlmPort } from "@vicissitude/memory/llm-port";
 import {
@@ -10,17 +8,16 @@ import {
 	type MemoryNamespace,
 	resolveMemoryDbDir,
 	resolveMemoryDbPath,
-	resolveNamespaceFromAgentId,
 } from "@vicissitude/memory/namespace";
 import { Retrieval } from "@vicissitude/memory/retrieval";
 import { SemanticMemory } from "@vicissitude/memory/semantic-memory";
 import { MemoryStorage } from "@vicissitude/memory/storage";
-import { ConsoleLogger } from "@vicissitude/observability/logger";
 import { OllamaEmbeddingAdapter } from "@vicissitude/ollama";
 import { JsonHeartbeatConfigRepository } from "@vicissitude/scheduling/heartbeat-config";
 
 import { LruCache } from "./lru-cache.ts";
 import { MemoryInstanceCache } from "./memory-cache.ts";
+import { runStdioMcpServer, type StdioMcpServerContext } from "./run-stdio-mcp-server.ts";
 import { registerMemoryTools } from "./tools/memory.ts";
 import { createToolDescriptionRecorder, registerMetaTools } from "./tools/meta.ts";
 import { registerScheduleTools } from "./tools/schedule.ts";
@@ -33,16 +30,8 @@ import { registerScheduleTools } from "./tools/schedule.ts";
  * 自分がどの agentId にバインドされているかを知る。
  *
  */
-async function main(): Promise<void> {
-	const logger = new ConsoleLogger({ destination: "stderr" });
-
+function setup(ctx: StdioMcpServerContext): () => void {
 	// --- Configuration from environment ---
-
-	const AGENT_ID = process.env.AGENT_ID;
-	if (!AGENT_ID) {
-		logger.error("[core-server] AGENT_ID environment variable is required");
-		process.exit(1);
-	}
 
 	const MEMORY_OLLAMA_BASE_URL =
 		process.env.MEMORY_OLLAMA_BASE_URL ?? process.env.OLLAMA_BASE_URL ?? "http://ollama:11434";
@@ -90,47 +79,31 @@ async function main(): Promise<void> {
 
 	// --- MCP Server ---
 
-	const server = new McpServer({ name: "core", version: "1.0.0" });
-	const { server: toolServer, toolDescriptions } = createToolDescriptionRecorder(server);
+	const { server: toolServer, toolDescriptions } = createToolDescriptionRecorder(ctx.server);
 
-	const boundNamespace: MemoryNamespace | undefined =
-		resolveNamespaceFromAgentId(AGENT_ID) ?? undefined;
-	if (!boundNamespace) {
-		logger.warn(
-			`[core-server] AGENT_ID=${AGENT_ID} did not resolve to a known namespace — tools require explicit scope_id`,
-		);
-	}
-	const boundScopeId =
-		boundNamespace?.surface === "agent-scope" ? boundNamespace.scopeId : undefined;
-
-	registerScheduleTools(toolServer, configRepo, boundScopeId);
+	registerScheduleTools(toolServer, configRepo, ctx.boundScopeId);
 
 	const retrieveCache = new LruCache<{ content: Array<{ type: "text"; text: string }> }>({
 		ttlMs: 30 * 60 * 1_000,
 		maxSize: 100,
 	});
-	registerMemoryTools(toolServer, { getOrCreateMemory, cache: retrieveCache }, boundNamespace);
+	registerMemoryTools(toolServer, { getOrCreateMemory, cache: retrieveCache }, ctx.boundNamespace);
 
 	registerMetaTools(toolServer, toolDescriptions);
 
-	// --- Graceful Shutdown ---
+	// --- Graceful Shutdown (helper calls this after server.close()) ---
 
-	async function shutdown() {
-		await server.close();
+	return () => {
 		retrieveCache.dispose();
 		memoryCache.closeAll();
-		process.exit(0);
-	}
-
-	process.on("SIGINT", () => void shutdown());
-	process.on("SIGTERM", () => void shutdown());
-
-	// --- Start server (stdio) ---
-
-	const transport = new StdioServerTransport();
-	await server.connect(transport);
+	};
 }
 
 if (import.meta.main) {
-	void main();
+	void runStdioMcpServer({
+		name: "core",
+		version: "1.0.0",
+		missingScopeHint: "scope_id",
+		setup,
+	});
 }

--- a/packages/mcp/src/discord-server.ts
+++ b/packages/mcp/src/discord-server.ts
@@ -1,17 +1,13 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
 	discordDmUserIdFromScopeId,
 	discordGuildIdFromScopeId,
-	type MemoryNamespace,
-	resolveNamespaceFromAgentId,
 } from "@vicissitude/memory/namespace";
-import { ConsoleLogger } from "@vicissitude/observability/logger";
 import { closeDb, createDb } from "@vicissitude/store/db";
 import { SqliteMoodStore } from "@vicissitude/store/mood-store";
 import { Client } from "discord.js";
 
 import { createEmotionAnalyzerWithStoreDb, readEmotionEstimationConfigFromEnv } from "./emotion.ts";
+import { runStdioMcpServer, type StdioMcpServerContext } from "./run-stdio-mcp-server.ts";
 import { registerDiscordTools } from "./tools/discord.ts";
 import { registerDiscordBridgeTools } from "./tools/mc-bridge-discord.ts";
 
@@ -21,18 +17,10 @@ import { registerDiscordBridgeTools } from "./tools/mc-bridge-discord.ts";
  * Discord REST 操作と Discord 側から使う Minecraft bridge を core MCP から分離する。
  * login() は呼ばず、Gateway セッションは作らない。
  */
-async function main(): Promise<void> {
-	const logger = new ConsoleLogger({ destination: "stderr" });
-
-	const AGENT_ID = process.env.AGENT_ID;
-	if (!AGENT_ID) {
-		logger.error("[discord-server] AGENT_ID environment variable is required");
-		process.exit(1);
-	}
-
+function setup(ctx: StdioMcpServerContext): () => void {
 	const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 	if (!DISCORD_TOKEN) {
-		logger.error("[discord-server] DISCORD_TOKEN environment variable is required");
+		ctx.logger.error("[discord-server] DISCORD_TOKEN environment variable is required");
 		process.exit(1);
 	}
 
@@ -46,61 +34,49 @@ async function main(): Promise<void> {
 	const moodStore = new SqliteMoodStore(db);
 	const emotionAnalyzer = createEmotionAnalyzerWithStoreDb(
 		readEmotionEstimationConfigFromEnv(process.env),
-		logger,
+		ctx.logger,
 		db,
 	);
 
-	const boundNamespace: MemoryNamespace | undefined =
-		resolveNamespaceFromAgentId(AGENT_ID) ?? undefined;
-	if (!boundNamespace) {
-		logger.warn(
-			`[discord-server] AGENT_ID=${AGENT_ID} did not resolve to a known namespace — tools require explicit guild_id`,
-		);
-	}
-	const boundScopeId =
-		boundNamespace?.surface === "agent-scope" ? boundNamespace.scopeId : undefined;
+	const boundScopeId = ctx.boundScopeId;
 	const boundGuildId = boundScopeId
 		? (discordGuildIdFromScopeId(boundScopeId) ?? undefined)
 		: undefined;
 	const boundDmUserId = boundScopeId
 		? (discordDmUserIdFromScopeId(boundScopeId) ?? undefined)
 		: undefined;
-	const moodKey = boundGuildId ? `discord:${boundGuildId}` : AGENT_ID;
-
-	const server = new McpServer({ name: "discord", version: "1.0.0" });
+	const moodKey = boundGuildId ? `discord:${boundGuildId}` : ctx.agentId;
 
 	registerDiscordTools(
-		server,
+		ctx.server,
 		{
 			discordClient,
 			emotionAnalyzer: emotionAnalyzer?.analyzer,
 			moodWriter: moodStore,
-			agentId: AGENT_ID,
+			agentId: ctx.agentId,
 			moodKey,
-			logger,
+			logger: ctx.logger,
 		},
 		{ guildId: boundGuildId, dmUserId: boundDmUserId },
 	);
 
 	if (process.env.MC_HOST) {
-		registerDiscordBridgeTools(server, { db }, boundGuildId);
+		registerDiscordBridgeTools(ctx.server, { db }, boundGuildId);
 	}
 
-	async function shutdown() {
-		await server.close();
+	// helper が server.close() 後に呼ぶ cleanup
+	return () => {
 		void discordClient.destroy();
 		emotionAnalyzer?.close();
 		closeDb(db);
-		process.exit(0);
-	}
-
-	process.on("SIGINT", () => void shutdown());
-	process.on("SIGTERM", () => void shutdown());
-
-	const transport = new StdioServerTransport();
-	await server.connect(transport);
+	};
 }
 
 if (import.meta.main) {
-	void main();
+	void runStdioMcpServer({
+		name: "discord",
+		version: "1.0.0",
+		missingScopeHint: "guild_id",
+		setup,
+	});
 }

--- a/packages/mcp/src/run-stdio-mcp-server.ts
+++ b/packages/mcp/src/run-stdio-mcp-server.ts
@@ -1,0 +1,114 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { type MemoryNamespace, resolveNamespaceFromAgentId } from "@vicissitude/memory/namespace";
+import { ConsoleLogger } from "@vicissitude/observability/logger";
+import type { Logger } from "@vicissitude/shared/types";
+
+/**
+ * AGENT_ID が namespace に解決できなかったときの warn 文言で使うヒント。
+ *
+ * - `"scope_id"`: tools が `scope_id` の明示を要求する場合（core-server）
+ * - `"guild_id"`: tools が `guild_id` の明示を要求する場合（discord-server）
+ */
+export type MissingScopeHint = "scope_id" | "guild_id";
+
+/**
+ * stdio MCP server セットアップコールバックが受け取るコンテキスト。
+ */
+export interface StdioMcpServerContext {
+	/** stderr に出力する logger（stdout は MCP 通信に使われるため）。 */
+	readonly logger: Logger;
+	/** 検証済みの AGENT_ID（空文字列ではないことが保証される）。 */
+	readonly agentId: string;
+	/** AGENT_ID から解決された namespace。解決できなければ `undefined`。 */
+	readonly boundNamespace: MemoryNamespace | undefined;
+	/** `boundNamespace` が agent-scope の場合の scopeId。それ以外は `undefined`。 */
+	readonly boundScopeId: string | undefined;
+	/** tool 登録対象の McpServer インスタンス。 */
+	readonly server: McpServer;
+}
+
+/**
+ * stdio MCP server の起動オプション。
+ */
+export interface RunStdioMcpServerOptions {
+	/** McpServer の `name`。ログプレフィックスにも `[${name}-server]` として使われる。 */
+	readonly name: string;
+	/** McpServer の `version`。 */
+	readonly version: string;
+	/** namespace 未解決時の warn 文言ヒント。 */
+	readonly missingScopeHint: MissingScopeHint;
+	/**
+	 * server 固有のセットアップ。tool 登録などを行い、shutdown 時に呼ばれる
+	 * cleanup 関数を返す（不要なら何も返さなくてよい）。
+	 *
+	 * DISCORD_TOKEN など追加の env 検証もこの中で行い、失敗時は
+	 * `ctx.logger.error(...)` の後に `process.exit(1)` する（呼び出し元の既存挙動を保存）。
+	 */
+	readonly setup: (
+		ctx: StdioMcpServerContext,
+	) => void | (() => void | Promise<void>) | Promise<void | (() => void | Promise<void>)>;
+}
+
+/**
+ * 3つの stdio MCP server エントリポイント（core / discord / mc-bridge）が共有する
+ * 起動骨格を共通化したヘルパ。
+ *
+ * 担うこと:
+ * 1. stderr 向け {@link ConsoleLogger} の生成
+ * 2. `AGENT_ID` env の検証（欠落時 `[${name}-server] AGENT_ID environment variable is required`
+ *    を error 出力し `process.exit(1)`）
+ * 3. `AGENT_ID` からの namespace 解決と、未解決時の warn
+ * 4. `boundScopeId` の導出
+ * 5. {@link McpServer} の生成
+ * 6. `setup` コールバックの呼び出し（tool 登録・追加検証）
+ * 7. SIGINT / SIGTERM ハンドラの配線（`server.close()` → setup の cleanup → `process.exit(0)`）
+ * 8. {@link StdioServerTransport} 経由の接続
+ *
+ * server 固有の処理（追加 env 検証・deps 構築・tool 登録・cleanup・server の wrap）は
+ * すべて `setup` コールバックに委ねる。
+ */
+export async function runStdioMcpServer(options: RunStdioMcpServerOptions): Promise<void> {
+	const { name, version, missingScopeHint } = options;
+	const logger = new ConsoleLogger({ destination: "stderr" });
+
+	const agentId = process.env.AGENT_ID;
+	if (!agentId) {
+		logger.error(`[${name}-server] AGENT_ID environment variable is required`);
+		process.exit(1);
+	}
+
+	const boundNamespace: MemoryNamespace | undefined =
+		resolveNamespaceFromAgentId(agentId) ?? undefined;
+	if (!boundNamespace) {
+		logger.warn(
+			`[${name}-server] AGENT_ID=${agentId} did not resolve to a known namespace — tools require explicit ${missingScopeHint}`,
+		);
+	}
+	const boundScopeId =
+		boundNamespace?.surface === "agent-scope" ? boundNamespace.scopeId : undefined;
+
+	const server = new McpServer({ name, version });
+
+	const cleanup = await options.setup({
+		logger,
+		agentId,
+		boundNamespace,
+		boundScopeId,
+		server,
+	});
+
+	async function shutdown(): Promise<void> {
+		await server.close();
+		if (cleanup) {
+			await cleanup();
+		}
+		process.exit(0);
+	}
+
+	process.on("SIGINT", () => void shutdown());
+	process.on("SIGTERM", () => void shutdown());
+
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+}

--- a/spec/mcp/run-stdio-mcp-server.spec.ts
+++ b/spec/mcp/run-stdio-mcp-server.spec.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * `runStdioMcpServer` のブラックボックス契約テスト。
+ *
+ * `process.exit` / `process.on(SIGINT|SIGTERM)` / stdio transport を絡むため、
+ * 子プロセスを起動して観測する。テスト用ハーネスは `runStdioMcpServer` を呼び、
+ * setup コールバック内で診断ログを出すだけのダミー server を構成する。
+ *
+ * setup の中で `server.connect` の前に発生する挙動（logger / exit / namespace warn）を
+ * stderr とプロセス終了コードで固定する。transport 接続後はプロセスが stdin 待ちで
+ * ブロックするため、その状態（exit していないこと）も検証する。
+ */
+
+interface RunResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+	/** タイムアウトで kill された（= main がブロック状態に入った）場合 true。 */
+	killed: boolean;
+}
+
+/**
+ * 子プロセスでテスト用ハーネスを実行する。
+ *
+ * `sendSignal` を指定すると、起動後一定時間待ってから当該シグナルを送り、
+ * graceful shutdown 経路を観測する。
+ */
+async function runHarness(opts: {
+	env: Record<string, string | undefined>;
+	sendSignal?: "SIGINT" | "SIGTERM";
+}): Promise<RunResult> {
+	const env: Record<string, string | undefined> = { ...process.env, ...opts.env };
+	for (const [k, v] of Object.entries(opts.env)) {
+		if (v === undefined) delete env[k];
+	}
+
+	const harness = `
+import { runStdioMcpServer } from "@vicissitude/mcp/run-stdio-mcp-server";
+
+await runStdioMcpServer({
+  name: "harness",
+  version: "9.9.9",
+  missingScopeHint: "scope_id",
+  setup: (ctx) => {
+    console.error("SETUP agentId=" + ctx.agentId);
+    console.error("SETUP boundScopeId=" + String(ctx.boundScopeId));
+    console.error("SETUP boundNamespace=" + (ctx.boundNamespace ? ctx.boundNamespace.surface : "undefined"));
+    console.error("SETUP serverName=" + (ctx.server ? "present" : "missing"));
+    return () => {
+      console.error("CLEANUP called");
+    };
+  },
+});
+`;
+
+	const proc = Bun.spawn(["bun", "-e", harness], {
+		cwd: process.cwd(),
+		env,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+
+	let killed = false;
+	if (opts.sendSignal) {
+		// transport.connect 後に shutdown 経路へ入れるよう少し待ってからシグナルを送る。
+		await Bun.sleep(400);
+		proc.kill(opts.sendSignal === "SIGINT" ? "SIGINT" : "SIGTERM");
+	}
+
+	const exitCode = await Promise.race([
+		proc.exited,
+		Bun.sleep(2_000).then(() => {
+			killed = true;
+			proc.kill();
+			return -1;
+		}),
+	]);
+
+	const stdout = await new Response(proc.stdout).text();
+	const stderr = await new Response(proc.stderr).text();
+	return { exitCode, stdout, stderr, killed };
+}
+
+// 有効な AGENT_ID（discord guild → agent-scope namespace に解決される）
+const RESOLVABLE_AGENT_ID = "discord:123456789012345678";
+// namespace に解決できない AGENT_ID
+const UNRESOLVABLE_AGENT_ID = "totally-not-a-valid-agent-id";
+
+describe("runStdioMcpServer", () => {
+	describe("AGENT_ID 検証", () => {
+		test("AGENT_ID が欠落していると error を出力して exit code 1 で終了する", async () => {
+			const result = await runHarness({ env: { AGENT_ID: undefined } });
+
+			expect(result.exitCode).toBe(1);
+		});
+
+		test("AGENT_ID 欠落時の error 文言は [<name>-server] プレフィックス付きで required を伝える", async () => {
+			const result = await runHarness({ env: { AGENT_ID: undefined } });
+
+			expect(result.stderr).toContain("[harness-server] AGENT_ID environment variable is required");
+		});
+
+		test("AGENT_ID 欠落時は setup コールバックを呼ばない", async () => {
+			const result = await runHarness({ env: { AGENT_ID: undefined } });
+
+			expect(result.stderr).not.toContain("SETUP");
+		});
+	});
+
+	describe("namespace 解決", () => {
+		test("解決可能な AGENT_ID では setup に agent-scope の boundNamespace を渡す", async () => {
+			const result = await runHarness({ env: { AGENT_ID: RESOLVABLE_AGENT_ID } });
+
+			expect(result.stderr).toContain("SETUP boundNamespace=agent-scope");
+		});
+
+		test("解決可能な AGENT_ID では setup に boundScopeId を導出して渡す", async () => {
+			const result = await runHarness({ env: { AGENT_ID: RESOLVABLE_AGENT_ID } });
+
+			expect(result.stderr).toContain("SETUP boundScopeId=discord:guild:123456789012345678");
+		});
+
+		test("解決可能な AGENT_ID では namespace 未解決 warn を出さない", async () => {
+			const result = await runHarness({ env: { AGENT_ID: RESOLVABLE_AGENT_ID } });
+
+			expect(result.stderr).not.toContain("did not resolve to a known namespace");
+		});
+
+		test("解決できない AGENT_ID では missingScopeHint を含む warn を出す", async () => {
+			const result = await runHarness({ env: { AGENT_ID: UNRESOLVABLE_AGENT_ID } });
+
+			expect(result.stderr).toContain(
+				`[harness-server] AGENT_ID=${UNRESOLVABLE_AGENT_ID} did not resolve to a known namespace — tools require explicit scope_id`,
+			);
+		});
+
+		test("解決できない AGENT_ID では boundScopeId を undefined として setup に渡す", async () => {
+			const result = await runHarness({ env: { AGENT_ID: UNRESOLVABLE_AGENT_ID } });
+
+			expect(result.stderr).toContain("SETUP boundScopeId=undefined");
+		});
+	});
+
+	describe("setup コンテキスト", () => {
+		test("setup に検証済み agentId を渡す", async () => {
+			const result = await runHarness({ env: { AGENT_ID: RESOLVABLE_AGENT_ID } });
+
+			expect(result.stderr).toContain(`SETUP agentId=${RESOLVABLE_AGENT_ID}`);
+		});
+
+		test("setup に McpServer インスタンスを渡す", async () => {
+			const result = await runHarness({ env: { AGENT_ID: RESOLVABLE_AGENT_ID } });
+
+			expect(result.stderr).toContain("SETUP serverName=present");
+		});
+	});
+
+	describe("起動", () => {
+		test("正常系では transport 接続後にプロセスがブロックし、setup 後すぐには終了しない", async () => {
+			const result = await runHarness({ env: { AGENT_ID: RESOLVABLE_AGENT_ID } });
+
+			// stdin 待ちでブロックするため、タイムアウト kill されるのが期待挙動。
+			expect(result.killed).toBe(true);
+			expect(result.stderr).toContain("SETUP serverName=present");
+		});
+	});
+
+	describe("graceful shutdown", () => {
+		test("SIGINT で setup が返した cleanup を呼んでから exit code 0 で終了する", async () => {
+			const result = await runHarness({
+				env: { AGENT_ID: RESOLVABLE_AGENT_ID },
+				sendSignal: "SIGINT",
+			});
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stderr).toContain("CLEANUP called");
+		});
+
+		test("SIGTERM でも cleanup を呼んでから exit code 0 で終了する", async () => {
+			const result = await runHarness({
+				env: { AGENT_ID: RESOLVABLE_AGENT_ID },
+				sendSignal: "SIGTERM",
+			});
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stderr).toContain("CLEANUP called");
+		});
+	});
+});


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 1** 第5弾。`core-server` / `discord-server` の `main()` が共有していた stdio MCP サーバー起動定型を `runStdioMcpServer` に集約する。

## 追加ヘルパ（`@vicissitude/mcp/run-stdio-mcp-server`）

ヘルパが担う共通処理:
- `ConsoleLogger({ destination: "stderr" })` 生成
- `AGENT_ID` 検証（欠落時 `[${name}-server] AGENT_ID ... required` + `exit(1)`）
- `resolveNamespaceFromAgentId` + warn（`missingScopeHint` で `scope_id`/`guild_id` を切替）
- `boundScopeId` 導出 / `McpServer` 生成
- SIGINT・SIGTERM 配線 / shutdown（`server.close()` → cleanup → `exit(0)`）
- `StdioServerTransport` connect

server 固有（deps 構築・tool 登録・discord の `DISCORD_TOKEN` 検証や `boundGuildId` 派生・core の `createToolDescriptionRecorder` wrap・cleanup）は `setup` コールバックへ。

## スコープ

`mc-bridge-server.ts`（minecraft）は AGENT_ID・namespace 解決・logger を持たず構造が乖離するため対象外（YAGNI）。共通化は mcp の2サーバーのみ。

## 検証

ログ文言・exit code・cleanup 順序（`server.close()` 先）を完全保存。
- `nr validate` green（root `nr check` 含む）
- `nr test`: **2622 pass / 0 fail**（entrypoint spec を無変更で通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)