### PR TITLE
feat: thread-level capability overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ coverage/
 *.log
 .tmp/
 /.direnv
+/backups/
+/config/model-routes.json
+/character-reviewed.json

--- a/README.md
+++ b/README.md
@@ -369,7 +369,16 @@ channel capability の主キーは `(guild_id, channel_id)` です。thread に�
 
 許可側の上書き（親 channel は拒否のまま、特定 thread だけ許可）と拒否側の上書き（親 channel は許可のまま、特定 thread だけ拒否）の両方ができます。forum のように「基本は入らないが指定 thread にだけ入る」運用は、親 channel を無効のままにして対象 thread だけ許可すれば実現できます。
 
-thread override の設定と確認は Discord のスラッシュコマンド `/vicissitude-channel thread-set` と `/vicissitude-channel thread-show` で行います。`thread-set` の `observe` / `mentions` / `reactions` の各オプションは `allow` / `deny` / `inherit` から選び、省略した項目は変更しません。全項目を `inherit` に戻すと上書き行は削除されます。admin-cli の `pnpm admin channel set` は親 channel の capability だけを操作し、thread override を操作する subcommand はありません。thread 単位の上書きは現状 Discord のスラッシュコマンドからのみ設定できます。`/vicissitude-channel show` に thread の ID を渡すと、親 channel の capability だけでなく、その thread の override と結果として実効になる capability も併せて返します。
+thread override の設定と確認は Discord のスラッシュコマンド `/vicissitude-channel thread-set` / `thread-show` と、admin-cli の `pnpm admin thread set` / `thread show` の両方で行えます。
+
+```
+pnpm admin thread show <guildId> <channelId> <threadId>
+pnpm admin thread set <guildId> <channelId> <threadId> \
+  [--observe allow|deny|inherit] [--mentions allow|deny|inherit] [--reactions allow|deny|inherit] \
+  --actor "$VICISSITUDE_ADMIN_ACTOR" --reason "<text>"
+```
+
+`<channelId>` は親 channel の ID、`<threadId>` は thread 自身の ID で、`thread_capability_overrides` の主キー `(guild_id, channel_id, thread_id)` にそのまま対応します。`--observe` / `--mentions` / `--reactions`（Discord 側では `observe` / `mentions` / `reactions`）は `allow` / `deny` / `inherit` から選び、省略した項目は変更しません。`channel set` の `--observe` / `--mentions` と異なり、`thread set` はどの capability オプションも必須ではありません。オプションを一つも指定せずに実行しても、上書き行を書き直し audit entry を残します。全項目を `inherit` に戻すと上書き行は削除されます。`thread show` は上書き行が存在しない場合も全項目 `inherit` の形で結果を返します。`/vicissitude-channel show` に thread の ID を渡すと、親 channel の capability だけでなく、その thread の override と結果として実効になる capability も併せて返します。
 
 capability は message 取り込み時と effect 実行直前の両方で再評価します。thread override を拒否側に変えると、すでに queued になっている返信も effect 実行時に `capability_revoked` として止まります。
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ SH
 
 ### Lease Recovery
 
-単一 guild、単一 channel の deploy で running job が消えない場合は、channel capability を変更せず、同じ worker を復旧します。planned または executing effect の処理中に capability を変えると `capability_revoked` になるためです。recovery 対象の guild id と channel id は下の `psql -v` 引数で固定し、別 channel を巻き込みません。別の admin が recovery 中に別 channel を enable しない、という排他運用が必要です。scope の安全性は変数ではなく、下の DB assertions で確認します。
+単一 guild、単一 channel の deploy で running job が消えない場合は、channel capability も thread override も変更せず、同じ worker を復旧します。planned または executing effect の処理中に capability を変えると `capability_revoked` になるためです。recovery 対象の guild id と channel id は下の `psql -v` 引数で固定し、別 channel を巻き込みません。別の admin が recovery 中に別 channel や thread override を enable しない、という排他運用が必要です。scope の安全性は変数ではなく、下の DB assertions で確認します。この assertion は `channel_capabilities` と `thread_capability_overrides` の両方を見て、recovery 対象以外の channel で `respond_to_mentions` が有効になっていないかを確認します。
 
 ```bash
 bash <<'SH'
@@ -289,7 +289,7 @@ set -euo pipefail
 : "${DATABASE_URL:?set DATABASE_URL in .env and let direnv load it}"
 : "${VICISSITUDE_GUILD_ID:?set VICISSITUDE_GUILD_ID in .env}"
 : "${VICISSITUDE_ADMIN_ACTOR:?set VICISSITUDE_ADMIN_ACTOR in .env}"
-violations="$(psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v guild_id="$VICISSITUDE_GUILD_ID" -v channel_id=discord-channel-id -Atc "SELECT (SELECT count(*) FROM channel_capabilities WHERE respond_to_mentions AND NOT (guild_id = :'guild_id' AND channel_id = :'channel_id')) + (SELECT count(*) FROM jobs j JOIN events e ON e.id = j.event_id WHERE j.state IN ('queued', 'running') AND NOT (e.guild_id = :'guild_id' AND e.channel_id = :'channel_id')) + (SELECT count(*) FROM effects WHERE state IN ('planned', 'executing') AND NOT (guild_id = :'guild_id' AND capability_channel_id = :'channel_id'));" )" || {
+violations="$(psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v guild_id="$VICISSITUDE_GUILD_ID" -v channel_id=discord-channel-id -Atc "SELECT (SELECT count(*) FROM channel_capabilities WHERE respond_to_mentions AND NOT (guild_id = :'guild_id' AND channel_id = :'channel_id')) + (SELECT count(*) FROM thread_capability_overrides WHERE respond_to_mentions AND NOT (guild_id = :'guild_id' AND channel_id = :'channel_id')) + (SELECT count(*) FROM jobs j JOIN events e ON e.id = j.event_id WHERE j.state IN ('queued', 'running') AND NOT (e.guild_id = :'guild_id' AND e.channel_id = :'channel_id')) + (SELECT count(*) FROM effects WHERE state IN ('planned', 'executing') AND NOT (guild_id = :'guild_id' AND capability_channel_id = :'channel_id'));" )" || {
   printf '%s\n' "failed to verify recovery scope" >&2
   exit 1
 }
@@ -365,7 +365,13 @@ Guilds、Guild Messages、Message Content intents を有効にします。`VICIS
 
 channel capability の主キーは `(guild_id, channel_id)` です。thread に投稿された message は親 channel の ID に正規化して扱い、thread ID は event の `thread_id` に入ります。thread を対象にするには **親 channel の ID** を `channel set` に渡します。thread ID を渡した行は照合されず、message は `channel_not_allowed` として無視され、event も残りません。
 
-有効化の粒度は親 channel 単位です。forum や text channel を有効にすると、その配下の thread はすべて対象になります。thread 単位で絞る機能はありません。
+有効化の粒度は基本的に親 channel 単位です。forum や text channel を有効にすると、その配下の thread はすべて対象になります。ただし `observeEvents` / `respondToMentions` / `addReactions` の3項目に限り、thread 単位で上書きできます。上書きは `thread_capability_overrides` table（主キーは `(guild_id, channel_id, thread_id)`）に保持し、各項目は「継承」「明示的に許可」「明示的に拒否」の3状態を取ります。既定は継承で、親 channel の設定がそのまま使われます。それ以外の capability は thread 単位で上書きできず、親 channel 単位のままです。
+
+許可側の上書き（親 channel は拒否のまま、特定 thread だけ許可）と拒否側の上書き（親 channel は許可のまま、特定 thread だけ拒否）の両方ができます。forum のように「基本は入らないが指定 thread にだけ入る」運用は、親 channel を無効のままにして対象 thread だけ許可すれば実現できます。
+
+thread override の設定と確認は Discord のスラッシュコマンド `/vicissitude-channel thread-set` と `/vicissitude-channel thread-show` で行います。`thread-set` の `observe` / `mentions` / `reactions` の各オプションは `allow` / `deny` / `inherit` から選び、省略した項目は変更しません。全項目を `inherit` に戻すと上書き行は削除されます。admin-cli の `pnpm admin channel set` は親 channel の capability だけを操作し、thread override を操作する subcommand はありません。thread 単位の上書きは現状 Discord のスラッシュコマンドからのみ設定できます。
+
+capability は message 取り込み時と effect 実行直前の両方で再評価します。thread override を拒否側に変えると、すでに queued になっている返信も effect 実行時に `capability_revoked` として止まります。
 
 対象 channel の ID が thread のものかどうかは Discord 側で確認します。`channel set` は capability 行を作るだけで、渡された ID が実在するか、thread かどうかは検証しません。
 

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ pnpm admin thread set <guildId> <channelId> <threadId> \
   --actor "$VICISSITUDE_ADMIN_ACTOR" --reason "<text>"
 ```
 
-`<channelId>` は親 channel の ID、`<threadId>` は thread 自身の ID で、`thread_capability_overrides` の主キー `(guild_id, channel_id, thread_id)` にそのまま対応します。`--observe` / `--mentions` / `--reactions`（Discord 側では `observe` / `mentions` / `reactions`）は `allow` / `deny` / `inherit` から選び、省略した項目は変更しません。`channel set` の `--observe` / `--mentions` と異なり、`thread set` はどの capability オプションも必須ではありません。オプションを一つも指定せずに実行しても、上書き行を書き直し audit entry を残します。全項目を `inherit` に戻すと上書き行は削除されます。`thread show` は上書き行が存在しない場合も全項目 `inherit` の形で結果を返します。`/vicissitude-channel show` に thread の ID を渡すと、親 channel の capability だけでなく、その thread の override と結果として実効になる capability も併せて返します。
+`<channelId>` は親 channel の ID、`<threadId>` は thread 自身の ID で、`thread_capability_overrides` の主キー `(guild_id, channel_id, thread_id)` にそのまま対応します。`--observe` / `--mentions` / `--reactions`（Discord 側では `observe` / `mentions` / `reactions`）は `allow` / `deny` / `inherit` から選び、省略した項目は変更しません。`channel set` の `--observe` / `--mentions` と異なり、`thread set` はどの capability オプションも必須ではありません。オプションを一つも指定せずに実行した場合、既存の上書き行があれば同じ値で書き直し、なければ何も作りません。audit entry はどちらの場合も残ります。全項目を `inherit` に戻すと上書き行は削除されます。`thread show` は上書き行が存在しない場合も全項目 `inherit` の形で結果を返します。`/vicissitude-channel show` に thread の ID を渡すと、親 channel の capability だけでなく、その thread の override と結果として実効になる capability も併せて返します。
 
 capability は message 取り込み時と effect 実行直前の両方で再評価します。thread override を拒否側に変えると、すでに queued になっている返信も effect 実行時に `capability_revoked` として止まります。
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ channel capability の主キーは `(guild_id, channel_id)` です。thread に�
 
 許可側の上書き（親 channel は拒否のまま、特定 thread だけ許可）と拒否側の上書き（親 channel は許可のまま、特定 thread だけ拒否）の両方ができます。forum のように「基本は入らないが指定 thread にだけ入る」運用は、親 channel を無効のままにして対象 thread だけ許可すれば実現できます。
 
-thread override の設定と確認は Discord のスラッシュコマンド `/vicissitude-channel thread-set` と `/vicissitude-channel thread-show` で行います。`thread-set` の `observe` / `mentions` / `reactions` の各オプションは `allow` / `deny` / `inherit` から選び、省略した項目は変更しません。全項目を `inherit` に戻すと上書き行は削除されます。admin-cli の `pnpm admin channel set` は親 channel の capability だけを操作し、thread override を操作する subcommand はありません。thread 単位の上書きは現状 Discord のスラッシュコマンドからのみ設定できます。
+thread override の設定と確認は Discord のスラッシュコマンド `/vicissitude-channel thread-set` と `/vicissitude-channel thread-show` で行います。`thread-set` の `observe` / `mentions` / `reactions` の各オプションは `allow` / `deny` / `inherit` から選び、省略した項目は変更しません。全項目を `inherit` に戻すと上書き行は削除されます。admin-cli の `pnpm admin channel set` は親 channel の capability だけを操作し、thread override を操作する subcommand はありません。thread 単位の上書きは現状 Discord のスラッシュコマンドからのみ設定できます。`/vicissitude-channel show` に thread の ID を渡すと、親 channel の capability だけでなく、その thread の override と結果として実効になる capability も併せて返します。
 
 capability は message 取り込み時と effect 実行直前の両方で再評価します。thread override を拒否側に変えると、すでに queued になっている返信も effect 実行時に `capability_revoked` として止まります。
 

--- a/docs/superpowers/plans/2026-07-29-thread-scope.md
+++ b/docs/superpowers/plans/2026-07-29-thread-scope.md
@@ -1,0 +1,1412 @@
+# Thread Scope Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** スレッド単位の capability override（親チャンネル継承 + 明示 override）を導入し、スレッド主体で運用するギルドで観察・応答範囲をスレッド粒度で制御できるようにする。
+
+**Architecture:** `channel_capabilities` は親チャンネルのデフォルトとして維持し、nullable boolean 列を持つ `thread_capability_overrides` テーブルを追加する（`NULL` = 親を継承）。ドメイン層の純関数 `resolveEffectiveCapabilities(channel, override)` が唯一の解決点で、ingest 経路（Gateway）と effect 実行経路（effect worker）の両方がこれを通る。Discord 側の設定は既存 `/vicissitude-channel` コマンドに thread subcommand を足して行う。
+
+**Tech Stack:** TypeScript (ESM, Node 24) / postgres.js / discord.js 14 / vitest / oxlint + oxfmt
+
+**Source spec:** [2026-07-29 Phase 2 Conversation Cognition 設計](../specs/2026-07-29-phase-2-conversation-cognition-design.md) §2（Thread Scope）。この計画は Phase 2A の先頭スライスのみを対象とし、durable batch（job の scope キー化・cursor・actor 状態）は後続の別計画で扱う。そのため migration 番号は spec §8 の論理的なまとめ方とは異なり、本スライスが `0002_thread_scope.sql`、durable batch が `0003_*` になる。
+
+**Conventions to follow:**
+- ユニットテストは実装と同じディレクトリに `*.test.ts`（`nr test:unit` = `vitest run src`）
+- PostgreSQL を使う統合テストは `spec/**/*.spec.ts`（`nr test:spec`。実 DB を起動するため spec 全体が走る）
+- postgres.js のテンプレートリテラル SQL。列名は snake_case、TS は camelCase で明示マッピング
+- capability の変更は必ず `audit_entries` に記録し、`actor` と `reason` を必須にする
+
+---
+
+### Task 1: migration 0002 — thread_capability_overrides と events index
+
+**Files:**
+- Create: `migrations/0002_thread_scope.sql`
+- Modify: `spec/adapters/postgres/migrations.spec.ts`（`0001` を期待している箇所）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`spec/adapters/postgres/migrations.spec.ts` の最初のテストを、両 migration が適用されることを期待する形に変更する。
+
+```ts
+  it("applies each migration once and records its checksum", async () => {
+    const first = await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, {
+      actor: "test-bootstrap",
+      backupConfirmedAt: new Date(),
+    });
+    const second = await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, {
+      actor: "test-bootstrap",
+      backupConfirmedAt: new Date(),
+    });
+    expect(first).toMatchObject({ appliedVersions: ["0001", "0002"] });
+    expect(second).toMatchObject({ appliedVersions: [] });
+    expect(first.appliedAt).toBeInstanceOf(Date);
+
+    const status = await migrationStatus(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!);
+    expect(status).toEqual([
+      expect.objectContaining({ version: "0001", name: "durable_spine", state: "applied" }),
+      expect.objectContaining({ version: "0002", name: "thread_scope", state: "applied" }),
+    ]);
+    expect(status[0]?.checksum).toMatch(/^[0-9a-f]{64}$/u);
+  });
+```
+
+同じファイル内で `appliedVersions` に `["0001"]` を期待している残りのテスト（"serializes concurrent migration runs..."、"returns applied versions and records an admin audit..."、"audits an explicit no-op..."）も `["0001", "0002"]` に更新する。
+
+```ts
+      expect([firstResult.appliedVersions, secondResult.appliedVersions].sort((a, b) => a.length - b.length)).toEqual([
+        [],
+        ["0001", "0002"],
+      ]);
+```
+
+```ts
+    expect(result.appliedVersions).toEqual(["0001", "0002"]);
+```
+
+```ts
+    expect(first.appliedVersions).toEqual(["0001", "0002"]);
+    expect(second.appliedVersions).toEqual([]);
+```
+
+さらに、新しいテーブルと index が作られたことを確認するテストを同じ `describe` の末尾に追加する。
+
+```ts
+  it("creates the thread override table and the thread-aware event index", async () => {
+    await sql`drop schema public cascade`;
+    await sql`create schema public`;
+    await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, {
+      actor: "test-bootstrap",
+      backupConfirmedAt: new Date(),
+    });
+
+    const columns = await sql<{ column_name: string; is_nullable: string }[]>`
+      select column_name, is_nullable from information_schema.columns
+      where table_name = 'thread_capability_overrides'
+        and column_name in ('observe_events', 'respond_to_mentions', 'add_reactions')
+      order by column_name
+    `;
+    expect(columns).toEqual([
+      { column_name: "add_reactions", is_nullable: "YES" },
+      { column_name: "observe_events", is_nullable: "YES" },
+      { column_name: "respond_to_mentions", is_nullable: "YES" },
+    ]);
+
+    const indexes = await sql<{ indexname: string }[]>`
+      select indexname from pg_indexes where tablename = 'events' and indexname = 'events_thread_scope_time_idx'
+    `;
+    expect(indexes).toHaveLength(1);
+  });
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `nr test:spec`
+Expected: FAIL。`appliedVersions` が `["0001"]` のままで `["0001", "0002"]` と一致せず、`thread_capability_overrides` の列が空配列で返る。
+
+- [ ] **Step 3: migration を書く**
+
+`migrations/0002_thread_scope.sql` を作成する。
+
+```sql
+CREATE TABLE thread_capability_overrides (
+  guild_id text NOT NULL, channel_id text NOT NULL, thread_id text NOT NULL,
+  observe_events boolean, respond_to_mentions boolean, add_reactions boolean,
+  updated_at timestamptz NOT NULL, updated_by text NOT NULL, reason text NOT NULL,
+  PRIMARY KEY (guild_id, channel_id, thread_id),
+  CHECK (observe_events IS NOT NULL OR respond_to_mentions IS NOT NULL OR add_reactions IS NOT NULL)
+);
+
+CREATE INDEX events_thread_scope_time_idx ON events (guild_id, channel_id, thread_id, occurred_at DESC);
+```
+
+`CHECK` 制約は「全 capability が継承の row は存在しない」という不変条件を DB 側で保証する。repository はこの状態になったとき row を削除する（Task 3）。
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `nr test:spec`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add migrations/0002_thread_scope.sql spec/adapters/postgres/migrations.spec.ts
+git commit -m "feat: add thread capability override schema"
+```
+
+---
+
+### Task 2: 実効 capability を解決するドメイン純関数
+
+**Files:**
+- Create: `src/modules/channels/thread-capability.ts`
+- Create: `src/modules/channels/thread-capability.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/modules/channels/thread-capability.test.ts` を作成する。
+
+```ts
+import { describe, expect, it } from "vitest";
+import { denyAllCapabilities, type ChannelCapabilities } from "./channel-capability.js";
+import { resolveEffectiveCapabilities, type ThreadCapabilityOverride } from "./thread-capability.js";
+
+const channel: ChannelCapabilities = {
+  ...denyAllCapabilities("guild-1", "channel-1"),
+  observeEvents: true,
+  respondToMentions: true,
+  createThreads: true,
+};
+
+function override(patch: Partial<ThreadCapabilityOverride>): ThreadCapabilityOverride {
+  return {
+    guildId: "guild-1",
+    channelId: "channel-1",
+    threadId: "thread-1",
+    observeEvents: null,
+    respondToMentions: null,
+    addReactions: null,
+    ...patch,
+  };
+}
+
+describe("resolveEffectiveCapabilities", () => {
+  it("returns the channel capabilities unchanged without an override", () => {
+    expect(resolveEffectiveCapabilities(channel, null)).toEqual(channel);
+  });
+
+  it("inherits the channel value for every null field", () => {
+    expect(resolveEffectiveCapabilities(channel, override({}))).toEqual(channel);
+  });
+
+  it("denies a capability the parent channel allows", () => {
+    expect(resolveEffectiveCapabilities(channel, override({ observeEvents: false }))).toEqual({
+      ...channel,
+      observeEvents: false,
+    });
+  });
+
+  it("allows a capability the parent channel denies", () => {
+    const quiet: ChannelCapabilities = { ...denyAllCapabilities("guild-1", "channel-1"), observeEvents: false };
+    expect(resolveEffectiveCapabilities(quiet, override({ observeEvents: true, respondToMentions: true }))).toEqual({
+      ...quiet,
+      observeEvents: true,
+      respondToMentions: true,
+    });
+  });
+
+  it("leaves capabilities that are not thread-overridable untouched", () => {
+    const resolved = resolveEffectiveCapabilities(channel, override({ addReactions: true }));
+    expect(resolved.createThreads).toBe(true);
+    expect(resolved.shareFiles).toBe(false);
+    expect(resolved.addReactions).toBe(true);
+  });
+
+  it("keeps the parent channel id so capability lookups stay stable", () => {
+    const resolved = resolveEffectiveCapabilities(channel, override({ observeEvents: false }));
+    expect(resolved.channelId).toBe("channel-1");
+    expect(resolved.guildId).toBe("guild-1");
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `pnpm exec vitest run src/modules/channels/thread-capability.test.ts`
+Expected: FAIL。`Failed to resolve import "./thread-capability.js"`
+
+- [ ] **Step 3: 実装を書く**
+
+`src/modules/channels/thread-capability.ts` を作成する。
+
+```ts
+import type { ChannelCapabilities } from "./channel-capability.js";
+
+export const THREAD_OVERRIDABLE_CAPABILITIES = ["observeEvents", "respondToMentions", "addReactions"] as const;
+
+export type ThreadOverridableCapability = (typeof THREAD_OVERRIDABLE_CAPABILITIES)[number];
+
+export interface ThreadCapabilityOverride {
+  guildId: string;
+  channelId: string;
+  threadId: string;
+  observeEvents: boolean | null;
+  respondToMentions: boolean | null;
+  addReactions: boolean | null;
+}
+
+export function inheritAllOverride(guildId: string, channelId: string, threadId: string): ThreadCapabilityOverride {
+  return { guildId, channelId, threadId, observeEvents: null, respondToMentions: null, addReactions: null };
+}
+
+export function isInheritOnly(override: ThreadCapabilityOverride): boolean {
+  return THREAD_OVERRIDABLE_CAPABILITIES.every((capability) => override[capability] === null);
+}
+
+export function resolveEffectiveCapabilities(
+  channel: ChannelCapabilities,
+  override: ThreadCapabilityOverride | null,
+): ChannelCapabilities {
+  if (!override) return channel;
+  const resolved = { ...channel };
+  for (const capability of THREAD_OVERRIDABLE_CAPABILITIES) {
+    const value = override[capability];
+    if (value !== null) resolved[capability] = value;
+  }
+  return resolved;
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `pnpm exec vitest run src/modules/channels/thread-capability.test.ts`
+Expected: PASS（6 tests）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/modules/channels/thread-capability.ts src/modules/channels/thread-capability.test.ts
+git commit -m "feat: resolve effective capabilities from thread overrides"
+```
+
+---
+
+### Task 3: thread override の PostgreSQL repository
+
+**Files:**
+- Create: `src/adapters/postgres/thread-capability-repository.ts`
+- Create: `spec/adapters/postgres/thread-capability-repository.spec.ts`
+
+`get` は row がなければ `null` を返す（`resolveEffectiveCapabilities` の第2引数にそのまま渡せる）。`patch` は `undefined` のフィールドを変更せず、`null` を「継承へ戻す」として扱い、全フィールドが `null` になったら row を削除して `null` を返す。同一 scope の並行更新は既存 channel repository と同じ advisory lock パターンで直列化する。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`spec/adapters/postgres/thread-capability-repository.spec.ts` を作成する。
+
+```ts
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Sql } from "postgres";
+import { createPostgresClient } from "../../../src/adapters/postgres/client.js";
+import { runMigrations } from "../../../src/adapters/postgres/migrations.js";
+import { PostgresThreadCapabilityRepository } from "../../../src/adapters/postgres/thread-capability-repository.js";
+
+let sql: Sql;
+
+beforeAll(async () => {
+  sql = createPostgresClient(process.env.TEST_DATABASE_URL!);
+  await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, {
+    actor: "test-bootstrap",
+    backupConfirmedAt: new Date(),
+  });
+});
+
+beforeEach(async () => {
+  await sql`truncate audit_entries, thread_capability_overrides cascade`;
+});
+
+afterAll(async () => {
+  await sql.end();
+});
+
+const now = new Date("2026-01-02T03:04:05.000Z");
+
+describe("PostgresThreadCapabilityRepository", () => {
+  it("returns null without writing a row for an unconfigured thread", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+
+    await expect(repository.get("guild-1", "channel-1", "thread-1")).resolves.toBeNull();
+    await expect(sql`select * from thread_capability_overrides`).resolves.toHaveLength(0);
+  });
+
+  it("stores an override and records the change audit", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+
+    const result = await repository.patch(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      { observeEvents: true },
+      "operator-1",
+      "watch this thread",
+      now,
+    );
+
+    expect(result).toEqual({
+      guildId: "guild-1",
+      channelId: "channel-1",
+      threadId: "thread-1",
+      observeEvents: true,
+      respondToMentions: null,
+      addReactions: null,
+    });
+    await expect(repository.get("guild-1", "channel-1", "thread-1")).resolves.toEqual(result);
+    const rows = await sql<{ category: string; summary: Record<string, unknown>; created_at: Date }[]>`
+      select category, summary, created_at from audit_entries
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      category: "thread.capability.changed",
+      created_at: now,
+      summary: {
+        actor: "operator-1",
+        reason: "watch this thread",
+        guildId: "guild-1",
+        channelId: "channel-1",
+        threadId: "thread-1",
+        before: null,
+        after: { observeEvents: true, respondToMentions: null, addReactions: null },
+      },
+    });
+  });
+
+  it("merges a patch into an existing override and leaves untouched fields alone", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+    await repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "operator-1", "first", now);
+
+    const result = await repository.patch(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      { respondToMentions: false },
+      "operator-2",
+      "second",
+      now,
+    );
+
+    expect(result).toMatchObject({ observeEvents: true, respondToMentions: false, addReactions: null });
+  });
+
+  it("deletes the row when every capability returns to inherit", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+    await repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "operator-1", "first", now);
+
+    const result = await repository.patch(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      { observeEvents: null },
+      "operator-1",
+      "back to inherit",
+      now,
+    );
+
+    expect(result).toBeNull();
+    await expect(sql`select * from thread_capability_overrides`).resolves.toHaveLength(0);
+    const rows = await sql<{ summary: { before: unknown; after: unknown } }[]>`
+      select summary from audit_entries where category = 'thread.capability.changed' order by created_at
+    `;
+    expect(rows.at(-1)?.summary.after).toBeNull();
+  });
+
+  it("scopes overrides to a single thread", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+    await repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "operator-1", "one", now);
+
+    await expect(repository.get("guild-1", "channel-1", "thread-2")).resolves.toBeNull();
+    await expect(repository.get("guild-1", "channel-2", "thread-1")).resolves.toBeNull();
+  });
+
+  it("rejects invalid metadata", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+
+    await expect(
+      repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, " ", "reason", now),
+    ).rejects.toThrow();
+    await expect(
+      repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "actor", " ", now),
+    ).rejects.toThrow();
+    await expect(
+      repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "actor", "reason", new Date("x")),
+    ).rejects.toThrow();
+  });
+
+  it("merges concurrent patches for one thread scope", async () => {
+    const firstSql = createPostgresClient(process.env.TEST_DATABASE_URL!);
+    const secondSql = createPostgresClient(process.env.TEST_DATABASE_URL!);
+    const first = new PostgresThreadCapabilityRepository(firstSql);
+    const second = new PostgresThreadCapabilityRepository(secondSql);
+
+    try {
+      await Promise.all([
+        first.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "actor-1", "first", now),
+        second.patch("guild-1", "channel-1", "thread-1", { addReactions: true }, "actor-2", "second", now),
+      ]);
+
+      await expect(first.get("guild-1", "channel-1", "thread-1")).resolves.toMatchObject({
+        observeEvents: true,
+        addReactions: true,
+      });
+      const audits = await sql`select id from audit_entries where category = 'thread.capability.changed'`;
+      expect(audits).toHaveLength(2);
+    } finally {
+      await firstSql.end();
+      await secondSql.end();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `nr test:spec`
+Expected: FAIL。`Failed to resolve import ".../thread-capability-repository.js"`
+
+- [ ] **Step 3: 実装を書く**
+
+`src/adapters/postgres/thread-capability-repository.ts` を作成する。
+
+```ts
+import type { Sql } from "postgres";
+import { newId } from "../../shared/ids.js";
+import {
+  inheritAllOverride,
+  isInheritOnly,
+  THREAD_OVERRIDABLE_CAPABILITIES,
+  type ThreadCapabilityOverride,
+} from "../../modules/channels/thread-capability.js";
+
+export type ThreadCapabilityPatch = Partial<
+  Pick<ThreadCapabilityOverride, "observeEvents" | "respondToMentions" | "addReactions">
+>;
+
+const LOCK_NAMESPACE = 84623818;
+
+function mapRow(row: Record<string, unknown>): ThreadCapabilityOverride {
+  return {
+    guildId: row.guild_id as string,
+    channelId: row.channel_id as string,
+    threadId: row.thread_id as string,
+    observeEvents: row.observe_events as boolean | null,
+    respondToMentions: row.respond_to_mentions as boolean | null,
+    addReactions: row.add_reactions as boolean | null,
+  };
+}
+
+function auditValue(override: ThreadCapabilityOverride | null): Record<string, boolean | null> | null {
+  if (!override) return null;
+  return Object.fromEntries(THREAD_OVERRIDABLE_CAPABILITIES.map((key) => [key, override[key]]));
+}
+
+function validateMetadata(actor: string, reason: string, now: Date): void {
+  if (!actor.trim() || !reason.trim()) throw new Error("actor and reason must be nonblank");
+  if (!(now instanceof Date) || Number.isNaN(now.getTime())) throw new Error("now must be a valid Date");
+}
+
+export class PostgresThreadCapabilityRepository {
+  public constructor(private readonly sql: Sql) {}
+
+  public async get(guildId: string, channelId: string, threadId: string): Promise<ThreadCapabilityOverride | null> {
+    const rows = await this.sql`
+      select * from thread_capability_overrides
+      where guild_id = ${guildId} and channel_id = ${channelId} and thread_id = ${threadId}
+    `;
+    return rows[0] ? mapRow(rows[0]) : null;
+  }
+
+  public async patch(
+    guildId: string,
+    channelId: string,
+    threadId: string,
+    patch: ThreadCapabilityPatch,
+    actor: string,
+    reason: string,
+    now: Date,
+  ): Promise<ThreadCapabilityOverride | null> {
+    validateMetadata(actor, reason, now);
+    const trimmedActor = actor.trim();
+    const trimmedReason = reason.trim();
+    return this.sql.begin(async (transaction) => {
+      await transaction`
+        select pg_advisory_xact_lock(hashtextextended(${`${guildId}:${channelId}:${threadId}`}, ${LOCK_NAMESPACE}))
+      `;
+      const rows = await transaction`
+        select * from thread_capability_overrides
+        where guild_id = ${guildId} and channel_id = ${channelId} and thread_id = ${threadId}
+        for update
+      `;
+      const before = rows[0] ? mapRow(rows[0]) : null;
+      const next: ThreadCapabilityOverride = {
+        ...(before ?? inheritAllOverride(guildId, channelId, threadId)),
+        ...patch,
+      };
+      const after = isInheritOnly(next) ? null : next;
+      if (after) {
+        await transaction`
+          insert into thread_capability_overrides (
+            guild_id, channel_id, thread_id, observe_events, respond_to_mentions, add_reactions,
+            updated_at, updated_by, reason
+          ) values (
+            ${guildId}, ${channelId}, ${threadId}, ${after.observeEvents}, ${after.respondToMentions},
+            ${after.addReactions}, ${now}, ${trimmedActor}, ${trimmedReason}
+          ) on conflict (guild_id, channel_id, thread_id) do update set
+            observe_events = excluded.observe_events, respond_to_mentions = excluded.respond_to_mentions,
+            add_reactions = excluded.add_reactions, updated_at = excluded.updated_at,
+            updated_by = excluded.updated_by, reason = excluded.reason
+        `;
+      } else {
+        await transaction`
+          delete from thread_capability_overrides
+          where guild_id = ${guildId} and channel_id = ${channelId} and thread_id = ${threadId}
+        `;
+      }
+      await transaction`
+        insert into audit_entries (id, category, summary, created_at)
+        values (
+          ${newId()}, 'thread.capability.changed',
+          ${transaction.json({
+            actor: trimmedActor,
+            reason: trimmedReason,
+            guildId,
+            channelId,
+            threadId,
+            before: auditValue(before),
+            after: auditValue(after),
+          })},
+          ${now}
+        )
+      `;
+      return after;
+    });
+  }
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `nr test:spec`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/adapters/postgres/thread-capability-repository.ts spec/adapters/postgres/thread-capability-repository.spec.ts
+git commit -m "feat: persist thread capability overrides"
+```
+
+---
+
+### Task 4: 実効 capability を返す合成 repository
+
+**Files:**
+- Create: `src/adapters/postgres/effective-capability-repository.ts`
+- Create: `spec/adapters/postgres/effective-capability-repository.spec.ts`
+
+Gateway と effect worker が使う単一の入口。`threadId` が `null` ならチャンネル capability をそのまま返す。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`spec/adapters/postgres/effective-capability-repository.spec.ts` を作成する。
+
+```ts
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Sql } from "postgres";
+import { createPostgresClient } from "../../../src/adapters/postgres/client.js";
+import { runMigrations } from "../../../src/adapters/postgres/migrations.js";
+import { denyAllCapabilities } from "../../../src/modules/channels/channel-capability.js";
+import { PostgresChannelCapabilityRepository } from "../../../src/adapters/postgres/channel-capability-repository.js";
+import { PostgresThreadCapabilityRepository } from "../../../src/adapters/postgres/thread-capability-repository.js";
+import { PostgresEffectiveCapabilityRepository } from "../../../src/adapters/postgres/effective-capability-repository.js";
+
+let sql: Sql;
+
+beforeAll(async () => {
+  sql = createPostgresClient(process.env.TEST_DATABASE_URL!);
+  await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, {
+    actor: "test-bootstrap",
+    backupConfirmedAt: new Date(),
+  });
+});
+
+beforeEach(async () => {
+  await sql`truncate audit_entries, thread_capability_overrides, channel_capabilities cascade`;
+});
+
+afterAll(async () => {
+  await sql.end();
+});
+
+const now = new Date("2026-01-02T03:04:05.000Z");
+
+function build(): PostgresEffectiveCapabilityRepository {
+  return new PostgresEffectiveCapabilityRepository(
+    new PostgresChannelCapabilityRepository(sql),
+    new PostgresThreadCapabilityRepository(sql),
+  );
+}
+
+describe("PostgresEffectiveCapabilityRepository", () => {
+  it("returns channel capabilities for a non-thread message", async () => {
+    const channels = new PostgresChannelCapabilityRepository(sql);
+    await channels.patch("guild-1", "channel-1", { observeEvents: true }, "operator", "enable", now);
+
+    await expect(build().get("guild-1", "channel-1", null)).resolves.toMatchObject({ observeEvents: true });
+  });
+
+  it("inherits channel capabilities in a thread without an override", async () => {
+    const channels = new PostgresChannelCapabilityRepository(sql);
+    await channels.patch("guild-1", "channel-1", { observeEvents: true }, "operator", "enable", now);
+
+    await expect(build().get("guild-1", "channel-1", "thread-1")).resolves.toMatchObject({ observeEvents: true });
+  });
+
+  it("applies a deny override inside an allowed channel", async () => {
+    const channels = new PostgresChannelCapabilityRepository(sql);
+    const threads = new PostgresThreadCapabilityRepository(sql);
+    await channels.patch("guild-1", "channel-1", { observeEvents: true }, "operator", "enable", now);
+    await threads.patch("guild-1", "channel-1", "thread-1", { observeEvents: false }, "operator", "quiet", now);
+
+    await expect(build().get("guild-1", "channel-1", "thread-1")).resolves.toMatchObject({ observeEvents: false });
+    await expect(build().get("guild-1", "channel-1", null)).resolves.toMatchObject({ observeEvents: true });
+  });
+
+  it("applies an allow override inside a denied channel", async () => {
+    const threads = new PostgresThreadCapabilityRepository(sql);
+    await threads.patch(
+      "guild-1",
+      "forum-1",
+      "thread-1",
+      { observeEvents: true, respondToMentions: true },
+      "operator",
+      "watch one thread",
+      now,
+    );
+
+    await expect(build().get("guild-1", "forum-1", "thread-1")).resolves.toMatchObject({
+      observeEvents: true,
+      respondToMentions: true,
+    });
+    await expect(build().get("guild-1", "forum-1", null)).resolves.toEqual(denyAllCapabilities("guild-1", "forum-1"));
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `nr test:spec`
+Expected: FAIL。`Failed to resolve import ".../effective-capability-repository.js"`
+
+- [ ] **Step 3: 実装を書く**
+
+`src/adapters/postgres/effective-capability-repository.ts` を作成する。
+
+```ts
+import type { ChannelCapabilities } from "../../modules/channels/channel-capability.js";
+import { resolveEffectiveCapabilities } from "../../modules/channels/thread-capability.js";
+import type { PostgresChannelCapabilityRepository } from "./channel-capability-repository.js";
+import type { PostgresThreadCapabilityRepository } from "./thread-capability-repository.js";
+
+export class PostgresEffectiveCapabilityRepository {
+  public constructor(
+    private readonly channels: PostgresChannelCapabilityRepository,
+    private readonly threads: PostgresThreadCapabilityRepository,
+  ) {}
+
+  public async get(guildId: string, channelId: string, threadId: string | null): Promise<ChannelCapabilities> {
+    const channel = await this.channels.get(guildId, channelId);
+    if (!threadId) return channel;
+    const override = await this.threads.get(guildId, channelId, threadId);
+    return resolveEffectiveCapabilities(channel, override);
+  }
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `nr test:spec`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/adapters/postgres/effective-capability-repository.ts spec/adapters/postgres/effective-capability-repository.spec.ts
+git commit -m "feat: compose channel and thread capabilities"
+```
+
+---
+
+### Task 5: Gateway の ingest を実効 capability で判定する
+
+**Files:**
+- Modify: `src/apps/discord-gateway.ts:95`（repository の構築）と `:120`（capability 取得）
+- Modify: `spec/apps/discord-gateway.spec.ts`（スレッド経路の確認を追加）
+
+Gateway は現在 `capabilities.get(config.guildId, input.channelId)` を呼んでいる。ここに `input.threadId` を渡す。`ingestDiscordMessage` 側は解決済みの `ChannelCapabilities` を受け取る契約のままで変更不要（`channelId` は親チャンネルのまま維持されるため既存の scope チェックも通る）。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`spec/apps/discord-gateway.spec.ts` に 2 つのテストを追加する。このファイルには既に `threadMessage(parentChannelId)` helper と、`handlers.messageCreate` を直接呼ぶパターンがあるのでそれを再利用する。ファイル冒頭に import を追加する。
+
+```ts
+import { PostgresChannelCapabilityRepository } from "../../src/adapters/postgres/channel-capability-repository.js";
+import { PostgresThreadCapabilityRepository } from "../../src/adapters/postgres/thread-capability-repository.js";
+```
+
+`describe("runGateway", ...)` の末尾に次を追加する。このファイルには `beforeEach` の truncate がないため、各テストが `finally` で自分の書き込みを消す。
+
+```ts
+  async function runGatewayOnce(message: unknown, logger: { error: () => void; debug: ReturnType<typeof vi.fn> }) {
+    const handlers: Record<string, (...args: unknown[]) => void> = {};
+    const inflight = createInFlightTracker();
+    const accepting = { value: false };
+    let release!: (signal: AbortSignal) => void;
+    const shutdown = new Promise<AbortSignal>((resolve) => {
+      release = resolve;
+    });
+    const run = runGateway({
+      sql,
+      client: {
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          handlers[event] = handler;
+        }),
+        user: { id: "bot" },
+      } as never,
+      config: { migrationsDir: "migrations", guildId: "guild", adminIds: ["admin"], discordToken: "token" } as never,
+      health: { setReady: vi.fn() } as never,
+      logger: logger as never,
+      shutdown,
+      prepared: true,
+      startClient: async () => undefined,
+      registerCommands: async () => undefined,
+      accepting,
+      inflight,
+    });
+    await vi.waitFor(() => expect(handlers.messageCreate).toBeTypeOf("function"));
+    handlers.messageCreate!(message);
+    await inflight.drain();
+    release(new AbortController().signal);
+    await run;
+  }
+
+  const cleanup = () =>
+    sql`truncate audit_entries, effects, model_calls, decision_runs, jobs, events, thread_capability_overrides, channel_capabilities cascade`;
+
+  it("ingests a thread message that a thread override allows in a denied channel", async () => {
+    const now = new Date();
+    await new PostgresChannelCapabilityRepository(sql).patch(
+      "guild",
+      "forum-1",
+      { respondToMentions: false },
+      "admin",
+      "closed forum",
+      now,
+    );
+    await new PostgresThreadCapabilityRepository(sql).patch(
+      "guild",
+      "forum-1",
+      "thread-1",
+      { respondToMentions: true },
+      "admin",
+      "watch one thread",
+      now,
+    );
+    const logger = { error: vi.fn(), debug: vi.fn() };
+
+    try {
+      await runGatewayOnce(threadMessage("forum-1"), logger);
+
+      await expect(sql`select channel_id, thread_id from events`).resolves.toEqual([
+        { channel_id: "forum-1", thread_id: "thread-1" },
+      ]);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: "forum-1", threadId: "thread-1", jobQueued: true }),
+        "Discord message ingested",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("ignores a thread message that a thread override denies in an allowed channel", async () => {
+    const now = new Date();
+    await new PostgresChannelCapabilityRepository(sql).patch(
+      "guild",
+      "channel-1",
+      { observeEvents: true, respondToMentions: true },
+      "admin",
+      "open channel",
+      now,
+    );
+    await new PostgresThreadCapabilityRepository(sql).patch(
+      "guild",
+      "channel-1",
+      "thread-1",
+      { observeEvents: false, respondToMentions: false },
+      "admin",
+      "quiet thread",
+      now,
+    );
+    const logger = { error: vi.fn(), debug: vi.fn() };
+
+    try {
+      await runGatewayOnce(threadMessage("channel-1"), logger);
+
+      await expect(sql`select id from events`).resolves.toHaveLength(0);
+      await expect(sql`select id from jobs`).resolves.toHaveLength(0);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: "channel-1", threadId: "thread-1", reason: "channel_not_allowed" }),
+        "Discord message ignored",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `nr test:spec`
+Expected: FAIL。1 つ目は thread override が無視されて event が作られず（`[]` が返る）、2 つ目は逆に event が 1 件作られる。
+
+- [ ] **Step 3: Gateway を変更する**
+
+`src/apps/discord-gateway.ts` の repository 構築（95 行目付近）を差し替える。
+
+```ts
+  const channelCapabilities = new PostgresChannelCapabilityRepository(sql);
+  const threadCapabilities = new PostgresThreadCapabilityRepository(sql);
+  const capabilities = new PostgresEffectiveCapabilityRepository(channelCapabilities, threadCapabilities);
+```
+
+capability 取得（120 行目付近）にスレッドを渡す。
+
+```ts
+      const capability = await capabilities.get(config.guildId, input.channelId, input.threadId);
+```
+
+import を追加する。
+
+```ts
+import { PostgresThreadCapabilityRepository } from "../adapters/postgres/thread-capability-repository.js";
+import { PostgresEffectiveCapabilityRepository } from "../adapters/postgres/effective-capability-repository.js";
+```
+
+`handleChannelCommand` に渡している `commandRepository` は `channelCapabilities` を参照するよう変更する（150-155 行目付近）。
+
+```ts
+    const commandRepository = {
+      get: channelCapabilities.get.bind(channelCapabilities),
+      patch: async (...args: Parameters<typeof channelCapabilities.patch>) => {
+        await channelCapabilities.patch(...args);
+      },
+    };
+```
+
+`runEffectLoop` の呼び出し（168 行目付近）は、このタスクでは `channelCapabilities` を渡すよう変更しておく。effect 実行経路をスレッド対応にするのは Task 7 で、そこで `capabilities` に切り替える。こうすることでこのタスク単体でも型が通る。
+
+```ts
+  const effectLoop = runEffectLoop(effects, channelCapabilities, executor, controller.signal, logger, rejectFatal);
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `nr test:spec`
+Expected: PASS
+
+- [ ] **Step 5: 型と lint を確認する**
+
+Run: `nr check && nr lint`
+Expected: エラーなし
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/apps/discord-gateway.ts spec/e2e/mention-response.spec.ts
+git commit -m "feat: apply thread overrides when ingesting messages"
+```
+
+---
+
+### Task 6: `/vicissitude-channel` に thread subcommand を追加する
+
+**Files:**
+- Modify: `src/adapters/discord/channel-command.ts`
+- Modify: `src/adapters/discord/channel-command.test.ts`（存在しない場合は Create）
+
+`thread-show` と `thread-set` を追加する。`thread-set` の各 capability は `allow` / `deny` / `inherit` の三値文字列オプションで受け取る。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/adapters/discord/channel-command.test.ts` に次を追加する（ファイルがなければ作成し、既存の `handleChannelCommand` テストがある場合はその interaction モックの作り方を踏襲する）。
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { handleChannelCommand } from "./channel-command.js";
+
+function interactionFor(subcommand: string, options: Record<string, string | boolean | null>, channel: unknown) {
+  return {
+    guildId: "guild-1",
+    user: { id: "admin-1" },
+    options: {
+      getSubcommand: () => subcommand,
+      getChannel: () => channel,
+      getString: (name: string, required?: boolean) => {
+        const value = options[name];
+        if (typeof value === "string") return value;
+        if (required) throw new Error(`missing ${name}`);
+        return null;
+      },
+      getBoolean: (name: string) => {
+        const value = options[name];
+        return typeof value === "boolean" ? value : null;
+      },
+    },
+    reply: vi.fn().mockResolvedValue(undefined),
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  } as never;
+}
+
+const thread = { id: "thread-1", parentId: "channel-1", isThread: () => true };
+const clock = { now: () => new Date("2026-01-02T03:04:05.000Z") };
+
+describe("handleChannelCommand thread subcommands", () => {
+  it("translates allow, deny and inherit into an override patch", async () => {
+    const repository = {
+      get: vi.fn(),
+      patch: vi.fn().mockResolvedValue(undefined),
+      getThread: vi.fn().mockResolvedValue(null),
+      patchThread: vi.fn().mockResolvedValue(undefined),
+    };
+    const interaction = interactionFor(
+      "thread-set",
+      { observe: "allow", mentions: "deny", reactions: "inherit", reason: "tune thread" },
+      thread,
+    );
+
+    await handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock);
+
+    expect(repository.patchThread).toHaveBeenCalledWith(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      { observeEvents: true, respondToMentions: false, addReactions: null },
+      "admin-1",
+      "tune thread",
+      clock.now(),
+    );
+  });
+
+  it("omits capabilities that were not supplied", async () => {
+    const repository = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      getThread: vi.fn().mockResolvedValue(null),
+      patchThread: vi.fn().mockResolvedValue(undefined),
+    };
+    const interaction = interactionFor("thread-set", { observe: "deny", reason: "quiet" }, thread);
+
+    await handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock);
+
+    expect(repository.patchThread).toHaveBeenCalledWith(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      { observeEvents: false },
+      "admin-1",
+      "quiet",
+      clock.now(),
+    );
+  });
+
+  it("rejects a thread subcommand on a non-thread channel", async () => {
+    const repository = { get: vi.fn(), patch: vi.fn(), getThread: vi.fn(), patchThread: vi.fn() };
+    const channel = { id: "channel-1", parentId: null, isThread: () => false };
+    const interaction = interactionFor("thread-set", { observe: "allow", reason: "nope" }, channel);
+
+    await expect(
+      handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock),
+    ).rejects.toThrow("Thread subcommands require a thread channel");
+    expect(repository.patchThread).not.toHaveBeenCalled();
+  });
+
+  it("shows the current override for a thread", async () => {
+    const repository = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      getThread: vi.fn().mockResolvedValue({
+        guildId: "guild-1",
+        channelId: "channel-1",
+        threadId: "thread-1",
+        observeEvents: true,
+        respondToMentions: null,
+        addReactions: null,
+      }),
+      patchThread: vi.fn(),
+    };
+    const interaction = interactionFor("thread-show", {}, thread);
+
+    await handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock);
+
+    expect(repository.getThread).toHaveBeenCalledWith("guild-1", "channel-1", "thread-1");
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining("observeEvents") }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `pnpm exec vitest run src/adapters/discord/channel-command.test.ts`
+Expected: FAIL。`Unsupported subcommand: thread-set`
+
+- [ ] **Step 3: コマンド定義とハンドラを実装する**
+
+`src/adapters/discord/channel-command.ts` の `channelCommand` に subcommand を追加する（既存の `.addSubcommand((sub) => sub.setName("set")...)` の後ろに続ける）。
+
+```ts
+  .addSubcommand((sub) =>
+    sub.setName("thread-show").setDescription("スレッドの権限overrideを表示します").addChannelOption(threadOption),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName("thread-set")
+      .setDescription("スレッド単位の権限overrideを設定します")
+      .addChannelOption(threadOption)
+      .addStringOption((o) =>
+        o.setName("reason").setDescription("変更理由").setMinLength(1).setMaxLength(500).setRequired(true),
+      )
+      .addStringOption((o) => o.setName("observe").setDescription("イベントを観察する").addChoices(...overrideChoices))
+      .addStringOption((o) => o.setName("mentions").setDescription("mentionへ応答する").addChoices(...overrideChoices))
+      .addStringOption((o) =>
+        o.setName("reactions").setDescription("reactionを追加する").addChoices(...overrideChoices),
+      ),
+  );
+```
+
+同ファイルの上部、`channelOption` の定義の隣に次を追加する。
+
+```ts
+const threadTypes = [
+  ChannelType.GuildPublicThread,
+  ChannelType.GuildPrivateThread,
+  ChannelType.GuildNewsThread,
+] as const;
+const threadOption = (option: SlashCommandChannelOption) =>
+  option
+    .setName("channel")
+    .setDescription("対象スレッド")
+    .addChannelTypes(...threadTypes)
+    .setRequired(true);
+const overrideChoices = [
+  { name: "allow", value: "allow" },
+  { name: "deny", value: "deny" },
+  { name: "inherit", value: "inherit" },
+] as const;
+```
+
+`src/apps/discord-gateway.ts` の `commandRepository` に thread 用のメソッドを追加する（Task 5 で `channelCapabilities` / `threadCapabilities` を用意済み）。
+
+```ts
+    const commandRepository = {
+      get: channelCapabilities.get.bind(channelCapabilities),
+      patch: async (...args: Parameters<typeof channelCapabilities.patch>) => {
+        await channelCapabilities.patch(...args);
+      },
+      getThread: threadCapabilities.get.bind(threadCapabilities),
+      patchThread: async (...args: Parameters<typeof threadCapabilities.patch>) => {
+        await threadCapabilities.patch(...args);
+      },
+    };
+```
+
+`src/adapters/discord/channel-command.ts` の `Repository` interface を拡張する。
+
+```ts
+interface Repository {
+  get(guildId: string, channelId: string): Promise<ChannelCapabilities>;
+  patch(
+    guildId: string,
+    channelId: string,
+    patch: ChannelCapabilitiesPatch,
+    actor: string,
+    reason: string,
+    now: Date,
+  ): Promise<void>;
+  getThread(guildId: string, channelId: string, threadId: string): Promise<ThreadCapabilityOverride | null>;
+  patchThread(
+    guildId: string,
+    channelId: string,
+    threadId: string,
+    patch: ThreadCapabilityPatch,
+    actor: string,
+    reason: string,
+    now: Date,
+  ): Promise<void>;
+}
+```
+
+import を追加する。
+
+```ts
+import type { ThreadCapabilityOverride } from "../../modules/channels/thread-capability.js";
+import type { ThreadCapabilityPatch } from "../postgres/thread-capability-repository.js";
+```
+
+三値文字列をドメイン値に変換する helper をファイル内に置く。
+
+```ts
+function overrideValue(raw: string | null): boolean | null | undefined {
+  if (raw === null) return undefined;
+  if (raw === "allow") return true;
+  if (raw === "deny") return false;
+  if (raw === "inherit") return null;
+  throw new Error(`Unsupported override value: ${raw}`);
+}
+```
+
+`handleChannelCommand` の `try` ブロック内、`const subcommand = interaction.options.getSubcommand();` の直後に thread 分岐を追加する。
+
+```ts
+    if (subcommand === "thread-show" || subcommand === "thread-set") {
+      if (!channel.isThread() || !channel.parentId) throw new Error("Thread subcommands require a thread channel");
+      const parentId = channel.parentId;
+      if (subcommand === "thread-show") {
+        const override = await repository.getThread(interaction.guildId, parentId, channel.id);
+        const shown = override ?? { guildId: interaction.guildId, channelId: parentId, threadId: channel.id,
+          observeEvents: null, respondToMentions: null, addReactions: null };
+        await interaction.editReply({ content: `\`\`\`json\n${JSON.stringify(shown, null, 2)}\n\`\`\`` });
+        return;
+      }
+      const patch: ThreadCapabilityPatch = {};
+      const options: Array<[string, keyof ThreadCapabilityPatch]> = [
+        ["observe", "observeEvents"],
+        ["mentions", "respondToMentions"],
+        ["reactions", "addReactions"],
+      ];
+      for (const [option, property] of options) {
+        const value = overrideValue(interaction.options.getString(option));
+        if (value !== undefined) patch[property] = value;
+      }
+      const reason = interaction.options.getString("reason", true).trim();
+      if (!reason) throw new Error("Reason is required");
+      await repository.patchThread(interaction.guildId, parentId, channel.id, patch, interaction.user.id, reason, clock.now());
+      await interaction.editReply({ content: "スレッド権限を更新しました。" });
+      return;
+    }
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `pnpm exec vitest run src/adapters/discord/channel-command.test.ts`
+Expected: PASS（4 tests）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/adapters/discord/channel-command.ts src/adapters/discord/channel-command.test.ts src/apps/discord-gateway.ts
+git commit -m "feat: manage thread capability overrides from Discord"
+```
+
+---
+
+### Task 7: Effect 実行時の再認可でスレッド override を見る
+
+**Files:**
+- Modify: `src/modules/effects/run-effect-worker.ts`
+- Modify: `src/modules/effects/run-effect-worker.test.ts`
+- Modify: `src/apps/discord-gateway.ts`（effect worker への repository 受け渡し）
+
+`ClaimedReplyEffect` は `capabilityChannelId`（親チャンネル）と `targetChannelId` を持つ。両者が異なるとき `targetChannelId` はスレッドなので、その thread override を含めて再評価する。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/modules/effects/run-effect-worker.test.ts` を次の内容に置き換える。
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { runOneEffect } from "./run-effect-worker.js";
+
+const effect = {
+  id: "e1",
+  runId: "r1",
+  guildId: "g1",
+  capabilityChannelId: "c1",
+  targetChannelId: "c1",
+  targetMessageId: "m1",
+  content: "hello",
+  attempts: 1,
+};
+const threadEffect = { ...effect, targetChannelId: "t1" };
+const clock = { now: () => new Date("2026-01-01T00:00:00Z") };
+
+describe("runOneEffect", () => {
+  it("rechecks capability and executes an allowed effect", async () => {
+    const queue = { claim: vi.fn().mockResolvedValue(effect), fail: vi.fn() };
+    const capabilities = {
+      get: vi.fn().mockResolvedValue({ guildId: "g1", channelId: "c1", respondToMentions: true }),
+    };
+    const executor = { execute: vi.fn().mockResolvedValue(undefined) };
+
+    await expect(runOneEffect(queue, capabilities, executor, "worker", clock)).resolves.toBe(true);
+
+    expect(capabilities.get).toHaveBeenCalledWith("g1", "c1", null);
+    expect(executor.execute).toHaveBeenCalledWith(effect, clock);
+  });
+
+  it("fails revoked capability without executing", async () => {
+    const queue = { claim: vi.fn().mockResolvedValue(effect), fail: vi.fn().mockResolvedValue(undefined) };
+    const capabilities = {
+      get: vi.fn().mockResolvedValue({ guildId: "g1", channelId: "c1", respondToMentions: false }),
+    };
+    const executor = { execute: vi.fn() };
+
+    await expect(runOneEffect(queue, capabilities, executor, "worker", clock)).resolves.toBe(true);
+
+    expect(queue.fail).toHaveBeenCalledWith("e1", "capability_revoked", clock.now());
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
+  it("resolves capability for the thread when the target is a thread", async () => {
+    const queue = { claim: vi.fn().mockResolvedValue(threadEffect), fail: vi.fn() };
+    const capabilities = {
+      get: vi.fn().mockResolvedValue({ guildId: "g1", channelId: "c1", respondToMentions: true }),
+    };
+    const executor = { execute: vi.fn().mockResolvedValue(undefined) };
+
+    await expect(runOneEffect(queue, capabilities, executor, "worker", clock)).resolves.toBe(true);
+
+    expect(capabilities.get).toHaveBeenCalledWith("g1", "c1", "t1");
+    expect(executor.execute).toHaveBeenCalledWith(threadEffect, clock);
+  });
+
+  it("fails an effect whose thread override revoked mention responses", async () => {
+    const queue = { claim: vi.fn().mockResolvedValue(threadEffect), fail: vi.fn().mockResolvedValue(undefined) };
+    const capabilities = {
+      get: vi.fn().mockResolvedValue({ guildId: "g1", channelId: "c1", respondToMentions: false }),
+    };
+    const executor = { execute: vi.fn() };
+
+    await expect(runOneEffect(queue, capabilities, executor, "worker", clock)).resolves.toBe(true);
+
+    expect(capabilities.get).toHaveBeenCalledWith("g1", "c1", "t1");
+    expect(queue.fail).toHaveBeenCalledWith("e1", "capability_revoked", clock.now());
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認する**
+
+Run: `pnpm exec vitest run src/modules/effects/run-effect-worker.test.ts`
+Expected: FAIL。`capabilities.get` が 2 引数でしか呼ばれておらず `toHaveBeenCalledWith("g1", "c1", null)` が一致しない。
+
+- [ ] **Step 3: 実装を変更する**
+
+`src/modules/effects/run-effect-worker.ts` の `CapabilityRepository` と `runOneEffect` を更新する。
+
+```ts
+interface CapabilityRepository {
+  get(guildId: string, channelId: string, threadId: string | null): Promise<ChannelCapabilities>;
+}
+```
+
+```ts
+export async function runOneEffect(
+  queue: Queue,
+  capabilities: CapabilityRepository,
+  executor: Executor,
+  workerId: string,
+  clock: Clock,
+): Promise<boolean> {
+  const effect = await queue.claim(workerId, clock.now());
+  if (!effect) return false;
+  const threadId = effect.targetChannelId === effect.capabilityChannelId ? null : effect.targetChannelId;
+  const capability = await capabilities.get(effect.guildId, effect.capabilityChannelId, threadId);
+  if (!capability.respondToMentions) {
+    await queue.fail(effect.id, "capability_revoked", clock.now());
+    return true;
+  }
+  await executor.execute(effect, clock);
+  return true;
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認する**
+
+Run: `pnpm exec vitest run src/modules/effects/run-effect-worker.test.ts`
+Expected: PASS（4 tests）
+
+- [ ] **Step 5: Gateway の effect loop を実効 capability に切り替える**
+
+`src/apps/discord-gateway.ts` の `runEffectLoop` の型注釈（182 行目付近）を差し替える。
+
+```ts
+async function runEffectLoop(
+  queue: PostgresEffectQueue,
+  capabilities: PostgresEffectiveCapabilityRepository,
+  executor: DiscordEffectExecutor,
+  signal: AbortSignal,
+  logger: ReturnType<typeof createLogger>,
+  fatal: (error: unknown) => void,
+): Promise<void> {
+```
+
+Task 5 で `channelCapabilities` を渡すようにした呼び出し（168 行目付近）を、実効 capability repository に戻す。
+
+```ts
+  const effectLoop = runEffectLoop(effects, capabilities, executor, controller.signal, logger, rejectFatal);
+```
+
+Run: `nr check`
+Expected: エラーなし
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/modules/effects/run-effect-worker.ts src/modules/effects/run-effect-worker.test.ts src/apps/discord-gateway.ts
+git commit -m "feat: recheck thread overrides before executing effects"
+```
+
+---
+
+### Task 8: 全体検証とドキュメント更新
+
+**Files:**
+- Modify: `docs/` 配下の運用ドキュメントのうち `/vicissitude-channel` の使い方を説明しているもの
+
+- [ ] **Step 1: `/vicissitude-channel` を説明しているドキュメントを探す**
+
+Run: `grep -rn "vicissitude-channel" docs/ README.md`
+Expected: 該当ファイルの一覧。ヒットがなければこの Step をスキップして Step 3 へ進む。
+
+- [ ] **Step 2: thread subcommand を追記する**
+
+見つかったドキュメントの `/vicissitude-channel set` を説明している箇所の直後に、次の内容を既存の文体に合わせて追記する。
+
+```markdown
+スレッド単位で権限を上書きする場合は `/vicissitude-channel thread-set` を使う。`observe` / `mentions` / `reactions` はそれぞれ `allow`（明示的に許可）、`deny`（明示的に拒否）、`inherit`（親チャンネルの設定を継承）から選ぶ。省略した項目は変更されない。現在の上書き内容は `/vicissitude-channel thread-show` で確認できる。
+
+スレッドは既定で親チャンネルの権限を継承する。フォーラムのように特定スレッドだけを対象にしたい場合は、親チャンネルを `observe: false` にしたうえで、対象スレッドに `thread-set observe:allow` を設定する。
+```
+
+- [ ] **Step 3: 全検証を実行する**
+
+Run: `nr validate`
+Expected: format / lint / typecheck / unit / spec すべて PASS
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add docs README.md
+git commit -m "docs: describe thread capability overrides"
+```
+
+- [ ] **Step 5: push して PR を作る**
+
+```bash
+git push -u origin HEAD
+gh pr create --fill
+```
+
+---
+
+## この計画の範囲外
+
+次のスライス（別計画）で扱う。
+
+- `conversation_evaluate` job への置き換えと scope キー化（spec §3.1）
+- short batch と typing 延長（spec §3.2）
+- `conversation_cursors` と `run_input_events`（spec §3.3）
+- `actor_states`（spec §3.4）
+- Scenario corpus（spec §6）

--- a/docs/superpowers/specs/2026-07-29-phase-2-conversation-cognition-design.md
+++ b/docs/superpowers/specs/2026-07-29-phase-2-conversation-cognition-design.md
@@ -1,0 +1,227 @@
+# Phase 2: Conversation Cognition 設計
+
+日付: 2026-07-29
+前提: [2026-07-23 アーキテクチャ設計](2026-07-23-ai-character-platform-architecture-design.md)、Phase 1 durable spine（migration 0001）
+
+## 1. 目的と分割
+
+Phase 1 は「明示 mention 1件を読み、モデルを1回呼び、600文字以内の reply effect を作る」直線的な処理である。Phase 2 はこれを会話単位の認知へ拡張する。一括実装は行わず、失敗原因を切り分けられるよう3段階に分割する。
+
+- **Phase 2A: Durable Conversation Assembly** — モデル判断を増やさず、会話入力を正しく組み立てる。Thread Scope の導入を先頭スライスとする
+- **Phase 2B: Typed Cognition Pipeline** — メッセージから直接文章を生成する処理を、型付きの監査可能な段階に分ける
+- **Phase 2C: Discord Actions and Conversation UX** — 行動種別と会話体験を広げる
+
+Scenario corpus は Phase 2A と並行して整備し、batch パラメータと宛先推定品質の判断基準にする。
+
+## 2. Thread Scope（Phase 2A 先頭スライス）
+
+### 2.1 背景
+
+Canonical event は既に `channelId`（親チャンネル）と `threadId` を分離して保持し、effect も `capability_channel_id`（認可用）と `target_channel_id`（送信先）を区別している。欠けているのは capability の粒度と会話 scope の定義の2点であり、スレッド主体で運用するギルド（特にフォーラムチャンネル）では `observe_events` を有効にした瞬間に配下の全スレッドが観察対象になってしまう。
+
+### 2.2 Capability 解決モデル
+
+`channel_capabilities` を「親チャンネルのデフォルト」として維持し、スレッド単位の override テーブルを追加する。
+
+```sql
+CREATE TABLE thread_capability_overrides (
+  guild_id text NOT NULL,
+  channel_id text NOT NULL,   -- 親チャンネル
+  thread_id text NOT NULL,
+  observe_events boolean,      -- NULL = 親を継承
+  respond_to_mentions boolean, -- NULL = 親を継承
+  add_reactions boolean,       -- NULL = 親を継承
+  updated_at timestamptz NOT NULL, updated_by text NOT NULL, reason text NOT NULL,
+  PRIMARY KEY (guild_id, channel_id, thread_id)
+);
+```
+
+- 各 capability カラムは nullable boolean。`NULL` は親チャンネル値の継承、`true` / `false` は明示 override。許可側 override（親 deny + スレッド allow）と拒否側 override（親 allow + スレッド deny）の両方を表現できる
+- override 対象はスレッド内で意味を持つ capability のみ（`observe_events` / `respond_to_mentions` / `add_reactions`）。`create_threads` や `share_files` 等はチャンネルレベルのまま。必要になった時点でカラムを追加する
+- 解決はドメイン層の純関数 `resolveEffectiveCapabilities(channel, threadOverride | null)` で行う。ingest 時（gateway）と effect 実行時（worker）の両方が同じ関数を通る。effect worker は `target_channel_id` がスレッドの場合、`capability_channel_id` のチャンネル capability に加えて thread override を参照する
+
+### 2.3 管理コマンド
+
+既存の `/channel` コマンドに thread 用 subcommand を追加する（例: `/channel thread-set thread:<id> capability:<name> value:<allow|deny|inherit>`）。`inherit` は該当カラムを NULL に戻し、全 capability カラムが NULL になった row は削除する。監査列（`updated_by` / `reason`）は既存規約に従う。
+
+### 2.4 Conversation scope キー
+
+Phase 2A の `conversation_evaluate` job が読む会話 scope を次で定義する。
+
+```text
+ConversationScope = (guildId, channelId, threadId | null)
+```
+
+- `threadId` を持つスレッドはそれ自体が独立した会話 scope であり、親チャンネルの会話と混ざらない
+- スレッドは cluster 推定の「強い証拠」（アーキテクチャ設計 7.3）から「決定的な境界」に格上げする。7.3 の cluster 推定は同一 scope 内の並行会話分離にのみ適用する
+- `events` に `(guild_id, channel_id, thread_id, occurred_at DESC)` の index を追加する
+
+### 2.5 やらないこと
+
+- フォーラムチャンネルの「新規スレッド自動方針」（threadDefault 項目）— 継承モデルにおいて channel 側 `observe_events=false` がその役割を果たす
+- スレッドのアーカイブ状態の追跡 — Phase 2C の自発投稿まで不要
+
+## 3. Phase 2A: Durable Conversation Assembly
+
+### 3.1 Job のスコープキー化
+
+Phase 1 の `mention_response` job（イベント1件 = job 1件、即時実行）を、`conversation_evaluate` job（会話 scope 1つ = 待機中 job 最大1件）に置き換える。後方互換パスは作らない。
+
+- `jobs` に scope 列（`guild_id`, `channel_id`, `thread_id`）と `first_triggered_at` を追加し、部分 unique index `UNIQUE (kind, guild_id, channel_id, thread_id) WHERE state = 'queued'` で「同一 scope の待機 job は常に1件」を保証する（`thread_id` は `COALESCE(thread_id, '')` で正規化した式 index とする）
+- `event_id` は nullable な `trigger_event_id`（初回トリガーイベント参照）に置き換える
+- ingest 時の動作:
+  - トリガー条件（Phase 2A では明示 mention のみ。`respond_to_mentions` の effective capability で判定）を満たすイベントが来たら、scope の queued job を upsert する。新規なら `available_at = now + batchWindow`、`first_triggered_at = now`
+  - すでに queued job がある scope に後続イベントが来たら（mention でなくてもよい）、`available_at = min(now + batchWindow, first_triggered_at + maxWait)` に延長する。これが short batch の実体
+  - observe のみのイベントは job を新規作成しない（保存と batch 参加のみ。賢い会話判定は 2B）
+
+インメモリタイマーは使わない。待機はすべて `available_at` として DB に永続化され、Gateway / worker の再起動で batch は失われない。
+
+### 3.2 Typing 延長
+
+Gateway が `typingStart` を受けたら、該当 scope の queued job の `available_at` を同じ式（maxWait 上限つき）で延長する UPDATE を発行する。best-effort であり、再起動で typing 延長が失われても job が少し早く発火するだけで安全側に倒れる。
+
+### 3.3 Batch の読み出しと cursor
+
+- 新テーブル `conversation_cursors`（PK = scope、`last_event_id` / `last_occurred_at`）を追加する
+- Worker は job を claim したら、cursor 以降・claim 時点までの canonical event を scope から読み出す
+- run の処理成功時に cursor を前進させる。失敗時は前進させず、retry が同じ範囲を再読する
+- run が読んだイベント集合は `run_input_events (run_id, event_id)` join テーブルに記録し、「この応答はどのメッセージ群を見たか」を監査可能にする
+- run 実行中に到着したイベントは claim 時点より後なので読み出し範囲に含まれず、次の job（部分 unique は queued のみ対象のため実行中でも新規 enqueue できる）が cursor 経由で拾う。取りこぼしと二重読みの両方が起きない
+
+認知そのものは Phase 1 と同じ（mention への 600 文字以内 reply）だが、入力が単一イベントから batch に変わる。
+
+### 3.4 Actor 状態
+
+新テーブル `actor_states (guild_id, actor_id, state, first_observed_at, last_interacted_at)` を追加する。
+
+- row なし = `unseen`
+- 初回 ingest で `observed`
+- そのユーザーのメッセージへの reply effect が成功したら `interacted`
+
+Phase 2A では記録のみで判断に使わない。2B の宛先推定の入力になる。
+
+### 3.5 パラメータ
+
+`batchWindow` / `typingExtension` / `maxWait` は設定値とし、初期値は仮置き（8秒 / 5秒 / 30秒）。確定は scenario corpus のラベル（許容最大待機時間）に基づく。
+
+## 4. Phase 2B: Typed Cognition Pipeline
+
+### 4.1 段階分割
+
+```text
+ConversationContext → AddresseeInference → ActionDecision → SpeechGeneration → Effect planning
+```
+
+`ActionDecision` は次の3種に限定する。`reaction` と新規 `post` は 2C に回す。
+
+```ts
+type ConversationAction =
+  | { type: "silence"; reasonCode: string }
+  | { type: "reply"; targetMessageId: string }
+  | { type: "defer"; resumeAt: Date; reasonCode: string };
+```
+
+### 4.2 記録と監査
+
+- 各段階の出力は既存の `audit_entries`（`summary jsonb` + run 参照）に category 付きで記録する（例: `cognition.addressee`、`cognition.action`）。新テーブルは作らない
+- `decision_runs.action_kind` の CHECK を `('reply')` から `('reply', 'silence', 'defer')` に拡張する。`silence` も run として記録し、`reason_codes` に理由を残す
+- これにより「宛先推定は正しかったが生成に失敗した」「宛先推定自体が間違っていた」「意図的に沈黙した」「後で回答することを選んだ」を区別して監査できる
+
+### 4.3 トリガーの拡張
+
+宛先推定が意味を持つのは非 mention イベントが評価対象になるときなので、observed イベントからの job 生成は 2B で解禁する。全メッセージでモデルを回さないよう二段構えにする。
+
+1. ingest 時: 決定的な安価トリガー（名前呼びパターン、bot 宛 reply、直近で bot が発話した scope）を通過したものだけ `conversation_evaluate` を enqueue
+2. worker 側: AddresseeInference が最終判断し、宛先でなければ `silence` として記録
+
+### 4.4 defer
+
+新種の job は作らず、同一 scope の `conversation_evaluate` job を `available_at = resumeAt` で再 enqueue し、`reason_codes` に defer 理由を記録する。Phase 2A の仕組みをそのまま使う。
+
+## 5. Phase 2C: Discord Actions and Conversation UX
+
+- effect kind を `discord.reply` から `discord.reaction` / `discord.post`（非 reply 投稿）/ typing 表示へ拡張する。effect ledger の構造と認可フロー（channel capability + thread override）は変更しない
+- Gateway だけが Discord token を持つ境界を維持する。cognition worker は effect を永続化するのみ
+- 発話量制御・詳細確認を返す判断・不確実性の表現は SpeechGeneration 段の入力（ConversationPolicy）として実装する
+- `defer` の継続 job、必要に応じた一次反応、最終回答の分割もこの段階で扱う
+
+## 6. Scenario Corpus（Phase 2A と並行）
+
+- 置き場所: `spec/corpus/conversations/*.json`。1ファイル = 1 scenario
+- 各 scenario はイベント列（相対タイミング付き）と人手ラベルを持つ
+  - 宛先
+  - 期待 action（reply / silence / defer）
+  - 参照すべきメッセージ
+  - 許容最大待機時間
+  - 誤介入の重大度
+
+初期セットは次の10ケース。
+
+| Scenario | 期待結果 |
+|---|---|
+| キャラクターへの明示 mention | reply |
+| 他人への reply 内にキャラクター名が出る | silence |
+| 「ふあはどう思う？」のような名前呼び | reply |
+| 複数人の連投中に明示 mention | batch 後に reply |
+| typing 中に追加メッセージが来る | 追加分を同じ batch に含める |
+| thread 内の会話 | thread を scope 境界にする |
+| 同じ channel で2会話が並行 | 誤った会話へ介入しない |
+| 質問が途中で分割投稿される | 最後まで待って reply |
+| 回答に追加情報が必要 | 詳細確認 |
+| キャラクターに向けられていない雑談 | silence |
+
+初期は人手評価のみとし、LLM 品質の数値化はしない。`spec/e2e/` ハーネスへの自動実行接続は 2B 以降に判断する。
+
+## 7. ConversationPolicy（CharacterDefinition への最小追加）
+
+`character_definitions.definition` (jsonb) に次の数値契約のみを追加する。既存のバージョニング（version + production unique index）に乗るためスキーマ変更は不要。
+
+```ts
+interface ConversationPolicy {
+  mentionResponsePriority: number;
+  implicitAddressThreshold: number;
+  interruptionAversion: number;
+  defaultUtteranceBudget: number;
+  clarificationPreference: number;
+  silenceBias: number;
+}
+```
+
+感情・relationship・interest は Phase 3 との境界を壊さないため入れない。
+
+## 8. DB 変更まとめ
+
+**migration 0002（Phase 2A / Thread Scope）**
+
+1. `thread_capability_overrides` テーブル追加（2.2）
+2. `jobs`: kind を `conversation_evaluate` に変更、scope 列 + `first_triggered_at` 追加、`event_id` → nullable `trigger_event_id`、`UNIQUE (kind, event_id)` を部分 unique index に置換（3.1）
+3. `conversation_cursors` テーブル追加（3.3）
+4. `run_input_events` テーブル追加（3.3）
+5. `actor_states` テーブル追加（3.4）
+6. `events` に `(guild_id, channel_id, thread_id, occurred_at DESC)` index 追加（2.4）
+
+**migration 0003（Phase 2B）**
+
+- `decision_runs.action_kind` CHECK 拡張: `('reply', 'silence', 'defer')`
+
+**migration 0004（Phase 2C）**
+
+- `effects.kind` CHECK 拡張: `('discord.reply', 'discord.reaction', 'discord.post')` ほか
+
+本番運用前のため、既存データの移行パスは最小限とする。
+
+## 9. Failure Handling
+
+- **batch job の失敗**: 既存の lease / max_attempts (3) / retry 機構をそのまま使う。cursor は成功時のみ前進するため、失敗した run のイベントは retry で再読され、取りこぼさない
+- **typing 延長の喪失**: 再起動で失われても job が早く発火するだけで安全
+- **重複防止**: 部分 unique index（queued のみ）により待機 job は scope あたり1件。実行中の新着イベントは次の job が cursor 経由で処理する
+- **effect 実行時の capability 変更**: Phase 1 同様、effect 実行直前に effective capability（thread override 込み）を再評価する
+- **defer job の失敗**: 通常の retry に従う
+
+## 10. 実装順序
+
+1. **Phase 2A**: Thread Scope（migration + 解決関数 + `/channel` 拡張）→ scope キー job + batch + cursor → typing 延長 → actor 状態。並行して scenario corpus 初期10ケース作成
+2. **Phase 2B**: 型付き段階 + audit 記録 → observed トリガー解禁 → defer
+3. **Phase 2C**: effect 種別拡張 → 会話 UX
+
+各 Phase の実装計画は writing-plans で個別に作成する。

--- a/migrations/0002_thread_scope.sql
+++ b/migrations/0002_thread_scope.sql
@@ -7,3 +7,6 @@ CREATE TABLE thread_capability_overrides (
 );
 
 CREATE INDEX events_thread_scope_time_idx ON events (guild_id, channel_id, thread_id, occurred_at DESC);
+
+ALTER TABLE effects ADD COLUMN thread_id text;
+UPDATE effects SET thread_id = target_channel_id WHERE target_channel_id <> capability_channel_id;

--- a/migrations/0002_thread_scope.sql
+++ b/migrations/0002_thread_scope.sql
@@ -1,0 +1,9 @@
+CREATE TABLE thread_capability_overrides (
+  guild_id text NOT NULL, channel_id text NOT NULL, thread_id text NOT NULL,
+  observe_events boolean, respond_to_mentions boolean, add_reactions boolean,
+  updated_at timestamptz NOT NULL, updated_by text NOT NULL, reason text NOT NULL,
+  PRIMARY KEY (guild_id, channel_id, thread_id),
+  CHECK (observe_events IS NOT NULL OR respond_to_mentions IS NOT NULL OR add_reactions IS NOT NULL)
+);
+
+CREATE INDEX events_thread_scope_time_idx ON events (guild_id, channel_id, thread_id, occurred_at DESC);

--- a/spec/adapters/postgres/decision-effect-store.spec.ts
+++ b/spec/adapters/postgres/decision-effect-store.spec.ts
@@ -57,6 +57,9 @@ describe("PostgresDecisionEffectStore", () => {
     await expect(sql`select count(*)::int as count from effects where run_id = ${run.runId}`).resolves.toEqual([
       { count: 1 },
     ]);
+    await expect(sql`select thread_id from effects where run_id = ${run.runId}`).resolves.toEqual([
+      { thread_id: null },
+    ]);
     await expect(sql`select count(*)::int as count from audit_entries where run_id = ${run.runId}`).resolves.toEqual([
       { count: 1 },
     ]);
@@ -84,12 +87,13 @@ describe("PostgresDecisionEffectStore", () => {
       now: f.now,
     });
     await expect(
-      sql`select guild_id, capability_channel_id, target_channel_id, target_message_id from effects`,
+      sql`select guild_id, capability_channel_id, target_channel_id, thread_id, target_message_id from effects`,
     ).resolves.toEqual([
       {
         guild_id: "g",
         capability_channel_id: "parent",
         target_channel_id: "thread-1",
+        thread_id: "thread-1",
         target_message_id: "message-20",
       },
     ]);

--- a/spec/adapters/postgres/effect-queue.spec.ts
+++ b/spec/adapters/postgres/effect-queue.spec.ts
@@ -35,6 +35,7 @@ describe.skipIf(!url)("PostgresEffectQueue", () => {
       guildId: "g",
       capabilityChannelId: "cap",
       targetChannelId: "target",
+      threadId: null,
       targetMessageId: "message",
       content: "hello",
       allowedMentions: { parse: [], repliedUser: false },
@@ -88,7 +89,7 @@ describe.skipIf(!url)("PostgresEffectQueue", () => {
     await sql`insert into jobs (id,kind,event_id,state,available_at,created_at,updated_at) values (${jobId},'mention_response',${eventId},'queued',${now},${now},${now})`;
     await sql`insert into decision_runs (id,job_id,event_id,character_id,character_version,model_route_version,state,started_at) values (${runId},${jobId},${eventId},'c',1,'r','succeeded',${now})`;
     const payload = sql.json({ content: "hello", allowedMentions: { parse: [], repliedUser: false } });
-    await sql`insert into effects (id,run_id,effect_slot,kind,state,guild_id,capability_channel_id,target_channel_id,target_message_id,payload,capability_decision,created_at,updated_at) values (${effectId},${runId},'primary_reply','discord.reply','planned','g2','cap2','target2','message2',${payload},${sql.json({})},${now},${now})`;
+    await sql`insert into effects (id,run_id,effect_slot,kind,state,guild_id,capability_channel_id,target_channel_id,thread_id,target_message_id,payload,capability_decision,created_at,updated_at) values (${effectId},${runId},'primary_reply','discord.reply','planned','g2','cap2','target2','target2','message2',${payload},${sql.json({})},${now},${now})`;
     await sql`update system_state set mode='stopped' where singleton`;
     await expect(new PostgresEffectQueue(sql).claim("stopped", now)).resolves.toBeNull();
     await sql`update system_state set mode='draining' where singleton`;
@@ -96,6 +97,7 @@ describe.skipIf(!url)("PostgresEffectQueue", () => {
     expect(claimed).toMatchObject({
       id: effectId,
       targetChannelId: "target2",
+      threadId: "target2",
       targetMessageId: "message2",
       content: "hello",
       attempts: 1,

--- a/spec/adapters/postgres/effective-capability-repository.spec.ts
+++ b/spec/adapters/postgres/effective-capability-repository.spec.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Sql } from "postgres";
+import { createPostgresClient } from "../../../src/adapters/postgres/client.js";
+import { runMigrations } from "../../../src/adapters/postgres/migrations.js";
+import { denyAllCapabilities } from "../../../src/modules/channels/channel-capability.js";
+import { PostgresChannelCapabilityRepository } from "../../../src/adapters/postgres/channel-capability-repository.js";
+import { PostgresThreadCapabilityRepository } from "../../../src/adapters/postgres/thread-capability-repository.js";
+import { PostgresEffectiveCapabilityRepository } from "../../../src/adapters/postgres/effective-capability-repository.js";
+
+let sql: Sql;
+
+beforeAll(async () => {
+  sql = createPostgresClient(process.env.TEST_DATABASE_URL!);
+  await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, {
+    actor: "test-bootstrap",
+    backupConfirmedAt: new Date(),
+  });
+});
+
+beforeEach(async () => {
+  await sql`truncate audit_entries, thread_capability_overrides, channel_capabilities cascade`;
+});
+
+afterAll(async () => {
+  await sql.end();
+});
+
+const now = new Date("2026-01-02T03:04:05.000Z");
+
+function build(): PostgresEffectiveCapabilityRepository {
+  return new PostgresEffectiveCapabilityRepository(
+    new PostgresChannelCapabilityRepository(sql),
+    new PostgresThreadCapabilityRepository(sql),
+  );
+}
+
+describe("PostgresEffectiveCapabilityRepository", () => {
+  it("returns channel capabilities for a non-thread message", async () => {
+    const channels = new PostgresChannelCapabilityRepository(sql);
+    await channels.patch("guild-1", "channel-1", { observeEvents: true }, "operator", "enable", now);
+
+    await expect(build().get("guild-1", "channel-1", null)).resolves.toMatchObject({ observeEvents: true });
+  });
+
+  it("inherits channel capabilities in a thread without an override", async () => {
+    const channels = new PostgresChannelCapabilityRepository(sql);
+    await channels.patch("guild-1", "channel-1", { observeEvents: true }, "operator", "enable", now);
+
+    await expect(build().get("guild-1", "channel-1", "thread-1")).resolves.toMatchObject({ observeEvents: true });
+  });
+
+  it("applies a deny override inside an allowed channel", async () => {
+    const channels = new PostgresChannelCapabilityRepository(sql);
+    const threads = new PostgresThreadCapabilityRepository(sql);
+    await channels.patch("guild-1", "channel-1", { observeEvents: true }, "operator", "enable", now);
+    await threads.patch("guild-1", "channel-1", "thread-1", { observeEvents: false }, "operator", "quiet", now);
+
+    await expect(build().get("guild-1", "channel-1", "thread-1")).resolves.toMatchObject({ observeEvents: false });
+    await expect(build().get("guild-1", "channel-1", null)).resolves.toMatchObject({ observeEvents: true });
+  });
+
+  it("applies an allow override inside a denied channel", async () => {
+    const threads = new PostgresThreadCapabilityRepository(sql);
+    await threads.patch(
+      "guild-1",
+      "forum-1",
+      "thread-1",
+      { observeEvents: true, respondToMentions: true },
+      "operator",
+      "watch one thread",
+      now,
+    );
+
+    await expect(build().get("guild-1", "forum-1", "thread-1")).resolves.toMatchObject({
+      observeEvents: true,
+      respondToMentions: true,
+    });
+    await expect(build().get("guild-1", "forum-1", null)).resolves.toEqual(denyAllCapabilities("guild-1", "forum-1"));
+  });
+});

--- a/spec/adapters/postgres/migrations.spec.ts
+++ b/spec/adapters/postgres/migrations.spec.ts
@@ -37,12 +37,15 @@ describe("versioned migrations", () => {
       actor: "test-bootstrap",
       backupConfirmedAt: new Date(),
     });
-    expect(first).toMatchObject({ appliedVersions: ["0001"] });
+    expect(first).toMatchObject({ appliedVersions: ["0001", "0002"] });
     expect(second).toMatchObject({ appliedVersions: [] });
     expect(first.appliedAt).toBeInstanceOf(Date);
 
     const status = await migrationStatus(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!);
-    expect(status).toEqual([expect.objectContaining({ version: "0001", name: "durable_spine", state: "applied" })]);
+    expect(status).toEqual([
+      expect.objectContaining({ version: "0001", name: "durable_spine", state: "applied" }),
+      expect.objectContaining({ version: "0002", name: "thread_scope", state: "applied" }),
+    ]);
     expect(status[0]?.checksum).toMatch(/^[0-9a-f]{64}$/u);
   });
 
@@ -81,7 +84,7 @@ describe("versioned migrations", () => {
       ])) as [{ appliedVersions: string[] }, { appliedVersions: string[] }];
       expect([firstResult.appliedVersions, secondResult.appliedVersions].sort((a, b) => a.length - b.length)).toEqual([
         [],
-        ["0001"],
+        ["0001", "0002"],
       ]);
       const rows = await sql`select version from schema_migrations where version = '0001'`;
       expect(rows).toHaveLength(1);
@@ -154,13 +157,13 @@ describe("versioned migrations", () => {
       actor: "admin@example.com",
       backupConfirmedAt,
     }))!;
-    expect(result.appliedVersions).toEqual(["0001"]);
+    expect(result.appliedVersions).toEqual(["0001", "0002"]);
     expect(result.appliedAt).toBeInstanceOf(Date);
     const rows = await sql<{ summary: { actor: string; backupConfirmedAt: string; appliedVersions: string[] } }[]>`
       select summary from audit_entries where category = 'migration.applied'
     `;
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.summary).toMatchObject({ actor: "admin@example.com", appliedVersions: ["0001"] });
+    expect(rows[0]?.summary).toMatchObject({ actor: "admin@example.com", appliedVersions: ["0001", "0002"] });
     expect(new Date(rows[0]!.summary.backupConfirmedAt).getTime()).toBe(backupConfirmedAt.getTime());
   });
 
@@ -170,7 +173,7 @@ describe("versioned migrations", () => {
     const context = { actor: "admin@example.com", backupConfirmedAt: new Date() };
     const first = (await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, context))!;
     const second = (await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, context))!;
-    expect(first.appliedVersions).toEqual(["0001"]);
+    expect(first.appliedVersions).toEqual(["0001", "0002"]);
     expect(second.appliedVersions).toEqual([]);
     const rows = await sql<{ summary: { appliedVersions: string[] } }[]>`
       select summary from audit_entries where category = 'migration.applied' order by created_at
@@ -242,5 +245,38 @@ describe("versioned migrations", () => {
     const rows = await sql<{ applied_at: Date }[]>`select applied_at from schema_migrations where version = '0001'`;
     await locker.end();
     expect(rows[0]!.applied_at.getTime()).toBeGreaterThanOrEqual(releasedAt.getTime());
+  });
+
+  it("creates the thread override table with an all-inherit guard and the thread-aware event index", async () => {
+    await sql`drop schema public cascade`;
+    await sql`create schema public`;
+    await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, {
+      actor: "test-bootstrap",
+      backupConfirmedAt: new Date(),
+    });
+
+    const columns = await sql<{ column_name: string; is_nullable: string }[]>`
+      select column_name, is_nullable from information_schema.columns
+      where table_name = 'thread_capability_overrides'
+        and column_name in ('observe_events', 'respond_to_mentions', 'add_reactions')
+      order by column_name
+    `;
+    expect(columns).toEqual([
+      { column_name: "add_reactions", is_nullable: "YES" },
+      { column_name: "observe_events", is_nullable: "YES" },
+      { column_name: "respond_to_mentions", is_nullable: "YES" },
+    ]);
+
+    const indexes = await sql<{ indexname: string }[]>`
+      select indexname from pg_indexes where tablename = 'events' and indexname = 'events_thread_scope_time_idx'
+    `;
+    expect(indexes).toHaveLength(1);
+
+    await expect(
+      sql`
+        insert into thread_capability_overrides (guild_id, channel_id, thread_id, updated_at, updated_by, reason)
+        values ('guild-1', 'channel-1', 'thread-1', now(), 'test', 'all inherit')
+      `,
+    ).rejects.toThrow();
   });
 });

--- a/spec/adapters/postgres/migrations.spec.ts
+++ b/spec/adapters/postgres/migrations.spec.ts
@@ -279,4 +279,19 @@ describe("versioned migrations", () => {
       `,
     ).rejects.toThrow();
   });
+
+  it("adds a nullable thread_id column to effects", async () => {
+    await sql`drop schema public cascade`;
+    await sql`create schema public`;
+    await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, {
+      actor: "test-bootstrap",
+      backupConfirmedAt: new Date(),
+    });
+
+    const columns = await sql<{ column_name: string; is_nullable: string }[]>`
+      select column_name, is_nullable from information_schema.columns
+      where table_name = 'effects' and column_name = 'thread_id'
+    `;
+    expect(columns).toEqual([{ column_name: "thread_id", is_nullable: "YES" }]);
+  });
 });

--- a/spec/adapters/postgres/thread-capability-repository.spec.ts
+++ b/spec/adapters/postgres/thread-capability-repository.spec.ts
@@ -54,6 +54,9 @@ describe("PostgresThreadCapabilityRepository", () => {
       addReactions: null,
     });
     await expect(repository.get("guild-1", "channel-1", "thread-1")).resolves.toEqual(result);
+    await expect(sql`select updated_by, reason, updated_at from thread_capability_overrides`).resolves.toEqual([
+      { updated_by: "operator-1", reason: "watch this thread", updated_at: now },
+    ]);
     const rows = await sql<{ category: string; summary: Record<string, unknown>; created_at: Date }[]>`
       select category, summary, created_at from audit_entries
     `;

--- a/spec/adapters/postgres/thread-capability-repository.spec.ts
+++ b/spec/adapters/postgres/thread-capability-repository.spec.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Sql } from "postgres";
+import { createPostgresClient } from "../../../src/adapters/postgres/client.js";
+import { runMigrations } from "../../../src/adapters/postgres/migrations.js";
+import { PostgresThreadCapabilityRepository } from "../../../src/adapters/postgres/thread-capability-repository.js";
+
+let sql: Sql;
+
+beforeAll(async () => {
+  sql = createPostgresClient(process.env.TEST_DATABASE_URL!);
+  await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, {
+    actor: "test-bootstrap",
+    backupConfirmedAt: new Date(),
+  });
+});
+
+beforeEach(async () => {
+  await sql`truncate audit_entries, thread_capability_overrides cascade`;
+});
+
+afterAll(async () => {
+  await sql.end();
+});
+
+const now = new Date("2026-01-02T03:04:05.000Z");
+
+describe("PostgresThreadCapabilityRepository", () => {
+  it("returns null without writing a row for an unconfigured thread", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+
+    await expect(repository.get("guild-1", "channel-1", "thread-1")).resolves.toBeNull();
+    await expect(sql`select * from thread_capability_overrides`).resolves.toHaveLength(0);
+  });
+
+  it("stores an override and records the change audit", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+
+    const result = await repository.patch(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      { observeEvents: true },
+      "operator-1",
+      "watch this thread",
+      now,
+    );
+
+    expect(result).toEqual({
+      guildId: "guild-1",
+      channelId: "channel-1",
+      threadId: "thread-1",
+      observeEvents: true,
+      respondToMentions: null,
+      addReactions: null,
+    });
+    await expect(repository.get("guild-1", "channel-1", "thread-1")).resolves.toEqual(result);
+    const rows = await sql<{ category: string; summary: Record<string, unknown>; created_at: Date }[]>`
+      select category, summary, created_at from audit_entries
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      category: "thread.capability.changed",
+      created_at: now,
+      summary: {
+        actor: "operator-1",
+        reason: "watch this thread",
+        guildId: "guild-1",
+        channelId: "channel-1",
+        threadId: "thread-1",
+        before: null,
+        after: { observeEvents: true, respondToMentions: null, addReactions: null },
+      },
+    });
+  });
+
+  it("merges a patch into an existing override and leaves untouched fields alone", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+    await repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "operator-1", "first", now);
+
+    const result = await repository.patch(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      { respondToMentions: false },
+      "operator-2",
+      "second",
+      now,
+    );
+
+    expect(result).toMatchObject({ observeEvents: true, respondToMentions: false, addReactions: null });
+  });
+
+  it("deletes the row when every capability returns to inherit", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+    await repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "operator-1", "first", now);
+
+    const result = await repository.patch(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      { observeEvents: null },
+      "operator-1",
+      "back to inherit",
+      now,
+    );
+
+    expect(result).toBeNull();
+    await expect(sql`select * from thread_capability_overrides`).resolves.toHaveLength(0);
+    const rows = await sql<{ summary: { before: unknown; after: unknown } }[]>`
+      select summary from audit_entries where category = 'thread.capability.changed' order by created_at
+    `;
+    expect(rows.at(-1)?.summary.after).toBeNull();
+  });
+
+  it("scopes overrides to a single thread", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+    await repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "operator-1", "one", now);
+
+    await expect(repository.get("guild-1", "channel-1", "thread-2")).resolves.toBeNull();
+    await expect(repository.get("guild-1", "channel-2", "thread-1")).resolves.toBeNull();
+  });
+
+  it("rejects invalid metadata", async () => {
+    const repository = new PostgresThreadCapabilityRepository(sql);
+
+    await expect(
+      repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, " ", "reason", now),
+    ).rejects.toThrow();
+    await expect(
+      repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "actor", " ", now),
+    ).rejects.toThrow();
+    await expect(
+      repository.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "actor", "reason", new Date("x")),
+    ).rejects.toThrow();
+  });
+
+  it("merges concurrent patches for one thread scope", async () => {
+    const firstSql = createPostgresClient(process.env.TEST_DATABASE_URL!);
+    const secondSql = createPostgresClient(process.env.TEST_DATABASE_URL!);
+    const first = new PostgresThreadCapabilityRepository(firstSql);
+    const second = new PostgresThreadCapabilityRepository(secondSql);
+
+    try {
+      await Promise.all([
+        first.patch("guild-1", "channel-1", "thread-1", { observeEvents: true }, "actor-1", "first", now),
+        second.patch("guild-1", "channel-1", "thread-1", { addReactions: true }, "actor-2", "second", now),
+      ]);
+
+      await expect(first.get("guild-1", "channel-1", "thread-1")).resolves.toMatchObject({
+        observeEvents: true,
+        addReactions: true,
+      });
+      const audits = await sql`select id from audit_entries where category = 'thread.capability.changed'`;
+      expect(audits).toHaveLength(2);
+    } finally {
+      await firstSql.end();
+      await secondSql.end();
+    }
+  });
+});

--- a/spec/apps/discord-gateway.spec.ts
+++ b/spec/apps/discord-gateway.spec.ts
@@ -4,6 +4,8 @@ import { createPostgresClient } from "../../src/adapters/postgres/client.js";
 import { runMigrations } from "../../src/adapters/postgres/migrations.js";
 import { runGateway } from "../../src/apps/discord-gateway.js";
 import { createInFlightTracker } from "../../src/apps/app-lifecycle.js";
+import { PostgresChannelCapabilityRepository } from "../../src/adapters/postgres/channel-capability-repository.js";
+import { PostgresThreadCapabilityRepository } from "../../src/adapters/postgres/thread-capability-repository.js";
 
 const threadMessage = (parentChannelId: string) => ({
   id: "message-1",
@@ -87,15 +89,32 @@ describe("runGateway", () => {
   });
 
   it("logs why a message was ignored, keyed on the parent channel of a thread", async () => {
-    const handlers: Record<string, (...args: unknown[]) => void> = {};
     const logger = { error: vi.fn(), debug: vi.fn() };
+
+    await runGatewayOnce(threadMessage("parent-without-capability"), logger);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: "parent-without-capability",
+        threadId: "thread-1",
+        reason: "channel_not_allowed",
+      }),
+      "Discord message ignored",
+    );
+    expect(logger.debug.mock.calls.flat()).not.toContain("mention");
+  });
+
+  async function runGatewayOnce(
+    message: unknown,
+    logger: { error: ReturnType<typeof vi.fn>; debug: ReturnType<typeof vi.fn> },
+  ) {
+    const handlers: Record<string, (...args: unknown[]) => void> = {};
     const inflight = createInFlightTracker();
     const accepting = { value: false };
     let release!: (signal: AbortSignal) => void;
     const shutdown = new Promise<AbortSignal>((resolve) => {
       release = resolve;
     });
-
     const run = runGateway({
       sql,
       client: {
@@ -114,21 +133,86 @@ describe("runGateway", () => {
       accepting,
       inflight,
     });
-
     await vi.waitFor(() => expect(handlers.messageCreate).toBeTypeOf("function"));
-    handlers.messageCreate!(threadMessage("parent-without-capability"));
+    handlers.messageCreate!(message);
     await inflight.drain();
     release(new AbortController().signal);
     await run;
+  }
 
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channelId: "parent-without-capability",
-        threadId: "thread-1",
-        reason: "channel_not_allowed",
-      }),
-      "Discord message ignored",
-    );
-    expect(logger.debug.mock.calls.flat()).not.toContain("mention");
+  const cleanup = () =>
+    sql`truncate audit_entries, effects, model_calls, decision_runs, jobs, events, thread_capability_overrides, channel_capabilities cascade`;
+
+  it("ingests a thread message that a thread override allows in a denied channel", async () => {
+    try {
+      const now = new Date();
+      await new PostgresChannelCapabilityRepository(sql).patch(
+        "guild",
+        "forum-1",
+        { respondToMentions: false },
+        "admin",
+        "closed forum",
+        now,
+      );
+      await new PostgresThreadCapabilityRepository(sql).patch(
+        "guild",
+        "forum-1",
+        "thread-1",
+        { respondToMentions: true },
+        "admin",
+        "watch one thread",
+        now,
+      );
+      const logger = { error: vi.fn(), debug: vi.fn() };
+
+      await runGatewayOnce(threadMessage("forum-1"), logger);
+
+      await expect(sql`select channel_id, thread_id from events where channel_id = 'forum-1'`).resolves.toEqual([
+        { channel_id: "forum-1", thread_id: "thread-1" },
+      ]);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: "forum-1", threadId: "thread-1", jobQueued: true }),
+        "Discord message ingested",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("ignores a thread message that a thread override denies in an allowed channel", async () => {
+    try {
+      const now = new Date();
+      await new PostgresChannelCapabilityRepository(sql).patch(
+        "guild",
+        "channel-1",
+        { observeEvents: true, respondToMentions: true },
+        "admin",
+        "open channel",
+        now,
+      );
+      await new PostgresThreadCapabilityRepository(sql).patch(
+        "guild",
+        "channel-1",
+        "thread-1",
+        { observeEvents: false, respondToMentions: false },
+        "admin",
+        "quiet thread",
+        now,
+      );
+      const logger = { error: vi.fn(), debug: vi.fn() };
+
+      await runGatewayOnce(threadMessage("channel-1"), logger);
+
+      await expect(sql`select id from events where channel_id = 'channel-1'`).resolves.toHaveLength(0);
+      await expect(
+        sql`select jobs.id from jobs join events on events.id = jobs.event_id where events.channel_id = 'channel-1'`,
+      ).resolves.toHaveLength(0);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: "channel-1", threadId: "thread-1", reason: "channel_not_allowed" }),
+        "Discord message ignored",
+      );
+    } finally {
+      await cleanup();
+    }
   });
 });

--- a/spec/e2e/mention-response.spec.ts
+++ b/spec/e2e/mention-response.spec.ts
@@ -130,6 +130,7 @@ describe("explicit mention durable spine", () => {
     const effectQueue = new PostgresEffectQueue(sql);
     const effect = await effectQueue.claim("gateway", now);
     expect(effect).not.toBeNull();
+    expect(effect).toMatchObject({ threadId: null });
     const reply = vi.fn().mockResolvedValue({ id: "discord-message-2" });
     await new DiscordEffectExecutor({ reply }, effectQueue).execute(effect!, clock);
     expect(reply).toHaveBeenCalledWith(

--- a/spec/modules/effects/run-effect-worker.spec.ts
+++ b/spec/modules/effects/run-effect-worker.spec.ts
@@ -1,0 +1,161 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createModels, fauxAssistantMessage, fauxProvider } from "@earendil-works/pi-ai";
+import type { Sql } from "postgres";
+import { PiAgentRuntime } from "../../../src/adapters/pi/pi-agent-runtime.js";
+import { PostgresChannelCapabilityRepository } from "../../../src/adapters/postgres/channel-capability-repository.js";
+import { PostgresCharacterRepository } from "../../../src/adapters/postgres/character-repository.js";
+import { createPostgresClient } from "../../../src/adapters/postgres/client.js";
+import { PostgresDecisionEffectStore } from "../../../src/adapters/postgres/decision-effect-store.js";
+import { PostgresEffectiveCapabilityRepository } from "../../../src/adapters/postgres/effective-capability-repository.js";
+import { PostgresEffectQueue } from "../../../src/adapters/postgres/effect-queue.js";
+import { PostgresIngestionStore } from "../../../src/adapters/postgres/ingestion-store.js";
+import { PostgresJobQueue } from "../../../src/adapters/postgres/job-queue.js";
+import { runMigrations } from "../../../src/adapters/postgres/migrations.js";
+import { PostgresThreadCapabilityRepository } from "../../../src/adapters/postgres/thread-capability-repository.js";
+import { runOneEffect } from "../../../src/modules/effects/run-effect-worker.js";
+import { ingestDiscordMessage } from "../../../src/modules/events/ingest-message.js";
+import { processMention } from "../../../src/modules/mentions/process-mention.js";
+import { FixedClock } from "../../../src/shared/clock.js";
+
+let sql: Sql;
+const now = new Date("2026-07-24T00:00:00.000Z");
+const clock = new FixedClock(now);
+const guildId = "run-effect-worker-guild";
+const channelId = "run-effect-worker-channel";
+const threadId = "run-effect-worker-thread";
+const definition = {
+  schemaVersion: 1 as const,
+  characterId: "primary",
+  version: 1,
+  name: "テストキャラクター",
+  language: "ja" as const,
+  systemPrompt: "あなたはDiscordコミュニティで暮らすキャラクターです。",
+  failureMessages: ["今ちょっとうまく考えられない。"],
+};
+
+beforeAll(async () => {
+  sql = createPostgresClient(process.env.TEST_DATABASE_URL!);
+});
+beforeEach(async () => {
+  await runMigrations(sql, process.env.VICISSITUDE_MIGRATIONS_DIR!, {
+    actor: "test-bootstrap",
+    backupConfirmedAt: new Date(),
+  });
+  await sql`
+    update system_state set mode = 'running', updated_at = ${now}, updated_by = 'spec', reason = 'reset' where singleton
+  `;
+  await sql`
+    truncate audit_entries, effects, model_calls, decision_runs, jobs, events,
+      character_definitions, channel_capabilities, thread_capability_overrides cascade
+  `;
+});
+afterAll(async () => sql.end());
+
+// Establishes whatever capability state `setup` describes, ingests a mention in `threadId` under that
+// state, and runs it through the real decision pipeline so it leaves behind a planned `effects` row
+// with capability_channel_id = channelId and target_channel_id = threadId - mirroring how
+// src/adapters/postgres/decision-effect-store.ts derives target_channel_id from the thread the message
+// was posted in. Capability state can then be changed again by the caller to simulate a revocation
+// that happens after the decision but before the effect is executed.
+async function queuePlannedThreadEffect(
+  setup: (channels: PostgresChannelCapabilityRepository, threads: PostgresThreadCapabilityRepository) => Promise<void>,
+): Promise<{
+  channels: PostgresChannelCapabilityRepository;
+  threads: PostgresThreadCapabilityRepository;
+  effectiveCapabilities: PostgresEffectiveCapabilityRepository;
+  effectQueue: PostgresEffectQueue;
+}> {
+  const channels = new PostgresChannelCapabilityRepository(sql);
+  const threads = new PostgresThreadCapabilityRepository(sql);
+  const effectiveCapabilities = new PostgresEffectiveCapabilityRepository(channels, threads);
+  await setup(channels, threads);
+  const characters = new PostgresCharacterRepository(sql);
+  await characters.importDraft(definition, "admin", now);
+  await characters.activate("primary", 1, "admin", now);
+
+  const capability = await effectiveCapabilities.get(guildId, channelId, threadId);
+  const ingestion = new PostgresIngestionStore(sql);
+  const input = {
+    externalEventId: "run-effect-worker-message",
+    externalVersion: "0",
+    guildId,
+    channelId,
+    threadId,
+    actorId: "user-1",
+    actorKind: "human" as const,
+    occurredAt: now,
+    content: "<@bot> こんにちは",
+    mentionedBot: true,
+    mentionIds: ["bot"],
+    replyToMessageId: null,
+    attachments: [] as Array<{ id: string; name: string; contentType: string | null; url: string; size: number }>,
+  };
+  const result = await ingestDiscordMessage(input, capability, "running", ingestion, clock);
+  if (result.kind !== "accepted" || !result.jobQueued) throw new Error("test setup failed to queue a mention job");
+
+  const jobQueue = new PostgresJobQueue(sql);
+  const job = await jobQueue.claim("worker", now, 60_000);
+  if (!job) throw new Error("test setup failed to claim the mention job");
+  const faux = fauxProvider();
+  const models = createModels();
+  models.setProvider(faux.provider);
+  faux.setResponses([fauxAssistantMessage("スレッドでのお返事です")]);
+  await processMention(
+    job,
+    definition,
+    {
+      version: "route-v1",
+      mentionResponseDeadlineMs: 25_000,
+      mentionResponse: [
+        { provider: faux.provider.id, model: faux.getModel().id, thinkingLevel: "off", timeoutMs: 5_000 },
+      ],
+    },
+    new PiAgentRuntime(models),
+    new PostgresDecisionEffectStore(sql),
+    clock,
+  );
+
+  return { channels, threads, effectiveCapabilities, effectQueue: new PostgresEffectQueue(sql) };
+}
+
+describe("runOneEffect + PostgresEffectiveCapabilityRepository", () => {
+  it("fails an effect once a thread override revokes mention responses after the decision was made", async () => {
+    const { threads, effectiveCapabilities, effectQueue } = await queuePlannedThreadEffect(async (channels) => {
+      await channels.patch(guildId, channelId, { respondToMentions: true }, "admin", "allow channel", now);
+    });
+    // Simulate the parent channel allowing the reply at decision time, then a moderator narrowing the
+    // thread after the effect was already queued but before it was executed.
+    await threads.patch(guildId, channelId, threadId, { respondToMentions: false }, "moderator", "quiet thread", now);
+
+    const executor = { execute: vi.fn().mockResolvedValue(undefined) };
+    await expect(runOneEffect(effectQueue, effectiveCapabilities, executor, "worker", clock)).resolves.toBe(true);
+
+    expect(executor.execute).not.toHaveBeenCalled();
+    const rows = await sql<Array<{ state: string; error: string | null }>>`
+      select state, error from effects where guild_id = ${guildId} and target_channel_id = ${threadId}
+    `;
+    expect(rows).toEqual([{ state: "failed", error: "capability_revoked" }]);
+  });
+
+  it("executes an effect that a thread override allows despite the parent channel denying it", async () => {
+    // Parent channel stays deny-all (channels.patch is never called); only the thread override allows it,
+    // and it must already be in place before ingest so the mention is accepted in the first place.
+    const { effectiveCapabilities, effectQueue } = await queuePlannedThreadEffect(async (_channels, threads) => {
+      await threads.patch(guildId, channelId, threadId, { respondToMentions: true }, "moderator", "allow thread", now);
+    });
+
+    const executor = { execute: vi.fn().mockResolvedValue(undefined) };
+    await expect(runOneEffect(effectQueue, effectiveCapabilities, executor, "worker", clock)).resolves.toBe(true);
+
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+    expect(executor.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId,
+        capabilityChannelId: channelId,
+        targetChannelId: threadId,
+        content: "スレッドでのお返事です",
+      }),
+      clock,
+    );
+  });
+});

--- a/spec/modules/effects/run-effect-worker.spec.ts
+++ b/spec/modules/effects/run-effect-worker.spec.ts
@@ -153,6 +153,7 @@ describe("runOneEffect + PostgresEffectiveCapabilityRepository", () => {
         guildId,
         capabilityChannelId: channelId,
         targetChannelId: threadId,
+        threadId,
         content: "スレッドでのお返事です",
       }),
       clock,

--- a/src/adapters/discord/channel-command.test.ts
+++ b/src/adapters/discord/channel-command.test.ts
@@ -49,7 +49,7 @@ describe("handleChannelCommand", () => {
   });
 
   it("does not read for DM or non-admin", async () => {
-    const repo = { get: vi.fn(), set: vi.fn(), patch: vi.fn() };
+    const repo = { get: vi.fn(), set: vi.fn(), patch: vi.fn(), getThread: vi.fn(), patchThread: vi.fn() };
     await handleChannelCommand(
       interaction({ guildId: null }),
       "g",
@@ -70,7 +70,13 @@ describe("handleChannelCommand", () => {
 
   it("shows current parent capability and preserves omitted values", async () => {
     const current = { ...denyAllCapabilities("g", "parent"), spontaneousJoin: true };
-    const repo = { get: vi.fn().mockResolvedValue(current), set: vi.fn(), patch: vi.fn() };
+    const repo = {
+      get: vi.fn().mockResolvedValue(current),
+      set: vi.fn(),
+      patch: vi.fn(),
+      getThread: vi.fn(),
+      patchThread: vi.fn(),
+    };
     await handleChannelCommand(
       interaction({ subcommand: "show" }),
       "g",
@@ -82,7 +88,13 @@ describe("handleChannelCommand", () => {
   });
 
   it("updates every independent flag and rejects blank or orphan reasons/threads", async () => {
-    const repo = { get: vi.fn(), set: vi.fn(), patch: vi.fn().mockResolvedValue(undefined) };
+    const repo = {
+      get: vi.fn(),
+      set: vi.fn(),
+      patch: vi.fn().mockResolvedValue(undefined),
+      getThread: vi.fn(),
+      patchThread: vi.fn(),
+    };
     await handleChannelCommand(
       interaction({
         channel: { id: "c", isThread: () => false },
@@ -137,7 +149,7 @@ describe("handleChannelCommand", () => {
 
   it("rejects another guild before admin, options, or repository work", async () => {
     const events: string[] = [];
-    const repo = { get: vi.fn(), set: vi.fn(), patch: vi.fn() };
+    const repo = { get: vi.fn(), set: vi.fn(), patch: vi.fn(), getThread: vi.fn(), patchThread: vi.fn() };
     const value = interaction({ guildId: "other", events });
     await handleChannelCommand(value, "g", new Set(["admin"]), repo, new FixedClock(new Date()));
     expect(repo.get).not.toHaveBeenCalled();
@@ -157,6 +169,8 @@ describe("handleChannelCommand", () => {
       ),
       set: vi.fn(),
       patch: vi.fn(),
+      getThread: vi.fn(),
+      patchThread: vi.fn(),
     };
     const value = interaction({ events, subcommand: "show" });
     const pending = handleChannelCommand(value, "g", new Set(["admin"]), repo, new FixedClock(new Date()));
@@ -171,13 +185,168 @@ describe("handleChannelCommand", () => {
     const events: string[] = [];
     const value = interaction({ events });
     const error = new Error("raw database secret");
-    const repo = { get: vi.fn(), patch: vi.fn().mockRejectedValue(error) };
+    const repo = { get: vi.fn(), patch: vi.fn().mockRejectedValue(error), getThread: vi.fn(), patchThread: vi.fn() };
     await expect(handleChannelCommand(value, "g", new Set(["admin"]), repo, new FixedClock(new Date()))).rejects.toBe(
       error,
     );
     expect(events).toEqual(["defer", "edit"]);
     expect((value as { editReply: ReturnType<typeof vi.fn> }).editReply.mock.calls[0]?.[0].content).not.toContain(
       "raw database secret",
+    );
+  });
+});
+
+function interactionFor(subcommand: string, options: Record<string, string | boolean | null>, channel: unknown) {
+  return {
+    guildId: "guild-1",
+    user: { id: "admin-1" },
+    options: {
+      getSubcommand: () => subcommand,
+      getChannel: () => channel,
+      getString: (name: string, required?: boolean) => {
+        const value = options[name];
+        if (typeof value === "string") return value;
+        if (required) throw new Error(`missing ${name}`);
+        return null;
+      },
+      getBoolean: (name: string) => {
+        const value = options[name];
+        return typeof value === "boolean" ? value : null;
+      },
+    },
+    reply: vi.fn().mockResolvedValue(undefined),
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  } as never;
+}
+
+const thread = { id: "thread-1", parentId: "channel-1", isThread: () => true };
+const clock = { now: () => new Date("2026-01-02T03:04:05.000Z") };
+
+describe("handleChannelCommand thread subcommands", () => {
+  it("translates allow, deny and inherit into an override patch", async () => {
+    const repository = {
+      get: vi.fn(),
+      patch: vi.fn().mockResolvedValue(undefined),
+      getThread: vi.fn().mockResolvedValue(null),
+      patchThread: vi.fn().mockResolvedValue(undefined),
+    };
+    const interaction = interactionFor(
+      "thread-set",
+      { observe: "allow", mentions: "deny", reactions: "inherit", reason: "tune thread" },
+      thread,
+    );
+
+    await handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock);
+
+    expect(repository.patchThread).toHaveBeenCalledWith(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      { observeEvents: true, respondToMentions: false, addReactions: null },
+      "admin-1",
+      "tune thread",
+      clock.now(),
+    );
+  });
+
+  it("omits capabilities that were not supplied", async () => {
+    const repository = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      getThread: vi.fn().mockResolvedValue(null),
+      patchThread: vi.fn().mockResolvedValue(undefined),
+    };
+    const interaction = interactionFor("thread-set", { observe: "deny", reason: "quiet" }, thread);
+
+    await handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock);
+
+    expect(repository.patchThread).toHaveBeenCalledWith(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      { observeEvents: false },
+      "admin-1",
+      "quiet",
+      clock.now(),
+    );
+  });
+
+  it("passes an empty patch through when reason is supplied but no capability is set", async () => {
+    const repository = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      getThread: vi.fn().mockResolvedValue(null),
+      patchThread: vi.fn().mockResolvedValue(undefined),
+    };
+    const interaction = interactionFor("thread-set", { reason: "no-op audit" }, thread);
+
+    await handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock);
+
+    expect(repository.patchThread).toHaveBeenCalledWith(
+      "guild-1",
+      "channel-1",
+      "thread-1",
+      {},
+      "admin-1",
+      "no-op audit",
+      clock.now(),
+    );
+  });
+
+  it("rejects a thread subcommand on a non-thread channel", async () => {
+    const repository = { get: vi.fn(), patch: vi.fn(), getThread: vi.fn(), patchThread: vi.fn() };
+    const channel = { id: "channel-1", parentId: null, isThread: () => false };
+    const interaction = interactionFor("thread-set", { observe: "allow", reason: "nope" }, channel);
+
+    await expect(handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock)).rejects.toThrow(
+      "Thread subcommands require a thread channel",
+    );
+    expect(repository.patchThread).not.toHaveBeenCalled();
+  });
+
+  it("rejects a thread subcommand on an orphaned thread with a distinct message", async () => {
+    const repository = { get: vi.fn(), patch: vi.fn(), getThread: vi.fn(), patchThread: vi.fn() };
+    const orphan = { id: "thread-1", parentId: null, isThread: () => true };
+    const interaction = interactionFor("thread-set", { observe: "allow", reason: "nope" }, orphan);
+
+    await expect(handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock)).rejects.toThrow(
+      "Thread has no parent channel",
+    );
+    expect(repository.patchThread).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported override value", async () => {
+    const repository = { get: vi.fn(), patch: vi.fn(), getThread: vi.fn(), patchThread: vi.fn() };
+    const interaction = interactionFor("thread-set", { observe: "maybe", reason: "typo" }, thread);
+
+    await expect(handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock)).rejects.toThrow(
+      "Unsupported override value: maybe",
+    );
+    expect(repository.patchThread).not.toHaveBeenCalled();
+  });
+
+  it("shows the current override for a thread", async () => {
+    const repository = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      getThread: vi.fn().mockResolvedValue({
+        guildId: "guild-1",
+        channelId: "channel-1",
+        threadId: "thread-1",
+        observeEvents: true,
+        respondToMentions: null,
+        addReactions: null,
+      }),
+      patchThread: vi.fn(),
+    };
+    const interaction = interactionFor("thread-show", {}, thread);
+
+    await handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock);
+
+    expect(repository.getThread).toHaveBeenCalledWith("guild-1", "channel-1", "thread-1");
+    expect((interaction as { editReply: ReturnType<typeof vi.fn> }).editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining("observeEvents") }),
     );
   });
 });

--- a/src/adapters/discord/channel-command.test.ts
+++ b/src/adapters/discord/channel-command.test.ts
@@ -350,3 +350,75 @@ describe("handleChannelCommand thread subcommands", () => {
     );
   });
 });
+
+describe("handleChannelCommand show on a thread channel", () => {
+  function jsonContent(interactionValue: unknown): unknown {
+    const content = (interactionValue as { editReply: ReturnType<typeof vi.fn> }).editReply.mock.calls[0]?.[0].content;
+    return JSON.parse(content.replace(/^```json\n|\n```$/g, ""));
+  }
+
+  it("reports the parent channel, the thread override, and the resolved effective capabilities", async () => {
+    const parentCapabilities = { ...denyAllCapabilities("guild-1", "channel-1"), spontaneousJoin: true };
+    const override = {
+      guildId: "guild-1",
+      channelId: "channel-1",
+      threadId: "thread-1",
+      observeEvents: true,
+      respondToMentions: null,
+      addReactions: null,
+    };
+    const repository = {
+      get: vi.fn().mockResolvedValue(parentCapabilities),
+      patch: vi.fn(),
+      getThread: vi.fn().mockResolvedValue(override),
+      patchThread: vi.fn(),
+    };
+    const interaction = interactionFor("show", {}, thread);
+
+    await handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock);
+
+    expect(repository.get).toHaveBeenCalledWith("guild-1", "channel-1");
+    expect(repository.getThread).toHaveBeenCalledWith("guild-1", "channel-1", "thread-1");
+    expect(jsonContent(interaction)).toEqual({
+      channel: parentCapabilities,
+      threadOverride: override,
+      effective: { ...parentCapabilities, observeEvents: true },
+    });
+  });
+
+  it("reports a null thread override when no override exists", async () => {
+    const parentCapabilities = denyAllCapabilities("guild-1", "channel-1");
+    const repository = {
+      get: vi.fn().mockResolvedValue(parentCapabilities),
+      patch: vi.fn(),
+      getThread: vi.fn().mockResolvedValue(null),
+      patchThread: vi.fn(),
+    };
+    const interaction = interactionFor("show", {}, thread);
+
+    await handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock);
+
+    expect(jsonContent(interaction)).toEqual({
+      channel: parentCapabilities,
+      threadOverride: null,
+      effective: parentCapabilities,
+    });
+  });
+
+  it("keeps the plain channel-capabilities JSON shape for a non-thread channel", async () => {
+    const capabilities = denyAllCapabilities("guild-1", "channel-1");
+    const nonThreadChannel = { id: "channel-1", parentId: null, isThread: () => false };
+    const repository = {
+      get: vi.fn().mockResolvedValue(capabilities),
+      patch: vi.fn(),
+      getThread: vi.fn(),
+      patchThread: vi.fn(),
+    };
+    const interaction = interactionFor("show", {}, nonThreadChannel);
+
+    await handleChannelCommand(interaction, "guild-1", new Set(["admin-1"]), repository, clock);
+
+    expect(repository.getThread).not.toHaveBeenCalled();
+    expect(jsonContent(interaction)).toEqual(capabilities);
+  });
+});

--- a/src/adapters/discord/channel-command.ts
+++ b/src/adapters/discord/channel-command.ts
@@ -5,22 +5,35 @@ import {
   type SlashCommandChannelOption,
 } from "discord.js";
 import type { ChannelCapabilities } from "../../modules/channels/channel-capability.js";
+import { inheritAllOverride, type ThreadCapabilityOverride } from "../../modules/channels/thread-capability.js";
+import type { ThreadCapabilityPatch } from "../postgres/thread-capability-repository.js";
 import type { Clock } from "../../shared/clock.js";
 
-const channelTypes = [
-  ChannelType.GuildText,
-  ChannelType.GuildAnnouncement,
-  ChannelType.GuildForum,
+const nonThreadChannelTypes = [ChannelType.GuildText, ChannelType.GuildAnnouncement, ChannelType.GuildForum] as const;
+const threadTypes = [
   ChannelType.GuildPublicThread,
   ChannelType.GuildPrivateThread,
   ChannelType.GuildNewsThread,
 ] as const;
+const channelTypes = [...nonThreadChannelTypes, ...threadTypes] as const;
 const channelOption = (option: SlashCommandChannelOption) =>
   option
     .setName("channel")
     .setDescription("対象チャンネル")
     .addChannelTypes(...channelTypes)
     .setRequired(true);
+
+const threadOption = (option: SlashCommandChannelOption) =>
+  option
+    .setName("channel")
+    .setDescription("対象スレッド")
+    .addChannelTypes(...threadTypes)
+    .setRequired(true);
+const overrideChoices = [
+  { name: "allow", value: "allow" },
+  { name: "deny", value: "deny" },
+  { name: "inherit", value: "inherit" },
+] as const;
 
 export const channelCommand = new SlashCommandBuilder()
   .setName("vicissitude-channel")
@@ -43,6 +56,36 @@ export const channelCommand = new SlashCommandBuilder()
       .addBooleanOption((o) => o.setName("threads").setDescription("threadを作成する"))
       .addBooleanOption((o) => o.setName("files").setDescription("fileを共有する"))
       .addBooleanOption((o) => o.setName("links").setDescription("外部linkを共有する")),
+  )
+  .addSubcommand((sub) =>
+    sub.setName("thread-show").setDescription("スレッドの権限overrideを表示します").addChannelOption(threadOption),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName("thread-set")
+      .setDescription("スレッド単位の権限overrideを設定します")
+      .addChannelOption(threadOption)
+      .addStringOption((o) =>
+        o.setName("reason").setDescription("変更理由").setMinLength(1).setMaxLength(500).setRequired(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName("observe")
+          .setDescription("イベントを観察する")
+          .addChoices(...overrideChoices),
+      )
+      .addStringOption((o) =>
+        o
+          .setName("mentions")
+          .setDescription("mentionへ応答する")
+          .addChoices(...overrideChoices),
+      )
+      .addStringOption((o) =>
+        o
+          .setName("reactions")
+          .setDescription("reactionを追加する")
+          .addChoices(...overrideChoices),
+      ),
   );
 
 interface Repository {
@@ -51,6 +94,16 @@ interface Repository {
     guildId: string,
     channelId: string,
     patch: ChannelCapabilitiesPatch,
+    actor: string,
+    reason: string,
+    now: Date,
+  ): Promise<void>;
+  getThread(guildId: string, channelId: string, threadId: string): Promise<ThreadCapabilityOverride | null>;
+  patchThread(
+    guildId: string,
+    channelId: string,
+    threadId: string,
+    patch: ThreadCapabilityPatch,
     actor: string,
     reason: string,
     now: Date,
@@ -70,6 +123,54 @@ export type ChannelCapabilitiesPatch = Partial<
     | "shareExternalLinks"
   >
 >;
+
+function overrideValue(raw: string | null): boolean | null | undefined {
+  if (raw === null) return undefined;
+  if (raw === "allow") return true;
+  if (raw === "deny") return false;
+  if (raw === "inherit") return null;
+  throw new Error(`Unsupported override value: ${raw}`);
+}
+
+async function handleThreadSubcommand(
+  interaction: ChatInputCommandInteraction<"cached">,
+  channel: NonNullable<ReturnType<ChatInputCommandInteraction<"cached">["options"]["getChannel"]>>,
+  subcommand: "thread-show" | "thread-set",
+  repository: Repository,
+  clock: Clock,
+): Promise<void> {
+  if (!channel.isThread()) throw new Error("Thread subcommands require a thread channel");
+  if (!channel.parentId) throw new Error("Thread has no parent channel");
+  const parentId = channel.parentId;
+  if (subcommand === "thread-show") {
+    const override = await repository.getThread(interaction.guildId, parentId, channel.id);
+    const shown = override ?? inheritAllOverride(interaction.guildId, parentId, channel.id);
+    await interaction.editReply({ content: `\`\`\`json\n${JSON.stringify(shown, null, 2)}\n\`\`\`` });
+    return;
+  }
+  const threadPatch: ThreadCapabilityPatch = {};
+  const threadOptions: Array<[string, keyof ThreadCapabilityPatch]> = [
+    ["observe", "observeEvents"],
+    ["mentions", "respondToMentions"],
+    ["reactions", "addReactions"],
+  ];
+  for (const [option, property] of threadOptions) {
+    const value = overrideValue(interaction.options.getString(option));
+    if (value !== undefined) threadPatch[property] = value;
+  }
+  const threadReason = interaction.options.getString("reason", true).trim();
+  if (!threadReason) throw new Error("Reason is required");
+  await repository.patchThread(
+    interaction.guildId,
+    parentId,
+    channel.id,
+    threadPatch,
+    interaction.user.id,
+    threadReason,
+    clock.now(),
+  );
+  await interaction.editReply({ content: "スレッド権限を更新しました。" });
+}
 
 export async function handleChannelCommand(
   interaction: ChatInputCommandInteraction<"cached">,
@@ -93,9 +194,13 @@ export async function handleChannelCommand(
   await interaction.deferReply({ ephemeral: true });
   try {
     const channel = interaction.options.getChannel("channel", true);
+    const subcommand = interaction.options.getSubcommand();
+    if (subcommand === "thread-show" || subcommand === "thread-set") {
+      await handleThreadSubcommand(interaction, channel, subcommand, repository, clock);
+      return;
+    }
     const capabilityChannelId = channel.isThread() ? channel.parentId : channel.id;
     if (!capabilityChannelId) throw new Error("Thread has no parent channel");
-    const subcommand = interaction.options.getSubcommand();
     if (subcommand === "set") {
       const patch: ChannelCapabilitiesPatch = {};
       const options: Array<[string, keyof ChannelCapabilitiesPatch]> = [

--- a/src/adapters/discord/channel-command.ts
+++ b/src/adapters/discord/channel-command.ts
@@ -5,7 +5,11 @@ import {
   type SlashCommandChannelOption,
 } from "discord.js";
 import type { ChannelCapabilities } from "../../modules/channels/channel-capability.js";
-import { inheritAllOverride, type ThreadCapabilityOverride } from "../../modules/channels/thread-capability.js";
+import {
+  inheritAllOverride,
+  resolveEffectiveCapabilities,
+  type ThreadCapabilityOverride,
+} from "../../modules/channels/thread-capability.js";
 import type { ThreadCapabilityPatch } from "../postgres/thread-capability-repository.js";
 import type { Clock } from "../../shared/clock.js";
 
@@ -225,6 +229,13 @@ export async function handleChannelCommand(
     }
     const current = await repository.get(interaction.guildId, capabilityChannelId);
     if (subcommand === "show") {
+      if (channel.isThread()) {
+        const override = await repository.getThread(interaction.guildId, capabilityChannelId, channel.id);
+        const effective = resolveEffectiveCapabilities(current, override);
+        const shown = { channel: current, threadOverride: override, effective };
+        await interaction.editReply({ content: `\`\`\`json\n${JSON.stringify(shown, null, 2)}\n\`\`\`` });
+        return;
+      }
       await interaction.editReply({ content: `\`\`\`json\n${JSON.stringify(current, null, 2)}\n\`\`\`` });
       return;
     }

--- a/src/adapters/discord/discord-client.test.ts
+++ b/src/adapters/discord/discord-client.test.ts
@@ -92,6 +92,7 @@ describe("DiscordClientMessenger", () => {
         guildId: "g",
         capabilityChannelId: "c",
         targetChannelId: "c",
+        threadId: null,
         targetMessageId: "m",
         content: "x",
         attempts: 1,

--- a/src/adapters/postgres/capability-metadata.ts
+++ b/src/adapters/postgres/capability-metadata.ts
@@ -1,0 +1,4 @@
+export function validateMetadata(actor: string, reason: string, now: Date): void {
+  if (!actor.trim() || !reason.trim()) throw new Error("actor and reason must be nonblank");
+  if (!(now instanceof Date) || Number.isNaN(now.getTime())) throw new Error("now must be a valid Date");
+}

--- a/src/adapters/postgres/channel-capability-repository.ts
+++ b/src/adapters/postgres/channel-capability-repository.ts
@@ -1,6 +1,7 @@
 import type { Sql, TransactionSql } from "postgres";
 import { newId } from "../../shared/ids.js";
 import { denyAllCapabilities, type ChannelCapabilities } from "../../modules/channels/channel-capability.js";
+import { validateMetadata } from "./capability-metadata.js";
 
 type CapabilityRow = ChannelCapabilities & { updatedAt: Date; updatedBy: string; reason: string };
 
@@ -73,11 +74,6 @@ export class PostgresChannelCapabilityRepository {
       return next;
     });
   }
-}
-
-function validateMetadata(actor: string, reason: string, now: Date): void {
-  if (!actor.trim() || !reason.trim()) throw new Error("actor and reason must be nonblank");
-  if (!(now instanceof Date) || Number.isNaN(now.getTime())) throw new Error("now must be a valid Date");
 }
 
 async function persist(

--- a/src/adapters/postgres/decision-effect-store.ts
+++ b/src/adapters/postgres/decision-effect-store.ts
@@ -154,7 +154,7 @@ export class PostgresDecisionEffectStore implements DecisionEffectStore {
         throw new Error("Invalid mention event");
       const effects = await tx<
         Array<{ id: string }>
-      >`insert into effects (id, run_id, effect_slot, kind, state, guild_id, capability_channel_id, target_channel_id, target_message_id, payload, capability_decision, created_at, updated_at) values (${newId()}, ${input.runId}, 'primary_reply', 'discord.reply', 'planned', ${event.guild_id}, ${event.channel_id}, ${event.thread_id ?? event.channel_id}, ${event.external_event_id}, ${tx.json(payload)}, ${tx.json({ action: "respond_to_mention", allowed: true })}, ${input.now}, ${input.now}) returning id`;
+      >`insert into effects (id, run_id, effect_slot, kind, state, guild_id, capability_channel_id, target_channel_id, thread_id, target_message_id, payload, capability_decision, created_at, updated_at) values (${newId()}, ${input.runId}, 'primary_reply', 'discord.reply', 'planned', ${event.guild_id}, ${event.channel_id}, ${event.thread_id ?? event.channel_id}, ${event.thread_id}, ${event.external_event_id}, ${tx.json(payload)}, ${tx.json({ action: "respond_to_mention", allowed: true })}, ${input.now}, ${input.now}) returning id`;
       await tx`insert into audit_entries (id, category, event_id, job_id, run_id, effect_id, summary, created_at) values (${newId()}, 'decision.completed', ${input.eventId}, ${input.jobId}, ${input.runId}, ${effects[0]!.id}, ${tx.json({ action: "reply", fallback: input.fallback })}, ${input.now})`;
     });
   }

--- a/src/adapters/postgres/effect-queue.ts
+++ b/src/adapters/postgres/effect-queue.ts
@@ -27,6 +27,7 @@ export interface EffectInspection {
   guildId: string;
   capabilityChannelId: string;
   targetChannelId: string;
+  threadId: string | null;
   targetMessageId: string;
   content: string;
   allowedMentions: { parse: []; repliedUser: false };
@@ -50,7 +51,7 @@ export class PostgresEffectQueue {
       if (mode[0].mode === "stopped") return null;
       const rows = await tx<
         (ClaimedReplyEffect & { payload: unknown })[]
-      >`with candidate as (select id from effects where state='planned' order by created_at for update skip locked limit 1) update effects e set state='executing', executor_id=${workerId}, attempts=e.attempts+1, updated_at=${now} from candidate c where e.id=c.id returning e.id, e.run_id as "runId", e.guild_id as "guildId", e.capability_channel_id as "capabilityChannelId", e.target_channel_id as "targetChannelId", e.target_message_id as "targetMessageId", e.attempts, e.payload`;
+      >`with candidate as (select id from effects where state='planned' order by created_at for update skip locked limit 1) update effects e set state='executing', executor_id=${workerId}, attempts=e.attempts+1, updated_at=${now} from candidate c where e.id=c.id returning e.id, e.run_id as "runId", e.guild_id as "guildId", e.capability_channel_id as "capabilityChannelId", e.target_channel_id as "targetChannelId", e.thread_id as "threadId", e.target_message_id as "targetMessageId", e.attempts, e.payload`;
       const row = rows[0];
       if (!row) return null;
       try {
@@ -123,6 +124,7 @@ export class PostgresEffectQueue {
         guildId: string;
         capabilityChannelId: string;
         targetChannelId: string;
+        threadId: string | null;
         targetMessageId: string;
         externalResourceId: string | null;
         executorId: string | null;
@@ -133,7 +135,7 @@ export class PostgresEffectQueue {
         payload: unknown;
         capabilityDecision: unknown;
       }[]
-    >`select id,run_id as "runId",effect_slot as "effectSlot",kind,state,guild_id as "guildId",capability_channel_id as "capabilityChannelId",target_channel_id as "targetChannelId",target_message_id as "targetMessageId",external_resource_id as "externalResourceId",executor_id as "executorId",attempts,error,created_at as "createdAt",updated_at as "updatedAt",payload,capability_decision as "capabilityDecision" from effects where id=${id}`;
+    >`select id,run_id as "runId",effect_slot as "effectSlot",kind,state,guild_id as "guildId",capability_channel_id as "capabilityChannelId",target_channel_id as "targetChannelId",thread_id as "threadId",target_message_id as "targetMessageId",external_resource_id as "externalResourceId",executor_id as "executorId",attempts,error,created_at as "createdAt",updated_at as "updatedAt",payload,capability_decision as "capabilityDecision" from effects where id=${id}`;
     if (!rows[0]) throw new Error("Effect not found");
     const row = rows[0];
     if (row.kind !== "discord.reply") throw new Error(`Unsupported effect kind: ${row.kind}`);

--- a/src/adapters/postgres/effective-capability-repository.ts
+++ b/src/adapters/postgres/effective-capability-repository.ts
@@ -1,9 +1,9 @@
-import type { ChannelCapabilities } from "../../modules/channels/channel-capability.js";
+import type { ChannelCapabilities, EffectiveCapabilityRepository } from "../../modules/channels/channel-capability.js";
 import { resolveEffectiveCapabilities } from "../../modules/channels/thread-capability.js";
 import type { PostgresChannelCapabilityRepository } from "./channel-capability-repository.js";
 import type { PostgresThreadCapabilityRepository } from "./thread-capability-repository.js";
 
-export class PostgresEffectiveCapabilityRepository {
+export class PostgresEffectiveCapabilityRepository implements EffectiveCapabilityRepository {
   public constructor(
     private readonly channels: PostgresChannelCapabilityRepository,
     private readonly threads: PostgresThreadCapabilityRepository,

--- a/src/adapters/postgres/effective-capability-repository.ts
+++ b/src/adapters/postgres/effective-capability-repository.ts
@@ -1,0 +1,18 @@
+import type { ChannelCapabilities } from "../../modules/channels/channel-capability.js";
+import { resolveEffectiveCapabilities } from "../../modules/channels/thread-capability.js";
+import type { PostgresChannelCapabilityRepository } from "./channel-capability-repository.js";
+import type { PostgresThreadCapabilityRepository } from "./thread-capability-repository.js";
+
+export class PostgresEffectiveCapabilityRepository {
+  public constructor(
+    private readonly channels: PostgresChannelCapabilityRepository,
+    private readonly threads: PostgresThreadCapabilityRepository,
+  ) {}
+
+  public async get(guildId: string, channelId: string, threadId: string | null): Promise<ChannelCapabilities> {
+    const channel = await this.channels.get(guildId, channelId);
+    if (threadId === null) return channel;
+    const override = await this.threads.get(guildId, channelId, threadId);
+    return resolveEffectiveCapabilities(channel, override);
+  }
+}

--- a/src/adapters/postgres/thread-capability-repository.ts
+++ b/src/adapters/postgres/thread-capability-repository.ts
@@ -1,0 +1,113 @@
+import type { Sql } from "postgres";
+import { newId } from "../../shared/ids.js";
+import {
+  inheritAllOverride,
+  isInheritOnly,
+  THREAD_OVERRIDABLE_CAPABILITIES,
+  type ThreadCapabilityOverride,
+} from "../../modules/channels/thread-capability.js";
+
+export type ThreadCapabilityPatch = Partial<
+  Pick<ThreadCapabilityOverride, "observeEvents" | "respondToMentions" | "addReactions">
+>;
+
+const LOCK_NAMESPACE = 84623818;
+
+function mapRow(row: Record<string, unknown>): ThreadCapabilityOverride {
+  return {
+    guildId: row.guild_id as string,
+    channelId: row.channel_id as string,
+    threadId: row.thread_id as string,
+    observeEvents: row.observe_events as boolean | null,
+    respondToMentions: row.respond_to_mentions as boolean | null,
+    addReactions: row.add_reactions as boolean | null,
+  };
+}
+
+function auditValue(override: ThreadCapabilityOverride | null): Record<string, boolean | null> | null {
+  if (!override) return null;
+  return Object.fromEntries(THREAD_OVERRIDABLE_CAPABILITIES.map((key) => [key, override[key]]));
+}
+
+function validateMetadata(actor: string, reason: string, now: Date): void {
+  if (!actor.trim() || !reason.trim()) throw new Error("actor and reason must be nonblank");
+  if (!(now instanceof Date) || Number.isNaN(now.getTime())) throw new Error("now must be a valid Date");
+}
+
+export class PostgresThreadCapabilityRepository {
+  public constructor(private readonly sql: Sql) {}
+
+  public async get(guildId: string, channelId: string, threadId: string): Promise<ThreadCapabilityOverride | null> {
+    const rows = await this.sql`
+      select * from thread_capability_overrides
+      where guild_id = ${guildId} and channel_id = ${channelId} and thread_id = ${threadId}
+    `;
+    return rows[0] ? mapRow(rows[0]) : null;
+  }
+
+  public async patch(
+    guildId: string,
+    channelId: string,
+    threadId: string,
+    patch: ThreadCapabilityPatch,
+    actor: string,
+    reason: string,
+    now: Date,
+  ): Promise<ThreadCapabilityOverride | null> {
+    validateMetadata(actor, reason, now);
+    const trimmedActor = actor.trim();
+    const trimmedReason = reason.trim();
+    return this.sql.begin(async (transaction) => {
+      await transaction`
+        select pg_advisory_xact_lock(hashtextextended(${`${guildId}:${channelId}:${threadId}`}, ${LOCK_NAMESPACE}))
+      `;
+      const rows = await transaction`
+        select * from thread_capability_overrides
+        where guild_id = ${guildId} and channel_id = ${channelId} and thread_id = ${threadId}
+        for update
+      `;
+      const before = rows[0] ? mapRow(rows[0]) : null;
+      const next: ThreadCapabilityOverride = {
+        ...(before ?? inheritAllOverride(guildId, channelId, threadId)),
+        ...patch,
+      };
+      const after = isInheritOnly(next) ? null : next;
+      if (after) {
+        await transaction`
+          insert into thread_capability_overrides (
+            guild_id, channel_id, thread_id, observe_events, respond_to_mentions, add_reactions,
+            updated_at, updated_by, reason
+          ) values (
+            ${guildId}, ${channelId}, ${threadId}, ${after.observeEvents}, ${after.respondToMentions},
+            ${after.addReactions}, ${now}, ${trimmedActor}, ${trimmedReason}
+          ) on conflict (guild_id, channel_id, thread_id) do update set
+            observe_events = excluded.observe_events, respond_to_mentions = excluded.respond_to_mentions,
+            add_reactions = excluded.add_reactions, updated_at = excluded.updated_at,
+            updated_by = excluded.updated_by, reason = excluded.reason
+        `;
+      } else {
+        await transaction`
+          delete from thread_capability_overrides
+          where guild_id = ${guildId} and channel_id = ${channelId} and thread_id = ${threadId}
+        `;
+      }
+      await transaction`
+        insert into audit_entries (id, category, summary, created_at)
+        values (
+          ${newId()}, 'thread.capability.changed',
+          ${transaction.json({
+            actor: trimmedActor,
+            reason: trimmedReason,
+            guildId,
+            channelId,
+            threadId,
+            before: auditValue(before),
+            after: auditValue(after),
+          })},
+          ${now}
+        )
+      `;
+      return after;
+    });
+  }
+}

--- a/src/adapters/postgres/thread-capability-repository.ts
+++ b/src/adapters/postgres/thread-capability-repository.ts
@@ -6,11 +6,13 @@ import {
   THREAD_OVERRIDABLE_CAPABILITIES,
   type ThreadCapabilityOverride,
 } from "../../modules/channels/thread-capability.js";
+import { validateMetadata } from "./capability-metadata.js";
 
 export type ThreadCapabilityPatch = Partial<
   Pick<ThreadCapabilityOverride, "observeEvents" | "respondToMentions" | "addReactions">
 >;
 
+// Channel scopes lock on 84623817; thread scopes need a namespace of their own.
 const LOCK_NAMESPACE = 84623818;
 
 function mapRow(row: Record<string, unknown>): ThreadCapabilityOverride {
@@ -27,11 +29,6 @@ function mapRow(row: Record<string, unknown>): ThreadCapabilityOverride {
 function auditValue(override: ThreadCapabilityOverride | null): Record<string, boolean | null> | null {
   if (!override) return null;
   return Object.fromEntries(THREAD_OVERRIDABLE_CAPABILITIES.map((key) => [key, override[key]]));
-}
-
-function validateMetadata(actor: string, reason: string, now: Date): void {
-  if (!actor.trim() || !reason.trim()) throw new Error("actor and reason must be nonblank");
-  if (!(now instanceof Date) || Number.isNaN(now.getTime())) throw new Error("now must be a valid Date");
 }
 
 export class PostgresThreadCapabilityRepository {

--- a/src/apps/admin-cli.test.ts
+++ b/src/apps/admin-cli.test.ts
@@ -124,6 +124,119 @@ describe("admin dispatch", () => {
     });
     expect(output.write).toHaveBeenLastCalledWith(value);
   });
+  it("patches thread capability overrides and writes only the provided fields", async () => {
+    const patched = {
+      guildId: "g",
+      channelId: "c",
+      threadId: "t",
+      observeEvents: true,
+      respondToMentions: null,
+      addReactions: null,
+    };
+    const patch = vi.fn(async () => patched);
+    const get = vi.fn(async () => null);
+    const output = out();
+    await dispatchAdminCommand(
+      {
+        kind: "thread.set",
+        guildId: "g",
+        channelId: "c",
+        threadId: "t",
+        observeEvents: true,
+        actor: "a",
+        reason: "r",
+      },
+      sql,
+      config,
+      { thread: () => ({ get, patch }), now: () => at, output },
+    );
+    expect(patch).toHaveBeenCalledWith("g", "c", "t", { observeEvents: true }, "a", "r", at);
+    expect(get).not.toHaveBeenCalled();
+    expect(output.write).toHaveBeenCalledWith(patched);
+  });
+
+  it("writes the all-inherit shape when a thread patch deletes the override row", async () => {
+    const patch = vi.fn(async () => null);
+    const output = out();
+    await dispatchAdminCommand(
+      {
+        kind: "thread.set",
+        guildId: "g",
+        channelId: "c",
+        threadId: "t",
+        observeEvents: null,
+        actor: "a",
+        reason: "r",
+      },
+      sql,
+      config,
+      { thread: () => ({ get: vi.fn(), patch }), now: () => at, output },
+    );
+    expect(patch).toHaveBeenCalledWith("g", "c", "t", { observeEvents: null }, "a", "r", at);
+    expect(output.write).toHaveBeenCalledWith({
+      guildId: "g",
+      channelId: "c",
+      threadId: "t",
+      observeEvents: null,
+      respondToMentions: null,
+      addReactions: null,
+    });
+  });
+
+  it("sends an empty patch when thread set has no capability options", async () => {
+    const patch = vi.fn(async () => ({
+      guildId: "g",
+      channelId: "c",
+      threadId: "t",
+      observeEvents: null,
+      respondToMentions: null,
+      addReactions: null,
+    }));
+    await dispatchAdminCommand(
+      { kind: "thread.set", guildId: "g", channelId: "c", threadId: "t", actor: "a", reason: "r" },
+      sql,
+      config,
+      { thread: () => ({ get: vi.fn(), patch }), now: () => at, output: out() },
+    );
+    expect(patch).toHaveBeenCalledWith("g", "c", "t", {}, "a", "r", at);
+  });
+
+  it("shows the stored thread override when one exists", async () => {
+    const override = {
+      guildId: "g",
+      channelId: "c",
+      threadId: "t",
+      observeEvents: true,
+      respondToMentions: null,
+      addReactions: false,
+    };
+    const get = vi.fn(async () => override);
+    const output = out();
+    await dispatchAdminCommand({ kind: "thread.show", guildId: "g", channelId: "c", threadId: "t" }, sql, config, {
+      thread: () => ({ get, patch: vi.fn() }),
+      output,
+    });
+    expect(get).toHaveBeenCalledWith("g", "c", "t");
+    expect(output.write).toHaveBeenCalledWith(override);
+  });
+
+  it("shows the all-inherit shape for thread show when no override row exists", async () => {
+    const get = vi.fn(async () => null);
+    const output = out();
+    await dispatchAdminCommand({ kind: "thread.show", guildId: "g", channelId: "c", threadId: "t" }, sql, config, {
+      thread: () => ({ get, patch: vi.fn() }),
+      output,
+    });
+    expect(output.write).toHaveBeenCalledWith({
+      guildId: "g",
+      channelId: "c",
+      threadId: "t",
+      observeEvents: null,
+      respondToMentions: null,
+      addReactions: null,
+    });
+  });
+
   it("imports and activates character", async () => {
     const value = {
       schemaVersion: 1,

--- a/src/apps/admin-cli.ts
+++ b/src/apps/admin-cli.ts
@@ -7,8 +7,13 @@ import { PostgresChannelCapabilityRepository } from "../adapters/postgres/channe
 import { PostgresCharacterRepository } from "../adapters/postgres/character-repository.js";
 import { PostgresEffectQueue } from "../adapters/postgres/effect-queue.js";
 import { PostgresSystemControlRepository } from "../adapters/postgres/system-control-repository.js";
+import {
+  PostgresThreadCapabilityRepository,
+  type ThreadCapabilityPatch,
+} from "../adapters/postgres/thread-capability-repository.js";
 import { CharacterDefinitionSchema } from "../modules/characters/character-definition.js";
 import type { ChannelCapabilities } from "../modules/channels/channel-capability.js";
+import { inheritAllOverride } from "../modules/channels/thread-capability.js";
 import { loadAdminConfig } from "../config/runtime-config.js";
 import { parseAdminCommand, type AdminCommand } from "../modules/admin/admin-command.js";
 export interface AdminOutput {
@@ -25,6 +30,7 @@ type AdminChannelRepository = Pick<PostgresChannelCapabilityRepository, "get"> &
     now: Date,
   ): Promise<ChannelCapabilities>;
 };
+type AdminThreadRepository = Pick<PostgresThreadCapabilityRepository, "get" | "patch">;
 export interface AdminDependencies {
   createClient?: (url: string) => Sql;
   now?: () => Date;
@@ -34,6 +40,7 @@ export interface AdminDependencies {
   runMigrations?: typeof runMigrations;
   system?: (sql: Sql) => Pick<PostgresSystemControlRepository, "setMode">;
   channel?: (sql: Sql) => AdminChannelRepository;
+  thread?: (sql: Sql) => AdminThreadRepository;
   character?: (sql: Sql) => Pick<PostgresCharacterRepository, "importDraft" | "activate">;
   effect?: (sql: Sql) => Pick<PostgresEffectQueue, "inspect" | "reconcileUnknown">;
   output?: AdminOutput;
@@ -116,6 +123,31 @@ export async function dispatchAdminCommand(
         clock(d),
       );
       write(d, next);
+      return;
+    }
+    case "thread.show": {
+      const r = (d.thread ?? ((db) => new PostgresThreadCapabilityRepository(db)))(sql);
+      const override = await r.get(command.guildId, command.channelId, command.threadId);
+      write(d, override ?? inheritAllOverride(command.guildId, command.channelId, command.threadId));
+      return;
+    }
+    case "thread.set": {
+      const r = (d.thread ?? ((db) => new PostgresThreadCapabilityRepository(db)))(sql);
+      const patch: ThreadCapabilityPatch = {
+        ...(command.observeEvents !== undefined ? { observeEvents: command.observeEvents } : {}),
+        ...(command.respondToMentions !== undefined ? { respondToMentions: command.respondToMentions } : {}),
+        ...(command.addReactions !== undefined ? { addReactions: command.addReactions } : {}),
+      };
+      const next = await r.patch(
+        command.guildId,
+        command.channelId,
+        command.threadId,
+        patch,
+        command.actor,
+        command.reason,
+        clock(d),
+      );
+      write(d, next ?? inheritAllOverride(command.guildId, command.channelId, command.threadId));
       return;
     }
     case "character.import": {

--- a/src/apps/discord-gateway.ts
+++ b/src/apps/discord-gateway.ts
@@ -4,6 +4,8 @@ import { createPostgresClient } from "../adapters/postgres/client.js";
 import { migrationStatus } from "../adapters/postgres/migrations.js";
 import { PostgresIngestionStore } from "../adapters/postgres/ingestion-store.js";
 import { PostgresChannelCapabilityRepository } from "../adapters/postgres/channel-capability-repository.js";
+import { PostgresThreadCapabilityRepository } from "../adapters/postgres/thread-capability-repository.js";
+import { PostgresEffectiveCapabilityRepository } from "../adapters/postgres/effective-capability-repository.js";
 import { PostgresSystemControlRepository } from "../adapters/postgres/system-control-repository.js";
 import { PostgresEffectQueue } from "../adapters/postgres/effect-queue.js";
 import { DiscordClientMessenger, snapshotDiscordMessage } from "../adapters/discord/discord-client.js";
@@ -92,7 +94,9 @@ export function handleGatewayFatal(
 export async function runGateway(d: GatewayDependencies): Promise<void> {
   const { sql, client, config, health, logger } = d;
   if (!d.prepared) requireNoPendingMigrations(await migrationStatus(sql, config.migrationsDir));
-  const capabilities = new PostgresChannelCapabilityRepository(sql);
+  const channelCapabilities = new PostgresChannelCapabilityRepository(sql);
+  const threadCapabilities = new PostgresThreadCapabilityRepository(sql);
+  const effectiveCapabilities = new PostgresEffectiveCapabilityRepository(channelCapabilities, threadCapabilities);
   const system = new PostgresSystemControlRepository(sql);
   await system.get();
   const ingestion = new PostgresIngestionStore(sql);
@@ -117,7 +121,7 @@ export async function runGateway(d: GatewayDependencies): Promise<void> {
     const task = (async () => {
       const snapshot = snapshotDiscordMessage(message);
       const input = toDiscordMessageInput(snapshot, client.user!.id);
-      const capability = await capabilities.get(config.guildId, input.channelId);
+      const capability = await effectiveCapabilities.get(config.guildId, input.channelId, input.threadId);
       const mode = await system.get();
       const result = await ingestDiscordMessage(input, capability, mode.mode, ingestion, SystemClock);
       logger.debug(
@@ -148,9 +152,9 @@ export async function runGateway(d: GatewayDependencies): Promise<void> {
     )
       return;
     const commandRepository = {
-      get: capabilities.get.bind(capabilities),
-      patch: async (...args: Parameters<typeof capabilities.patch>) => {
-        await capabilities.patch(...args);
+      get: channelCapabilities.get.bind(channelCapabilities),
+      patch: async (...args: Parameters<typeof channelCapabilities.patch>) => {
+        await channelCapabilities.patch(...args);
       },
     };
     inflight
@@ -165,7 +169,8 @@ export async function runGateway(d: GatewayDependencies): Promise<void> {
   await d.registerCommands?.();
   health.setReady(true);
   const controller = new AbortController();
-  const effectLoop = runEffectLoop(effects, capabilities, executor, controller.signal, logger, rejectFatal);
+  // runOneEffect still resolves capability without a thread; Task 7 widens it and switches this over.
+  const effectLoop = runEffectLoop(effects, channelCapabilities, executor, controller.signal, logger, rejectFatal);
   let fatalError: unknown;
   try {
     await Promise.race([d.shutdown, fatal]);

--- a/src/apps/discord-gateway.ts
+++ b/src/apps/discord-gateway.ts
@@ -156,6 +156,10 @@ export async function runGateway(d: GatewayDependencies): Promise<void> {
       patch: async (...args: Parameters<typeof channelCapabilities.patch>) => {
         await channelCapabilities.patch(...args);
       },
+      getThread: threadCapabilities.get.bind(threadCapabilities),
+      patchThread: async (...args: Parameters<typeof threadCapabilities.patch>) => {
+        await threadCapabilities.patch(...args);
+      },
     };
     inflight
       .track(

--- a/src/apps/discord-gateway.ts
+++ b/src/apps/discord-gateway.ts
@@ -173,8 +173,7 @@ export async function runGateway(d: GatewayDependencies): Promise<void> {
   await d.registerCommands?.();
   health.setReady(true);
   const controller = new AbortController();
-  // runOneEffect still resolves capability without a thread; Task 7 widens it and switches this over.
-  const effectLoop = runEffectLoop(effects, channelCapabilities, executor, controller.signal, logger, rejectFatal);
+  const effectLoop = runEffectLoop(effects, effectiveCapabilities, executor, controller.signal, logger, rejectFatal);
   let fatalError: unknown;
   try {
     await Promise.race([d.shutdown, fatal]);
@@ -190,7 +189,7 @@ export async function runGateway(d: GatewayDependencies): Promise<void> {
 }
 async function runEffectLoop(
   queue: PostgresEffectQueue,
-  capabilities: PostgresChannelCapabilityRepository,
+  capabilities: PostgresEffectiveCapabilityRepository,
   executor: DiscordEffectExecutor,
   signal: AbortSignal,
   logger: ReturnType<typeof createLogger>,

--- a/src/modules/admin/admin-command.test.ts
+++ b/src/modules/admin/admin-command.test.ts
@@ -35,6 +35,53 @@ describe("admin parser exact union", () => {
         reason: "r",
       },
     ],
+    [["thread", "show", "g", "c", "t"], { kind: "thread.show", guildId: "g", channelId: "c", threadId: "t" }],
+    [
+      [
+        "thread",
+        "set",
+        "g",
+        "c",
+        "t",
+        "--observe",
+        "allow",
+        "--mentions",
+        "deny",
+        "--reactions",
+        "inherit",
+        "--actor",
+        ACTOR,
+        "--reason",
+        "r",
+      ],
+      {
+        kind: "thread.set",
+        guildId: "g",
+        channelId: "c",
+        threadId: "t",
+        observeEvents: true,
+        respondToMentions: false,
+        addReactions: null,
+        actor: ACTOR,
+        reason: "r",
+      },
+    ],
+    [
+      ["thread", "set", "g", "c", "t", "--observe", "allow", "--actor", ACTOR, "--reason", "r"],
+      {
+        kind: "thread.set",
+        guildId: "g",
+        channelId: "c",
+        threadId: "t",
+        observeEvents: true,
+        actor: ACTOR,
+        reason: "r",
+      },
+    ],
+    [
+      ["thread", "set", "g", "c", "t", "--actor", ACTOR, "--reason", "r"],
+      { kind: "thread.set", guildId: "g", channelId: "c", threadId: "t", actor: ACTOR, reason: "r" },
+    ],
     [["character", "import", "x", "--actor", ACTOR], { kind: "character.import", path: "x", actor: ACTOR }],
     [
       ["character", "activate", "id", "2", "--actor", ACTOR],
@@ -91,6 +138,35 @@ describe("admin parser exact union", () => {
     expect(command).not.toHaveProperty("mentions");
   });
 
+  it("omits unset thread override fields entirely rather than setting them to undefined", () => {
+    const command = parseAdminCommand([
+      "thread",
+      "set",
+      "g",
+      "c",
+      "t",
+      "--observe",
+      "allow",
+      "--actor",
+      ACTOR,
+      "--reason",
+      "r",
+    ]);
+    expect(command).toHaveProperty("observeEvents", true);
+    expect(command).not.toHaveProperty("respondToMentions");
+    expect(command).not.toHaveProperty("addReactions");
+    expect(Object.keys(command)).not.toContain("observe");
+    expect(Object.keys(command)).not.toContain("mentions");
+    expect(Object.keys(command)).not.toContain("reactions");
+  });
+
+  it("omits all thread override fields when no capability option is supplied", () => {
+    const command = parseAdminCommand(["thread", "set", "g", "c", "t", "--actor", ACTOR, "--reason", "r"]);
+    expect(command).not.toHaveProperty("observeEvents");
+    expect(command).not.toHaveProperty("respondToMentions");
+    expect(command).not.toHaveProperty("addReactions");
+  });
+
   it.each([
     ["missing", []],
     ["unknown action", ["system", "set"]],
@@ -103,6 +179,22 @@ describe("admin parser exact union", () => {
       ["channel", "set", "g", "c", "--observe", "yes", "--mentions", "false", "--actor", ACTOR, "--reason", "r"],
     ],
     ["bad date", ["migration", "apply", "--backup-confirmed-at", "x", "--actor", ACTOR]],
+    ["thread show missing positional", ["thread", "show", "g", "c"]],
+    ["thread show extra positional", ["thread", "show", "g", "c", "t", "x"]],
+    [
+      "bad thread override value",
+      ["thread", "set", "g", "c", "t", "--observe", "yes", "--actor", ACTOR, "--reason", "r"],
+    ],
+    ["thread set missing actor", ["thread", "set", "g", "c", "t", "--observe", "allow", "--reason", "r"]],
+    ["thread set missing reason", ["thread", "set", "g", "c", "t", "--observe", "allow", "--actor", ACTOR]],
+    [
+      "thread set invalid actor",
+      ["thread", "set", "g", "c", "t", "--observe", "allow", "--actor", "not-an-id", "--reason", "r"],
+    ],
+    [
+      "thread set old option",
+      ["thread", "set", "g", "c", "t", "--observed", "allow", "--actor", ACTOR, "--reason", "r"],
+    ],
     ["bad version", ["character", "activate", "id", "0", "--actor", ACTOR]],
     [
       "failed external id",
@@ -165,6 +257,10 @@ describe("admin parser exact union", () => {
       ["effect", "reconcile", "e", "--state", "failed", "--state", "succeeded", "--actor", ACTOR, "--reason", "r"],
     ],
     ["reason", ["system", "stop", "--actor", ACTOR, "--reason", "r1", "--reason", "r2"]],
+    [
+      "thread observe",
+      ["thread", "set", "g", "c", "t", "--observe", "allow", "--observe", "deny", "--actor", ACTOR, "--reason", "r"],
+    ],
   ] as const)("rejects duplicate %s", (_, args) => expect(() => parseAdminCommand([...args])).toThrow());
 
   it.each([

--- a/src/modules/admin/admin-command.ts
+++ b/src/modules/admin/admin-command.ts
@@ -14,6 +14,16 @@ export type AdminCommand =
       observeEvents: boolean;
       respondToMentions: boolean;
     } & ActorReason)
+  | { kind: "thread.show"; guildId: string; channelId: string; threadId: string }
+  | ({
+      kind: "thread.set";
+      guildId: string;
+      channelId: string;
+      threadId: string;
+      observeEvents?: boolean | null;
+      respondToMentions?: boolean | null;
+      addReactions?: boolean | null;
+    } & ActorReason)
   | ({ kind: "character.import"; path: string } & Pick<ActorReason, "actor">)
   | ({ kind: "character.activate"; characterId: string; version: number } & Pick<ActorReason, "actor">)
   | { kind: "effect.inspect"; effectId: string }
@@ -33,6 +43,13 @@ const booleanValue = (value: unknown, name: string): boolean => {
   if (normalized === "true") return true;
   if (normalized === "false") return false;
   throw new Error(`${name} must be true or false`);
+};
+const overrideValue = (value: unknown, name: string): boolean | null => {
+  const normalized = text(value, name);
+  if (normalized === "allow") return true;
+  if (normalized === "deny") return false;
+  if (normalized === "inherit") return null;
+  throw new Error(`${name} must be allow, deny, or inherit`);
 };
 const snowflake = /^[0-9]{17,20}$/u;
 const actorId = (value: unknown): string => {
@@ -114,6 +131,46 @@ export function parseAdminCommand(argv: string[]): AdminCommand {
       channelId: text(channelId, "channelId"),
       observeEvents: booleanValue(result.values.observe, "observe"),
       respondToMentions: booleanValue(result.values.mentions, "mentions"),
+      ...actorReason(result.values),
+    };
+  }
+  if (command === "thread.show") {
+    const result = parse(args, {}, 3);
+    const [guildId, channelId, threadId] = result.positionals;
+    return {
+      kind: "thread.show",
+      guildId: text(guildId, "guildId"),
+      channelId: text(channelId, "channelId"),
+      threadId: text(threadId, "threadId"),
+    };
+  }
+  if (command === "thread.set") {
+    const result = parse(
+      args,
+      {
+        observe: { type: "string" },
+        mentions: { type: "string" },
+        reactions: { type: "string" },
+        actor: { type: "string" },
+        reason: { type: "string" },
+      },
+      3,
+    );
+    const [guildId, channelId, threadId] = result.positionals;
+    return {
+      kind: "thread.set",
+      guildId: text(guildId, "guildId"),
+      channelId: text(channelId, "channelId"),
+      threadId: text(threadId, "threadId"),
+      ...(result.values.observe !== undefined
+        ? { observeEvents: overrideValue(result.values.observe, "observe") }
+        : {}),
+      ...(result.values.mentions !== undefined
+        ? { respondToMentions: overrideValue(result.values.mentions, "mentions") }
+        : {}),
+      ...(result.values.reactions !== undefined
+        ? { addReactions: overrideValue(result.values.reactions, "reactions") }
+        : {}),
       ...actorReason(result.values),
     };
   }

--- a/src/modules/channels/channel-capability.ts
+++ b/src/modules/channels/channel-capability.ts
@@ -11,6 +11,10 @@ export interface ChannelCapabilities {
   shareExternalLinks: boolean;
 }
 
+export interface EffectiveCapabilityRepository {
+  get(guildId: string, channelId: string, threadId: string | null): Promise<ChannelCapabilities>;
+}
+
 export function denyAllCapabilities(guildId: string, channelId: string): ChannelCapabilities {
   return {
     guildId,

--- a/src/modules/channels/thread-capability.test.ts
+++ b/src/modules/channels/thread-capability.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { denyAllCapabilities, type ChannelCapabilities } from "./channel-capability.js";
+import {
+  resolveEffectiveCapabilities,
+  type ThreadCapabilityOverride,
+  type ThreadOverridableCapability,
+} from "./thread-capability.js";
+
+const channel: ChannelCapabilities = {
+  ...denyAllCapabilities("guild-1", "channel-1"),
+  observeEvents: true,
+  respondToMentions: true,
+  createThreads: true,
+};
+
+function override(patch: Partial<Pick<ThreadCapabilityOverride, ThreadOverridableCapability>>): ThreadCapabilityOverride {
+  return {
+    guildId: "guild-1",
+    channelId: "channel-1",
+    threadId: "thread-1",
+    observeEvents: null,
+    respondToMentions: null,
+    addReactions: null,
+    ...patch,
+  };
+}
+
+describe("resolveEffectiveCapabilities", () => {
+  it("returns the channel capabilities unchanged without an override", () => {
+    expect(resolveEffectiveCapabilities(channel, null)).toEqual(channel);
+  });
+
+  it("inherits the channel value for every null field", () => {
+    expect(resolveEffectiveCapabilities(channel, override({}))).toEqual(channel);
+  });
+
+  it("denies a capability the parent channel allows", () => {
+    expect(resolveEffectiveCapabilities(channel, override({ observeEvents: false }))).toEqual({
+      ...channel,
+      observeEvents: false,
+    });
+  });
+
+  it("allows a capability the parent channel denies", () => {
+    const quiet: ChannelCapabilities = { ...denyAllCapabilities("guild-1", "channel-1"), observeEvents: false };
+    expect(resolveEffectiveCapabilities(quiet, override({ observeEvents: true, respondToMentions: true }))).toEqual({
+      ...quiet,
+      observeEvents: true,
+      respondToMentions: true,
+    });
+  });
+
+  it("leaves capabilities that are not thread-overridable untouched", () => {
+    const resolved = resolveEffectiveCapabilities(channel, override({ addReactions: true }));
+    expect(resolved.createThreads).toBe(true);
+    expect(resolved.shareFiles).toBe(false);
+    expect(resolved.addReactions).toBe(true);
+  });
+
+  it("keeps the parent channel id so capability lookups stay stable", () => {
+    const resolved = resolveEffectiveCapabilities(channel, override({ observeEvents: false }));
+    expect(resolved.channelId).toBe("channel-1");
+    expect(resolved.guildId).toBe("guild-1");
+  });
+});

--- a/src/modules/channels/thread-capability.test.ts
+++ b/src/modules/channels/thread-capability.test.ts
@@ -13,7 +13,9 @@ const channel: ChannelCapabilities = {
   createThreads: true,
 };
 
-function override(patch: Partial<Pick<ThreadCapabilityOverride, ThreadOverridableCapability>>): ThreadCapabilityOverride {
+function override(
+  patch: Partial<Pick<ThreadCapabilityOverride, ThreadOverridableCapability>>,
+): ThreadCapabilityOverride {
   return {
     guildId: "guild-1",
     channelId: "channel-1",

--- a/src/modules/channels/thread-capability.ts
+++ b/src/modules/channels/thread-capability.ts
@@ -1,0 +1,34 @@
+import type { ChannelCapabilities } from "./channel-capability.js";
+
+export const THREAD_OVERRIDABLE_CAPABILITIES = ["observeEvents", "respondToMentions", "addReactions"] as const;
+
+export type ThreadOverridableCapability = (typeof THREAD_OVERRIDABLE_CAPABILITIES)[number];
+
+export interface ThreadCapabilityOverride {
+  guildId: string;
+  channelId: string;
+  threadId: string;
+  observeEvents: boolean | null;
+  respondToMentions: boolean | null;
+  addReactions: boolean | null;
+}
+
+export function inheritAllOverride(guildId: string, channelId: string, threadId: string): ThreadCapabilityOverride {
+  return { guildId, channelId, threadId, observeEvents: null, respondToMentions: null, addReactions: null };
+}
+
+export function isInheritOnly(override: ThreadCapabilityOverride): boolean {
+  return THREAD_OVERRIDABLE_CAPABILITIES.every((capability) => override[capability] === null);
+}
+
+export function resolveEffectiveCapabilities(
+  channel: ChannelCapabilities,
+  override: ThreadCapabilityOverride | null,
+): ChannelCapabilities {
+  const resolved = { ...channel };
+  for (const capability of THREAD_OVERRIDABLE_CAPABILITIES) {
+    const value = override?.[capability] ?? null;
+    if (value !== null) resolved[capability] = value;
+  }
+  return resolved;
+}

--- a/src/modules/effects/effect.test.ts
+++ b/src/modules/effects/effect.test.ts
@@ -9,6 +9,7 @@ const effect: ClaimedReplyEffect = {
   guildId: "guild-1",
   capabilityChannelId: "cap-1",
   targetChannelId: "target-1",
+  threadId: "target-1",
   targetMessageId: "message-1",
   content: "hello",
   attempts: 1,

--- a/src/modules/effects/effect.ts
+++ b/src/modules/effects/effect.ts
@@ -13,6 +13,7 @@ export interface ClaimedReplyEffect {
   guildId: string;
   capabilityChannelId: string;
   targetChannelId: string;
+  threadId: string | null;
   targetMessageId: string;
   content: string;
   attempts: number;

--- a/src/modules/effects/run-effect-worker.test.ts
+++ b/src/modules/effects/run-effect-worker.test.ts
@@ -11,6 +11,9 @@ const effect = {
   content: "hello",
   attempts: 1,
 };
+const threadEffect = { ...effect, targetChannelId: "t1" };
+const clock = { now: () => new Date("2026-01-01T00:00:00Z") };
+
 describe("runOneEffect", () => {
   it("rechecks capability and executes an allowed effect", async () => {
     const queue = { claim: vi.fn().mockResolvedValue(effect), fail: vi.fn() };
@@ -18,8 +21,10 @@ describe("runOneEffect", () => {
       get: vi.fn().mockResolvedValue({ guildId: "g1", channelId: "c1", respondToMentions: true }),
     };
     const executor = { execute: vi.fn().mockResolvedValue(undefined) };
-    const clock = { now: vi.fn().mockReturnValue(new Date("2026-01-01T00:00:00Z")) };
+
     await expect(runOneEffect(queue, capabilities, executor, "worker", clock)).resolves.toBe(true);
+
+    expect(capabilities.get).toHaveBeenCalledWith("g1", "c1", null);
     expect(executor.execute).toHaveBeenCalledWith(effect, clock);
   });
 
@@ -29,8 +34,36 @@ describe("runOneEffect", () => {
       get: vi.fn().mockResolvedValue({ guildId: "g1", channelId: "c1", respondToMentions: false }),
     };
     const executor = { execute: vi.fn() };
-    const clock = { now: vi.fn().mockReturnValue(new Date("2026-01-01T00:00:00Z")) };
+
     await expect(runOneEffect(queue, capabilities, executor, "worker", clock)).resolves.toBe(true);
+
+    expect(queue.fail).toHaveBeenCalledWith("e1", "capability_revoked", clock.now());
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
+  it("resolves capability for the thread when the target is a thread", async () => {
+    const queue = { claim: vi.fn().mockResolvedValue(threadEffect), fail: vi.fn() };
+    const capabilities = {
+      get: vi.fn().mockResolvedValue({ guildId: "g1", channelId: "c1", respondToMentions: true }),
+    };
+    const executor = { execute: vi.fn().mockResolvedValue(undefined) };
+
+    await expect(runOneEffect(queue, capabilities, executor, "worker", clock)).resolves.toBe(true);
+
+    expect(capabilities.get).toHaveBeenCalledWith("g1", "c1", "t1");
+    expect(executor.execute).toHaveBeenCalledWith(threadEffect, clock);
+  });
+
+  it("fails an effect whose thread override revoked mention responses", async () => {
+    const queue = { claim: vi.fn().mockResolvedValue(threadEffect), fail: vi.fn().mockResolvedValue(undefined) };
+    const capabilities = {
+      get: vi.fn().mockResolvedValue({ guildId: "g1", channelId: "c1", respondToMentions: false }),
+    };
+    const executor = { execute: vi.fn() };
+
+    await expect(runOneEffect(queue, capabilities, executor, "worker", clock)).resolves.toBe(true);
+
+    expect(capabilities.get).toHaveBeenCalledWith("g1", "c1", "t1");
     expect(queue.fail).toHaveBeenCalledWith("e1", "capability_revoked", clock.now());
     expect(executor.execute).not.toHaveBeenCalled();
   });

--- a/src/modules/effects/run-effect-worker.test.ts
+++ b/src/modules/effects/run-effect-worker.test.ts
@@ -7,11 +7,12 @@ const effect = {
   guildId: "g1",
   capabilityChannelId: "c1",
   targetChannelId: "c1",
+  threadId: null,
   targetMessageId: "m1",
   content: "hello",
   attempts: 1,
 };
-const threadEffect = { ...effect, targetChannelId: "t1" };
+const threadEffect = { ...effect, targetChannelId: "t1", threadId: "t1" };
 const clock = { now: () => new Date("2026-01-01T00:00:00Z") };
 
 describe("runOneEffect", () => {

--- a/src/modules/effects/run-effect-worker.ts
+++ b/src/modules/effects/run-effect-worker.ts
@@ -1,10 +1,7 @@
 import type { Clock } from "../../shared/clock.js";
-import type { ChannelCapabilities } from "../channels/channel-capability.js";
+import type { EffectiveCapabilityRepository } from "../channels/channel-capability.js";
 import type { ClaimedReplyEffect, EffectQueue } from "./effect.js";
 
-interface CapabilityRepository {
-  get(guildId: string, channelId: string): Promise<ChannelCapabilities>;
-}
 interface Executor {
   execute(effect: ClaimedReplyEffect, clock: Clock): Promise<void>;
 }
@@ -14,14 +11,16 @@ interface Queue extends Pick<EffectQueue, "fail"> {
 
 export async function runOneEffect(
   queue: Queue,
-  capabilities: CapabilityRepository,
+  capabilities: EffectiveCapabilityRepository,
   executor: Executor,
   workerId: string,
   clock: Clock,
 ): Promise<boolean> {
   const effect = await queue.claim(workerId, clock.now());
   if (!effect) return false;
-  const capability = await capabilities.get(effect.guildId, effect.capabilityChannelId);
+  // decision-effect-store writes target_channel_id = thread_id ?? channel_id, so equality means "not a thread".
+  const threadId = effect.targetChannelId === effect.capabilityChannelId ? null : effect.targetChannelId;
+  const capability = await capabilities.get(effect.guildId, effect.capabilityChannelId, threadId);
   if (!capability.respondToMentions) {
     await queue.fail(effect.id, "capability_revoked", clock.now());
     return true;

--- a/src/modules/effects/run-effect-worker.ts
+++ b/src/modules/effects/run-effect-worker.ts
@@ -18,9 +18,7 @@ export async function runOneEffect(
 ): Promise<boolean> {
   const effect = await queue.claim(workerId, clock.now());
   if (!effect) return false;
-  // decision-effect-store writes target_channel_id = thread_id ?? channel_id, so equality means "not a thread".
-  const threadId = effect.targetChannelId === effect.capabilityChannelId ? null : effect.targetChannelId;
-  const capability = await capabilities.get(effect.guildId, effect.capabilityChannelId, threadId);
+  const capability = await capabilities.get(effect.guildId, effect.capabilityChannelId, effect.threadId);
   if (!capability.respondToMentions) {
     await queue.fail(effect.id, "capability_revoked", clock.now());
     return true;


### PR DESCRIPTION
Phase 2A の先頭スライス。設計は #1097 の `docs/superpowers/specs/2026-07-29-phase-2-conversation-cognition-design.md` §2、実装計画は `docs/superpowers/plans/2026-07-29-thread-scope.md`。

**このPRは #1097 をベースにしている。** #1097 をマージしてからこちらをマージするか、base を main に付け替えること。

## 背景

スレッド主体で運用するギルド（特にフォーラムチャンネル）では、`observe_events` を有効にした瞬間に配下の全スレッドが観察対象になってしまい、粒度を絞れなかった。canonical event は既に `channelId`（親）と `threadId` を分離して保持していたが、capability の粒度と会話 scope の定義が欠けていた。

## 変更内容

`channel_capabilities` は親チャンネルのデフォルトとして維持し、nullable boolean 列を持つ `thread_capability_overrides` を追加する。`NULL` = 親を継承、`true`/`false` = 明示 override。許可側（親 deny + スレッド allow）と拒否側（親 allow + スレッド deny）の両方を表現できる。

override できるのはスレッド内で意味を持つ 3 つ（`observeEvents` / `respondToMentions` / `addReactions`）のみ。それ以外はチャンネルレベルのまま。

- `migrations/0002_thread_scope.sql` — override テーブル（全継承 row を禁止する CHECK 付き）、会話 scope 用の `events (guild_id, channel_id, thread_id, occurred_at DESC)` index、`effects.thread_id` 列の追加とバックフィル
- `src/modules/channels/thread-capability.ts` — 純関数 `resolveEffectiveCapabilities`。解決点はここ 1 箇所
- `src/adapters/postgres/thread-capability-repository.ts` — 全項目が継承に戻ったら row を DELETE、`thread.capability.changed` を監査記録、scope 単位の advisory lock
- `src/adapters/postgres/effective-capability-repository.ts` — チャンネル + スレッドの合成。capability 参照の単一入口
- `src/apps/discord-gateway.ts` — ingest 時に実効 capability で判定
- `src/modules/effects/run-effect-worker.ts` — effect 実行直前の再認可でもスレッド override を見る（設計書 §9）

capability は取り込み時と effect 実行直前の両方で再評価するため、スレッド override を拒否側に変えると既に queued の返信も `capability_revoked` で止まる。

### 操作手段

Discord とコマンドラインの両方から同じ意味論で操作できる。

- `/vicissitude-channel thread-set` / `thread-show` — `observe` / `mentions` / `reactions` を `allow` / `deny` / `inherit` から選ぶ
- `pnpm admin thread show <guildId> <channelId> <threadId>` / `pnpm admin thread set ... [--observe allow|deny|inherit] [--mentions ...] [--reactions ...] --actor ... --reason ...`

どちらも省略した項目は変更せず、全項目を `inherit` に戻すと上書き行を削除する。`channel set` が両オプション必須なのと違い、`thread set` はどの capability オプションも任意（`inherit` が「未指定」とは別の第三の状態だから）。

`/vicissitude-channel show` にスレッドを渡した場合は、親チャンネルの値だけでなく override と実効値も併せて返す。

## テスト

`nr validate` 通過。unit 178 tests / spec 79 tests。spec は他ファイル由来のデータ汚染で flake を起こした経緯があるため、各タスクで最大 10 回連続実行して安定を確認している。

`spec/modules/effects/run-effect-worker.spec.ts` は ingest → job → decision → effect の実パイプラインを実 DB で通し、決定後にスレッド override を拒否側へ変えると effect が止まること、および親チャンネル拒否 + スレッド許可で実行されることを検証する。

## レビューで見つかって直したもの

- gateway spec の新規テストが `events` を無条件 select しており、他 spec ファイルの残留行で約 40% の確率で落ちていた（7 回中 3 回失敗を実測）。クエリを scope 限定して解消
- `validateMetadata` が channel / thread の両 repository で重複していたため `capability-metadata.ts` に共通化
- `CapabilityRepository` が構造的部分型により 2 引数リポジトリも受け入れてしまい、将来スレッド判定が黙って抜ける穴があったため、共有 interface `EffectiveCapabilityRepository` を導入して `implements` を明示
- `/vicissitude-channel show` にスレッドを渡すと親の値しか出ず、override がある場合に誤解を招くため、スレッド指定時は override と実効値も併せて返すよう修正
- README の復旧手順の DB assertion が `thread_capability_overrides` を見ておらず、スレッド override で有効化された対象を見落としていたため修正
- **effect 実行時のスレッド判定を `target_channel_id !== capability_channel_id` の導出から `effects.thread_id` 列へ移した。** 導出は Discord のスノーフレークが親子で一致しないことに依存した暗黙の不変条件で、かつ取り込み側が message snapshot から直接 `threadId` を得ているのと二重の導出になっていた。Phase 2C で effect 種別が増えると導出が広がるため、本番前の今のうちに解消した。`migrations/0002` は未適用だったため新規 migration を足さずその場で `ALTER TABLE` + バックフィルを追加している
- **admin-cli にも thread subcommand を追加した。** README の運用手順は admin-cli を主経路としているのに、当初は Discord からしか設定できず操作面が食い違っていた

## その他

`.gitignore` に `backups/` / `config/model-routes.json` / `character-reviewed.json` を追加した。`nr validate` の `format:check` が `oxfmt .` なので、これらのローカル成果物があると素の状態で落ちていた。

## 既知の制約

監査の `before`/`after` の形が channel（8 フィールド、常に非 null）と thread（3 フィールド、null は「未設定」）で異なる。それぞれ内部では一貫しているが、両方を横断して読む場合は注意が必要。

## 次のスライス

durable batch（`conversation_evaluate` job の scope キー化、short batch、typing 延長、`conversation_cursors`、`actor_states`）と scenario corpus。設計書 §3 と §6。