### PR TITLE
chore(deps): opencode を llm-agents.nix 経由にし、@opencode-ai/sdk を 1.17.8 に bump する

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "vicissitude",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@opencode-ai/sdk": "^1.15.5",
+        "@opencode-ai/sdk": "^1.17.8",
         "canvas": "^3.2.1",
         "discord.js": "^14.25.1",
         "drizzle-orm": "^0.45.1",
@@ -153,7 +153,7 @@
     "packages/opencode": {
       "name": "@vicissitude/opencode",
       "dependencies": {
-        "@opencode-ai/sdk": "^1.15.5",
+        "@opencode-ai/sdk": "^1.17.8",
         "@vicissitude/infrastructure": "workspace:*",
         "@vicissitude/shared": "workspace:*",
       },
@@ -273,7 +273,7 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.15.5", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-ozJuEmXzrOvia5n0L1KAuvpyf9ESGmTk1FiPhn0RK5X1whbzjlTXL0NAxqNCEkqETxL35jS1KHArEiTpvtJ6FQ=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.8", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-6MKmsj2ujZyL44jy+12dpwWYDYKPS9fUr+0wVQxaIlPYQ/eAt8T8T3QrybplJ5ZtHfZUX+esXZ02x2UYYm7oEw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,63 @@
 {
   "nodes": {
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778446047,
+        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -15,6 +73,68 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "llm-agents": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "llm-agents-nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1781918497,
+        "narHash": "sha256-v5nllSaPZ41hqE+pDHh8iyLafi/Th/pLxfwENdSD5lc=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "c6d1e9c23a0de016ac37f9fafe3b123c3788e8a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
+    "llm-agents-nixpkgs": {
+      "locked": {
+        "lastModified": 1780145889,
+        "narHash": "sha256-md0zn0RnwNvPyASas1yG5YUuwQ4ALA6ucL50l0DvqCo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8c50a710ddca43d7a530fb805ad55bde8d0141c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "26.05",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -52,7 +172,45 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "llm-agents": "llm-agents",
+        "llm-agents-nixpkgs": "llm-agents-nixpkgs",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,13 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    # llm-agents.nix は upstream の nixpkgs-unstable で electron 等の評価が
+    # 壊れるため、26.05 stable を別途ピン留めして使う。
+    llm-agents-nixpkgs.url = "github:NixOS/nixpkgs/26.05";
+    llm-agents = {
+      url = "github:numtide/llm-agents.nix";
+      inputs.nixpkgs.follows = "llm-agents-nixpkgs";
+    };
   };
 
   outputs =
@@ -18,43 +25,7 @@
         { pkgs, system, ... }:
         let
           inherit (pkgs) lib stdenv;
-          opencodeVersion = "1.15.5";
-          opencodePlatform =
-            {
-              x86_64-linux = {
-                packageName = "opencode-linux-x64";
-                hash = "sha256-taZkHun5OsGO6VQ3ZAnnCDne+bsaRRpfPExtrerNy8Q=";
-              };
-              aarch64-linux = {
-                packageName = "opencode-linux-arm64";
-                hash = "sha256-O2hVGCK+aRHjL87VOKww6yMnzcFFJbMZoarA6vNq+V8=";
-              };
-              aarch64-darwin = {
-                packageName = "opencode-darwin-arm64";
-                hash = "sha256-B+1EjtGts6FC06aYCqKcQ5wmVnrxorA60Np15OZfqXM=";
-              };
-              x86_64-darwin = {
-                packageName = "opencode-darwin-x64";
-                hash = "sha256-+KxzBty9aCKS72WzKouy5r3LvSrAWZCOHUvwBAWrv0Y=";
-              };
-            }
-            .${system};
-          opencode = pkgs.stdenvNoCC.mkDerivation {
-            pname = "opencode";
-            version = opencodeVersion;
-            src = pkgs.fetchurl {
-              url = "https://registry.npmjs.org/${opencodePlatform.packageName}/-/${opencodePlatform.packageName}-${opencodeVersion}.tgz";
-              hash = opencodePlatform.hash;
-            };
-            dontBuild = true;
-            unpackPhase = "tar -xzf $src";
-            installPhase = ''
-              runHook preInstall
-              mkdir -p $out/bin
-              install -m 755 package/bin/opencode $out/bin/opencode
-              runHook postInstall
-            '';
-          };
+          opencode = inputs.llm-agents.packages.${system}.opencode;
           baseRuntimePackages = with pkgs; [
             bun
             ni

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.1",
-		"@opencode-ai/sdk": "^1.15.5",
+		"@opencode-ai/sdk": "^1.17.8",
 		"canvas": "^3.2.1",
 		"discord.js": "^14.25.1",
 		"drizzle-orm": "^0.45.1",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -8,7 +8,7 @@
 		"./stream-helpers": "./src/stream-helpers.ts"
 	},
 	"dependencies": {
-		"@opencode-ai/sdk": "^1.15.5",
+		"@opencode-ai/sdk": "^1.17.8",
 		"@vicissitude/infrastructure": "workspace:*",
 		"@vicissitude/shared": "workspace:*"
 	}

--- a/packages/opencode/src/stream-helpers.ts
+++ b/packages/opencode/src/stream-helpers.ts
@@ -10,7 +10,9 @@ import type {
 import { extractBackgroundTaskFailure } from "./background-task-activity.ts";
 
 export type AbortableAsyncStream<T> = AsyncIterator<T> & {
-	return?: (value?: unknown) => Promise<IteratorResult<T>>;
+	// SDK 側 (AsyncGenerator) の `return` は値を読み取らないため、ジェネリクスの
+	// 衝突を避ける目的で引数型を void に緩める。実装は値を yield 側に渡さない。
+	return?: (value?: void) => Promise<IteratorResult<T>>;
 };
 const STREAM_RETURNED = Symbol("streamReturned"),
 	STREAM_RETURN_PROMISE = Symbol("streamReturnPromise");


### PR DESCRIPTION
## 概要

`flake.nix` の opencode を自前 `mkDerivation` から `numtide/llm-agents.nix` のパッケージに切替え、同時に `@opencode-ai/sdk` を `1.15.5` から `1.17.8` に bump する。

## 変更内容

### flake.nix
- `inputs.llm-agents` (numtide/llm-agents.nix) を新規追加。自前ビルドを削除して `inputs.llm-agents.packages.${system}.opencode` を使うように変更。
- llm-agents.nix 内部の nixpkgs は upstream `nixpkgs-unstable` で `electron_42` 等の評価が壊れるため、`26.05` stable タグを別途 `llm-agents-nixpkgs` としてピン留めし、`llm-agents.inputs.nixpkgs.follows` で参照。

### @opencode-ai/sdk 1.15.5 → 1.17.8
- root と `packages/opencode` の両方を bump。
- 公開 API（`createOpencode`, `Config`, `AgentConfig`, `McpLocalConfig`, `McpRemoteConfig`, `Event` ユニオン、各 EventSession*/EventMessage* 型）は維持されており、コード修正は最小。
- `oc.event.subscribe` の戻り値 `AsyncGenerator<Event, void, unknown>` と内部抽象型 `AbortableAsyncStream<unknown>` の `return` メソッド引数型の不整合を、`AbortableAsyncStream<T>` 側で `void` に緩めて吸収。

## 検証

- `nr check`: 型チェック通過
- `nr lint`: 0 errors
- `nr test`: 2715 / 2715 pass
- `nr fmt:check`: 通過
- `nix build .#opencode`: 成功 (`/nix/store/...-opencode-1.17.8`)
- `nix flake check`: `all checks passed!`

## 補足

`nix flake check` の incompatible システム（aarch64-darwin, aarch64-linux, x86_64-darwin）は実行環境不在のため未検証だが、`packages.${system}.opencode` の参照方法は cross-platform で同一。