### PR TITLE
refactor(scheduling): 周期 tick の重複実行ガードを基底クラスに抽出する

### DIFF
--- a/apps/discord/src/bootstrap.ts
+++ b/apps/discord/src/bootstrap.ts
@@ -576,13 +576,13 @@ export async function setupMemoryRecording(
 			: undefined;
 
 		const recorder = new MemoryConversationRecorder(llm, dataDir);
-		const consolidationScheduler = new ConsolidationScheduler(
-			recorder,
+		const consolidationScheduler = new ConsolidationScheduler({
+			consolidator: recorder,
 			logger,
-			opts.metricsCollector,
+			metrics: opts.metricsCollector,
 			criticAuditor,
-			githubIssuePort,
-		);
+			issueReporter: githubIssuePort,
+		});
 
 		logger.info(`[bootstrap] Memory auto-recording enabled (port=${opts.memoryPort})`);
 		return { chatAdapter, recorder, consolidationScheduler };

--- a/packages/scheduling/package.json
+++ b/packages/scheduling/package.json
@@ -2,6 +2,7 @@
 	"name": "@vicissitude/scheduling",
 	"private": true,
 	"exports": {
+		"./periodic-tick-scheduler": "./src/periodic-tick-scheduler.ts",
 		"./heartbeat-helpers": "./src/heartbeat-helpers.ts",
 		"./heartbeat-scheduler": "./src/heartbeat-scheduler.ts",
 		"./heartbeat-config": "./src/heartbeat-config.ts",

--- a/packages/scheduling/src/consolidation-scheduler.test.ts
+++ b/packages/scheduling/src/consolidation-scheduler.test.ts
@@ -26,9 +26,9 @@ function createConsolidator(): MemoryConsolidator {
 async function executeConsolidation(scheduler: ConsolidationScheduler): Promise<void> {
 	await (
 		scheduler as unknown as {
-			executeConsolidation(): Promise<void>;
+			runTick(): Promise<void>;
 		}
-	).executeConsolidation();
+	).runTick();
 }
 
 describe("ConsolidationScheduler critic audit observability", () => {
@@ -38,12 +38,12 @@ describe("ConsolidationScheduler critic audit observability", () => {
 		const criticAuditor: CriticAuditorPort = {
 			audit: mock(() => Promise.resolve({ status: "skipped", reason: "no_bot_id" } as const)),
 		};
-		const scheduler = new ConsolidationScheduler(
-			createConsolidator(),
+		const scheduler = new ConsolidationScheduler({
+			consolidator: createConsolidator(),
 			logger,
 			metrics,
 			criticAuditor,
-		);
+		});
 
 		await executeConsolidation(scheduler);
 
@@ -64,12 +64,12 @@ describe("ConsolidationScheduler critic audit observability", () => {
 				Promise.resolve({ status: "skipped", reason: "low_drift", driftScore: 0.01 } as const),
 			),
 		};
-		const scheduler = new ConsolidationScheduler(
-			createConsolidator(),
+		const scheduler = new ConsolidationScheduler({
+			consolidator: createConsolidator(),
 			logger,
 			metrics,
 			criticAuditor,
-		);
+		});
 
 		await executeConsolidation(scheduler);
 
@@ -89,12 +89,12 @@ describe("ConsolidationScheduler critic audit observability", () => {
 		const criticAuditor: CriticAuditorPort = {
 			audit: mock(() => Promise.resolve({ status: "skipped", reason: "no_messages" } as const)),
 		};
-		const scheduler = new ConsolidationScheduler(
-			createConsolidator(),
+		const scheduler = new ConsolidationScheduler({
+			consolidator: createConsolidator(),
 			logger,
 			metrics,
 			criticAuditor,
-		);
+		});
 
 		await executeConsolidation(scheduler);
 		await executeConsolidation(scheduler);

--- a/packages/scheduling/src/consolidation-scheduler.ts
+++ b/packages/scheduling/src/consolidation-scheduler.ts
@@ -1,5 +1,4 @@
 import { METRIC } from "@vicissitude/observability/metrics";
-import { withTimeout } from "@vicissitude/shared/functions";
 import { defaultSubject, namespaceKey } from "@vicissitude/shared/namespace";
 import type {
 	CriticAuditSkipReason,
@@ -8,6 +7,8 @@ import type {
 } from "@vicissitude/shared/ports";
 import type { Logger, MemoryConsolidator, MetricsCollector } from "@vicissitude/shared/types";
 
+import { type PeriodicTickConfig, PeriodicTickScheduler } from "./periodic-tick-scheduler.ts";
+
 /** 30 minutes */
 const CONSOLIDATION_TICK_INTERVAL_MS = 30 * 60_000;
 /** 10 minutes (LLM calls are slow) */
@@ -15,21 +16,36 @@ const CONSOLIDATION_TICK_TIMEOUT_MS = 10 * 60_000;
 /** 5 minutes delay before first tick */
 const CONSOLIDATION_INITIAL_DELAY_MS = 5 * 60_000;
 
-export class ConsolidationScheduler {
+const tickConfig: PeriodicTickConfig = {
+	logPrefix: "[memory-consolidation]",
+	tickTimeoutMs: CONSOLIDATION_TICK_TIMEOUT_MS,
+	timeoutMessage: "memory consolidation tick timed out",
+	tickCounterMetric: METRIC.MEMORY_CONSOLIDATION_TICKS,
+	tickDurationMetric: METRIC.MEMORY_CONSOLIDATION_TICK_DURATION,
+};
+
+export interface ConsolidationSchedulerDeps {
+	consolidator: MemoryConsolidator;
+	logger: Logger;
+	metrics?: MetricsCollector;
+	criticAuditor?: CriticAuditorPort;
+	issueReporter?: GitHubIssuePort;
+}
+
+export class ConsolidationScheduler extends PeriodicTickScheduler {
 	private timer: ReturnType<typeof setInterval> | null = null;
 	private initialTimer: ReturnType<typeof setTimeout> | null = null;
-	private running = false;
-	private executePromise: Promise<void> | null = null;
+	private readonly consolidator: MemoryConsolidator;
+	private readonly criticAuditor?: CriticAuditorPort;
+	private readonly issueReporter?: GitHubIssuePort;
 	private readonly lastCriticAuditSkipReasons = new Map<string, CriticAuditSkipReason>();
 
-	/* oxlint-disable-next-line max-params -- DI: all dependencies are required ports */
-	constructor(
-		private readonly consolidator: MemoryConsolidator,
-		private readonly logger: Logger,
-		private readonly metrics?: MetricsCollector,
-		private readonly criticAuditor?: CriticAuditorPort,
-		private readonly issueReporter?: GitHubIssuePort,
-	) {}
+	constructor(deps: ConsolidationSchedulerDeps) {
+		super(tickConfig, deps.logger, deps.metrics);
+		this.consolidator = deps.consolidator;
+		this.criticAuditor = deps.criticAuditor;
+		this.issueReporter = deps.issueReporter;
+	}
 
 	start(): void {
 		if (this.timer || this.initialTimer) return;
@@ -58,63 +74,8 @@ export class ConsolidationScheduler {
 		this.logger.info("[memory-consolidation] scheduler stopped");
 	}
 
-	private async tick(): Promise<void> {
-		if (this.running) {
-			this.logger.info("[memory-consolidation] previous tick still running, skipping");
-			return;
-		}
-
-		this.running = true;
-		const start = performance.now();
-		const execution = this.executeConsolidation();
-		this.executePromise = execution;
-		let executionSettled = false;
-		void execution.then(
-			() => {
-				executionSettled = true;
-				return null;
-			},
-			() => {
-				executionSettled = true;
-				return null;
-			},
-		);
-		try {
-			await withTimeout(
-				execution,
-				CONSOLIDATION_TICK_TIMEOUT_MS,
-				"memory consolidation tick timed out",
-			);
-			this.metrics?.incrementCounter(METRIC.MEMORY_CONSOLIDATION_TICKS, { outcome: "success" });
-		} catch (error) {
-			this.metrics?.incrementCounter(METRIC.MEMORY_CONSOLIDATION_TICKS, { outcome: "error" });
-			this.logger.error("[memory-consolidation] tick error:", error);
-		} finally {
-			const duration = (performance.now() - start) / 1000;
-			this.metrics?.observeHistogram(METRIC.MEMORY_CONSOLIDATION_TICK_DURATION, duration);
-		}
-
-		if (executionSettled) {
-			this.releaseExecution(execution);
-			return;
-		}
-
-		void this.releaseExecutionWhenSettled(execution);
-	}
-
-	private releaseExecution(execution: Promise<void>): void {
-		if (this.executePromise !== execution) return;
-		this.executePromise = null;
-		this.running = false;
-	}
-
-	private async releaseExecutionWhenSettled(execution: Promise<void>): Promise<void> {
-		await execution.catch(() => {});
-		this.releaseExecution(execution);
-	}
-
 	/** Inlined ConsolidateMemoryUseCase.execute */
-	private async executeConsolidation(): Promise<void> {
+	protected async runTick(): Promise<void> {
 		const namespaces = this.consolidator.getActiveNamespaces();
 		if (namespaces.length === 0) {
 			this.logger.info("[memory-consolidation] no active namespaces, skipping");

--- a/packages/scheduling/src/heartbeat-scheduler.test.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.test.ts
@@ -32,7 +32,7 @@ describe("HeartbeatScheduler", () => {
 			metrics,
 		});
 
-		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+		await (scheduler as unknown as { runTick(): Promise<void> }).runTick();
 
 		expect(metrics.incrementCounter).not.toHaveBeenCalledWith("heartbeat_reminders_executed_total");
 	});
@@ -58,7 +58,7 @@ describe("HeartbeatScheduler", () => {
 			metrics,
 		});
 
-		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+		await (scheduler as unknown as { runTick(): Promise<void> }).runTick();
 
 		expect(metrics.incrementCounter).toHaveBeenCalledWith("heartbeat_reminders_executed_total");
 	});
@@ -85,7 +85,7 @@ describe("HeartbeatScheduler", () => {
 			logger: createMockLogger(),
 		});
 
-		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+		await (scheduler as unknown as { runTick(): Promise<void> }).runTick();
 
 		expect(configRepo.save).not.toHaveBeenCalled();
 		expect(configRepo.markRemindersExecuted).toHaveBeenCalledTimes(1);
@@ -115,7 +115,7 @@ describe("HeartbeatScheduler", () => {
 		});
 
 		// executed=true（execute は呼ばれた）だが succeededIds が空なので config 更新は無し
-		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+		await (scheduler as unknown as { runTick(): Promise<void> }).runTick();
 
 		expect(heartbeatService.execute).toHaveBeenCalledTimes(1);
 		expect(configRepo.markRemindersExecuted).not.toHaveBeenCalled();
@@ -147,7 +147,7 @@ describe("HeartbeatScheduler", () => {
 			logger: createMockLogger(),
 		});
 
-		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+		await (scheduler as unknown as { runTick(): Promise<void> }).runTick();
 
 		expect(receivedIds).toEqual(["due-1"]);
 	});
@@ -176,7 +176,7 @@ describe("HeartbeatScheduler", () => {
 			preFilter: mock(() => Promise.resolve({ reminders: [], markExecutedIds: [] })),
 		});
 
-		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+		await (scheduler as unknown as { runTick(): Promise<void> }).runTick();
 
 		expect(heartbeatService.execute).not.toHaveBeenCalled();
 		expect(configRepo.markRemindersExecuted).not.toHaveBeenCalled();
@@ -191,7 +191,7 @@ describe("HeartbeatScheduler", () => {
 			preFilter,
 		});
 
-		await (scheduler as unknown as { executeTick(): Promise<void> }).executeTick();
+		await (scheduler as unknown as { runTick(): Promise<void> }).runTick();
 
 		expect(preFilter).not.toHaveBeenCalled();
 	});

--- a/packages/scheduling/src/heartbeat-scheduler.ts
+++ b/packages/scheduling/src/heartbeat-scheduler.ts
@@ -1,5 +1,4 @@
 import { METRIC } from "@vicissitude/observability/metrics";
-import { withTimeout } from "@vicissitude/shared/functions";
 import type { HeartbeatConfigPort } from "@vicissitude/shared/ports";
 import type {
 	DueReminder,
@@ -9,11 +8,20 @@ import type {
 } from "@vicissitude/shared/types";
 
 import { evaluateDueReminders } from "./heartbeat-helpers.ts";
+import { type PeriodicTickConfig, PeriodicTickScheduler } from "./periodic-tick-scheduler.ts";
 
 // ─── HeartbeatScheduler ─────────────────────────────────────────
 
 const HEARTBEAT_TICK_INTERVAL_MS = 60_000;
 const HEARTBEAT_TICK_TIMEOUT_MS = 180_000;
+
+const tickConfig: PeriodicTickConfig = {
+	logPrefix: "[heartbeat]",
+	tickTimeoutMs: HEARTBEAT_TICK_TIMEOUT_MS,
+	timeoutMessage: "heartbeat tick timed out",
+	tickCounterMetric: METRIC.HEARTBEAT_TICKS,
+	tickDurationMetric: METRIC.HEARTBEAT_TICK_DURATION,
+};
 
 /**
  * preFilter の戻り値。
@@ -34,13 +42,13 @@ export interface HeartbeatSchedulerDeps {
 	preFilter?: (dueReminders: DueReminder[]) => Promise<PreFilterResult>;
 }
 
-export class HeartbeatScheduler {
+export class HeartbeatScheduler extends PeriodicTickScheduler {
 	private timer: ReturnType<typeof setInterval> | null = null;
-	private running = false;
-	private executePromise: Promise<void> | null = null;
 	private tickIntervalMs = HEARTBEAT_TICK_INTERVAL_MS;
 
-	constructor(private readonly deps: HeartbeatSchedulerDeps) {}
+	constructor(private readonly deps: HeartbeatSchedulerDeps) {
+		super(tickConfig, deps.logger, deps.metrics);
+	}
 
 	start(): void {
 		if (this.timer) return;
@@ -57,47 +65,7 @@ export class HeartbeatScheduler {
 		this.deps.logger.info("[heartbeat] scheduler stopped");
 	}
 
-	private async tick(): Promise<void> {
-		if (this.running) {
-			this.deps.logger.info("[heartbeat] previous tick still running, skipping");
-			return;
-		}
-
-		this.running = true;
-		const start = performance.now();
-		const execution = this.executeTick();
-		this.executePromise = execution;
-		let executionSettled = false;
-		void execution.then(
-			() => {
-				executionSettled = true;
-				return null;
-			},
-			() => {
-				executionSettled = true;
-				return null;
-			},
-		);
-		try {
-			await withTimeout(execution, HEARTBEAT_TICK_TIMEOUT_MS, "heartbeat tick timed out");
-			this.deps.metrics?.incrementCounter(METRIC.HEARTBEAT_TICKS, { outcome: "success" });
-		} catch (error) {
-			this.deps.metrics?.incrementCounter(METRIC.HEARTBEAT_TICKS, { outcome: "error" });
-			this.deps.logger.error("[heartbeat] tick error:", error);
-		} finally {
-			const duration = (performance.now() - start) / 1000;
-			this.deps.metrics?.observeHistogram(METRIC.HEARTBEAT_TICK_DURATION, duration);
-		}
-
-		if (executionSettled) {
-			this.releaseExecution(execution);
-			return;
-		}
-
-		void this.releaseExecutionWhenSettled(execution);
-	}
-
-	private async executeTick(): Promise<void> {
+	protected async runTick(): Promise<void> {
 		const config = await this.deps.configRepo.load();
 		this.applyBaseInterval(config.baseIntervalMinutes);
 		const executed = await this.executeHeartbeat(config);
@@ -118,17 +86,6 @@ export class HeartbeatScheduler {
 		this.deps.logger.info(
 			`[heartbeat] scheduler interval updated (${String(baseIntervalMinutes)}min interval)`,
 		);
-	}
-
-	private releaseExecution(execution: Promise<void>): void {
-		if (this.executePromise !== execution) return;
-		this.executePromise = null;
-		this.running = false;
-	}
-
-	private async releaseExecutionWhenSettled(execution: Promise<void>): Promise<void> {
-		await execution.catch(() => {});
-		this.releaseExecution(execution);
 	}
 
 	private async executeHeartbeat(config: HeartbeatConfig): Promise<boolean> {

--- a/packages/scheduling/src/periodic-tick-scheduler.ts
+++ b/packages/scheduling/src/periodic-tick-scheduler.ts
@@ -1,0 +1,102 @@
+import { withTimeout } from "@vicissitude/shared/functions";
+import type { Logger, MetricsCollector } from "@vicissitude/shared/types";
+
+// ─── PeriodicTickScheduler ──────────────────────────────────────
+//
+// 周期 tick を駆動する scheduler の共通基底。
+//
+// 責務は「1 tick の重複実行ガード + タイムアウト + 計測 + 後始末」に限定する。
+// - `running` フラグで前 tick 実行中の再入を防ぐ（再入時は skip ログのみ）。
+// - `withTimeout` で 1 tick をガードし、タイムアウト後も実処理が継続中なら
+//   settle するまで `running` を解放しない（= 次 tick を開始させない）。
+// - tick の成否を counter に、所要時間を histogram に記録する。
+//
+// start/stop の timer 構成（即時 tick / 初回遅延 / dynamic interval /
+// stop 時の in-flight 待機など）はサブクラスごとに異なるため基底に持たせない。
+// サブクラスは start/stop を自前で実装し、その中から `tick()` を呼ぶ。
+
+/** tick 計測・ログ用のメタ情報。サブクラスが固定値として供給する。 */
+export interface PeriodicTickConfig {
+	/** ログ prefix（例: "[heartbeat]"）。 */
+	readonly logPrefix: string;
+	/** 1 tick のタイムアウト（ms）。 */
+	readonly tickTimeoutMs: number;
+	/** タイムアウト時のエラーメッセージ。 */
+	readonly timeoutMessage: string;
+	/** tick の成否を記録する counter 名。 */
+	readonly tickCounterMetric: string;
+	/** 1 tick の所要時間（秒）を記録する histogram 名。 */
+	readonly tickDurationMetric: string;
+}
+
+export abstract class PeriodicTickScheduler {
+	private running = false;
+	protected executePromise: Promise<void> | null = null;
+
+	protected constructor(
+		private readonly tickConfig: PeriodicTickConfig,
+		protected readonly logger: Logger,
+		protected readonly metrics: MetricsCollector | undefined,
+	) {}
+
+	/**
+	 * 1 tick の実体。サブクラスが固有処理（due reminder 評価 / consolidation 等）を実装する。
+	 * ここで投げられた例外は基底側の `withTimeout` で捕捉され error ログ + error counter になる。
+	 */
+	protected abstract runTick(): Promise<void>;
+
+	/**
+	 * 周期 tick の 1 回分。重複実行ガード・タイムアウト・計測・後始末を行う。
+	 * 前 tick が実行中の場合は skip ログのみ出して即 return する。
+	 */
+	protected async tick(): Promise<void> {
+		if (this.running) {
+			this.logger.info(`${this.tickConfig.logPrefix} previous tick still running, skipping`);
+			return;
+		}
+
+		this.running = true;
+		const start = performance.now();
+		const execution = this.runTick();
+		this.executePromise = execution;
+		let executionSettled = false;
+		void execution.then(
+			() => {
+				executionSettled = true;
+				return null;
+			},
+			() => {
+				executionSettled = true;
+				return null;
+			},
+		);
+		try {
+			await withTimeout(execution, this.tickConfig.tickTimeoutMs, this.tickConfig.timeoutMessage);
+			this.metrics?.incrementCounter(this.tickConfig.tickCounterMetric, { outcome: "success" });
+		} catch (error) {
+			this.metrics?.incrementCounter(this.tickConfig.tickCounterMetric, { outcome: "error" });
+			this.logger.error(`${this.tickConfig.logPrefix} tick error:`, error);
+		} finally {
+			const duration = (performance.now() - start) / 1000;
+			this.metrics?.observeHistogram(this.tickConfig.tickDurationMetric, duration);
+		}
+
+		if (executionSettled) {
+			this.releaseExecution(execution);
+			return;
+		}
+
+		void this.releaseExecutionWhenSettled(execution);
+	}
+
+	private releaseExecution(execution: Promise<void>): void {
+		if (this.executePromise !== execution) return;
+		this.executePromise = null;
+		this.running = false;
+	}
+
+	private async releaseExecutionWhenSettled(execution: Promise<void>): Promise<void> {
+		await execution.catch(() => {});
+		this.releaseExecution(execution);
+	}
+}

--- a/spec/scheduling/consolidation-scheduler-critic-audit.spec.ts
+++ b/spec/scheduling/consolidation-scheduler-critic-audit.spec.ts
@@ -31,7 +31,12 @@ describe("ConsolidationScheduler critic audit skip logging", () => {
 		const auditor: CriticAuditorPort = {
 			audit: mock(() => Promise.resolve({ status: "skipped", reason: "no_messages" } as const)),
 		};
-		const scheduler = new ConsolidationScheduler(createConsolidator(), logger, metrics, auditor);
+		const scheduler = new ConsolidationScheduler({
+			consolidator: createConsolidator(),
+			logger,
+			metrics,
+			criticAuditor: auditor,
+		});
 
 		await (scheduler as unknown as TickFn).tick();
 		await (scheduler as unknown as TickFn).tick();

--- a/spec/scheduling/consolidation-scheduler-timeout.spec.ts
+++ b/spec/scheduling/consolidation-scheduler-timeout.spec.ts
@@ -48,7 +48,7 @@ describe("ConsolidationScheduler timeout exclusivity", () => {
 						}),
 				),
 			};
-			const scheduler = new ConsolidationScheduler(consolidator, createMockLogger());
+			const scheduler = new ConsolidationScheduler({ consolidator, logger: createMockLogger() });
 			const tick = scheduler as unknown as { tick(): Promise<void> };
 
 			await tick.tick();

--- a/spec/scheduling/consolidation-scheduler.spec.ts
+++ b/spec/scheduling/consolidation-scheduler.spec.ts
@@ -62,7 +62,7 @@ describe("ConsolidationScheduler", () => {
 		const metrics = createMockMetrics();
 		const consolidator = createMockConsolidator();
 
-		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics);
+		const scheduler = new ConsolidationScheduler({ consolidator, logger, metrics });
 		await (scheduler as unknown as TickFn).tick();
 
 		expect(consolidator.consolidate).not.toHaveBeenCalled();
@@ -86,7 +86,7 @@ describe("ConsolidationScheduler", () => {
 			),
 		});
 
-		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics);
+		const scheduler = new ConsolidationScheduler({ consolidator, logger, metrics });
 		await (scheduler as unknown as TickFn).tick();
 
 		expect(consolidator.consolidate).toHaveBeenCalledWith(ns);
@@ -117,7 +117,7 @@ describe("ConsolidationScheduler", () => {
 			}),
 		});
 
-		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics);
+		const scheduler = new ConsolidationScheduler({ consolidator, logger, metrics });
 		await (scheduler as unknown as TickFn).tick();
 
 		expect(logger.error).toHaveBeenCalledWith(
@@ -150,7 +150,7 @@ describe("ConsolidationScheduler", () => {
 			),
 		});
 
-		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics);
+		const scheduler = new ConsolidationScheduler({ consolidator, logger, metrics });
 		const tick = scheduler as unknown as TickFn;
 
 		// 1 回目の tick を開始（未完了のまま保留）
@@ -189,7 +189,7 @@ describe("ConsolidationScheduler", () => {
 			),
 		});
 
-		const scheduler = new ConsolidationScheduler(consolidator, logger);
+		const scheduler = new ConsolidationScheduler({ consolidator, logger });
 		const tick = scheduler as unknown as TickFn;
 
 		// tick を開始
@@ -223,7 +223,7 @@ describe("ConsolidationScheduler", () => {
 			});
 
 			// 第4引数を省略
-			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics);
+			const scheduler = new ConsolidationScheduler({ consolidator, logger, metrics });
 			await (scheduler as unknown as TickFn).tick();
 
 			// consolidate は呼ばれるが audit は呼ばれない（そもそも auditor がない）
@@ -245,7 +245,12 @@ describe("ConsolidationScheduler", () => {
 				consolidate: mock(() => Promise.resolve(successResult)),
 			});
 
-			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
+			const scheduler = new ConsolidationScheduler({
+				consolidator,
+				logger,
+				metrics,
+				criticAuditor: auditor,
+			});
 			await (scheduler as unknown as TickFn).tick();
 
 			// audit が agent-scope の default subject（scopeId）で呼ばれる
@@ -266,7 +271,12 @@ describe("ConsolidationScheduler", () => {
 				consolidate: mock(() => Promise.resolve(successResult)),
 			});
 
-			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
+			const scheduler = new ConsolidationScheduler({
+				consolidator,
+				logger,
+				metrics,
+				criticAuditor: auditor,
+			});
 			await (scheduler as unknown as TickFn).tick();
 
 			expect(metrics.incrementCounter).toHaveBeenCalledWith("drift_audits_total", {
@@ -288,7 +298,12 @@ describe("ConsolidationScheduler", () => {
 				consolidate: mock(() => Promise.resolve(successResult)),
 			});
 
-			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
+			const scheduler = new ConsolidationScheduler({
+				consolidator,
+				logger,
+				metrics,
+				criticAuditor: auditor,
+			});
 			await (scheduler as unknown as TickFn).tick();
 
 			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("MAJOR drift detected"));
@@ -308,7 +323,12 @@ describe("ConsolidationScheduler", () => {
 				consolidate: mock(() => Promise.resolve(successResult)),
 			});
 
-			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
+			const scheduler = new ConsolidationScheduler({
+				consolidator,
+				logger,
+				metrics,
+				criticAuditor: auditor,
+			});
 			await (scheduler as unknown as TickFn).tick();
 
 			expect(auditor.audit).toHaveBeenCalledTimes(1);
@@ -340,7 +360,12 @@ describe("ConsolidationScheduler", () => {
 				consolidate: mock(() => Promise.resolve(successResult)),
 			});
 
-			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
+			const scheduler = new ConsolidationScheduler({
+				consolidator,
+				logger,
+				metrics,
+				criticAuditor: auditor,
+			});
 			await (scheduler as unknown as TickFn).tick();
 
 			// ns1 の audit 失敗で error ログが出る
@@ -371,7 +396,12 @@ describe("ConsolidationScheduler", () => {
 				consolidate: mock(() => Promise.resolve(successResult)),
 			});
 
-			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
+			const scheduler = new ConsolidationScheduler({
+				consolidator,
+				logger,
+				metrics,
+				criticAuditor: auditor,
+			});
 			await (scheduler as unknown as TickFn).tick();
 
 			expect(metrics.setGauge).toHaveBeenCalledWith("drift_score", 0.42, {
@@ -397,7 +427,12 @@ describe("ConsolidationScheduler", () => {
 				}),
 			});
 
-			const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
+			const scheduler = new ConsolidationScheduler({
+				consolidator,
+				logger,
+				metrics,
+				criticAuditor: auditor,
+			});
 			await (scheduler as unknown as TickFn).tick();
 
 			// ns1 で consolidate が失敗 → audit はスキップされる
@@ -439,7 +474,13 @@ describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", 
 			consolidate: mock(() => Promise.resolve(successResult)),
 		});
 
-		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor, issuePort);
+		const scheduler = new ConsolidationScheduler({
+			consolidator,
+			logger,
+			metrics,
+			criticAuditor: auditor,
+			issueReporter: issuePort,
+		});
 		await (scheduler as unknown as TickFn).tick();
 
 		// findRecentIssues で重複チェックが行われる
@@ -484,7 +525,13 @@ describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", 
 			consolidate: mock(() => Promise.resolve(successResult)),
 		});
 
-		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor, issuePort);
+		const scheduler = new ConsolidationScheduler({
+			consolidator,
+			logger,
+			metrics,
+			criticAuditor: auditor,
+			issueReporter: issuePort,
+		});
 		await (scheduler as unknown as TickFn).tick();
 
 		// findRecentIssues は呼ばれるが、同タイトルが見つかるので createIssue はスキップ
@@ -514,7 +561,13 @@ describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", 
 			consolidate: mock(() => Promise.resolve(successResult)),
 		});
 
-		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor, issuePort);
+		const scheduler = new ConsolidationScheduler({
+			consolidator,
+			logger,
+			metrics,
+			criticAuditor: auditor,
+			issueReporter: issuePort,
+		});
 		await (scheduler as unknown as TickFn).tick();
 
 		// issueTitle がないので Issue 関連の呼び出しは一切行われない
@@ -543,7 +596,12 @@ describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", 
 		});
 
 		// 第5引数（issueReporter）を省略
-		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor);
+		const scheduler = new ConsolidationScheduler({
+			consolidator,
+			logger,
+			metrics,
+			criticAuditor: auditor,
+		});
 		await (scheduler as unknown as TickFn).tick();
 
 		// warn ログは出る（既存動作）がクラッシュしない
@@ -575,7 +633,13 @@ describe("ConsolidationScheduler - GitHub Issue 自動起票 (severity major)", 
 			consolidate: mock(() => Promise.resolve(successResult)),
 		});
 
-		const scheduler = new ConsolidationScheduler(consolidator, logger, metrics, auditor, issuePort);
+		const scheduler = new ConsolidationScheduler({
+			consolidator,
+			logger,
+			metrics,
+			criticAuditor: auditor,
+			issueReporter: issuePort,
+		});
 
 		// クラッシュせずに完了する
 		await (scheduler as unknown as TickFn).tick();

--- a/spec/scheduling/periodic-tick-scheduler.spec.ts
+++ b/spec/scheduling/periodic-tick-scheduler.spec.ts
@@ -1,0 +1,176 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+	type PeriodicTickConfig,
+	PeriodicTickScheduler,
+} from "@vicissitude/scheduling/periodic-tick-scheduler";
+import type { Logger, MetricsCollector } from "@vicissitude/shared/types";
+
+import { createMockLogger, createMockMetrics } from "../test-helpers.ts";
+
+const TICK_TIMEOUT_MS = 180_000;
+
+const config: PeriodicTickConfig = {
+	logPrefix: "[probe]",
+	tickTimeoutMs: TICK_TIMEOUT_MS,
+	timeoutMessage: "probe tick timed out",
+	tickCounterMetric: "probe_ticks_total",
+	tickDurationMetric: "probe_tick_duration_seconds",
+};
+
+/**
+ * テスト用の最小サブクラス。`runTick` の挙動を差し替え可能にし、
+ * private な `tick()` をテストから呼べるよう公開する。
+ */
+class ProbeScheduler extends PeriodicTickScheduler {
+	constructor(
+		private readonly runImpl: () => Promise<void>,
+		logger: Logger,
+		metrics?: MetricsCollector,
+	) {
+		super(config, logger, metrics);
+	}
+
+	protected runTick(): Promise<void> {
+		return this.runImpl();
+	}
+
+	runTickPublic(): Promise<void> {
+		return this.tick();
+	}
+}
+
+function flushMacrotask(): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, 0);
+	});
+}
+
+function accelerateTimeout(targetMs: number): () => void {
+	const originalSetTimeout = globalThis.setTimeout;
+	globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
+		originalSetTimeout(
+			handler,
+			timeout === targetMs ? 0 : timeout,
+			...args,
+		)) as typeof globalThis.setTimeout;
+	return () => {
+		globalThis.setTimeout = originalSetTimeout;
+	};
+}
+
+describe("PeriodicTickScheduler", () => {
+	test("tick が成功すると success outcome の counter と duration histogram を記録する", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const runTick = mock(() => Promise.resolve());
+		const scheduler = new ProbeScheduler(runTick, logger, metrics);
+
+		await scheduler.runTickPublic();
+
+		expect(runTick).toHaveBeenCalledTimes(1);
+		expect(metrics.incrementCounter).toHaveBeenCalledWith("probe_ticks_total", {
+			outcome: "success",
+		});
+		expect(metrics.observeHistogram).toHaveBeenCalledWith(
+			"probe_tick_duration_seconds",
+			expect.any(Number),
+		);
+	});
+
+	test("runTick が例外を投げると error outcome の counter と error ログを記録し、クラッシュしない", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const tickError = new Error("boom");
+		const scheduler = new ProbeScheduler(() => Promise.reject(tickError), logger, metrics);
+
+		await scheduler.runTickPublic();
+
+		expect(metrics.incrementCounter).toHaveBeenCalledWith("probe_ticks_total", {
+			outcome: "error",
+		});
+		expect(logger.error).toHaveBeenCalledWith("[probe] tick error:", tickError);
+	});
+
+	test("error 時も duration histogram を記録する", async () => {
+		const logger = createMockLogger();
+		const metrics = createMockMetrics();
+		const scheduler = new ProbeScheduler(() => Promise.reject(new Error("boom")), logger, metrics);
+
+		await scheduler.runTickPublic();
+
+		expect(metrics.observeHistogram).toHaveBeenCalledWith(
+			"probe_tick_duration_seconds",
+			expect.any(Number),
+		);
+	});
+
+	test("前 tick 実行中に tick を呼ぶと skip ログを出し runTick を再実行しない", async () => {
+		const logger = createMockLogger();
+		let resolveRun!: () => void;
+		const runTick = mock(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveRun = resolve;
+				}),
+		);
+		const scheduler = new ProbeScheduler(runTick, logger);
+
+		const first = scheduler.runTickPublic();
+		const second = scheduler.runTickPublic();
+
+		await second;
+		expect(runTick).toHaveBeenCalledTimes(1);
+		expect(logger.info).toHaveBeenCalledWith("[probe] previous tick still running, skipping");
+
+		resolveRun();
+		await first;
+	});
+
+	test("tick 完了後は running が解放され、次の tick で runTick を再実行する", async () => {
+		const logger = createMockLogger();
+		const runTick = mock(() => Promise.resolve());
+		const scheduler = new ProbeScheduler(runTick, logger);
+
+		await scheduler.runTickPublic();
+		await scheduler.runTickPublic();
+
+		expect(runTick).toHaveBeenCalledTimes(2);
+	});
+
+	test("metrics 未指定でもクラッシュしない", async () => {
+		const logger = createMockLogger();
+		const scheduler = new ProbeScheduler(() => Promise.resolve(), logger);
+
+		await scheduler.runTickPublic();
+
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	test("tick timeout 後も実処理が継続中なら次 tick を開始しない", async () => {
+		const restoreSetTimeout = accelerateTimeout(TICK_TIMEOUT_MS);
+		try {
+			const logger = createMockLogger();
+			let resolveRun!: () => void;
+			const runTick = mock(
+				() =>
+					new Promise<void>((resolve) => {
+						resolveRun = resolve;
+					}),
+			);
+			const scheduler = new ProbeScheduler(runTick, logger);
+
+			// 1 回目: timeout で抜けるが実処理は未完了 → running は解放されない
+			await scheduler.runTickPublic();
+			// 2 回目: 前 tick の実処理がまだ継続中なので skip される
+			await scheduler.runTickPublic();
+
+			expect(runTick).toHaveBeenCalledTimes(1);
+
+			resolveRun();
+			await flushMacrotask();
+		} finally {
+			restoreSetTimeout();
+		}
+	});
+});


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 1** 第7弾。`HeartbeatScheduler` と `ConsolidationScheduler` が逐語重複していた tick ライフサイクル機構を抽象基底 `PeriodicTickScheduler` に集約する。

## 変更

- 新規 `packages/scheduling/src/periodic-tick-scheduler.ts`: `running` ガード・`withTimeout`・成否 counter・duration histogram・in-flight 解放を担う抽象基底。サブクラスは `runTick()`（1 tick の実体）と `PeriodicTickConfig`（logPrefix・timeout・metric 名）を供給。
- start/stop の timer 構成は各 scheduler 固有として保存（heartbeat: 即時 tick + 同期 `stop()` / consolidation: 5分初回遅延 + `async stop()` の in-flight 待機）。
- `ConsolidationScheduler` のコンストラクタを **5引数位置パラメータ → `ConsolidationSchedulerDeps` オブジェクト**に統一（`max-params` 抑制を解消、`HeartbeatScheduler` と様式を揃える）。呼び出し元（`bootstrap.ts`）と spec/test を新 IF へ追従。`HeartbeatScheduler` の IF は不変。

## 挙動保存

重複実行ガード・タイムアウト・メトリクス（ticks counter / duration histogram の名前・ラベル）・stop 時の in-flight 待機を完全保存。

## 検証

- `nr validate` green（exit 0）
- `nr test`: **2643 pass / 0 fail**

## 既知の warning（フォローアップ）

deps-IF 移行で `consolidation-scheduler.spec.ts` が 652 行となり `max-lines` 警告（warning レベル・CI 非ブロッキング）を出す。spec 分割は別 Issue で追跡。

🤖 Generated with [Claude Code](https://claude.com/claude-code)