### PR TITLE
ci: unify the quality job on nix develop and add a Cachix binary cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-      # This job builds nothing of its own, so Cachix would have nothing to push;
-      # the ~1.2GB devShell is all upstream paths. Caching the store in the GitHub
-      # Actions cache is what actually avoids re-substituting it from cache.nixos.org.
-      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size: 2G
-          purge: true
-          purge-prefixes: nix-${{ runner.os }}-
-          purge-created: 604800
+      # No Cachix here: this job builds nothing of its own, so there would be
+      # nothing to push. Caching /nix in the Actions cache was measured too, and
+      # restoring it cost as much as substituting from cache.nixos.org.
       # devShells.ci supplies node and postgresql; pnpm resolves its own version
       # from the packageManager field, so this caches both the store and pnpm itself.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,39 +16,27 @@ jobs:
   quality:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    services:
-      postgres:
-        image: postgres:17.10@sha256:a426e44bac0b759c95894d68e1a0ac03ecc20b619f498a91aae373bf06d8508d
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: vicissitude_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-    env:
-      TEST_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/vicissitude_test
-      VICISSITUDE_MIGRATIONS_DIR: migrations
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: cachix/cachix-action@02b16339eddcf6ea27126a830c7f1992855cae13 # v17
         with:
-          version: 11.16.0
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+          name: vicissitude
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      # devShells.ci supplies node and postgresql; pnpm resolves its own version
+      # from the packageManager field, so this caches both the store and pnpm itself.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          node-version: 24.18.0
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - run: pnpm format:check
-      - run: pnpm lint
-      - run: pnpm check
-      - run: pnpm test:unit
-      - run: pnpm exec vitest run spec
-      - run: pnpm build
+          path: ~/.local/share/pnpm
+          key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-
+      - run: nix develop .#ci -c pnpm install --frozen-lockfile --ignore-scripts
+      - run: nix develop .#ci -c pnpm format:check
+      - run: nix develop .#ci -c pnpm lint
+      - run: nix develop .#ci -c pnpm check
+      - run: nix develop .#ci -c pnpm test:unit
+      - run: nix develop .#ci -c pnpm test:spec
+      - run: nix develop .#ci -c pnpm build
 
   staging-validation:
     runs-on: ubuntu-24.04
@@ -58,5 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: cachix/cachix-action@02b16339eddcf6ea27126a830c7f1992855cae13 # v17
+        with:
+          name: vicissitude
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: nix build .#default
       - run: nix build .#checks.x86_64-linux.staging-db-rehearsal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-      - uses: cachix/cachix-action@02b16339eddcf6ea27126a830c7f1992855cae13 # v17
+      # This job builds nothing of its own, so Cachix would have nothing to push;
+      # the ~1.2GB devShell is all upstream paths. Caching the store in the GitHub
+      # Actions cache is what actually avoids re-substituting it from cache.nixos.org.
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
-          name: vicissitude
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size: 2G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 604800
       # devShells.ci supplies node and postgresql; pnpm resolves its own version
       # from the packageManager field, so this caches both the store and pnpm itself.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
       # No Cachix here: this job builds nothing of its own, so there would be
       # nothing to push. Caching /nix in the Actions cache was measured too, and
       # restoring it cost as much as substituting from cache.nixos.org.
-      # devShells.ci supplies node and postgresql; pnpm resolves its own version
-      # from the packageManager field, so this caches both the store and pnpm itself.
+      #
+      # pnpm resolves its own version from the packageManager field, so this
+      # caches both the package store and pnpm itself.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.local/share/pnpm

--- a/flake.nix
+++ b/flake.nix
@@ -22,14 +22,18 @@
           ...
         }:
         {
-          devShells.default = pkgs.mkShell {
-            packages = with pkgs; [
-              nodejs_24
-              pnpm
-              postgresql_17
-              pi-coding-agent
-            ];
-          };
+          devShells =
+            let
+              base = with pkgs; [
+                nodejs_24
+                pnpm_11
+                postgresql_17
+              ];
+            in
+            {
+              ci = pkgs.mkShell { packages = base; };
+              default = pkgs.mkShell { packages = base ++ [ pkgs.pi-coding-agent ]; };
+            };
           formatter = pkgs.nixfmt;
           packages.default = pkgs.callPackage ./nix/package.nix { };
           checks = pkgs.lib.optionalAttrs (system == "x86_64-linux") {


### PR DESCRIPTION
CI が nix と setup-node のどっちつかずになっていた点を整理します。

**先に結論**: quality job は **51s → 81s(+30秒 / 1.6倍)遅くなります**。その代償として、ツールチェーンの二重管理と spec テストの二重経路が解消されます。このトレードオフを受け入れるかどうかがこの PR の判断点です。

## 1. quality job を `nix develop .#ci` 配下に移す

`setup-node` / `pnpm/action-setup` を削除しました。

pnpm については、調査の結果**真の source of truth は既に `package.json` の `packageManager` フィールド**でした。nix が渡す pnpm 11.15.0 はリポジトリ内で実行すると自分で 11.16.0 をダウンロードして再 exec します(`manage-package-manager-versions` が既定で有効)。

```
リポジトリ内で nix の pnpm を実行 → 11.16.0
リポジトリ外で同じ pnpm を実行   → 11.15.0
```

そのため `action-setup` の `version:` 入力は何にも置き換えていません。なお **CI のピン留めは既に nixpkgs とズレていました**(CI: pnpm 11.16.0 / nixpkgs: 11.15.0)。実質的に一元化されるのは Node です。

## 2. postgres の services コンテナを廃止

`scripts/test-with-postgres.mjs` が initdb で一時クラスタを立てる処理を既に持っており、ローカルではこれが使われていました。一方 CI は services コンテナ + `pnpm exec vitest run spec` という**別経路**を維持していました。

`pnpm test:spec` に統一し、`services` ブロックと `TEST_DATABASE_URL` / `VICISSITUDE_MIGRATIONS_DIR` を削除しています。新規に書いたコードはありません。

## 3. Cachix は staging-validation のみに追加

キャッシュ手段は 4 つ比較し、**CI 外(開発機・将来の Docker イメージ)から pull できること**を要件として Cachix を選びました。`cache-nix-action` と Magic Nix Cache は GHA cache ベースで CI 専用のため脱落、FlakeHub Cache は public cache を作れない設計かつ fork PR で使えず public repo に不向きでした。

対象を staging-validation に限ったのは、**quality job が nix で何もビルドしないため push 対象がゼロ**だからです(devShell は全て上流 path の substitution)。実測でも Cachix step は 3 秒払って何も得ていませんでした。

規模の実測値:

- staging-validation の全ビルド closure: **13.87GB / 1930 paths**
- リポジトリ固有 path のみ: **約 500MB/revision**(出力 NAR 106MB + vendored pnpm deps 387MB)

Cachix は cache.nixos.org 収録分を push しないため、後者だけが対象となり 5GB 無料枠に収まります。

## 4. `devShells.ci` を分離

`nodejs_24` / `pnpm_11` / `postgresql_17` を `base` として括り、`default = base + pi-coding-agent` としています。バージョン定義を 1 箇所に保ったまま、CI では closure 548MB の pi-coding-agent を取得せずに済みます。

あわせて devShell 側の `pkgs.pnpm`(エイリアス)を `nix/package.nix` と同じ `pnpm_11` に揃えました。nixpkgs がエイリアスを 12 系に進めた際の無言の乖離を防ぐためです。

## 性能: 実測と、試して駄目だった対策

| 構成 | quality 合計 |
|---|---|
| main(`setup-node`) | **51s** |
| nix + Cachix | 91s |
| nix + `cache-nix-action` | 89s |
| **nix(キャッシュ機構なし・本 PR)** | **81s** |

step 内訳での比較:

| step | main | 本 PR | 差 |
|---|---|---|---|
| Initialize containers | 14s | — | **−14s** |
| セットアップ系 actions | 8s | 9s | +1s |
| `pnpm install`(初回 `nix develop` を含む) | 3s | 27s | **+24s** |
| format:check / lint / check | 5s | 13s | +8s |
| test:unit | 4s | 7s | +3s |
| spec | 6s | 16s | +10s |
| build | 3s | 5s | +2s |

services コンテナ廃止で 14 秒稼げていますが、devShell(約 1.2GB)の実体化コストが最初の `nix develop` に集中し、それを上回ります。

**quality 向けのキャッシュは 2 種類とも純損失でした。** `cache-nix-action` は `pnpm install` を 28s → 12s に縮めましたが、復元自体に 15s かかり差し引きゼロ。GHA cache からの復元コストが cache.nixos.org からの substitution とほぼ同額のためです。Cachix も前述のとおり push 対象がゼロで 3 秒の純損失でした。両方外した構成が最速だったため、そうしています。

## マージ前に必要な作業(完了済み)

- cachix.org に public キャッシュ `vicissitude` を作成
- Secrets に `CACHIX_AUTH_TOKEN` を登録

注意: `cachix use` はキャッシュ未作成やトークン不正の場合に**ハードエラーで落ちます**。public キャッシュが存在していれば、トークンを持たない fork PR でも pull は可能です。

## 検証

`devShells.ci` 内でローカル実行し `format:check` / `lint` / `check` / `test:unit` / `build` が PASS、`test:spec` は 13 files / 79 tests がクラスタ起動込み約 18 秒で通過。CI 上でも quality job が success。`actionlint` は指摘なしです。

## 既知の無関係な失敗

`staging-validation` の `nix build .#checks.x86_64-linux.staging-db-rehearsal` が落ちますが、**これは本 PR とは無関係な main 由来の既存不具合**です。main の最新コミット `bc74529` でも同じ step が failure で、ローカルでも再現します。ログは 1 行しか出ません。

```
check=staging-db-rehearsal role=internal operation=integration expected=success
```

別途調査予定です。
