### PR TITLE
fix: distinguish dispatch failure from connection close failure in admin-cli

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL=postgresql://vicissitude:vicissitude@127.0.0.1:5432/vicissitude
+MAINTENANCE_DATABASE_URL=postgresql://vicissitude:vicissitude@127.0.0.1:5432/vicissitude
 DISCORD_TOKEN=
 VICISSITUDE_GUILD_ID=
 VICISSITUDE_ADMIN_USER_IDS=

--- a/src/apps/admin-cli.test.ts
+++ b/src/apps/admin-cli.test.ts
@@ -244,6 +244,26 @@ describe("admin dispatch", () => {
     error.mockRestore();
   });
 
+  it("reports success separately from a close failure after a successful dispatch", async () => {
+    const end = vi.fn(async () => {
+      throw new Error("connection reset");
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await main(
+      ["migration", "status"],
+      { DATABASE_URL: "postgres://db", MIGRATIONS_DIR: "migrations" },
+      {
+        createClient: () => ({ end }) as never,
+        migrationStatus: vi.fn(async () => []) as never,
+        output: out(),
+      },
+    );
+    expect(error).toHaveBeenCalledWith("Admin command succeeded, but closing the database connection failed");
+    expect(process.exitCode).toBe(1);
+    error.mockRestore();
+    process.exitCode = undefined;
+  });
+
   it("does not expose dependency or close errors", async () => {
     const secret = "postgres://secret\nTOKEN";
     const end = vi.fn(async () => {

--- a/src/apps/admin-cli.ts
+++ b/src/apps/admin-cli.ts
@@ -159,24 +159,28 @@ export async function dispatchAdminCommand(
 }
 export async function main(argv = process.argv.slice(2), env = process.env, d: AdminDependencies = {}): Promise<void> {
   let sql: Sql | undefined;
-  let failed = false;
+  let dispatchFailed = false;
+  let closeFailed = false;
   try {
     const config = loadAdminConfig(env);
     sql = (d.createClient ?? createPostgresClient)(config.databaseUrl);
     await dispatchAdminCommand(parseAdminCommand(argv), sql, config, d);
   } catch {
-    failed = true;
+    dispatchFailed = true;
   } finally {
     if (sql) {
       try {
         await sql.end();
       } catch {
-        failed = true;
+        closeFailed = true;
       }
     }
   }
-  if (failed) {
+  if (dispatchFailed) {
     console.error("Admin command failed");
+    process.exitCode = 1;
+  } else if (closeFailed) {
+    console.error("Admin command succeeded, but closing the database connection failed");
     process.exitCode = 1;
   }
 }


### PR DESCRIPTION
## Summary
- `main()` の `finally` ブロックで `sql.end()` が失敗すると、直前の `dispatchAdminCommand`（実際のDB操作）が成功していても一律 `"Admin command failed"` と報告し、exit code 1 にしていた。
- 運用手順(`migration apply` など)実行中にこれが発生し、DB上ではマイグレーションが正常にコミットされていたにもかかわらず「失敗」と表示され、原因調査に手間取った(監査ログ `audit_entries` / `schema_migrations.applied_at` で実際の成功を確認済み)。
- `dispatchAdminCommand` の成功/失敗と、後続の接続クローズの成功/失敗を別フラグで管理し、後者のみが失敗した場合は `"Admin command succeeded, but closing the database connection failed"` という区別可能なメッセージを出すようにした。既存のエラー詳細非公開(secret漏洩防止)方針は維持。

## Test plan
- [x] `npx vitest run src/apps/admin-cli.test.ts` — 新規テストを含め11件成功
- [x] `npx vitest run src` — 既存の全ユニットテスト136件成功
- [x] `npx tsc --noEmit -p tsconfig.json` — 型エラーなし