### PR TITLE
feat: log why the gateway ignored a Discord message

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,14 @@ queued job は deploy 後に処理できるため、drain-to-zero の count に�
 
 Guilds、Guild Messages、Message Content intents を有効にします。`VICISSITUDE_GUILD_ID` は対象を単一 guild に限定し、`VICISSITUDE_ADMIN_USER_IDS` は管理者 allowlist をカンマ区切りで指定します。DM は対象外です。Gateway は singleton として動かします。
 
+### Channel And Thread
+
+channel capability の主キーは `(guild_id, channel_id)` です。thread に投稿された message は親 channel の ID に正規化して扱い、thread ID は event の `thread_id` に入ります。thread を対象にするには **親 channel の ID** を `channel set` に渡します。thread ID を渡した行は照合されず、message は `channel_not_allowed` として無視され、event も残りません。
+
+有効化の粒度は親 channel 単位です。forum や text channel を有効にすると、その配下の thread はすべて対象になります。thread 単位で絞る機能はありません。
+
+対象 channel の ID が thread のものかどうかは Discord 側で確認します。`channel set` は capability 行を作るだけで、渡された ID が実在するか、thread かどうかは検証しません。
+
 ### Admin Actor
 
 admin-cli の `--actor` には操作者自身の Discord user ID を渡します。`audit_entries.summary.actor` には Discord のスラッシュコマンド経由の操作も `interaction.user.id` として記録されるため、両経路を同じ値空間に揃えないと監査記録を actor で追えません。admin-cli は `--actor` が17〜20桁の数字であることを検証し、`admin-id` のような placeholder を拒否します。
@@ -378,6 +386,8 @@ admin-cli の `--actor` には操作者自身の Discord user ID を渡します
 ### Health
 
 長時間プロセスは localhost の設定ポートで `GET /live` と `GET /ready` を公開します。`/live` はプロセス生存を返します。Gateway の `/ready` は DB migration preflight、system singleton と recovery、Discord login、command registration の完了を確認します。Gateway は production CharacterDefinition を確認しません。Worker の `/ready` は migration、production CharacterDefinition、model routes の起動 preflight が完了した時点で true になります。iteration が失敗すると false に戻り、次に成功した iteration で true に戻ります。`draining` と `stopped` は readiness を直接変えず、job claim を止めます。`/health` は使用しません。
+
+readiness は message が取り込まれることを保証しません。両 process が ready でも、channel capability が対象 channel と一致しなければ message は無視されます。`LOG_LEVEL=debug` で Gateway を起動すると、message ごとに取り込んだか無視したかと、無視した理由、照合に使った channel ID と thread ID が出ます。message 本文は出しません。mention しても何も起きない場合は、まずこれで capability の照合先を確認します。
 
 ### Credential Boundary
 

--- a/spec/apps/discord-gateway.spec.ts
+++ b/spec/apps/discord-gateway.spec.ts
@@ -3,6 +3,20 @@ import type { Sql } from "postgres";
 import { createPostgresClient } from "../../src/adapters/postgres/client.js";
 import { runMigrations } from "../../src/adapters/postgres/migrations.js";
 import { runGateway } from "../../src/apps/discord-gateway.js";
+import { createInFlightTracker } from "../../src/apps/app-lifecycle.js";
+
+const threadMessage = (parentChannelId: string) => ({
+  id: "message-1",
+  guildId: "guild",
+  channelId: "thread-1",
+  channel: { isThread: () => true, parentId: parentChannelId },
+  author: { id: "human-1", bot: false },
+  createdTimestamp: Date.now(),
+  content: "mention",
+  mentions: { users: new Map([["bot", {}]]) },
+  reference: null,
+  attachments: new Map(),
+});
 
 const url = process.env.TEST_DATABASE_URL;
 let sql: Sql;
@@ -70,5 +84,51 @@ describe("runGateway", () => {
     } finally {
       await sql`insert into system_state (singleton, mode, updated_at, updated_by, reason) values (${saved.singleton}, ${saved.mode}, ${saved.updatedAt}, ${saved.updatedBy}, ${saved.reason})`;
     }
+  });
+
+  it("logs why a message was ignored, keyed on the parent channel of a thread", async () => {
+    const handlers: Record<string, (...args: unknown[]) => void> = {};
+    const logger = { error: vi.fn(), debug: vi.fn() };
+    const inflight = createInFlightTracker();
+    const accepting = { value: false };
+    let release!: (signal: AbortSignal) => void;
+    const shutdown = new Promise<AbortSignal>((resolve) => {
+      release = resolve;
+    });
+
+    const run = runGateway({
+      sql,
+      client: {
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          handlers[event] = handler;
+        }),
+        user: { id: "bot" },
+      } as never,
+      config: { migrationsDir: "migrations", guildId: "guild", adminIds: ["admin"], discordToken: "token" } as never,
+      health: { setReady: vi.fn() } as never,
+      logger: logger as never,
+      shutdown,
+      prepared: true,
+      startClient: async () => undefined,
+      registerCommands: async () => undefined,
+      accepting,
+      inflight,
+    });
+
+    await vi.waitFor(() => expect(handlers.messageCreate).toBeTypeOf("function"));
+    handlers.messageCreate!(threadMessage("parent-without-capability"));
+    await inflight.drain();
+    release(new AbortController().signal);
+    await run;
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: "parent-without-capability",
+        threadId: "thread-1",
+        reason: "channel_not_allowed",
+      }),
+      "Discord message ignored",
+    );
+    expect(logger.debug.mock.calls.flat()).not.toContain("mention");
   });
 });

--- a/src/apps/discord-gateway.ts
+++ b/src/apps/discord-gateway.ts
@@ -119,7 +119,18 @@ export async function runGateway(d: GatewayDependencies): Promise<void> {
       const input = toDiscordMessageInput(snapshot, client.user!.id);
       const capability = await capabilities.get(config.guildId, input.channelId);
       const mode = await system.get();
-      await ingestDiscordMessage(input, capability, mode.mode, ingestion, SystemClock);
+      const result = await ingestDiscordMessage(input, capability, mode.mode, ingestion, SystemClock);
+      logger.debug(
+        {
+          channelId: input.channelId,
+          threadId: input.threadId,
+          mode: mode.mode,
+          ...(result.kind === "ignored"
+            ? { reason: result.reason }
+            : { duplicate: result.duplicate, jobQueued: result.jobQueued }),
+        },
+        result.kind === "ignored" ? "Discord message ignored" : "Discord message ingested",
+      );
     })().catch((error) => {
       handleGatewayFatal(accepting, health, rejectFatal, error);
       logger.error({ err: error }, "Discord ingestion failed");


### PR DESCRIPTION
## 背景

「該当チャンネルで mention しても何も起きない」の切り分けに、Discord API を手で叩く必要があった。

`runGateway` は `ingestDiscordMessage` の戻り値を捨てていた（`discord-gateway.ts:122`）。`channel_not_allowed` で無視された message は event 行も残らず、ログにも一切出ない。両 process が ready、`system_state` が running、capability 行も存在する、という状態で `events` が 0 のまま、という観測不能な状況になっていた。

実際の原因は、capability に登録された ID が thread のものだったこと。thread の message は `toDiscordMessageInput` で親 channel に正規化されるため（`message-snapshot.ts:35`）、capability の照合先は親 channel になり、thread ID の行は構造上どうやっても一致しない。

## 変更

- ingest の結果を debug ログに出す。照合に使った `channelId` と `threadId`、無視なら `reason`、受理なら `duplicate` と `jobQueued`
- message 本文は出さない。content / credential の境界は変えていない
- debug level にしている。guild 内の全 message が ingest まで来るため、info だと対象外 channel の message でログが埋まる
- README に、capability が親 channel キーであること、有効化の粒度が親 channel 単位（配下の全 thread が対象）であること、`LOG_LEVEL=debug` が確認手段であることを追記

## 確認

- `pnpm lint` / `pnpm check` / `pnpm test:unit` (141) / `pnpm test:spec` (62、+1)
- 追加した spec は `runGateway` を実際に起動して `messageCreate` handler を捕まえ、thread message を流して「親 channel ID で照合され、`channel_not_allowed` が debug に出る」ことを検証する。message 本文がログに含まれないことも合わせて assert している

## 関連

- capability を親 channel で登録する運用上の修正は本 PR には含まない（実環境では適用済み）
- `--actor` の regression 修正は #1095