### PR TITLE
fix(heartbeat): Discord 内部 API を webfetch で叩かないよう明示する

### DIFF
--- a/context/HEARTBEAT.md
+++ b/context/HEARTBEAT.md
@@ -9,6 +9,7 @@ heartbeat はこの存在が定期的に自律的に行動するための仕組�
 - やりたいことがあれば MCP ツールを自由に使っていい
 - スケジュールを変えたいときは schedule ツール（`core_list_reminders`, `core_add_reminder`, `core_update_reminder`, `core_remove_reminder`）を使う
 - discord の `discord_read_messages` で様子を見てから、必要なら `discord_send_message` で話しかける
+- Discord の内部 API（`discord.com/api/...` 等）を `webfetch` で直接叩かない。必ず Discord MCP ツールを使う。`webfetch` は Discord 認証ヘッダを持たないため 401 になる
 - 不自然な「見回り報告」はしない。自然に会話に入る
 
 ### デフォルトリマインダー


### PR DESCRIPTION
## 概要

Issue #1022: heartbeat agent が `webfetch` で Discord REST API (`https://discord.com/api/v9/channels/.../messages`) を直接叩き 401 を返す事象に対応。

## 原因

`context/HEARTBEAT.md` には「`discord_read_messages` で様子を見てから」と書かれていたが、`webfetch` で Discord 内部 API を叩く行為を禁じる明示ルールが無かった。結果、agent が MCP ツールを回避して `webfetch` を選び、bot トークン無しの GET で 401 になっていた。

## 対応

`context/HEARTBEAT.md` のルールに Discord MCP ツールを必ず使う旨と、`webfetch` では Discord 認証ヘッダを付与できないため 401 になる旨を 1 行追加。

```diff
- discord の `discord_read_messages` で様子を見てから、必要なら `discord_send_message` で話しかける
+ discord の `discord_read_messages` で様子を見てから、必要なら `discord_send_message` で話しかける
+ Discord の内部 API（`discord.com/api/...` 等）を `webfetch` で直接叩かない。必ず Discord MCP ツールを使う。`webfetch` は Discord 認証ヘッダを持たないため 401 になる
```

## 検証

- `nr validate`: pass（既存 warning のみ、#1061 関連）
- `nr test:spec`: 1967 pass / 0 fail
- `nr test` (full): 2694 pass / 0 fail（CI 完了次第）

## 補足

プロンプト依存の対策のため、agent が指示を逸脱した場合は再発し得ます。恒久策としては OpenCode profile の allowed tools から `webfetch` を除外する選択肢 (#1010 系の判断領域) もありますが、本 Issue はまずドキュメント側でガイドする最小修正とします。