### PR TITLE
refactor(memory): 検索コアを search-core に集約する

### DIFF
--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -10,6 +10,7 @@
 		"./storage": "./src/storage.ts",
 		"./episodic": "./src/episodic.ts",
 		"./retrieval": "./src/retrieval.ts",
+		"./search-core": "./src/search-core.ts",
 		"./semantic-memory": "./src/semantic-memory.ts",
 		"./semantic-fact": "./src/semantic-fact.ts",
 		"./llm-port": "./src/llm-port.ts",

--- a/packages/memory/src/fact-reader.ts
+++ b/packages/memory/src/fact-reader.ts
@@ -9,12 +9,9 @@ import {
 	namespaceKey,
 	resolveMemoryDbPath,
 } from "./namespace.ts";
-import { reciprocalRankFusion } from "./retrieval.ts";
+import { CANDIDATE_LIMIT, hybridSearchFactsRRF } from "./search-core.ts";
 import type { SemanticFact } from "./semantic-fact.ts";
 import { MemoryStorage } from "./storage.ts";
-
-/** Candidate limit for text/vector search before RRF ranking */
-const CANDIDATE_LIMIT = 50;
 
 /** Maximum number of guideline facts to reserve in results */
 const MAX_GUIDELINES = 3;
@@ -113,20 +110,7 @@ export class MemoryFactReaderImpl implements MemoryFactReader {
 			CANDIDATE_LIMIT,
 		);
 
-		const rrfScores = reciprocalRankFusion(
-			[
-				{ items: textFacts, weight: 1.0 },
-				{ items: vectorFacts, weight: 1.0 },
-			],
-			(f) => f.id,
-		);
-
-		const factMap = new Map([...textFacts, ...vectorFacts].map((f) => [f.id, f]));
-
-		return [...rrfScores.entries()]
-			.map(([id, score]) => ({ fact: factMap.get(id), score }))
-			.filter((s): s is { fact: SemanticFact; score: number } => s.fact !== undefined)
-			.toSorted((a, b) => b.score - a.score);
+		return hybridSearchFactsRRF(textFacts, vectorFacts);
 	}
 
 	private getOrCreate(namespace: MemoryNamespace, dbPath: string): MemoryStorage {

--- a/packages/memory/src/retrieval.ts
+++ b/packages/memory/src/retrieval.ts
@@ -1,12 +1,15 @@
 import type { Episode } from "./episode.ts";
 import { retrievability } from "./fsrs.ts";
 import type { MemoryLlmPort } from "./llm-port.ts";
+import { CANDIDATE_LIMIT, reciprocalRankFusion } from "./search-core.ts";
 import type { SemanticFact } from "./semantic-fact.ts";
 import type { MemoryStorage } from "./storage.ts";
 import { validateUserId } from "./utils.ts";
 
 export { RetrievalReviewCommand } from "./retrieval-review-command.ts";
 export type { RetrievalReviewOptions } from "./retrieval-review-command.ts";
+// reciprocalRankFusion / CANDIDATE_LIMIT は search-core を正本とし、後方互換で再エクスポートする
+export { reciprocalRankFusion };
 
 /** Options for configuring retrieval behavior */
 export interface RetrievalOptions {
@@ -41,34 +44,6 @@ export interface ScoredFact {
 export interface RetrievalResult {
 	episodes: ScoredEpisode[];
 	facts: ScoredFact[];
-}
-
-/** RRF constant (TREC standard) */
-const RRF_K = 60;
-
-/**
- * Reciprocal Rank Fusion — merge multiple ranked lists into a single score map.
- *
- * @param rankedLists Array of { items, weight } where items are in rank order (best first)
- * @param getId Function to extract a unique key from each item
- * @returns Map of id → fused score
- */
-export function reciprocalRankFusion<T>(
-	rankedLists: { items: T[]; weight: number }[],
-	getId: (item: T) => string,
-): Map<string, number> {
-	const scores = new Map<string, number>();
-	for (const { items, weight } of rankedLists) {
-		for (let rank = 0; rank < items.length; rank++) {
-			const item = items[rank];
-			if (item !== undefined) {
-				const id = getId(item);
-				const prev = scores.get(id) ?? 0;
-				scores.set(id, prev + weight / (RRF_K + rank + 1));
-			}
-		}
-	}
-	return scores;
 }
 
 /** Build an id → item lookup map from multiple arrays */
@@ -123,9 +98,6 @@ function scoreFacts(
 	}
 	return scored.toSorted((a, b) => b.score - a.score);
 }
-
-/** Default candidate limit for search queries */
-const CANDIDATE_LIMIT = 50;
 
 interface ResolvedOptions {
 	limit: number;

--- a/packages/memory/src/search-core.ts
+++ b/packages/memory/src/search-core.ts
@@ -1,0 +1,78 @@
+import type { SemanticFact } from "./semantic-fact.ts";
+
+/** Candidate limit for text/vector search before RRF ranking */
+export const CANDIDATE_LIMIT = 50;
+
+/** Default RRF weight for the text-search ranked list */
+export const DEFAULT_TEXT_WEIGHT = 1.0;
+
+/** Default RRF weight for the vector-search ranked list */
+export const DEFAULT_VECTOR_WEIGHT = 1.0;
+
+/** RRF constant (TREC standard) */
+export const RRF_K = 60;
+
+/**
+ * Reciprocal Rank Fusion — merge multiple ranked lists into a single score map.
+ *
+ * @param rankedLists Array of { items, weight } where items are in rank order (best first)
+ * @param getId Function to extract a unique key from each item
+ * @returns Map of id → fused score
+ */
+export function reciprocalRankFusion<T>(
+	rankedLists: { items: T[]; weight: number }[],
+	getId: (item: T) => string,
+): Map<string, number> {
+	const scores = new Map<string, number>();
+	for (const { items, weight } of rankedLists) {
+		for (let rank = 0; rank < items.length; rank++) {
+			const item = items[rank];
+			if (item !== undefined) {
+				const id = getId(item);
+				const prev = scores.get(id) ?? 0;
+				scores.set(id, prev + weight / (RRF_K + rank + 1));
+			}
+		}
+	}
+	return scores;
+}
+
+/** A semantic fact paired with its fused retrieval score */
+export interface ScoredFact {
+	fact: SemanticFact;
+	score: number;
+}
+
+/**
+ * Fact-only hybrid ranking primitive.
+ *
+ * Merges text- and vector-search fact candidates via Reciprocal Rank Fusion
+ * and returns them sorted by fused score (descending). Pure function — does no
+ * I/O; callers supply the already-fetched candidate lists.
+ *
+ * @param textFacts Facts from text search, in rank order (best first)
+ * @param vectorFacts Facts from vector search, in rank order (best first)
+ * @param weights Optional RRF weights (default: text 1.0 / vector 1.0)
+ */
+export function hybridSearchFactsRRF(
+	textFacts: SemanticFact[],
+	vectorFacts: SemanticFact[],
+	weights: { textWeight?: number; vectorWeight?: number } = {},
+): ScoredFact[] {
+	const { textWeight = DEFAULT_TEXT_WEIGHT, vectorWeight = DEFAULT_VECTOR_WEIGHT } = weights;
+
+	const rrfScores = reciprocalRankFusion(
+		[
+			{ items: textFacts, weight: textWeight },
+			{ items: vectorFacts, weight: vectorWeight },
+		],
+		(f) => f.id,
+	);
+
+	const factMap = new Map([...textFacts, ...vectorFacts].map((f) => [f.id, f]));
+
+	return [...rrfScores.entries()]
+		.map(([id, score]) => ({ fact: factMap.get(id), score }))
+		.filter((s): s is ScoredFact => s.fact !== undefined)
+		.toSorted((a, b) => b.score - a.score);
+}

--- a/spec/memory/search-core.spec.ts
+++ b/spec/memory/search-core.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	CANDIDATE_LIMIT,
+	DEFAULT_TEXT_WEIGHT,
+	DEFAULT_VECTOR_WEIGHT,
+	hybridSearchFactsRRF,
+	reciprocalRankFusion,
+	RRF_K,
+} from "@vicissitude/memory/search-core";
+
+import { makeFact } from "./test-helpers.ts";
+
+describe("search-core constants (single source of truth)", () => {
+	test("CANDIDATE_LIMIT は検索候補数のチューニング値である", () => {
+		expect(CANDIDATE_LIMIT).toBe(50);
+	});
+
+	test("RRF_K は TREC 標準値である", () => {
+		expect(RRF_K).toBe(60);
+	});
+
+	test("RRF 重みのデフォルトは text/vector ともに 1.0 である", () => {
+		expect(DEFAULT_TEXT_WEIGHT).toBe(1.0);
+		expect(DEFAULT_VECTOR_WEIGHT).toBe(1.0);
+	});
+});
+
+describe("search-core が retrieval の re-export と同一実体である", () => {
+	test("reciprocalRankFusion は retrieval から再エクスポートされた同一関数である", async () => {
+		const fromRetrieval = await import("@vicissitude/memory/retrieval");
+		expect(fromRetrieval.reciprocalRankFusion).toBe(reciprocalRankFusion);
+	});
+});
+
+describe("reciprocalRankFusion", () => {
+	test("単一リストはランク順にスコアを付与する", () => {
+		const items = [{ id: "a" }, { id: "b" }, { id: "c" }];
+		const scores = reciprocalRankFusion([{ items, weight: 1.0 }], (x) => x.id);
+
+		expect(scores.get("a")).toBeCloseTo(1 / 61, 10);
+		expect(scores.get("b")).toBeCloseTo(1 / 62, 10);
+		expect(scores.get("c")).toBeCloseTo(1 / 63, 10);
+	});
+
+	test("両リストに含まれる項目はスコアが合算される", () => {
+		const list1 = [{ id: "a" }, { id: "b" }];
+		const list2 = [{ id: "b" }, { id: "c" }];
+		const scores = reciprocalRankFusion(
+			[
+				{ items: list1, weight: 1.0 },
+				{ items: list2, weight: 1.0 },
+			],
+			(x) => x.id,
+		);
+
+		expect(scores.get("b")).toBeCloseTo(1 / 62 + 1 / 61, 10);
+	});
+
+	test("空リストは空マップを返す", () => {
+		const scores = reciprocalRankFusion(
+			[{ items: [] as { id: string }[], weight: 1.0 }],
+			(x) => x.id,
+		);
+		expect(scores.size).toBe(0);
+	});
+});
+
+describe("hybridSearchFactsRRF (fact-only ランキングプリミティブ)", () => {
+	test("text と vector の両方にマッチする fact が最上位になる", () => {
+		const both = makeFact({ fact: "both", keywords: ["x"] });
+		const textOnly = makeFact({ fact: "text-only", keywords: ["y"] });
+		const vectorOnly = makeFact({ fact: "vector-only", keywords: ["z"] });
+
+		const ranked = hybridSearchFactsRRF([both, textOnly], [both, vectorOnly]);
+
+		expect(ranked[0]?.fact.id).toBe(both.id);
+		expect(ranked).toHaveLength(3);
+	});
+
+	test("スコア降順でソートされる", () => {
+		const a = makeFact({ fact: "a", keywords: ["a"] });
+		const b = makeFact({ fact: "b", keywords: ["b"] });
+		const c = makeFact({ fact: "c", keywords: ["c"] });
+
+		const scores = hybridSearchFactsRRF([a, b, c], []).map((r) => r.score);
+
+		for (let i = 1; i < scores.length; i++) {
+			expect(scores[i - 1] ?? 0).toBeGreaterThanOrEqual(scores[i] ?? 0);
+		}
+	});
+
+	test("両リストが空なら空配列を返す", () => {
+		expect(hybridSearchFactsRRF([], [])).toEqual([]);
+	});
+
+	test("重複 id は1件に統合され合算スコアを持つ", () => {
+		const fact = makeFact({ fact: "dup", keywords: ["d"] });
+
+		const ranked = hybridSearchFactsRRF([fact], [fact]);
+
+		expect(ranked).toHaveLength(1);
+		expect(ranked[0]?.score).toBeCloseTo(1 / 61 + 1 / 61, 10);
+	});
+
+	test("weight=0 のリストはスコアに寄与しない", () => {
+		const t = makeFact({ fact: "t", keywords: ["t"] });
+		const v = makeFact({ fact: "v", keywords: ["v"] });
+
+		const ranked = hybridSearchFactsRRF([t], [v], { textWeight: 1.0, vectorWeight: 0 });
+
+		const vScore = ranked.find((r) => r.fact.id === v.id)?.score;
+		expect(vScore).toBe(0);
+	});
+});


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 1** 第12弾。`fact-reader.ts` と `retrieval.ts` に重複していた検索チューニング定数と RRF コアを `packages/memory/src/search-core.ts` に単一ソース化する。

## 変更

- **`search-core.ts`（新規）**: `CANDIDATE_LIMIT` / `RRF_K` / RRF 重みデフォルト定数、`reciprocalRankFusion`（retrieval から移設）、純粋プリミティブ `hybridSearchFactsRRF(textFacts, vectorFacts, weights)`（text/vector の fact 候補を RRF マージしスコア降順ソート、I/O なし）。
- **`fact-reader.ts`**: ローカル `CANDIDATE_LIMIT` と独自 RRF/sort 実装を削除し `hybridSearchFactsRRF` へ委譲。**guideline 予約・category 多様性は fact-reader に保持**（Retrieval に持ち込まない）。
- **`retrieval.ts`**: 二重定義していた `RRF_K`/`reciprocalRankFusion`/`CANDIDATE_LIMIT` を削除し search-core を参照。`reciprocalRankFusion` は後方互換で**同一実体を再エクスポート**（`index.ts`/`retrieval.spec.ts` の import 互換維持）。

## スコープ判断（過剰マージ回避）

`Retrieval`（episode+fact 汎用検索 + FSRS boost）と `fact-reader`（fact-only + guideline/category 後処理）は責務が異なるため**完全マージはせず**、真に重複する「定数」と「fact-RRF プリミティブ」のみ集約。`getRelevantFacts` の guideline 予約・category 多様性・スコア順・件数を完全保存。

## 検証

- `nr validate` green
- `nr test`: **2661 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)