### PR TITLE
docs: annotate .env.example with per-file placement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
+# このファイルは全変数の一覧です。そのまま一つの secret set にせず、
+# 下の見出しに従って共通値と process 固有値を別ファイルへ分けてください。
+
+# --- .env: direnv (.envrc の dotenv) が全 terminal で読み込む共通値 ---
+# admin-cli terminal が参照できるのはここに置いた値だけです。
 DATABASE_URL=postgresql://vicissitude:vicissitude@127.0.0.1:5432/vicissitude
 MAINTENANCE_DATABASE_URL=postgresql://vicissitude:vicissitude@127.0.0.1:5432/vicissitude
-DISCORD_TOKEN=
 VICISSITUDE_GUILD_ID=
-VICISSITUDE_ADMIN_USER_IDS=
 VICISSITUDE_GATEWAY_HEALTH_PORT=8080
 VICISSITUDE_WORKER_ID=cognition-1
 VICISSITUDE_WORKER_HEALTH_PORT=8081
@@ -10,3 +13,12 @@ VICISSITUDE_CHARACTER_ID=primary
 VICISSITUDE_MODEL_ROUTES_PATH=config/model-routes.json
 VICISSITUDE_MIGRATIONS_DIR=migrations
 LOG_LEVEL=info
+
+# --- .env.gateway.local: Gateway terminal だけが追加で読み込む Discord credential ---
+# DISCORD_TOKEN=
+# VICISSITUDE_ADMIN_USER_IDS=
+
+# --- .env.worker.local: worker terminal だけが追加で読み込む model provider credential ---
+# 変数名は config/model-routes.json で選んだ provider に合わせます。
+# 例: provider に opencode-go を使う場合
+# OPENCODE_API_KEY=


### PR DESCRIPTION
## 背景

運用中に `pnpm admin channel set "$VICISSITUDE_GUILD_ID" ...` が空文字に展開され、`channel_capabilities` に実 guild ID ではないプレースホルダの行が登録される事故があった。

原因は `.env.example` の構成。README は

- `.env` は共通値を置く場所で、`VICISSITUDE_GUILD_ID` もそこに含まれる (README:23)
- admin-cli terminal は process 固有ファイルを追加で読み込まない (README:121)
- Go-live block は `: "${VICISSITUDE_GUILD_ID:?set VICISSITUDE_GUILD_ID in .env}"` で guard する (README:146)

と書いているが、`.env.example` は12変数のフラットな一覧で、どれがどのファイルへ行くのかを示していなかった。結果として guild ID が `.env.gateway.local` 側にだけ置かれ、admin-cli terminal では未定義になっていた。

## 変更

- 変数を配置先ファイル (`.env` / `.env.gateway.local` / `.env.worker.local`) ごとに見出しでグルーピング
- process 固有 credential はコメントアウト。このファイルをそのままコピーしても共通値だけが入り、README の process 境界を壊さない
- worker の provider credential の例として `OPENCODE_API_KEY` を追加 (`config/model-routes.json` で `opencode-go` を選んだ場合の変数名)

`.env.example` のみの変更で、コードと README には触れていない。

## 補足

作業前のローカルで `DISCORD_TOKEN=` の行が削除されていたが、`loadGatewayConfig` の必須項目であり README:348 の Gateway 設定契約にも含まれるため、gateway 見出しの下にコメントとして戻してある。意図的な削除だった場合はこのコミットから外す。