### PR TITLE
feat: require a Discord user ID for the admin-cli actor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@
 DATABASE_URL=postgresql://vicissitude:vicissitude@127.0.0.1:5432/vicissitude
 MAINTENANCE_DATABASE_URL=postgresql://vicissitude:vicissitude@127.0.0.1:5432/vicissitude
 VICISSITUDE_GUILD_ID=
+# admin-cli の --actor に渡す操作者自身の Discord user ID。
+# 管理者 allowlist の VICISSITUDE_ADMIN_USER_IDS とは別物です。
+VICISSITUDE_ADMIN_ACTOR=
 VICISSITUDE_GATEWAY_HEALTH_PORT=8080
 VICISSITUDE_WORKER_ID=cognition-1
 VICISSITUDE_WORKER_HEALTH_PORT=8081

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pnpm build
 pnpm test
 ```
 
-`.env` は常に読み込まれる共通設定として扱います。`DATABASE_URL`、`VICISSITUDE_GUILD_ID`、`VICISSITUDE_MIGRATIONS_DIR`、health port、`VICISSITUDE_CHARACTER_ID`、`VICISSITUDE_MODEL_ROUTES_PATH`、`LOG_LEVEL` のように複数 process で共有する値だけを置きます。
+`.env` は常に読み込まれる共通設定として扱います。`DATABASE_URL`、`VICISSITUDE_GUILD_ID`、`VICISSITUDE_ADMIN_ACTOR`、`VICISSITUDE_MIGRATIONS_DIR`、health port、`VICISSITUDE_CHARACTER_ID`、`VICISSITUDE_MODEL_ROUTES_PATH`、`LOG_LEVEL` のように複数 process で共有する値だけを置きます。
 
 process 固有の secret や credential は `.env.gateway.local`、`.env.worker.local` などに分け、起動する process の terminal でだけ追加で読み込みます。例えば Gateway は Discord credential だけ、worker は model provider credential だけを読み込みます。このリポジトリは process manager や secret 配布方式を固定しませんが、foreground 起動時も外部 deployment adapter も同じ境界を維持してください。
 
@@ -84,6 +84,7 @@ pnpm install
 pnpm build
 : "${DATABASE_URL:?set DATABASE_URL in .env and let direnv load it}"
 : "${VICISSITUDE_MIGRATIONS_DIR:?set VICISSITUDE_MIGRATIONS_DIR in .env}"
+: "${VICISSITUDE_ADMIN_ACTOR:?set VICISSITUDE_ADMIN_ACTOR in .env}"
 psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c 'SELECT 1;'
 BACKUP_DIR=${BACKUP_DIR:-./backups}
 mkdir -p "$BACKUP_DIR"
@@ -92,9 +93,9 @@ pg_dump --format=custom --file "$BACKUP_PATH" "$DATABASE_URL"
 pg_restore --list "$BACKUP_PATH" >/dev/null
 BACKUP_CONFIRMED_AT="$(date --iso-8601=seconds --reference="$BACKUP_PATH")"
 pnpm admin migration status
-pnpm admin migration apply --backup-confirmed-at "$BACKUP_CONFIRMED_AT" --actor admin-id
-pnpm admin character import ./character-reviewed.json --actor admin-id
-pnpm admin character activate primary 1 --actor admin-id
+pnpm admin migration apply --backup-confirmed-at "$BACKUP_CONFIRMED_AT" --actor "$VICISSITUDE_ADMIN_ACTOR"
+pnpm admin character import ./character-reviewed.json --actor "$VICISSITUDE_ADMIN_ACTOR"
+pnpm admin character activate primary 1 --actor "$VICISSITUDE_ADMIN_ACTOR"
 SH
 ```
 
@@ -157,10 +158,11 @@ set -euo pipefail
 : "${VICISSITUDE_GUILD_ID:?set VICISSITUDE_GUILD_ID in .env}"
 : "${VICISSITUDE_GATEWAY_HEALTH_PORT:?set gateway health port in .env}"
 : "${VICISSITUDE_WORKER_HEALTH_PORT:?set worker health port in .env}"
+: "${VICISSITUDE_ADMIN_ACTOR:?set VICISSITUDE_ADMIN_ACTOR in .env}"
 # terminal 3: Gateway と worker は terminal 1、2 または外部deployment adapterで起動済みとする。
 curl --fail http://127.0.0.1:${VICISSITUDE_GATEWAY_HEALTH_PORT}/ready
 curl --fail http://127.0.0.1:${VICISSITUDE_WORKER_HEALTH_PORT}/ready
-pnpm admin channel set "$VICISSITUDE_GUILD_ID" <discord-channel-id> --observe true --mentions true --actor admin-id --reason "enable reviewed target channel"
+pnpm admin channel set "$VICISSITUDE_GUILD_ID" <discord-channel-id> --observe true --mentions true --actor "$VICISSITUDE_ADMIN_ACTOR" --reason "enable reviewed target channel"
 SH
 ```
 
@@ -174,7 +176,8 @@ set -euo pipefail
 : "${DATABASE_URL:?set DATABASE_URL in .env and let direnv load it}"
 : "${VICISSITUDE_GATEWAY_HEALTH_PORT:?set gateway health port in .env}"
 : "${VICISSITUDE_WORKER_HEALTH_PORT:?set worker health port in .env}"
-pnpm admin system drain --actor admin-id --reason "deploy"
+: "${VICISSITUDE_ADMIN_ACTOR:?set VICISSITUDE_ADMIN_ACTOR in .env}"
+pnpm admin system drain --actor "$VICISSITUDE_ADMIN_ACTOR" --reason "deploy"
 while true; do
   active="$(psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc "SELECT (SELECT count(*) FROM jobs WHERE state = 'running') + (SELECT count(*) FROM effects WHERE state IN ('planned', 'executing'));")" || {
     printf '%s\n' "failed to query active leases" >&2
@@ -201,7 +204,7 @@ pg_dump --format=custom --file "$BACKUP_PATH" "$DATABASE_URL"
 pg_restore --list "$BACKUP_PATH" >/dev/null
 BACKUP_CONFIRMED_AT="$(date --iso-8601=seconds --reference="$BACKUP_PATH")"
 pnpm admin migration status
-pnpm admin migration apply --backup-confirmed-at "$BACKUP_CONFIRMED_AT" --actor admin-id
+pnpm admin migration apply --backup-confirmed-at "$BACKUP_CONFIRMED_AT" --actor "$VICISSITUDE_ADMIN_ACTOR"
 SH
 ```
 
@@ -237,9 +240,10 @@ set -euo pipefail
 : "${DATABASE_URL:?set DATABASE_URL in .env and let direnv load it}"
 : "${VICISSITUDE_GATEWAY_HEALTH_PORT:?set gateway health port in .env}"
 : "${VICISSITUDE_WORKER_HEALTH_PORT:?set worker health port in .env}"
+: "${VICISSITUDE_ADMIN_ACTOR:?set VICISSITUDE_ADMIN_ACTOR in .env}"
 curl --fail http://127.0.0.1:${VICISSITUDE_GATEWAY_HEALTH_PORT}/ready
 curl --fail http://127.0.0.1:${VICISSITUDE_WORKER_HEALTH_PORT}/ready
-pnpm admin system resume --actor admin-id --reason "deploy complete"
+pnpm admin system resume --actor "$VICISSITUDE_ADMIN_ACTOR" --reason "deploy complete"
 SH
 ```
 
@@ -265,8 +269,9 @@ SH
 bash <<'SH'
 set -euo pipefail
 : "${DATABASE_URL:?set DATABASE_URL in .env and let direnv load it}"
+: "${VICISSITUDE_ADMIN_ACTOR:?set VICISSITUDE_ADMIN_ACTOR in .env}"
 pnpm admin effect inspect effect-id
-pnpm admin effect reconcile effect-id --state succeeded --external-resource-id discord-message-id --actor admin-id --reason "verified in Discord"
+pnpm admin effect reconcile effect-id --state succeeded --external-resource-id discord-message-id --actor "$VICISSITUDE_ADMIN_ACTOR" --reason "verified in Discord"
 SH
 ```
 
@@ -283,6 +288,7 @@ bash <<'SH'
 set -euo pipefail
 : "${DATABASE_URL:?set DATABASE_URL in .env and let direnv load it}"
 : "${VICISSITUDE_GUILD_ID:?set VICISSITUDE_GUILD_ID in .env}"
+: "${VICISSITUDE_ADMIN_ACTOR:?set VICISSITUDE_ADMIN_ACTOR in .env}"
 violations="$(psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v guild_id="$VICISSITUDE_GUILD_ID" -v channel_id=discord-channel-id -Atc "SELECT (SELECT count(*) FROM channel_capabilities WHERE respond_to_mentions AND NOT (guild_id = :'guild_id' AND channel_id = :'channel_id')) + (SELECT count(*) FROM jobs j JOIN events e ON e.id = j.event_id WHERE j.state IN ('queued', 'running') AND NOT (e.guild_id = :'guild_id' AND e.channel_id = :'channel_id')) + (SELECT count(*) FROM effects WHERE state IN ('planned', 'executing') AND NOT (guild_id = :'guild_id' AND capability_channel_id = :'channel_id'));" )" || {
   printf '%s\n' "failed to verify recovery scope" >&2
   exit 1
@@ -314,7 +320,7 @@ while true; do
   esac
   sleep 5
 done
-pnpm admin system resume --actor admin-id --reason "allow worker reclaim"
+pnpm admin system resume --actor "$VICISSITUDE_ADMIN_ACTOR" --reason "allow worker reclaim"
 while true; do
   active="$(psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc "SELECT count(*) FROM jobs WHERE state = 'running' AND (leased_until IS NULL OR leased_until <= clock_timestamp());")" || {
     printf '%s\n' "failed to query recovery state" >&2
@@ -329,7 +335,7 @@ while true; do
   esac
   sleep 5
 done
-pnpm admin system drain --actor admin-id --reason "prepare deploy after recovery"
+pnpm admin system drain --actor "$VICISSITUDE_ADMIN_ACTOR" --reason "prepare deploy after recovery"
 while true; do
   active="$(psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc "SELECT (SELECT count(*) FROM jobs WHERE state = 'running') + (SELECT count(*) FROM effects WHERE state IN ('planned', 'executing'));")" || {
     printf '%s\n' "failed to query active pipeline" >&2
@@ -354,6 +360,12 @@ queued job は deploy 後に処理できるため、drain-to-zero の count に�
 ### Discord
 
 Guilds、Guild Messages、Message Content intents を有効にします。`VICISSITUDE_GUILD_ID` は対象を単一 guild に限定し、`VICISSITUDE_ADMIN_USER_IDS` は管理者 allowlist をカンマ区切りで指定します。DM は対象外です。Gateway は singleton として動かします。
+
+### Admin Actor
+
+admin-cli の `--actor` には操作者自身の Discord user ID を渡します。`audit_entries.summary.actor` には Discord のスラッシュコマンド経由の操作も `interaction.user.id` として記録されるため、両経路を同じ値空間に揃えないと監査記録を actor で追えません。admin-cli は `--actor` が17〜20桁の数字であることを検証し、`admin-id` のような placeholder を拒否します。
+
+`VICISSITUDE_ADMIN_ACTOR` は操作者ごとに自分の ID を設定する変数で、`.env` に置きます。`VICISSITUDE_ADMIN_USER_IDS` を流用しないでください。あれは「誰が操作してよいか」を示す Gateway 専用の allowlist で、複数の ID を持ちうるため「誰が操作したか」の記録には使えません。
 
 ### Model
 

--- a/src/modules/admin/admin-command.test.ts
+++ b/src/modules/admin/admin-command.test.ts
@@ -1,42 +1,44 @@
 import { describe, expect, it } from "vitest";
 import { parseAdminCommand } from "./admin-command.js";
 
+const ACTOR = "883258849254072341";
+
 describe("admin parser exact union", () => {
   it.each([
     [["migration", "status"], { kind: "migration.status" }],
     [
-      ["migration", "apply", "--backup-confirmed-at", "2026-07-24T00:00:00Z", "--actor", "a"],
-      { kind: "migration.apply", backupConfirmedAt: new Date("2026-07-24T00:00:00Z"), actor: "a" },
+      ["migration", "apply", "--backup-confirmed-at", "2026-07-24T00:00:00Z", "--actor", ACTOR],
+      { kind: "migration.apply", backupConfirmedAt: new Date("2026-07-24T00:00:00Z"), actor: ACTOR },
     ],
     [
-      ["system", "resume", "--actor", "a", "--reason", "r"],
-      { kind: "system.set", mode: "running", actor: "a", reason: "r" },
+      ["system", "resume", "--actor", ACTOR, "--reason", "r"],
+      { kind: "system.set", mode: "running", actor: ACTOR, reason: "r" },
     ],
     [
-      ["system", "drain", "--actor", "a", "--reason", "r"],
-      { kind: "system.set", mode: "draining", actor: "a", reason: "r" },
+      ["system", "drain", "--actor", ACTOR, "--reason", "r"],
+      { kind: "system.set", mode: "draining", actor: ACTOR, reason: "r" },
     ],
     [
-      ["system", "stop", "--actor", "a", "--reason", "r"],
-      { kind: "system.set", mode: "stopped", actor: "a", reason: "r" },
+      ["system", "stop", "--actor", ACTOR, "--reason", "r"],
+      { kind: "system.set", mode: "stopped", actor: ACTOR, reason: "r" },
     ],
     [["channel", "show", "g", "c"], { kind: "channel.show", guildId: "g", channelId: "c" }],
     [
-      ["channel", "set", "g", "c", "--observe", "true", "--mentions", "false", "--actor", "a", "--reason", "r"],
+      ["channel", "set", "g", "c", "--observe", "true", "--mentions", "false", "--actor", ACTOR, "--reason", "r"],
       {
         kind: "channel.set",
         guildId: "g",
         channelId: "c",
         observeEvents: true,
         respondToMentions: false,
-        actor: "a",
+        actor: ACTOR,
         reason: "r",
       },
     ],
-    [["character", "import", "x", "--actor", "a"], { kind: "character.import", path: "x", actor: "a" }],
+    [["character", "import", "x", "--actor", ACTOR], { kind: "character.import", path: "x", actor: ACTOR }],
     [
-      ["character", "activate", "id", "2", "--actor", "a"],
-      { kind: "character.activate", characterId: "id", version: 2, actor: "a" },
+      ["character", "activate", "id", "2", "--actor", ACTOR],
+      { kind: "character.activate", characterId: "id", version: 2, actor: ACTOR },
     ],
     [["effect", "inspect", "e"], { kind: "effect.inspect", effectId: "e" }],
     [
@@ -49,15 +51,22 @@ describe("admin parser exact union", () => {
         "--external-resource-id",
         "x",
         "--actor",
-        "a",
+        ACTOR,
         "--reason",
         "r",
       ],
-      { kind: "effect.reconcile", effectId: "e", state: "succeeded", externalResourceId: "x", actor: "a", reason: "r" },
+      {
+        kind: "effect.reconcile",
+        effectId: "e",
+        state: "succeeded",
+        externalResourceId: "x",
+        actor: ACTOR,
+        reason: "r",
+      },
     ],
     [
-      ["effect", "reconcile", "e", "--state", "failed", "--actor", "a", "--reason", "r"],
-      { kind: "effect.reconcile", effectId: "e", state: "failed", externalResourceId: null, actor: "a", reason: "r" },
+      ["effect", "reconcile", "e", "--state", "failed", "--actor", ACTOR, "--reason", "r"],
+      { kind: "effect.reconcile", effectId: "e", state: "failed", externalResourceId: null, actor: ACTOR, reason: "r" },
     ],
   ] as const)("parses %j exactly", (args, expected) => expect(parseAdminCommand([...args])).toEqual(expected));
 
@@ -72,7 +81,7 @@ describe("admin parser exact union", () => {
       "--mentions",
       "false",
       "--actor",
-      "a",
+      ACTOR,
       "--reason",
       "r",
     ]);
@@ -85,23 +94,42 @@ describe("admin parser exact union", () => {
   it.each([
     ["missing", []],
     ["unknown action", ["system", "set"]],
-    ["old action", ["system", "set", "--mode", "running", "--actor", "a", "--reason", "r"]],
+    ["old action", ["system", "set", "--mode", "running", "--actor", ACTOR, "--reason", "r"]],
     ["old option", ["channel", "set", "--guild-id", "g"]],
     ["extra positional", ["channel", "show", "g", "c", "x"]],
     ["blank value", ["channel", "show", " ", "c"]],
     [
       "bad bool",
-      ["channel", "set", "g", "c", "--observe", "yes", "--mentions", "false", "--actor", "a", "--reason", "r"],
+      ["channel", "set", "g", "c", "--observe", "yes", "--mentions", "false", "--actor", ACTOR, "--reason", "r"],
     ],
-    ["bad date", ["migration", "apply", "--backup-confirmed-at", "x", "--actor", "a"]],
-    ["bad version", ["character", "activate", "id", "0", "--actor", "a"]],
+    ["bad date", ["migration", "apply", "--backup-confirmed-at", "x", "--actor", ACTOR]],
+    ["bad version", ["character", "activate", "id", "0", "--actor", ACTOR]],
     [
       "failed external id",
-      ["effect", "reconcile", "e", "--state", "failed", "--external-resource-id", "x", "--actor", "a", "--reason", "r"],
+      [
+        "effect",
+        "reconcile",
+        "e",
+        "--state",
+        "failed",
+        "--external-resource-id",
+        "x",
+        "--actor",
+        ACTOR,
+        "--reason",
+        "r",
+      ],
     ],
-    ["missing external id", ["effect", "reconcile", "e", "--state", "succeeded", "--actor", "a", "--reason", "r"]],
+    ["missing external id", ["effect", "reconcile", "e", "--state", "succeeded", "--actor", ACTOR, "--reason", "r"]],
     ["unknown option", ["migration", "status", "--old", "x"]],
   ] as const)("rejects %s", (_, args) => expect(() => parseAdminCommand([...args])).toThrow());
+
+  it.each(["admin-id", "883258849254072341x", "8832588492540", "883258849254072341883258849254072341", " "])(
+    "rejects actor %j that is not a Discord user ID",
+    (value) => {
+      expect(() => parseAdminCommand(["system", "drain", "--actor", value, "--reason", "r"])).toThrow();
+    },
+  );
 
   it.each([
     ["--help", "c"],
@@ -111,8 +139,14 @@ describe("admin parser exact union", () => {
   });
 
   it.each([
-    ["actor", ["migration", "apply", "--backup-confirmed-at", "2026-07-24T00:00:00Z", "--actor", "a", "--actor", "b"]],
-    ["actor equals", ["migration", "apply", "--backup-confirmed-at=2026-07-24T00:00:00Z", "--actor=a", "--actor=b"]],
+    [
+      "actor",
+      ["migration", "apply", "--backup-confirmed-at", "2026-07-24T00:00:00Z", "--actor", ACTOR, "--actor", "b"],
+    ],
+    [
+      "actor equals",
+      ["migration", "apply", "--backup-confirmed-at=2026-07-24T00:00:00Z", `--actor=${ACTOR}`, "--actor=b"],
+    ],
     [
       "backup",
       [
@@ -123,24 +157,24 @@ describe("admin parser exact union", () => {
         "--backup-confirmed-at",
         "2026-07-24T01:00:00Z",
         "--actor",
-        "a",
+        ACTOR,
       ],
     ],
     [
       "state",
-      ["effect", "reconcile", "e", "--state", "failed", "--state", "succeeded", "--actor", "a", "--reason", "r"],
+      ["effect", "reconcile", "e", "--state", "failed", "--state", "succeeded", "--actor", ACTOR, "--reason", "r"],
     ],
-    ["reason", ["system", "stop", "--actor", "a", "--reason", "r1", "--reason", "r2"]],
+    ["reason", ["system", "stop", "--actor", ACTOR, "--reason", "r1", "--reason", "r2"]],
   ] as const)("rejects duplicate %s", (_, args) => expect(() => parseAdminCommand([...args])).toThrow());
 
   it.each([
     ["2026-07-24T00:00:00Z", new Date("2026-07-24T00:00:00Z")],
     ["2026-07-24T09:00:00+09:00", new Date("2026-07-24T00:00:00Z")],
   ])("accepts ISO datetime %s", (value, expected) => {
-    expect(parseAdminCommand(["migration", "apply", "--backup-confirmed-at", value, "--actor", "a"])).toEqual({
+    expect(parseAdminCommand(["migration", "apply", "--backup-confirmed-at", value, "--actor", ACTOR])).toEqual({
       kind: "migration.apply",
       backupConfirmedAt: expected,
-      actor: "a",
+      actor: ACTOR,
     });
   });
 
@@ -148,7 +182,7 @@ describe("admin parser exact union", () => {
     "rejects non-valid ISO datetime %s without echoing input",
     (value) => {
       try {
-        parseAdminCommand(["migration", "apply", "--backup-confirmed-at", value, "--actor", "a"]);
+        parseAdminCommand(["migration", "apply", "--backup-confirmed-at", value, "--actor", ACTOR]);
         throw new Error("expected parser to reject");
       } catch (error) {
         expect(error).toBeInstanceOf(Error);

--- a/src/modules/admin/admin-command.ts
+++ b/src/modules/admin/admin-command.ts
@@ -34,8 +34,14 @@ const booleanValue = (value: unknown, name: string): boolean => {
   if (normalized === "false") return false;
   throw new Error(`${name} must be true or false`);
 };
+const snowflake = /^[0-9]{17,20}$/u;
+const actorId = (value: unknown): string => {
+  const normalized = text(value, "actor");
+  if (!snowflake.test(normalized)) throw new Error("actor must be a Discord user ID");
+  return normalized;
+};
 const actorReason = (values: Record<string, unknown>): ActorReason => ({
-  actor: text(values.actor, "actor"),
+  actor: actorId(values.actor),
   reason: text(values.reason, "reason"),
 });
 const isoDatetime = z.iso.datetime({ offset: true });
@@ -87,7 +93,7 @@ export function parseAdminCommand(argv: string[]): AdminCommand {
     return {
       kind: "migration.apply",
       backupConfirmedAt: new Date(validValue.data),
-      actor: text(result.values.actor, "actor"),
+      actor: actorId(result.values.actor),
     };
   }
   if (command === "channel.set") {
@@ -116,7 +122,7 @@ export function parseAdminCommand(argv: string[]): AdminCommand {
     return {
       kind: "character.import",
       path: text(result.positionals[0], "path"),
-      actor: text(result.values.actor, "actor"),
+      actor: actorId(result.values.actor),
     };
   }
   if (command === "character.activate") {
@@ -127,7 +133,7 @@ export function parseAdminCommand(argv: string[]): AdminCommand {
       kind: "character.activate",
       characterId: text(result.positionals[0], "characterId"),
       version,
-      actor: text(result.values.actor, "actor"),
+      actor: actorId(result.values.actor),
     };
   }
   if (command === "effect.inspect") {


### PR DESCRIPTION
## 問題

`audit_entries.summary.actor` に、値空間の違う2経路が書き込んでいた。

| 経路 | 書き込む値 | 検証 |
|---|---|---|
| Discord スラッシュコマンド (`channel-command.ts:117`) | `interaction.user.id`（snowflake） | `adminUserIds` allowlist |
| admin-cli (`admin-command.ts`) | `--actor` の文字列そのまま | 非空のみ |

runbook が全箇所で `--actor admin-id` というリテラルを渡していたため、CLI 由来の audit 行は**全て `admin-id`** になり、誰が操作したか一切追えない状態だった。実際に稼働中の DB でも CLI 由来の行は全て `admin-id` だった。

## 変更

- `--actor` を17〜20桁の数字（Discord user ID）として検証し、`admin-id` のような placeholder を parse 時点で拒否する
- runbook は `.env` の `VICISSITUDE_ADMIN_ACTOR` を渡す。他の必須変数と同様に `: "${VAR:?...}"` で guard する
- `.env.example` と Configuration Reference に契約を追記

`VICISSITUDE_ADMIN_USER_IDS` は流用していない。あれは「誰が操作してよいか」を示す Gateway 専用の allowlist で、複数 ID を持ちうるうえ `.env.gateway.local` にあるため admin-cli terminal からは見えない。identity として使うのは category error であり、直前に修正した guild ID と同じ踏み方になる。

## 確認

- `pnpm lint` / `pnpm check` / `pnpm test:unit` (141) / `pnpm test:spec` (61) すべて通過
- 新規テスト5件: `admin-id`、桁不足、桁超過、末尾に非数字、空白 をいずれも拒否
- README の全 bash block を抽出して `bash -n`（全 OK）。`--actor` を使う全 block に guard があること、`$VICISSITUDE_GUILD_ID` を使う全 block に guard があることを機械的に確認
- ビルド後の実 CLI で `--actor admin-id` が失敗し、実 ID では成功して audit に snowflake が記録されることを確認

`pnpm format:check` は未追跡の `character-reviewed.json` でのみ失敗する。本変更の前後で同じ。

## 補足

既存の `admin-id` の audit 行は遡って修正できない。今後の行から追跡可能になる。