### PR TITLE
refactor(minecraft): action 登録の bot ガードと逃走ゴールを共通化する

### DIFF
--- a/packages/minecraft/package.json
+++ b/packages/minecraft/package.json
@@ -16,6 +16,7 @@
 		"./mc-metrics": "./src/mc-metrics.ts",
 		"./stuck-recovery": "./src/stuck-recovery.ts",
 		"./helpers": "./src/helpers.ts",
+		"./actions/shared": "./src/actions/shared.ts",
 		"./actions/jobs": "./src/actions/jobs.ts",
 		"./actions/smelting": "./src/actions/smelting.ts",
 		"./actions/survival": "./src/actions/survival/index.ts",

--- a/packages/minecraft/src/actions/combat.ts
+++ b/packages/minecraft/src/actions/combat.ts
@@ -13,6 +13,7 @@ import {
 	registerAbortHandler,
 	textResult,
 	tryStartJob,
+	withConnectedBot,
 } from "./shared.ts";
 
 const { goals } = pathfinderPkg;
@@ -178,23 +179,23 @@ export function registerAttackEntity(
 					.describe("最大攻撃回数（デフォルト: 20、安全弁）"),
 			},
 		},
-		async ({ entityName, maxHits }: { entityName: string; maxHits: number }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
+		withConnectedBot(
+			getBot,
+			async (bot, { entityName, maxHits }: { entityName: string; maxHits: number }) => {
+				const target = await findPerceivedEntityByName(bot, entityName);
+				if (!target) {
+					return textResult(`"${entityName}" が近距離または視界内に見つかりません`);
+				}
 
-			const target = await findPerceivedEntityByName(bot, entityName);
-			if (!target) {
-				return textResult(`"${entityName}" が近距離または視界内に見つかりません`);
-			}
+				const started = tryStartJob(jobManager, "attacking", entityName, (signal, updateProgress) =>
+					executeAttack({ bot, target, maxHits, signal, updateProgress }),
+				);
+				if (!started.ok) return started.result;
 
-			const started = tryStartJob(jobManager, "attacking", entityName, (signal, updateProgress) =>
-				executeAttack({ bot, target, maxHits, signal, updateProgress }),
-			);
-			if (!started.ok) return started.result;
-
-			return textResult(
-				`${entityName} への攻撃を開始しました（jobId: ${started.jobId}, 最大攻撃回数: ${String(maxHits)}）`,
-			);
-		},
+				return textResult(
+					`${entityName} への攻撃を開始しました（jobId: ${started.jobId}, 最大攻撃回数: ${String(maxHits)}）`,
+				);
+			},
+		),
 	);
 }

--- a/packages/minecraft/src/actions/exploration.ts
+++ b/packages/minecraft/src/actions/exploration.ts
@@ -10,6 +10,7 @@ import {
 	registerAbortHandler,
 	textResult,
 	tryStartJob,
+	withConnectedBot,
 } from "./shared.ts";
 
 const { goals } = pathfinderPkg;
@@ -61,28 +62,34 @@ export function registerSearchForBlock(
 					.describe("最大探索半径（デフォルト: 128）"),
 			},
 		},
-		({ blockName, maxRadius }: { blockName: string; maxRadius: number }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
-			const blockType = bot.registry.blocksByName[blockName];
-			if (!blockType) return textResult(`不明なブロック名: "${blockName}"`);
+		withConnectedBot(
+			getBot,
+			(bot, { blockName, maxRadius }: { blockName: string; maxRadius: number }) => {
+				const blockType = bot.registry.blocksByName[blockName];
+				if (!blockType) return textResult(`不明なブロック名: "${blockName}"`);
 
-			const started = tryStartJob(jobManager, "searching", blockName, (signal, updateProgress) => {
-				searchForBlockSync({
-					bot,
-					blockId: blockType.id,
+				const started = tryStartJob(
+					jobManager,
+					"searching",
 					blockName,
-					maxRadius,
-					signal,
-					updateProgress,
-				});
-				return Promise.resolve();
-			});
-			if (!started.ok) return started.result;
-			return textResult(
-				`${blockName} の探索を開始しました（jobId: ${started.jobId}, 最大半径: ${String(maxRadius)}）`,
-			);
-		},
+					(signal, updateProgress) => {
+						searchForBlockSync({
+							bot,
+							blockId: blockType.id,
+							blockName,
+							maxRadius,
+							signal,
+							updateProgress,
+						});
+						return Promise.resolve();
+					},
+				);
+				if (!started.ok) return started.result;
+				return textResult(
+					`${blockName} の探索を開始しました（jobId: ${started.jobId}, 最大半径: ${String(maxRadius)}）`,
+				);
+			},
+		),
 	);
 }
 
@@ -111,32 +118,37 @@ export function registerExploreDirection(
 				distance: z.number().min(16).max(256).default(100).describe("移動距離（デフォルト: 100）"),
 			},
 		},
-		({
-			direction,
-			distance,
-		}: {
-			direction?: "north" | "south" | "east" | "west";
-			distance: number;
-		}) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
+		withConnectedBot(
+			getBot,
+			(
+				bot,
+				{
+					direction,
+					distance,
+				}: {
+					direction?: "north" | "south" | "east" | "west";
+					distance: number;
+				},
+			) => {
+				const dir =
+					direction ??
+					DIRECTION_NAMES[Math.floor(Math.random() * DIRECTION_NAMES.length)] ??
+					"north";
+				const offset = DIRECTION_OFFSETS[dir] ?? { x: 0, z: -1 };
 
-			const dir =
-				direction ?? DIRECTION_NAMES[Math.floor(Math.random() * DIRECTION_NAMES.length)] ?? "north";
-			const offset = DIRECTION_OFFSETS[dir] ?? { x: 0, z: -1 };
-
-			const started = tryStartJob(jobManager, "exploring", dir, async (signal) => {
-				ensureMovements(bot);
-				registerAbortHandler(bot, signal);
-				const pos = bot.entity.position;
-				const targetX = pos.x + offset.x * distance;
-				const targetZ = pos.z + offset.z * distance;
-				await bot.pathfinder.goto(new goals.GoalNear(targetX, pos.y, targetZ, 3));
-			});
-			if (!started.ok) return started.result;
-			return textResult(
-				`${dir} 方面への探検を開始しました（jobId: ${started.jobId}, 距離: ${String(distance)}）`,
-			);
-		},
+				const started = tryStartJob(jobManager, "exploring", dir, async (signal) => {
+					ensureMovements(bot);
+					registerAbortHandler(bot, signal);
+					const pos = bot.entity.position;
+					const targetX = pos.x + offset.x * distance;
+					const targetZ = pos.z + offset.z * distance;
+					await bot.pathfinder.goto(new goals.GoalNear(targetX, pos.y, targetZ, 3));
+				});
+				if (!started.ok) return started.result;
+				return textResult(
+					`${dir} 方面への探検を開始しました（jobId: ${started.jobId}, 距離: ${String(distance)}）`,
+				);
+			},
+		),
 	);
 }

--- a/packages/minecraft/src/actions/interaction.ts
+++ b/packages/minecraft/src/actions/interaction.ts
@@ -3,7 +3,7 @@ import type mineflayer from "mineflayer";
 import { Vec3 } from "vec3";
 import { z } from "zod/v4";
 
-import { type GetBot, textResult } from "./shared.ts";
+import { type GetBot, textResult, withConnectedBot } from "./shared.ts";
 
 const MAX_CHAT_LENGTH = 256;
 type EquipmentDestination = "hand" | "head" | "torso" | "legs" | "feet" | "off-hand";
@@ -51,13 +51,11 @@ export function registerSendChat(server: McpServer, getBot: GetBot): void {
 					.describe(`送信するメッセージ（最大 ${String(MAX_CHAT_LENGTH)} 文字、"/" 始まり禁止）`),
 			},
 		},
-		({ message }: { message: string }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
+		withConnectedBot(getBot, (bot, { message }: { message: string }) => {
 			if (message.startsWith("/")) return textResult("コマンド送信は許可されていません");
 			bot.chat(message);
 			return textResult(`チャット送信: "${message}"`);
-		},
+		}),
 	);
 }
 
@@ -74,16 +72,19 @@ export function registerEquipItem(server: McpServer, getBot: GetBot): void {
 					.describe("装備先（デフォルト: hand）"),
 			},
 		},
-		async ({ itemName, destination }: { itemName: string; destination: EquipmentDestination }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
+		withConnectedBot(
+			getBot,
+			async (
+				bot,
+				{ itemName, destination }: { itemName: string; destination: EquipmentDestination },
+			) => {
+				const item = bot.inventory.items().find((i) => i.name === itemName);
+				if (!item) return textResult(`インベントリに "${itemName}" がありません`);
 
-			const item = bot.inventory.items().find((i) => i.name === itemName);
-			if (!item) return textResult(`インベントリに "${itemName}" がありません`);
-
-			await bot.equip(item, destination);
-			return textResult(`${itemName} を ${destination} に装備しました`);
-		},
+				await bot.equip(item, destination);
+				return textResult(`${itemName} を ${destination} に装備しました`);
+			},
+		),
 	);
 }
 
@@ -101,35 +102,38 @@ export function registerPlaceBlock(server: McpServer, getBot: GetBot): void {
 				z: z.number().int().describe("設置先の Z 座標"),
 			},
 		},
-		async ({
-			blockName,
-			x,
-			y,
-			z: zCoord,
-		}: {
-			blockName: string;
-			x: number;
-			y: number;
-			z: number;
-		}) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
+		withConnectedBot(
+			getBot,
+			async (
+				bot,
+				{
+					blockName,
+					x,
+					y,
+					z: zCoord,
+				}: {
+					blockName: string;
+					x: number;
+					y: number;
+					z: number;
+				},
+			) => {
+				const item = bot.inventory.items().find((i) => i.name === blockName);
+				if (!item) return textResult(`インベントリに "${blockName}" がありません`);
 
-			const item = bot.inventory.items().find((i) => i.name === blockName);
-			if (!item) return textResult(`インベントリに "${blockName}" がありません`);
+				await bot.equip(item, "hand");
 
-			await bot.equip(item, "hand");
+				const targetPos = new Vec3(x, y, zCoord);
+				const targetBlock = bot.blockAt(targetPos);
+				if (targetBlock && targetBlock.name !== "air" && targetBlock.name !== "cave_air") {
+					return textResult(
+						`(${String(x)}, ${String(y)}, ${String(zCoord)}) は ${targetBlock.name} で埋まっています`,
+					);
+				}
 
-			const targetPos = new Vec3(x, y, zCoord);
-			const targetBlock = bot.blockAt(targetPos);
-			if (targetBlock && targetBlock.name !== "air" && targetBlock.name !== "cave_air") {
-				return textResult(
-					`(${String(x)}, ${String(y)}, ${String(zCoord)}) は ${targetBlock.name} で埋まっています`,
-				);
-			}
-
-			const result = await placeOnAdjacentBlock(bot, targetPos, blockName);
-			return textResult(result);
-		},
+				const result = await placeOnAdjacentBlock(bot, targetPos, blockName);
+				return textResult(result);
+			},
+		),
 	);
 }

--- a/packages/minecraft/src/actions/jobs.ts
+++ b/packages/minecraft/src/actions/jobs.ts
@@ -14,6 +14,7 @@ import {
 	registerAbortHandler,
 	textResult,
 	tryStartJob,
+	withConnectedBot,
 } from "./shared.ts";
 
 const { goals } = pathfinderPkg;
@@ -147,10 +148,7 @@ export function registerCraftItem(server: McpServer, getBot: GetBot, jobManager:
 					.describe(`クラフト個数（デフォルト: 1、最大: ${String(MAX_CRAFT_COUNT)}）`),
 			},
 		},
-		({ itemName, count }: { itemName: string; count: number }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
-
+		withConnectedBot(getBot, (bot, { itemName, count }: { itemName: string; count: number }) => {
 			const itemType = bot.registry.itemsByName[itemName];
 			if (!itemType) return textResult(`不明なアイテム名: "${itemName}"`);
 
@@ -164,7 +162,7 @@ export function registerCraftItem(server: McpServer, getBot: GetBot, jobManager:
 			return textResult(
 				`${itemName} のクラフトを開始しました（jobId: ${started.jobId}, 目標: ${String(count)} 個）`,
 			);
-		},
+		}),
 	);
 }
 
@@ -187,10 +185,7 @@ export function registerSleepInBed(
 					.describe("ベッド検索範囲（デフォルト: 32、最大: 64）"),
 			},
 		},
-		({ maxDistance }: { maxDistance: number }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
-
+		withConnectedBot(getBot, (bot, { maxDistance }: { maxDistance: number }) => {
 			const bedIds = collectBedIds(bot);
 			if (bedIds.length === 0) return textResult("ベッドブロックの定義が見つかりません");
 
@@ -202,6 +197,6 @@ export function registerSleepInBed(
 			if (!started.ok) return started.result;
 
 			return textResult(`就寝を開始しました（jobId: ${started.jobId}）`);
-		},
+		}),
 	);
 }

--- a/packages/minecraft/src/actions/movement.ts
+++ b/packages/minecraft/src/actions/movement.ts
@@ -13,6 +13,7 @@ import {
 	registerAbortHandler,
 	textResult,
 	tryStartJob,
+	withConnectedBot,
 } from "./shared.ts";
 
 const { goals } = pathfinderPkg;
@@ -126,24 +127,24 @@ export function registerFollowPlayer(
 				range: z.number().min(1).default(3).describe("何ブロック以内に接近するか（デフォルト: 3）"),
 			},
 		},
-		async ({ username, range }: { username: string; range: number }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
+		withConnectedBot(
+			getBot,
+			async (bot, { username, range }: { username: string; range: number }) => {
+				const entity = bot.players[username]?.entity;
+				if (!entity || !(await canPerceiveEntity(bot, entity))) {
+					return textResult(`プレイヤー "${username}" が見つからないか、視界内にいません`);
+				}
 
-			const entity = bot.players[username]?.entity;
-			if (!entity || !(await canPerceiveEntity(bot, entity))) {
-				return textResult(`プレイヤー "${username}" が見つからないか、視界内にいません`);
-			}
+				const started = tryStartJob(jobManager, "following", username, (signal) =>
+					executeFollow({ bot, entity, username, range, signal }),
+				);
+				if (!started.ok) return started.result;
 
-			const started = tryStartJob(jobManager, "following", username, (signal) =>
-				executeFollow({ bot, entity, username, range, signal }),
-			);
-			if (!started.ok) return started.result;
-
-			return textResult(
-				`${username} への追従を開始しました（jobId: ${started.jobId}, range: ${String(range)}）`,
-			);
-		},
+				return textResult(
+					`${username} への追従を開始しました（jobId: ${started.jobId}, range: ${String(range)}）`,
+				);
+			},
+		),
 	);
 }
 
@@ -159,27 +160,27 @@ export function registerGoTo(server: McpServer, getBot: GetBot, jobManager: JobM
 				range: z.number().min(0).default(2).describe("目標地点からの許容距離（デフォルト: 2）"),
 			},
 		},
-		({ x, y, z: zCoord, range }: { x: number; y: number; z: number; range: number }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
+		withConnectedBot(
+			getBot,
+			(bot, { x, y, z: zCoord, range }: { x: number; y: number; z: number; range: number }) => {
+				const coord = `(${String(x)}, ${String(y)}, ${String(zCoord)})`;
 
-			const coord = `(${String(x)}, ${String(y)}, ${String(zCoord)})`;
+				const started = tryStartJob(jobManager, "moving", coord, async (signal) => {
+					ensureMovements(bot);
+					registerAbortHandler(bot, signal);
+					try {
+						await bot.pathfinder.goto(new goals.GoalNear(x, y, zCoord, range));
+					} catch (err) {
+						const context = buildGoToContext(bot, { x, y, z: zCoord });
+						const msg = err instanceof Error ? err.message : String(err);
+						throw new Error(`${msg}\n${context}`, { cause: err });
+					}
+				});
+				if (!started.ok) return started.result;
 
-			const started = tryStartJob(jobManager, "moving", coord, async (signal) => {
-				ensureMovements(bot);
-				registerAbortHandler(bot, signal);
-				try {
-					await bot.pathfinder.goto(new goals.GoalNear(x, y, zCoord, range));
-				} catch (err) {
-					const context = buildGoToContext(bot, { x, y, z: zCoord });
-					const msg = err instanceof Error ? err.message : String(err);
-					throw new Error(`${msg}\n${context}`, { cause: err });
-				}
-			});
-			if (!started.ok) return started.result;
-
-			return textResult(`${coord} への移動を開始しました（jobId: ${started.jobId}）`);
-		},
+				return textResult(`${coord} への移動を開始しました（jobId: ${started.jobId}）`);
+			},
+		),
 	);
 }
 
@@ -205,38 +206,41 @@ export function registerCollectBlock(
 				maxDistance: z.number().min(1).default(32).describe("検索範囲（デフォルト: 32）"),
 			},
 		},
-		({
-			blockName,
-			count,
-			maxDistance,
-		}: {
-			blockName: string;
-			count: number;
-			maxDistance: number;
-		}) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
-
-			const blockType = bot.registry.blocksByName[blockName];
-			if (!blockType) return textResult(`不明なブロック名: "${blockName}"`);
-
-			const started = tryStartJob(jobManager, "collecting", blockName, (signal, updateProgress) =>
-				executeCollectBlock({
-					bot,
-					blockId: blockType.id,
+		withConnectedBot(
+			getBot,
+			(
+				bot,
+				{
 					blockName,
 					count,
 					maxDistance,
-					signal,
-					updateProgress,
-				}),
-			);
-			if (!started.ok) return started.result;
+				}: {
+					blockName: string;
+					count: number;
+					maxDistance: number;
+				},
+			) => {
+				const blockType = bot.registry.blocksByName[blockName];
+				if (!blockType) return textResult(`不明なブロック名: "${blockName}"`);
 
-			return textResult(
-				`${blockName} の採集を開始しました（jobId: ${started.jobId}, 目標: ${String(count)} 個）`,
-			);
-		},
+				const started = tryStartJob(jobManager, "collecting", blockName, (signal, updateProgress) =>
+					executeCollectBlock({
+						bot,
+						blockId: blockType.id,
+						blockName,
+						count,
+						maxDistance,
+						signal,
+						updateProgress,
+					}),
+				);
+				if (!started.ok) return started.result;
+
+				return textResult(
+					`${blockName} の採集を開始しました（jobId: ${started.jobId}, 目標: ${String(count)} 個）`,
+				);
+			},
+		),
 	);
 }
 

--- a/packages/minecraft/src/actions/queries.ts
+++ b/packages/minecraft/src/actions/queries.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
 
 import { getNearbyBlockCounts } from "../bot-queries.ts";
-import { type GetBot, textResult } from "./shared.ts";
+import { type GetBot, textResult, withConnectedBot } from "./shared.ts";
 
 const MAX_NEARBY_DISTANCE = 32;
 
@@ -20,15 +20,12 @@ export function registerNearbyBlocks(server: McpServer, getBot: GetBot): void {
 					.describe("探索範囲（デフォルト: 16、最大: 32）"),
 			},
 		},
-		({ maxDistance }: { maxDistance: number }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
-
+		withConnectedBot(getBot, (bot, { maxDistance }: { maxDistance: number }) => {
 			const counts = getNearbyBlockCounts(bot, maxDistance);
 			if (counts.size === 0) return textResult("周辺にブロックが見つかりません");
 			const lines = [...counts.entries()].map(([name, count]) => `${name}: ${String(count)}`);
 			return textResult(lines.join("\n"));
-		},
+		}),
 	);
 }
 
@@ -36,10 +33,7 @@ export function registerCraftableItems(server: McpServer, getBot: GetBot): void 
 	server.registerTool(
 		"craftable_items",
 		{ description: "現在のインベントリでクラフト可能なアイテム一覧を返す" },
-		() => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
-
+		withConnectedBot(getBot, (bot) => {
 			const craftable: { name: string; needsTable: boolean }[] = [];
 			for (const item of bot.registry.itemsArray) {
 				const withoutTable = bot.recipesFor(item.id, null, null, false);
@@ -57,18 +51,19 @@ export function registerCraftableItems(server: McpServer, getBot: GetBot): void 
 
 			const lines = craftable.map((c) => (c.needsTable ? `${c.name} (要作業台)` : c.name));
 			return textResult(`クラフト可能: ${lines.join(", ")}`);
-		},
+		}),
 	);
 }
 
 export function registerGetBiome(server: McpServer, getBot: GetBot): void {
-	server.registerTool("get_biome", { description: "現在のバイオーム名を返す" }, () => {
-		const bot = getBot();
-		if (!bot?.entity) return textResult("ボット未接続");
-
-		const pos = bot.entity.position;
-		const biomeId = bot.world.getBiome(pos);
-		const biome = bot.registry.biomes?.[biomeId];
-		return textResult(biome?.name ?? `不明なバイオーム (ID: ${String(biomeId)})`);
-	});
+	server.registerTool(
+		"get_biome",
+		{ description: "現在のバイオーム名を返す" },
+		withConnectedBot(getBot, (bot) => {
+			const pos = bot.entity.position;
+			const biomeId = bot.world.getBiome(pos);
+			const biome = bot.registry.biomes?.[biomeId];
+			return textResult(biome?.name ?? `不明なバイオーム (ID: ${String(biomeId)})`);
+		}),
+	);
 }

--- a/packages/minecraft/src/actions/shared.ts
+++ b/packages/minecraft/src/actions/shared.ts
@@ -1,5 +1,6 @@
 import type mineflayer from "mineflayer";
-import pathfinderPkg from "mineflayer-pathfinder";
+import pathfinderPkg, { type goals as GoalsNamespace } from "mineflayer-pathfinder";
+import type { Entity } from "prismarine-entity";
 
 import type { JobExecutor, JobManager } from "../job-manager.ts";
 
@@ -10,6 +11,38 @@ export type TextResult = { content: { type: "text"; text: string }[] };
 
 export function textResult(text: string): TextResult {
 	return { content: [{ type: "text", text }] };
+}
+
+/**
+ * bot 未接続ガードの高階ラッパ。
+ *
+ * `getBot()` が `null`、または `bot.entity` を持たない場合は接続前とみなし、
+ * `textResult("ボット未接続")` を返す。接続済みの場合のみ `handler` を呼び出す。
+ *
+ * 各 registerTool の callback を `withConnectedBot(getBot, async (bot, args) => {...})`
+ * の形へ置換するために使う。args は MCP SDK が callback へ渡す入力をそのまま受け渡す。
+ */
+export function withConnectedBot<Args>(
+	getBot: GetBot,
+	handler: (bot: mineflayer.Bot, args: Args) => TextResult | Promise<TextResult>,
+): (args: Args) => TextResult | Promise<TextResult> {
+	return (args: Args) => {
+		const bot = getBot();
+		if (!bot?.entity) return textResult("ボット未接続");
+		return handler(bot, args);
+	};
+}
+
+/**
+ * 逃走ゴール（対象から離れる pathfinder ゴール）を構築する。
+ *
+ * `GoalFollow`（対象へ近づくゴール）を `GoalInvert` で反転させることで
+ * 「対象から `distance` ブロック分離れる」挙動になる。
+ * `actions/survival/escape.ts` と `reactive-layer.ts` の双方で共有する。
+ */
+export function createFleeGoal(target: Entity, distance: number): GoalsNamespace.Goal {
+	const { goals } = pathfinderPkg;
+	return new goals.GoalInvert(new goals.GoalFollow(target, distance));
 }
 
 export function ensureMovements(b: mineflayer.Bot): void {

--- a/packages/minecraft/src/actions/smelting.ts
+++ b/packages/minecraft/src/actions/smelting.ts
@@ -11,6 +11,7 @@ import {
 	registerAbortHandler,
 	textResult,
 	tryStartJob,
+	withConnectedBot,
 } from "./shared.ts";
 
 const { goals } = pathfinderPkg;
@@ -155,36 +156,39 @@ export function registerSmeltItem(server: McpServer, getBot: GetBot, jobManager:
 					.describe('燃料アイテム名（デフォルト: "coal"、例: "charcoal", "oak_planks"）'),
 			},
 		},
-		({ itemName, count, fuelName }: { itemName: string; count: number; fuelName: string }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
+		withConnectedBot(
+			getBot,
+			(
+				bot,
+				{ itemName, count, fuelName }: { itemName: string; count: number; fuelName: string },
+			) => {
+				const itemType = bot.registry.itemsByName[itemName];
+				if (!itemType) return textResult(`不明なアイテム名: "${itemName}"`);
 
-			const itemType = bot.registry.itemsByName[itemName];
-			if (!itemType) return textResult(`不明なアイテム名: "${itemName}"`);
+				const fuelType = bot.registry.itemsByName[fuelName];
+				if (!fuelType) return textResult(`不明な燃料名: "${fuelName}"`);
 
-			const fuelType = bot.registry.itemsByName[fuelName];
-			if (!fuelType) return textResult(`不明な燃料名: "${fuelName}"`);
+				const itemInInventory = bot.inventory.items().find((i) => i.name === itemName);
+				if (!itemInInventory) return textResult(`インベントリに "${itemName}" がありません`);
 
-			const itemInInventory = bot.inventory.items().find((i) => i.name === itemName);
-			if (!itemInInventory) return textResult(`インベントリに "${itemName}" がありません`);
-
-			const started = tryStartJob(jobManager, "smelting", itemName, async (signal) => {
-				ensureMovements(bot);
-				registerAbortHandler(bot, signal);
-				await executeSmelt({
-					bot,
-					itemId: itemType.id,
-					fuelId: fuelType.id,
-					fuelName,
-					count,
-					signal,
+				const started = tryStartJob(jobManager, "smelting", itemName, async (signal) => {
+					ensureMovements(bot);
+					registerAbortHandler(bot, signal);
+					await executeSmelt({
+						bot,
+						itemId: itemType.id,
+						fuelId: fuelType.id,
+						fuelName,
+						count,
+						signal,
+					});
 				});
-			});
-			if (!started.ok) return started.result;
+				if (!started.ok) return started.result;
 
-			return textResult(
-				`${itemName} の精錬を開始しました（jobId: ${started.jobId}, 目標: ${String(count)} 個, 燃料: ${fuelName}）`,
-			);
-		},
+				return textResult(
+					`${itemName} の精錬を開始しました（jobId: ${started.jobId}, 目標: ${String(count)} 個, 燃料: ${fuelName}）`,
+				);
+			},
+		),
 	);
 }

--- a/packages/minecraft/src/actions/survival/escape.ts
+++ b/packages/minecraft/src/actions/survival/escape.ts
@@ -1,18 +1,17 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import pathfinderPkg from "mineflayer-pathfinder";
 import { z } from "zod/v4";
 
 import { findPerceivedEntityByName } from "../../bot-queries.ts";
 import type { JobManager } from "../../job-manager.ts";
 import {
 	type GetBot,
+	createFleeGoal,
 	ensureMovements,
 	registerAbortHandler,
 	textResult,
 	tryStartJob,
+	withConnectedBot,
 } from "../shared.ts";
-
-const { goals } = pathfinderPkg;
 
 export function registerFleeFromEntity(
 	server: McpServer,
@@ -37,27 +36,27 @@ export function registerFleeFromEntity(
 					.describe("逃走距離（デフォルト: 32ブロック）"),
 			},
 		},
-		async ({ entityName, distance }: { entityName: string; distance: number }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
+		withConnectedBot(
+			getBot,
+			async (bot, { entityName, distance }: { entityName: string; distance: number }) => {
+				const target = await findPerceivedEntityByName(bot, entityName, distance + 16);
+				if (!target) {
+					return textResult(
+						`"${entityName}" が近距離または視界内に見つかりません。すでに安全かもしれません`,
+					);
+				}
 
-			const target = await findPerceivedEntityByName(bot, entityName, distance + 16);
-			if (!target) {
+				const started = tryStartJob(jobManager, "fleeing", entityName, async (signal) => {
+					ensureMovements(bot);
+					registerAbortHandler(bot, signal);
+					await bot.pathfinder.goto(createFleeGoal(target, distance));
+				});
+				if (!started.ok) return started.result;
+
 				return textResult(
-					`"${entityName}" が近距離または視界内に見つかりません。すでに安全かもしれません`,
+					`${entityName} からの逃走を開始しました（jobId: ${started.jobId}, 距離: ${String(distance)}）`,
 				);
-			}
-
-			const started = tryStartJob(jobManager, "fleeing", entityName, async (signal) => {
-				ensureMovements(bot);
-				registerAbortHandler(bot, signal);
-				await bot.pathfinder.goto(new goals.GoalInvert(new goals.GoalFollow(target, distance)));
-			});
-			if (!started.ok) return started.result;
-
-			return textResult(
-				`${entityName} からの逃走を開始しました（jobId: ${started.jobId}, 距離: ${String(distance)}）`,
-			);
-		},
+			},
+		),
 	);
 }

--- a/packages/minecraft/src/actions/survival/food.ts
+++ b/packages/minecraft/src/actions/survival/food.ts
@@ -3,7 +3,7 @@ import type mineflayer from "mineflayer";
 import { z } from "zod/v4";
 
 import type { GetBot } from "../shared.ts";
-import { textResult } from "../shared.ts";
+import { textResult, withConnectedBot } from "../shared.ts";
 
 export interface FoodInfo {
 	name: string;
@@ -63,10 +63,7 @@ export function registerEatFood(server: McpServer, getBot: GetBot): void {
 					.describe("緊急時のみ true（golden_apple の使用を許可）"),
 			},
 		},
-		async ({ emergency }: { emergency: boolean }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
-
+		withConnectedBot(getBot, async (bot, { emergency }: { emergency: boolean }) => {
 			if (bot.food >= 20) return textResult("空腹度は満タンです。食べる必要はありません");
 
 			const inventory = bot.inventory.items();
@@ -89,6 +86,6 @@ export function registerEatFood(server: McpServer, getBot: GetBot): void {
 			}
 
 			return textResult("インベントリに食料がありません");
-		},
+		}),
 	);
 }

--- a/packages/minecraft/src/actions/survival/shelter.ts
+++ b/packages/minecraft/src/actions/survival/shelter.ts
@@ -12,6 +12,7 @@ import {
 	registerAbortHandler,
 	textResult,
 	tryStartJob,
+	withConnectedBot,
 } from "../shared.ts";
 
 const { goals } = pathfinderPkg;
@@ -128,10 +129,7 @@ export function registerFindShelter(
 					.describe("ベッド検索範囲（デフォルト: 48）"),
 			},
 		},
-		({ maxDistance }: { maxDistance: number }) => {
-			const bot = getBot();
-			if (!bot?.entity) return textResult("ボット未接続");
-
+		withConnectedBot(getBot, (bot, { maxDistance }: { maxDistance: number }) => {
 			const started = tryStartJob(jobManager, "sheltering", "避難場所", async (signal) => {
 				ensureMovements(bot);
 				registerAbortHandler(bot, signal);
@@ -156,6 +154,6 @@ export function registerFindShelter(
 			if (!started.ok) return started.result;
 
 			return textResult(`避難場所の検索を開始しました（jobId: ${started.jobId}）`);
-		},
+		}),
 	);
 }

--- a/packages/minecraft/src/reactive-layer.ts
+++ b/packages/minecraft/src/reactive-layer.ts
@@ -1,13 +1,10 @@
 import type mineflayer from "mineflayer";
-import pathfinderModule from "mineflayer-pathfinder";
 import type { Entity } from "prismarine-entity";
 
+import { createFleeGoal } from "./actions/shared.ts";
 import { listEdibleFoods } from "./actions/survival/food.ts";
 import type { BotContext } from "./bot-context.ts";
 import { isHostileMob } from "./helpers.ts";
-
-const { goals } = pathfinderModule;
-const { GoalInvert, GoalFollow } = goals;
 
 /** クリーパー/ウォーデンの逃走距離閾値 */
 const EXTENDED_FLEE_DISTANCE = 16;
@@ -175,7 +172,7 @@ export class ReactiveLayer {
 		this.ctx.setActionState({ type: "fleeing", target: hostile.entity.name });
 
 		try {
-			const goal = new GoalInvert(new GoalFollow(hostile.entity as unknown as Entity, 1));
+			const goal = createFleeGoal(hostile.entity as unknown as Entity, 1);
 			await bot.pathfinder.goto(goal);
 			this.ctx.pushEvent(
 				"reactive_flee",

--- a/spec/mcp/minecraft/actions/shared.spec.ts
+++ b/spec/mcp/minecraft/actions/shared.spec.ts
@@ -1,0 +1,107 @@
+/* oxlint-disable max-classes-per-file -- モック内の小クラス定義 */
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// モジュールモック
+//
+// createFleeGoal は mineflayer-pathfinder の GoalInvert / GoalFollow を使う。
+// 実クラスは描画/座標計算を要するため、構造を検証できるスタブに差し替える。
+// reactive-layer.spec.ts と同一形式のモックを用いる。
+// ---------------------------------------------------------------------------
+
+void mock.module("mineflayer-pathfinder", () => ({
+	default: {
+		Movements: class {
+			label = "movements";
+		},
+		goals: {
+			GoalInvert: class {
+				constructor(public goal: unknown) {}
+			},
+			GoalFollow: class {
+				constructor(
+					public entity: unknown,
+					public distance: number,
+				) {}
+			},
+		},
+	},
+}));
+
+// モックが確定してから動的 import する
+const { withConnectedBot, createFleeGoal, textResult } =
+	await import("@vicissitude/minecraft/actions/shared");
+
+// 接続済み bot を模した最小スタブ。`entity` を持つことが「接続済み」の条件。
+function makeConnectedBot() {
+	return { entity: { id: 1 } } as never;
+}
+
+describe("withConnectedBot", () => {
+	test("getBot() が null のとき handler を呼ばず『ボット未接続』を返す", async () => {
+		const handler = mock(() => textResult("呼ばれてはいけない"));
+		const wrapped = withConnectedBot(() => null, handler);
+
+		const result = await wrapped({});
+
+		expect(result).toEqual(textResult("ボット未接続"));
+		expect(handler).not.toHaveBeenCalled();
+	});
+
+	test("bot に entity が無いとき handler を呼ばず『ボット未接続』を返す", async () => {
+		const handler = mock(() => textResult("呼ばれてはいけない"));
+		const wrapped = withConnectedBot(() => ({}) as never, handler);
+
+		const result = await wrapped({});
+
+		expect(result).toEqual(textResult("ボット未接続"));
+		expect(handler).not.toHaveBeenCalled();
+	});
+
+	test("接続済みのとき handler に接続済み bot を渡す", async () => {
+		const bot = makeConnectedBot();
+		const handler = mock((b: unknown) => textResult(`bot=${String(b === bot)}`));
+		const wrapped = withConnectedBot(() => bot, handler);
+
+		const result = await wrapped({});
+
+		expect(result).toEqual(textResult("bot=true"));
+	});
+
+	test("接続済みのとき handler に呼び出し引数 args をそのまま渡す", async () => {
+		const handler = mock((_b: unknown, args: { count: number }) =>
+			textResult(`count=${String(args.count)}`),
+		);
+		const wrapped = withConnectedBot(makeConnectedBot, handler);
+
+		const result = await wrapped({ count: 7 });
+
+		expect(result).toEqual(textResult("count=7"));
+	});
+
+	test("handler が Promise を返す場合は解決値が返る", async () => {
+		const wrapped = withConnectedBot(makeConnectedBot, () =>
+			Promise.resolve(textResult("非同期成功")),
+		);
+
+		const result = await wrapped({});
+
+		expect(result).toEqual(textResult("非同期成功"));
+	});
+});
+
+describe("createFleeGoal", () => {
+	test("GoalFollow を GoalInvert で反転したゴールを構築する", () => {
+		const target = { id: 42 } as never;
+
+		const goal = createFleeGoal(target, 32) as unknown as {
+			goal: { entity: unknown; distance: number };
+		};
+
+		// 反転ゴールであること
+		expect(goal).toHaveProperty("goal");
+		// 内側の GoalFollow が target と distance を保持していること（挙動保存）
+		expect(goal.goal.entity).toBe(target);
+		expect(goal.goal.distance).toBe(32);
+	});
+});


### PR DESCRIPTION
## 概要

モノレポ全体リファクタ **Phase 1** 第13弾（Phase 1 最終）。`packages/minecraft/src/actions/` の各 tool 登録で反復していた定型を `actions/shared.ts` のヘルパに集約する。

## 変更

- **`withConnectedBot(getBot, handler)`**: bot 未接続ガード（`const bot = getBot(); if (!bot?.entity) return textResult("ボット未接続")`）を高階ラッパ化。movement / combat / smelting / exploration / interaction / queries / jobs / survival の **17 callback** を置換し、接続済み bot を handler 第1引数で受ける。
- **`createFleeGoal(target, distance)`**: `new GoalInvert(new GoalFollow(...))` の逃走ゴール構築を一元化。`reactive-layer.ts` と `survival/escape.ts` の重複を解消（bun `mock.module` 対策で `goals` は遅延取得）。

## スコープ外

- `GoalInvert` を伴わない追従/攻撃接近の `GoalFollow`（movement/combat）は置換しない。
- `mcp-tools.ts` の3箇所のインライン「ボット未接続」（action register と別系統）。
- entity の loose 構造型 → prismarine `Entity` 健全化は別 Issue。

## 検証

全 tool の出力文言・ジョブ起動引数・lookup・視界判定を完全保存（「ボット未接続」は全17箇所同一文言を確認）。
- `nr validate` green（root `nr check` 含む）
- `nr test`: **2667 pass / 0 fail**（`spec/mcp/minecraft/` 244 pass を無変更で通過 + shared.spec 6 件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)