### PR TITLE
fix: use a Discord user ID for the rehearsal actor

### DIFF
--- a/nix/db-rehearsal.sh
+++ b/nix/db-rehearsal.sh
@@ -223,7 +223,7 @@ encoded_socket=$(printf '%s' "$(socket_dir source)" | sed 's#/#%2F#g')
 database_url="postgresql://vicissitude_migrator@$encoded_socket/vicissitude?port=$port"
 DATABASE_URL="$database_url" VICISSITUDE_MIGRATIONS_DIR="$package/lib/vicissitude/migrations" \
   "$package/bin/vicissitude-admin" migration apply --backup-confirmed-at "$backup_confirmed_at" \
-  --actor staging-validation >/dev/null
+  --actor 100000000000000001 >/dev/null
 
 run_sql_file source vicissitude_migrator "$sql_dir/runtime-acl.sql"
 run_sql_file source vicissitude_migrator "$sql_dir/fixture.sql"


### PR DESCRIPTION
## 症状

main の `staging-validation` が失敗している。

```
> check=staging-db-rehearsal role=internal operation=integration expected=success
error: Cannot build staging-db-rehearsal.drv
```

## 原因

#1094 で admin-cli の `--actor` を17〜20桁の Discord user ID に限定したが、`nix/db-rehearsal.sh:226` が `--actor staging-validation` を渡したままだった。rehearsal の `migration apply` が parse 時点で弾かれる。#1094 の見落としによる regression。

## 変更

format を満たす合成 ID を渡す。rehearsal は使い捨て database に対して走るので、値は契約を満たしていれば足りる。

## 確認

同一コミットで修正の有無を比較した。

| | 結果 |
|---|---|
| 修正なし | CI と同じ `expected=success` で失敗 |
| 修正あり | `nix build .#checks.x86_64-linux.staging-db-rehearsal` が exit 0 |